### PR TITLE
Feature/assistant support

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -65,6 +65,12 @@
                 <category android:name="android.intent.category.DEFAULT" />
                 <data android:mimeType="*/*" />
             </intent-filter>
+
+            <!-- Handle Android Assistant voice actions -->
+            <intent-filter>
+                <action android:name="android.intent.action.ASSIST" />
+                <category android:name="android.intent.category.DEFAULT" />
+            </intent-filter>
         </activity>
         
         <!-- Adds a text-selection action (Android) shown in the selection toolbar.

--- a/android/app/src/main/kotlin/app/cogwheel/conduit/MainActivity.kt
+++ b/android/app/src/main/kotlin/app/cogwheel/conduit/MainActivity.kt
@@ -2,18 +2,28 @@ package app.cogwheel.conduit
 
 import io.flutter.embedding.android.FlutterActivity
 import io.flutter.embedding.engine.FlutterEngine
+import io.flutter.plugin.common.MethodChannel
+import android.content.Intent
 import android.os.Build
 import android.os.Bundle
 import androidx.core.view.WindowCompat
 
 class MainActivity : FlutterActivity() {
     private lateinit var backgroundStreamingHandler: BackgroundStreamingHandler
+    private lateinit var assistIntentChannel: MethodChannel
+    
+    companion object {
+        private const val ASSIST_INTENT_CHANNEL = "conduit/assist_intent"
+    }
     
     override fun onCreate(savedInstanceState: Bundle?) {
         // Ensure content draws behind system bars (backwards compatible helper)
         WindowCompat.setDecorFitsSystemWindows(window, false)
         
         super.onCreate(savedInstanceState)
+        
+        // Handle ASSIST intent if launched with it
+        handleAssistIntent(intent)
     }
     
     override fun configureFlutterEngine(flutterEngine: FlutterEngine) {
@@ -22,6 +32,23 @@ class MainActivity : FlutterActivity() {
         // Initialize background streaming handler
         backgroundStreamingHandler = BackgroundStreamingHandler(this)
         backgroundStreamingHandler.setup(flutterEngine)
+        
+        // Initialize ASSIST intent channel
+        assistIntentChannel = MethodChannel(flutterEngine.dartExecutor.binaryMessenger, ASSIST_INTENT_CHANNEL)
+    }
+    
+    override fun onNewIntent(intent: Intent) {
+        super.onNewIntent(intent)
+        handleAssistIntent(intent)
+    }
+    
+    private fun handleAssistIntent(intent: Intent?) {
+        if (intent?.action == Intent.ACTION_ASSIST) {
+            // Notify Flutter side that ASSIST intent was triggered
+            if (::assistIntentChannel.isInitialized) {
+                assistIntentChannel.invokeMethod("assistTriggered", null)
+            }
+        }
     }
     
     override fun onDestroy() {

--- a/lib/core/providers/app_providers.dart
+++ b/lib/core/providers/app_providers.dart
@@ -107,6 +107,32 @@ class LocaleNotifier extends StateNotifier<Locale?> {
   }
 }
 
+// TTS Language provider
+final ttsLanguageProvider = StateNotifierProvider<TTSLanguageNotifier, String?>(
+  (ref) {
+    final storage = ref.watch(optimizedStorageServiceProvider);
+    return TTSLanguageNotifier(storage);
+  },
+);
+
+class TTSLanguageNotifier extends StateNotifier<String?> {
+  final OptimizedStorageService _storage;
+
+  TTSLanguageNotifier(this._storage) : super(null) {
+    _loadTTSLanguage();
+  }
+
+  void _loadTTSLanguage() {
+    final languageCode = _storage.getTTSLanguage();
+    state = languageCode; // null means system default
+  }
+
+  Future<void> setTTSLanguage(String? languageCode) async {
+    state = languageCode;
+    await _storage.setTTSLanguage(languageCode);
+  }
+}
+
 // Server connection providers - optimized with caching
 final serverConfigsProvider = FutureProvider<List<ServerConfig>>((ref) async {
   final storage = ref.watch(optimizedStorageServiceProvider);
@@ -334,7 +360,8 @@ final defaultModelAutoSelectionProvider = Provider<void>((ref) {
         } catch (_) {}
 
         // Fallback: keep current selection or pick first available
-        selected ??= ref.read(selectedModelProvider) ??
+        selected ??=
+            ref.read(selectedModelProvider) ??
             (models.isNotEmpty ? models.first : null);
 
         if (selected != null) {

--- a/lib/core/services/assist_intent_service.dart
+++ b/lib/core/services/assist_intent_service.dart
@@ -77,6 +77,9 @@ void _processAssistIntent(Ref ref) {
     ref.read(chatMessagesProvider.notifier).clearMessages();
     ref.read(activeConversationProvider.notifier).state = null;
 
+    // Enable TTS for AI responses in ASSIST intent sessions
+    ref.read(shouldUseTTSForResponseProvider.notifier).state = true;
+
     // Trigger input focus and voice input with staggered delays
     // Shorter delays since we know the UI is ready at this point
     Future.delayed(const Duration(milliseconds: 300), () {

--- a/lib/core/services/assist_intent_service.dart
+++ b/lib/core/services/assist_intent_service.dart
@@ -1,0 +1,98 @@
+import 'dart:async';
+
+import 'package:flutter/services.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../features/auth/providers/unified_auth_providers.dart';
+import '../../features/chat/providers/chat_providers.dart';
+import '../providers/app_providers.dart';
+import '../utils/debug_logger.dart';
+import 'navigation_service.dart';
+
+/// Holds a pending ASSIST intent trigger until the app is ready
+final pendingAssistIntentProvider = StateProvider<bool>((ref) => false);
+
+const MethodChannel _assistIntentChannel = MethodChannel(
+  'conduit/assist_intent',
+);
+
+/// Initializes listening to ASSIST intents and handles them when app is ready
+final assistIntentInitializerProvider = Provider<void>((ref) {
+  // Listen for app readiness: authenticated, model available, and on chat route
+  void maybeProcessPendingAssist() {
+    final navState = ref.read(authNavigationStateProvider);
+    final model = ref.read(selectedModelProvider);
+    final pendingAssist = ref.read(pendingAssistIntentProvider);
+    final isOnChatRoute = NavigationService.currentRoute == Routes.chat;
+
+    if (pendingAssist &&
+        navState == AuthNavigationState.authenticated &&
+        model != null &&
+        isOnChatRoute) {
+      _processAssistIntent(ref);
+      ref.read(pendingAssistIntentProvider.notifier).state = false;
+    }
+  }
+
+  // React when auth/model changes to process a queued ASSIST intent
+  ref.listen<AuthNavigationState>(
+    authNavigationStateProvider,
+    (_, __) => maybeProcessPendingAssist(),
+  );
+  ref.listen(selectedModelProvider, (_, __) => maybeProcessPendingAssist());
+
+  // Also poll once shortly after navigation settles to ensure ChatPage is ready
+  Future.delayed(
+    const Duration(milliseconds: 150),
+    () => maybeProcessPendingAssist(),
+  );
+
+  // Setup method call handler for ASSIST intents
+  _assistIntentChannel.setMethodCallHandler((call) async {
+    switch (call.method) {
+      case 'assistTriggered':
+        DebugLogger.log('AssistIntentService: ASSIST intent received');
+        ref.read(pendingAssistIntentProvider.notifier).state = true;
+        maybeProcessPendingAssist();
+        break;
+      default:
+        DebugLogger.log('AssistIntentService: Unknown method ${call.method}');
+    }
+  });
+
+  DebugLogger.log('AssistIntentService: Initialized');
+
+  // Ensure cleanup
+  ref.onDispose(() {
+    DebugLogger.log('AssistIntentService: Disposing');
+  });
+});
+
+void _processAssistIntent(Ref ref) {
+  try {
+    DebugLogger.log('AssistIntentService: Processing ASSIST intent');
+
+    // Start a new chat (clear current conversation)
+    DebugLogger.log('AssistIntentService: Starting new chat');
+    ref.read(chatMessagesProvider.notifier).clearMessages();
+    ref.read(activeConversationProvider.notifier).state = null;
+
+    // Trigger input focus and voice input with staggered delays
+    // Shorter delays since we know the UI is ready at this point
+    Future.delayed(const Duration(milliseconds: 300), () {
+      DebugLogger.log('AssistIntentService: Triggering input focus');
+      final currentFocusTick = ref.read(inputFocusTriggerProvider);
+      ref.read(inputFocusTriggerProvider.notifier).state = currentFocusTick + 1;
+    });
+
+    Future.delayed(const Duration(milliseconds: 800), () {
+      DebugLogger.log('AssistIntentService: Triggering voice input');
+      // Mark this voice session as ASSIST intent triggered for auto-send
+      ref.read(isAssistIntentVoiceSessionProvider.notifier).state = true;
+      final currentVoiceTick = ref.read(voiceInputTriggerProvider);
+      ref.read(voiceInputTriggerProvider.notifier).state = currentVoiceTick + 1;
+    });
+  } catch (e) {
+    DebugLogger.error('AssistIntentService: Error processing ASSIST intent', e);
+  }
+}

--- a/lib/core/services/optimized_storage_service.dart
+++ b/lib/core/services/optimized_storage_service.dart
@@ -24,6 +24,7 @@ class OptimizedStorageService {
   static const String _rememberCredentialsKey = 'remember_credentials';
   static const String _themeModeKey = 'theme_mode';
   static const String _localeCodeKey = 'locale_code_v1';
+  static const String _ttsLanguageKey = 'tts_language_v1';
   static const String _localConversationsKey = 'local_conversations';
   static const String _onboardingSeenKey = 'onboarding_seen_v1';
   static const String _reviewerModeKey = 'reviewer_mode_v1';
@@ -238,6 +239,20 @@ class OptimizedStorageService {
       await _prefs.remove(_localeCodeKey);
     } else {
       await _prefs.setString(_localeCodeKey, code);
+    }
+  }
+
+  /// TTS Language Management
+  String? getTTSLanguage() {
+    // Returns a language code like 'en-US', 'es-ES', 'de-DE', 'fr-FR', 'it-IT'. Null means system.
+    return _prefs.getString(_ttsLanguageKey);
+  }
+
+  Future<void> setTTSLanguage(String? languageCode) async {
+    if (languageCode == null || languageCode.isEmpty) {
+      await _prefs.remove(_ttsLanguageKey);
+    } else {
+      await _prefs.setString(_ttsLanguageKey, languageCode);
     }
   }
 

--- a/lib/core/services/tts_service.dart
+++ b/lib/core/services/tts_service.dart
@@ -1,0 +1,533 @@
+import 'dart:async';
+import 'dart:io';
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_tts/flutter_tts.dart';
+
+import '../utils/debug_logger.dart';
+import '../providers/app_providers.dart';
+
+/// Service to handle Text-to-Speech functionality
+///
+/// Provides TTS capabilities with platform-specific optimizations
+class TTSService {
+  static TTSService? _instance;
+  static TTSService get instance {
+    _instance ??= TTSService._();
+    return _instance!;
+  }
+
+  TTSService._() {
+    DebugLogger.log('TTS: New TTSService instance created');
+  }
+
+  FlutterTts? _flutterTts;
+  bool _isInitialized = false;
+  bool _isSpeaking = false;
+  String? _currentMessageId;
+
+  /// Initialize the TTS service
+  Future<bool> initialize() async {
+    return initializeWithLanguage(null);
+  }
+
+  /// Initialize the TTS service with specific language
+  Future<bool> initializeWithLanguage(String? languageCode) async {
+    if (_isInitialized) {
+      // If already initialized, always update language (including null/system)
+      await updateLanguage(languageCode);
+      return true;
+    }
+
+    try {
+      _flutterTts = FlutterTts();
+      DebugLogger.log('TTS: FlutterTts instance created');
+
+      // Determine language to use
+      final targetLanguage = _resolveTargetLanguage(languageCode);
+
+      // Check if target language is available on this device
+      final isAvailable = await _flutterTts!.isLanguageAvailable(
+        targetLanguage,
+      );
+      if (!isAvailable) {
+        DebugLogger.log(
+          'TTS: $targetLanguage not available, falling back to en-US',
+        );
+      }
+
+      if (Platform.isAndroid) {
+        await _setupAndroid(languageCode: languageCode);
+      } else if (Platform.isIOS) {
+        await _setupiOS(languageCode: languageCode);
+      }
+
+      // Set up completion handlers
+      _flutterTts!.setCompletionHandler(() {
+        DebugLogger.log('TTS: Speech completed');
+        _isSpeaking = false;
+        _currentMessageId = null;
+      });
+
+      _flutterTts!.setErrorHandler((msg) {
+        DebugLogger.error('TTS: Error occurred', msg);
+        _isSpeaking = false;
+        _currentMessageId = null;
+      });
+
+      _isInitialized = true;
+      DebugLogger.log(
+        'TTS: Service initialized successfully with language: $targetLanguage',
+      );
+      return true;
+    } catch (e) {
+      DebugLogger.error('TTS: Failed to initialize', e);
+      return false;
+    }
+  }
+
+  /// Setup Android-specific TTS configuration
+  Future<void> _setupAndroid({String? languageCode}) async {
+    try {
+      final language = languageCode ?? 'en-US';
+      await _flutterTts!.setLanguage(language);
+      await _flutterTts!.setSpeechRate(
+        0.5,
+      ); // Slightly slower for better comprehension
+      await _flutterTts!.setVolume(0.8);
+      await _flutterTts!.setPitch(1.0);
+      DebugLogger.log(
+        'TTS: Basic Android configuration completed with language: $language',
+      );
+    } catch (e) {
+      DebugLogger.error('TTS: Failed to set basic Android configuration', e);
+      // Continue anyway with default settings
+    }
+
+    // Use Android's high-quality TTS engine if available
+    try {
+      final engines = await _flutterTts!.getEngines;
+      if (engines != null && engines.isNotEmpty) {
+        // Prefer Google TTS engine if available
+        String? selectedEngine;
+
+        // Search for Google TTS engine
+        for (final engine in engines) {
+          if (engine is Map<String, dynamic> && engine['name'] != null) {
+            final engineName = engine['name'].toString().toLowerCase();
+            if (engineName.contains('google')) {
+              selectedEngine = engine['name'].toString();
+              break;
+            }
+          }
+        }
+
+        // If no Google engine found, use the first available
+        if (selectedEngine == null && engines.isNotEmpty) {
+          final firstEngine = engines.first;
+          if (firstEngine is Map<String, dynamic> &&
+              firstEngine['name'] != null) {
+            selectedEngine = firstEngine['name'].toString();
+          }
+        }
+
+        if (selectedEngine != null) {
+          await _flutterTts!.setEngine(selectedEngine);
+          DebugLogger.log('TTS: Using engine: $selectedEngine');
+        }
+      }
+    } catch (e) {
+      DebugLogger.log('TTS: Failed to set custom engine, using default: $e');
+      // Continue with default engine
+    }
+  }
+
+  /// Setup iOS-specific TTS configuration
+  Future<void> _setupiOS({String? languageCode}) async {
+    final language = languageCode ?? 'en-US';
+    await _flutterTts!.setLanguage(language);
+    await _flutterTts!.setSpeechRate(0.5);
+    await _flutterTts!.setVolume(0.8);
+    await _flutterTts!.setPitch(1.0);
+
+    // Use shared audio session for iOS
+    await _flutterTts!.setSharedInstance(true);
+    DebugLogger.log(
+      'TTS: iOS configuration completed with language: $language',
+    );
+  }
+
+  /// Speak the provided text with optional message ID for tracking
+  Future<void> speak(String text, {String? messageId}) async {
+    DebugLogger.log(
+      'TTS: speak() called for message: $messageId, initialized: $_isInitialized',
+    );
+
+    if (!_isInitialized) {
+      DebugLogger.log(
+        'TTS: Service not initialized, waiting for initialization...',
+      );
+
+      // Wait up to 5 seconds for initialization to complete
+      var attempts = 0;
+      const maxAttempts = 50; // 50 * 100ms = 5 seconds
+
+      while (!_isInitialized && attempts < maxAttempts) {
+        await Future.delayed(const Duration(milliseconds: 100));
+        attempts++;
+        DebugLogger.log('TTS: Waiting for initialization... attempt $attempts');
+      }
+
+      if (!_isInitialized) {
+        DebugLogger.error('TTS: Timeout waiting for initialization', null);
+        return;
+      }
+
+      DebugLogger.log('TTS: Initialization completed, proceeding with speech');
+    }
+
+    if (_isSpeaking) {
+      DebugLogger.log('TTS: Already speaking, stopping current speech');
+      await stop();
+    }
+
+    try {
+      // Get current language setting and log it
+      final currentLanguages = await _flutterTts!.getLanguages;
+      DebugLogger.log('TTS: Available languages: $currentLanguages');
+
+      // Clean up text for better TTS pronunciation
+      final cleanText = _preprocessTextForTTS(text);
+
+      DebugLogger.log(
+        'TTS: Speaking text: ${cleanText.substring(0, cleanText.length > 50 ? 50 : cleanText.length)}...',
+      );
+      _isSpeaking = true;
+      _currentMessageId = messageId;
+
+      await _flutterTts!.speak(cleanText);
+    } catch (e) {
+      DebugLogger.error('TTS: Failed to speak text', e);
+      _isSpeaking = false;
+      _currentMessageId = null;
+    }
+  }
+
+  /// Stop current speech
+  Future<void> stop() async {
+    if (_flutterTts != null && _isSpeaking) {
+      try {
+        await _flutterTts!.stop();
+        _isSpeaking = false;
+        _currentMessageId = null;
+        DebugLogger.log('TTS: Speech stopped');
+      } catch (e) {
+        DebugLogger.error('TTS: Failed to stop speech', e);
+      }
+    }
+  }
+
+  /// Pause current speech
+  Future<void> pause() async {
+    if (_flutterTts != null && _isSpeaking) {
+      try {
+        await _flutterTts!.pause();
+        DebugLogger.log('TTS: Speech paused');
+      } catch (e) {
+        DebugLogger.error('TTS: Failed to pause speech', e);
+      }
+    }
+  }
+
+  /// Check if TTS is currently speaking
+  bool get isSpeaking => _isSpeaking;
+
+  /// Check if a specific message is currently being spoken
+  bool isPlayingMessage(String messageId) =>
+      _isSpeaking && _currentMessageId == messageId;
+
+  /// Get the currently playing message ID
+  String? get currentMessageId => _currentMessageId;
+
+  /// Check if TTS is available on this platform
+  bool get isAvailable => Platform.isAndroid || Platform.isIOS;
+
+  /// Check if TTS service is initialized
+  bool get isInitialized => _isInitialized;
+
+  /// Update the TTS language setting
+  Future<void> updateLanguage(String? languageCode) async {
+    DebugLogger.log(
+      'TTS: updateLanguage called with languageCode: $languageCode',
+    );
+
+    if (!_isInitialized) {
+      DebugLogger.log(
+        'TTS: Service not initialized, calling initializeWithLanguage',
+      );
+      await initializeWithLanguage(languageCode);
+      return;
+    }
+
+    final targetLanguage = _resolveTargetLanguage(languageCode);
+    DebugLogger.log('TTS: Resolved target language: $targetLanguage');
+
+    try {
+      await _flutterTts!.setLanguage(targetLanguage);
+      DebugLogger.log('TTS: Language updated successfully to $targetLanguage');
+    } catch (e) {
+      DebugLogger.error('TTS: Failed to update language to $targetLanguage', e);
+    }
+  }
+
+  /// Resolve the target language based on user setting and system locale
+  String _resolveTargetLanguage(String? languageCode) {
+    if (languageCode != null) {
+      return languageCode;
+    }
+
+    // When languageCode is null (System), try to use system locale
+    // This could be enhanced to detect system language, for now default to en-US
+    // TODO: In future, could use Platform.localeName or Intl.systemLocale
+    return 'en-US';
+  }
+
+  /// Test TTS with a simple phrase
+  Future<bool> testTTS() async {
+    try {
+      await speak('TTS test successful', messageId: 'test');
+      return true;
+    } catch (e) {
+      DebugLogger.error('TTS: Test failed', e);
+      return false;
+    }
+  }
+
+  /// Preprocess text to improve TTS pronunciation (remove special characters and markdown symbols)
+  String _preprocessTextForTTS(String text) {
+    String processed = text;
+
+    // Remove code blocks first (they contain backticks that could interfere)
+    processed = processed.replaceAll(
+      RegExp(r'```[\s\S]*?```'),
+      ' [code block] ',
+    );
+
+    // Remove markdown formatting - keep the content, remove the formatting
+    processed = processed.replaceAllMapped(
+      RegExp(r'\*\*(.*?)\*\*'),
+      (match) => match.group(1) ?? '',
+    ); // **bold**
+    processed = processed.replaceAllMapped(
+      RegExp(r'\*(.*?)\*'),
+      (match) => match.group(1) ?? '',
+    ); // *italic*
+    processed = processed.replaceAllMapped(
+      RegExp(r'`([^`]+)`'),
+      (match) => match.group(1) ?? '',
+    ); // `code`
+
+    // Remove headers but keep the text
+    processed = processed.replaceAllMapped(
+      RegExp(r'^#{1,6}\s+(.*)$', multiLine: true),
+      (match) => match.group(1) ?? '',
+    );
+
+    // Remove links but keep the text: [text](url) -> text
+    processed = processed.replaceAllMapped(
+      RegExp(r'\[([^\]]+)\]\([^)]+\)'),
+      (match) => match.group(1) ?? '',
+    );
+
+    // Remove remaining markdown artifacts
+    processed = processed.replaceAll(
+      RegExp(r'[_~]'),
+      '',
+    ); // underlines and strikethroughs
+    processed = processed.replaceAll(RegExp(r'>\s*'), ''); // blockquotes
+
+    // Replace symbols with speakable text ONLY when they're standalone or at word boundaries
+    processed = processed.replaceAll(RegExp(r'\b&\b'), ' and ');
+    processed = processed.replaceAll(RegExp(r'\b@\b'), ' at ');
+    processed = processed.replaceAll(
+      RegExp(r'(?<!\w)#(?!\w)'),
+      ' hash ',
+    ); // # not part of words
+    processed = processed.replaceAll(
+      RegExp(r'(?<!\d)%(?!\d)'),
+      ' percent',
+    ); // % not between digits
+
+    // Handle dollar sign more carefully - only replace standalone $ or at word boundaries
+    processed = processed.replaceAll(
+      RegExp(r'(?<!\w)\$(?=\d)'),
+      'dollar ',
+    ); // $100 -> dollar 100
+    processed = processed.replaceAll(
+      RegExp(r'(?<!\w)\$(?!\w)'),
+      ' dollar ',
+    ); // standalone $
+
+    // Clean up multiple spaces and trim
+    processed = processed.replaceAll(RegExp(r'\s+'), ' ');
+    processed = processed.trim();
+
+    // Limit length for very long responses (TTS can timeout)
+    if (processed.length > 1000) {
+      // Find a good breaking point (end of sentence)
+      final sentences = processed.split(RegExp(r'[.!?]+\s+'));
+      final truncated = StringBuffer();
+      for (final sentence in sentences) {
+        if (truncated.length + sentence.length > 950) break;
+        truncated.write(sentence.trim());
+        if (!sentence.trim().endsWith('.') &&
+            !sentence.trim().endsWith('!') &&
+            !sentence.trim().endsWith('?')) {
+          truncated.write('.');
+        }
+        truncated.write(' ');
+      }
+      processed = truncated.toString().trim();
+      if (!processed.endsWith('.') &&
+          !processed.endsWith('!') &&
+          !processed.endsWith('?')) {
+        processed = '$processed. Response truncated for voice playback.';
+      }
+    }
+
+    return processed;
+  }
+
+  /// Dispose of resources
+  void dispose() {
+    _flutterTts?.stop();
+    _isInitialized = false;
+    _isSpeaking = false;
+    DebugLogger.log('TTS: Service disposed');
+  }
+}
+
+/// Provider for the TTS service
+final ttsServiceProvider = Provider<TTSService>((ref) {
+  DebugLogger.log('TTS: ttsServiceProvider called');
+
+  final service = TTSService.instance;
+
+  // Ensure the language updater is active first
+  ref.read(ttsLanguageUpdaterProvider);
+
+  // Only initialize if not already initialized
+  if (!service.isInitialized) {
+    final ttsLanguage = ref.read(ttsLanguageProvider);
+    DebugLogger.log('TTS: Initial initialization with language: $ttsLanguage');
+    service.initializeWithLanguage(ttsLanguage);
+  } else {
+    DebugLogger.log(
+      'TTS: Service already initialized, skipping re-initialization',
+    );
+  }
+
+  return service;
+});
+
+/// Provider to listen for TTS language changes and update the service
+final ttsLanguageUpdaterProvider = Provider<void>((ref) {
+  // Watch for language changes
+  ref.listen(ttsLanguageProvider, (previous, next) {
+    // Only update if the language actually changed
+    if (previous != next) {
+      final service = TTSService.instance;
+      service.updateLanguage(next);
+    }
+  });
+});
+
+/// Provider for TTS message control
+final ttsMessageControllerProvider =
+    StateNotifierProvider<TTSMessageController, Map<String, bool>>((ref) {
+      return TTSMessageController(ref);
+    });
+
+/// Controller for TTS message playback state
+class TTSMessageController extends StateNotifier<Map<String, bool>> {
+  final Ref _ref;
+
+  TTSMessageController(this._ref) : super(<String, bool>{}) {
+    DebugLogger.log('TTS: TTSMessageController initialized');
+
+    // Initialize the language updater
+    _ref.read(ttsLanguageUpdaterProvider);
+
+    DebugLogger.log('TTS: TTSMessageController setup complete');
+  }
+
+  /// Toggle TTS playback for a specific message
+  Future<void> toggleTTS(String messageId, String messageText) async {
+    await playTTS(messageId, messageText, toggle: true);
+  }
+
+  /// Play TTS for a specific message
+  Future<void> playTTS(
+    String messageId,
+    String messageText, {
+    bool toggle = false,
+  }) async {
+    DebugLogger.log(
+      'TTS: playTTS called for message $messageId, toggle: $toggle',
+    );
+
+    final ttsService = _ref.read(ttsServiceProvider);
+    final isCurrentlyPlaying = ttsService.isPlayingMessage(messageId);
+
+    DebugLogger.log(
+      'TTS: Currently playing: $isCurrentlyPlaying, TTS service speaking: ${ttsService.isSpeaking}',
+    );
+
+    if (isCurrentlyPlaying && toggle) {
+      // Stop current playback (only if toggling)
+      DebugLogger.log('TTS: Stopping current playback for toggle');
+      await ttsService.stop();
+      state = {...state}..remove(messageId);
+    } else if (!isCurrentlyPlaying) {
+      // Stop any other playing message first
+      if (ttsService.isSpeaking) {
+        DebugLogger.log('TTS: Stopping other playing message');
+        await ttsService.stop();
+        state = <String, bool>{}; // Clear all playing states
+      }
+
+      // Start playing this message
+      DebugLogger.log('TTS: Starting playback for message $messageId');
+      state = {...state, messageId: true};
+      await ttsService.speak(messageText, messageId: messageId);
+
+      // The completion handler in TTS service will automatically update state
+      // Add a listener to update state when speech completes
+      _checkCompletionPeriodically(messageId);
+    }
+  }
+
+  /// Check if TTS has completed and update state accordingly
+  void _checkCompletionPeriodically(String messageId) {
+    Future.delayed(const Duration(milliseconds: 500), () {
+      final ttsService = _ref.read(ttsServiceProvider);
+      if (!ttsService.isPlayingMessage(messageId) &&
+          state.containsKey(messageId)) {
+        state = {...state}..remove(messageId);
+      } else if (state.containsKey(messageId)) {
+        // Still playing, check again
+        _checkCompletionPeriodically(messageId);
+      }
+    });
+  }
+
+  /// Check if a message is currently playing
+  bool isPlaying(String messageId) => state[messageId] ?? false;
+
+  /// Stop all TTS playback
+  Future<void> stopAll() async {
+    final ttsService = _ref.read(ttsServiceProvider);
+    await ttsService.stop();
+    state = <String, bool>{};
+  }
+}

--- a/lib/features/auth/views/authentication_page.dart
+++ b/lib/features/auth/views/authentication_page.dart
@@ -420,6 +420,7 @@ class _AuthenticationPageState extends ConsumerState<AuthenticationPage> {
             ),
             child: Row(
               mainAxisAlignment: MainAxisAlignment.center,
+              mainAxisSize: MainAxisSize.min,
               children: [
                 Icon(
                   icon,
@@ -429,13 +430,19 @@ class _AuthenticationPageState extends ConsumerState<AuthenticationPage> {
                       : context.conduitTheme.iconSecondary,
                 ),
                 const SizedBox(width: Spacing.sm),
-                Text(
-                  label,
-                  style: context.conduitTheme.bodyMedium?.copyWith(
-                    color: isSelected
-                        ? context.conduitTheme.buttonPrimaryText
-                        : context.conduitTheme.textSecondary,
-                    fontWeight: isSelected ? FontWeight.w600 : FontWeight.w500,
+                Flexible(
+                  child: Text(
+                    label,
+                    style: context.conduitTheme.bodyMedium?.copyWith(
+                      color: isSelected
+                          ? context.conduitTheme.buttonPrimaryText
+                          : context.conduitTheme.textSecondary,
+                      fontWeight: isSelected
+                          ? FontWeight.w600
+                          : FontWeight.w500,
+                    ),
+                    overflow: TextOverflow.ellipsis,
+                    textAlign: TextAlign.center,
                   ),
                 ),
               ],

--- a/lib/features/profile/views/profile_page.dart
+++ b/lib/features/profile/views/profile_page.dart
@@ -232,6 +232,8 @@ class ProfilePage extends ConsumerWidget {
               Divider(color: context.conduitTheme.dividerColor, height: 1),
               _buildLanguageTile(context, ref),
               Divider(color: context.conduitTheme.dividerColor, height: 1),
+              _buildTTSLanguageTile(context, ref),
+              Divider(color: context.conduitTheme.dividerColor, height: 1),
               _buildAboutTile(context),
               Divider(color: context.conduitTheme.dividerColor, height: 1),
               _buildAccountOption(
@@ -517,6 +519,156 @@ class ProfilePage extends ConsumerWidget {
           }
         }
       },
+    );
+  }
+
+  Widget _buildTTSLanguageTile(BuildContext context, WidgetRef ref) {
+    final currentTTSLanguage = ref.watch(ttsLanguageProvider);
+
+    final label = () {
+      switch (currentTTSLanguage) {
+        case 'en-US':
+          return AppLocalizations.of(context)!.english;
+        case 'es-ES':
+          return AppLocalizations.of(context)!.espanol;
+        case 'de-DE':
+          return AppLocalizations.of(context)!.deutsch;
+        case 'fr-FR':
+          return AppLocalizations.of(context)!.francais;
+        case 'it-IT':
+          return AppLocalizations.of(context)!.italiano;
+        default:
+          return 'System';
+      }
+    }();
+
+    return ListTile(
+      contentPadding: const EdgeInsets.symmetric(
+        horizontal: Spacing.listItemPadding,
+        vertical: Spacing.sm,
+      ),
+      leading: Container(
+        padding: const EdgeInsets.all(Spacing.sm),
+        decoration: BoxDecoration(
+          color: context.conduitTheme.buttonPrimary.withValues(
+            alpha: Alpha.highlight,
+          ),
+          borderRadius: BorderRadius.circular(AppBorderRadius.small),
+        ),
+        child: Icon(
+          UiUtils.platformIcon(
+            ios: CupertinoIcons.speaker_2_fill,
+            android: Icons.record_voice_over,
+          ),
+          color: context.conduitTheme.buttonPrimary,
+          size: IconSize.medium,
+        ),
+      ),
+      title: Text(
+        AppLocalizations.of(context)!.ttsLanguage,
+        style: context.conduitTheme.bodyLarge?.copyWith(
+          color: context.conduitTheme.textPrimary,
+          fontWeight: FontWeight.w500,
+        ),
+      ),
+      subtitle: Text(
+        label,
+        style: context.conduitTheme.bodySmall?.copyWith(
+          color: context.conduitTheme.textSecondary,
+        ),
+      ),
+      trailing: Icon(
+        UiUtils.platformIcon(
+          ios: CupertinoIcons.chevron_right,
+          android: Icons.chevron_right,
+        ),
+        color: context.conduitTheme.iconSecondary,
+        size: IconSize.small,
+      ),
+      onTap: () async {
+        final selected = await _showTTSLanguageSelector(
+          context,
+          currentTTSLanguage ?? 'system',
+        );
+        if (selected != null) {
+          if (selected == 'system') {
+            await ref.read(ttsLanguageProvider.notifier).setTTSLanguage(null);
+          } else {
+            await ref
+                .read(ttsLanguageProvider.notifier)
+                .setTTSLanguage(selected);
+          }
+        }
+      },
+    );
+  }
+
+  Future<String?> _showTTSLanguageSelector(
+    BuildContext context,
+    String current,
+  ) {
+    return showModalBottomSheet<String>(
+      context: context,
+      backgroundColor: Colors.transparent,
+      isScrollControlled: true,
+      builder: (context) => Container(
+        decoration: BoxDecoration(
+          color: context.conduitTheme.surfaceBackground,
+          borderRadius: const BorderRadius.vertical(
+            top: Radius.circular(AppBorderRadius.modal),
+          ),
+          boxShadow: ConduitShadows.modal,
+        ),
+        child: SafeArea(
+          top: false,
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              const SizedBox(height: Spacing.sm),
+              const SheetHandle(),
+              const SizedBox(height: Spacing.md),
+              Text(
+                AppLocalizations.of(context)!.ttsLanguage,
+                style: context.conduitTheme.headingSmall?.copyWith(
+                  color: context.conduitTheme.textPrimary,
+                ),
+              ),
+              const SizedBox(height: Spacing.md),
+              ListTile(
+                title: Text('System'),
+                trailing: current == 'system' ? const Icon(Icons.check) : null,
+                onTap: () => Navigator.pop(context, 'system'),
+              ),
+              ListTile(
+                title: Text(AppLocalizations.of(context)!.english),
+                trailing: current == 'en-US' ? const Icon(Icons.check) : null,
+                onTap: () => Navigator.pop(context, 'en-US'),
+              ),
+              ListTile(
+                title: Text(AppLocalizations.of(context)!.espanol),
+                trailing: current == 'es-ES' ? const Icon(Icons.check) : null,
+                onTap: () => Navigator.pop(context, 'es-ES'),
+              ),
+              ListTile(
+                title: Text(AppLocalizations.of(context)!.deutsch),
+                trailing: current == 'de-DE' ? const Icon(Icons.check) : null,
+                onTap: () => Navigator.pop(context, 'de-DE'),
+              ),
+              ListTile(
+                title: Text(AppLocalizations.of(context)!.francais),
+                trailing: current == 'fr-FR' ? const Icon(Icons.check) : null,
+                onTap: () => Navigator.pop(context, 'fr-FR'),
+              ),
+              ListTile(
+                title: Text(AppLocalizations.of(context)!.italiano),
+                trailing: current == 'it-IT' ? const Icon(Icons.check) : null,
+                onTap: () => Navigator.pop(context, 'it-IT'),
+              ),
+              const SizedBox(height: Spacing.sm),
+            ],
+          ),
+        ),
+      ),
     );
   }
 

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -184,6 +184,7 @@
   "deutsch": "Deutsch",
   "francais": "Französisch",
   "italiano": "Italienisch",
+  "espanol": "Spanisch",
   "deleteMessagesTitle": "Nachrichten löschen",
   "deleteMessagesMessage": "{count} Nachrichten löschen?",
   "@deleteMessagesMessage": {
@@ -258,5 +259,10 @@
   "@thoughtForDuration": {
     "description": "Zeigt an, wie lange der Assistent nachgedacht hat.",
     "placeholders": {"duration": {"type": "String", "example": "3 s"}}
-  }
+  },
+  "ttsLanguage": "TTS-Sprache",
+  "ttsLanguageDescription": "Sprache für Text-zu-Sprache wählen",
+  "espanol": "Spanisch",
+  "listen": "Anhören",
+  "stop": "Stoppen"
 }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -208,6 +208,7 @@
   "deutsch": "Deutsch",
   "francais": "Français",
   "italiano": "Italiano",
+  "espanol": "Spanish",
   "deleteMessagesTitle": "Delete Messages",
   "deleteMessagesMessage": "Delete {count} messages?",
   "@deleteMessagesMessage": {
@@ -282,5 +283,10 @@
   "@thoughtForDuration": {
     "description": "Shows how long the assistant thought before replying.",
     "placeholders": {"duration": {"type": "String", "example": "3s"}}
-  }
+  },
+  "ttsLanguage": "TTS Language",
+  "ttsLanguageDescription": "Choose language for text-to-speech",
+  "espanol": "Spanish",
+  "listen": "Listen",
+  "stop": "Stop"
 }

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -184,6 +184,7 @@
   "deutsch": "Allemand",
   "francais": "Français",
   "italiano": "Italien",
+  "espanol": "Espagnol",
   "deleteMessagesTitle": "Supprimer les messages",
   "deleteMessagesMessage": "Supprimer {count} messages ?",
   "@deleteMessagesMessage": {
@@ -258,5 +259,10 @@
   "@thoughtForDuration": {
     "description": "Indique la durée de réflexion de l'assistant.",
     "placeholders": {"duration": {"type": "String", "example": "3 s"}}
-  }
+  },
+  "ttsLanguage": "Langue TTS",
+  "ttsLanguageDescription": "Choisir la langue pour la synthèse vocale",
+  "espanol": "Espagnol",
+  "listen": "Écouter",
+  "stop": "Arrêter"
 }

--- a/lib/l10n/app_it.arb
+++ b/lib/l10n/app_it.arb
@@ -184,6 +184,7 @@
   "deutsch": "Tedesco",
   "francais": "Francese",
   "italiano": "Italiano",
+  "espanol": "Spagnolo",
   "deleteMessagesTitle": "Elimina messaggi",
   "deleteMessagesMessage": "Eliminare {count} messaggi?",
   "@deleteMessagesMessage": {
@@ -258,5 +259,10 @@
   "@thoughtForDuration": {
     "description": "Mostra per quanto tempo ha pensato l'assistente.",
     "placeholders": {"duration": {"type": "String", "example": "3 s"}}
-  }
+  },
+  "ttsLanguage": "Lingua TTS",
+  "ttsLanguageDescription": "Scegli la lingua per la sintesi vocale",
+  "espanol": "Spagnolo",
+  "listen": "Ascolta",
+  "stop": "Ferma"
 }

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -64,7 +64,8 @@ import 'app_localizations_it.dart';
 /// be consistent with the languages listed in the AppLocalizations.supportedLocales
 /// property.
 abstract class AppLocalizations {
-  AppLocalizations(String locale) : localeName = intl.Intl.canonicalizedLocale(locale.toString());
+  AppLocalizations(String locale)
+    : localeName = intl.Intl.canonicalizedLocale(locale.toString());
 
   final String localeName;
 
@@ -72,7 +73,8 @@ abstract class AppLocalizations {
     return Localizations.of<AppLocalizations>(context, AppLocalizations);
   }
 
-  static const LocalizationsDelegate<AppLocalizations> delegate = _AppLocalizationsDelegate();
+  static const LocalizationsDelegate<AppLocalizations> delegate =
+      _AppLocalizationsDelegate();
 
   /// A list of this localizations delegate along with the default localizations
   /// delegates.
@@ -84,19 +86,20 @@ abstract class AppLocalizations {
   /// Additional delegates can be added by appending to this list in
   /// MaterialApp. This list does not have to be used at all if a custom list
   /// of delegates is preferred or required.
-  static const List<LocalizationsDelegate<dynamic>> localizationsDelegates = <LocalizationsDelegate<dynamic>>[
-    delegate,
-    GlobalMaterialLocalizations.delegate,
-    GlobalCupertinoLocalizations.delegate,
-    GlobalWidgetsLocalizations.delegate,
-  ];
+  static const List<LocalizationsDelegate<dynamic>> localizationsDelegates =
+      <LocalizationsDelegate<dynamic>>[
+        delegate,
+        GlobalMaterialLocalizations.delegate,
+        GlobalCupertinoLocalizations.delegate,
+        GlobalWidgetsLocalizations.delegate,
+      ];
 
   /// A list of this localizations delegate's supported locales.
   static const List<Locale> supportedLocales = <Locale>[
-    Locale('de'),
     Locale('en'),
+    Locale('de'),
     Locale('fr'),
-    Locale('it')
+    Locale('it'),
   ];
 
   /// No description provided for @appTitle.
@@ -1149,6 +1152,12 @@ abstract class AppLocalizations {
   /// **'Italiano'**
   String get italiano;
 
+  /// No description provided for @espanol.
+  ///
+  /// In en, this message translates to:
+  /// **'Spanish'**
+  String get espanol;
+
   /// No description provided for @deleteMessagesTitle.
   ///
   /// In en, this message translates to:
@@ -1472,9 +1481,34 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Thought for {duration}'**
   String thoughtForDuration(String duration);
+
+  /// No description provided for @ttsLanguage.
+  ///
+  /// In en, this message translates to:
+  /// **'TTS Language'**
+  String get ttsLanguage;
+
+  /// No description provided for @ttsLanguageDescription.
+  ///
+  /// In en, this message translates to:
+  /// **'Choose language for text-to-speech'**
+  String get ttsLanguageDescription;
+
+  /// No description provided for @listen.
+  ///
+  /// In en, this message translates to:
+  /// **'Listen'**
+  String get listen;
+
+  /// No description provided for @stop.
+  ///
+  /// In en, this message translates to:
+  /// **'Stop'**
+  String get stop;
 }
 
-class _AppLocalizationsDelegate extends LocalizationsDelegate<AppLocalizations> {
+class _AppLocalizationsDelegate
+    extends LocalizationsDelegate<AppLocalizations> {
   const _AppLocalizationsDelegate();
 
   @override
@@ -1483,27 +1517,30 @@ class _AppLocalizationsDelegate extends LocalizationsDelegate<AppLocalizations> 
   }
 
   @override
-  bool isSupported(Locale locale) => <String>['de', 'en', 'fr', 'it'].contains(locale.languageCode);
+  bool isSupported(Locale locale) =>
+      <String>['de', 'en', 'fr', 'it'].contains(locale.languageCode);
 
   @override
   bool shouldReload(_AppLocalizationsDelegate old) => false;
 }
 
 AppLocalizations lookupAppLocalizations(Locale locale) {
-
-
   // Lookup logic when only language code is specified.
   switch (locale.languageCode) {
-    case 'de': return AppLocalizationsDe();
-    case 'en': return AppLocalizationsEn();
-    case 'fr': return AppLocalizationsFr();
-    case 'it': return AppLocalizationsIt();
+    case 'de':
+      return AppLocalizationsDe();
+    case 'en':
+      return AppLocalizationsEn();
+    case 'fr':
+      return AppLocalizationsFr();
+    case 'it':
+      return AppLocalizationsIt();
   }
 
   throw FlutterError(
     'AppLocalizations.delegate failed to load unsupported locale "$locale". This is likely '
     'an issue with the localizations generation tool. Please file an issue '
     'on GitHub with a reproducible sample app and the gen-l10n configuration '
-    'that was used.'
+    'that was used.',
   );
 }

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -553,6 +553,9 @@ class AppLocalizationsDe extends AppLocalizations {
   String get italiano => 'Italienisch';
 
   @override
+  String get espanol => 'Spanisch';
+
+  @override
   String get deleteMessagesTitle => 'Nachrichten löschen';
 
   @override
@@ -727,4 +730,16 @@ class AppLocalizationsDe extends AppLocalizations {
   String thoughtForDuration(String duration) {
     return 'Gedacht für $duration';
   }
+
+  @override
+  String get ttsLanguage => 'TTS-Sprache';
+
+  @override
+  String get ttsLanguageDescription => 'Sprache für Text-zu-Sprache wählen';
+
+  @override
+  String get listen => 'Anhören';
+
+  @override
+  String get stop => 'Stoppen';
 }

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -553,6 +553,9 @@ class AppLocalizationsEn extends AppLocalizations {
   String get italiano => 'Italiano';
 
   @override
+  String get espanol => 'Spanish';
+
+  @override
   String get deleteMessagesTitle => 'Delete Messages';
 
   @override
@@ -727,4 +730,16 @@ class AppLocalizationsEn extends AppLocalizations {
   String thoughtForDuration(String duration) {
     return 'Thought for $duration';
   }
+
+  @override
+  String get ttsLanguage => 'TTS Language';
+
+  @override
+  String get ttsLanguageDescription => 'Choose language for text-to-speech';
+
+  @override
+  String get listen => 'Listen';
+
+  @override
+  String get stop => 'Stop';
 }

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -553,6 +553,9 @@ class AppLocalizationsFr extends AppLocalizations {
   String get italiano => 'Italien';
 
   @override
+  String get espanol => 'Espagnol';
+
+  @override
   String get deleteMessagesTitle => 'Supprimer les messages';
 
   @override
@@ -727,4 +730,16 @@ class AppLocalizationsFr extends AppLocalizations {
   String thoughtForDuration(String duration) {
     return 'A réfléchi pendant $duration';
   }
+
+  @override
+  String get ttsLanguage => 'Langue TTS';
+
+  @override
+  String get ttsLanguageDescription => 'Choisir la langue pour la synthèse vocale';
+
+  @override
+  String get listen => 'Écouter';
+
+  @override
+  String get stop => 'Arrêter';
 }

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -553,6 +553,9 @@ class AppLocalizationsIt extends AppLocalizations {
   String get italiano => 'Italiano';
 
   @override
+  String get espanol => 'Spagnolo';
+
+  @override
   String get deleteMessagesTitle => 'Elimina messaggi';
 
   @override
@@ -727,4 +730,16 @@ class AppLocalizationsIt extends AppLocalizations {
   String thoughtForDuration(String duration) {
     return 'Ha pensato per $duration';
   }
+
+  @override
+  String get ttsLanguage => 'Lingua TTS';
+
+  @override
+  String get ttsLanguageDescription => 'Scegli la lingua per la sintesi vocale';
+
+  @override
+  String get listen => 'Ascolta';
+
+  @override
+  String get stop => 'Ferma';
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -21,6 +21,7 @@ import 'features/chat/views/chat_page.dart';
 import 'features/navigation/views/splash_launcher_page.dart';
 import 'core/services/share_receiver_service.dart';
 import 'core/services/assist_intent_service.dart';
+import 'core/services/tts_service.dart';
 
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
@@ -83,6 +84,8 @@ class _ConduitAppState extends ConsumerState<ConduitApp> {
     // Initialize ASSIST intent service for Android assistant integration
     ref.read(assistIntentInitializerProvider);
 
+    // Initialize TTS language updater for reactive language changes
+    ref.read(ttsLanguageUpdaterProvider);
   }
 
   @override
@@ -136,14 +139,11 @@ class _ConduitAppState extends ConsumerState<ConduitApp> {
             return MediaQuery(
               data: MediaQuery.of(context).copyWith(
                 // Ensure proper text scaling for edge-to-edge
-                textScaler: MediaQuery.of(context).textScaler.clamp(
-                  minScaleFactor: 0.8,
-                  maxScaleFactor: 1.3,
-                ),
+                textScaler: MediaQuery.of(
+                  context,
+                ).textScaler.clamp(minScaleFactor: 0.8, maxScaleFactor: 1.3),
               ),
-              child: OfflineIndicator(
-                child: child ?? const SizedBox.shrink(),
-              ),
+              child: OfflineIndicator(child: child ?? const SizedBox.shrink()),
             );
           },
           home: _getInitialPageWithReactiveState(),

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -20,6 +20,7 @@ import 'package:conduit/l10n/app_localizations.dart';
 import 'features/chat/views/chat_page.dart';
 import 'features/navigation/views/splash_launcher_page.dart';
 import 'core/services/share_receiver_service.dart';
+import 'core/services/assist_intent_service.dart';
 
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
@@ -78,6 +79,10 @@ class _ConduitAppState extends ConsumerState<ConduitApp> {
 
     // Initialize OS share receiver so users can share text/files to Conduit
     ref.read(shareReceiverInitializerProvider);
+
+    // Initialize ASSIST intent service for Android assistant integration
+    ref.read(assistIntentInitializerProvider);
+
   }
 
   @override

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -456,6 +456,14 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  flutter_tts:
+    dependency: "direct main"
+    description:
+      name: flutter_tts
+      sha256: bdf2fc4483e74450dc9fc6fe6a9b6a5663e108d4d0dad3324a22c8e26bf48af4
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.2.3"
   flutter_web_plugins:
     dependency: transitive
     description: flutter

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -37,6 +37,7 @@ dependencies:
   # Platform Features
   record: ^6.0.0
   stts: ^1.2.5
+  flutter_tts: ^4.2.3
   image_picker: ^1.1.2
   file_picker: ^10.2.1
   path_provider: ^2.1.4


### PR DESCRIPTION
## Android Assistant Integration with Text-to-Speech Support

![Imagen de WhatsApp 2025-08-29 a las 11 45 41_7da4867c](https://github.com/user-attachments/assets/4c6004b4-d28d-4a87-9e2e-0725539197f5)

### Message from the PR author

Hi there! Manu here, I wanted to implement some kind of Android assistant that answers to a wake word (such as `Hey Jarvis`) and allows me to talk to any of my assistants in Open-WebUI. I'm using a N8N function to use a custom workflow that has a lot of different tools (a RAG for document search, calendar, tasks, email, etc.) so it's very nice and handy to do with this app. Thanks to @cogwheel0!

I did this using Cursor, so please review carefully as I'm doing. This is my very first time with Flutter and Dart so it's very likely that there are some things to solve. I'm sorry in advance!

### Overview

This PR implements Android Assistant integration with automatic text-to-speech functionality, enabling voice-driven interactions with the Conduit app.

### Features Added

**Android ASSIST Intent Support**
- App responds to `android.intent.action.ASSIST` intent filter. This can be configured by the user in the Android settings to trigger on long push of the power button or, as in my case, using a hotword app to wake up the phone and trigger the Assist intent with Tasker.
- Automatically opens new chat and activates voice input when triggered via Android Assistant
- Auto-selects default AI model and sends captured voice input without manual intervention
- Pending: if the LLM answers with a question maybe we could trigger the voice input again so it's a full hands free experience. What do you think?

**Text-to-Speech System**
- Multi-language TTS support (English, Spanish, German, French, Italian)
- User-configurable TTS language setting in profile with persistent storage
- Platform-specific optimizations for Android and iOS TTS engines. We have to test TTS in iOS! I don't have any device :(
- Automatic playback of AI responses when triggered via ASSIST intent. Non-Assist chats can click the "Listen button"
- Manual TTS controls with Listen/Stop buttons on assistant messages

**Localization**
- Added TTS-related strings to all supported language files

### Technical Implementation

**Android Integration**
- Modified `AndroidManifest.xml` to declare ASSIST intent filter
- Enhanced `MainActivity.kt` to handle ASSIST intents via MethodChannel communication
- Created `AssistIntentService` to manage intent processing and coordinate app state

**TTS Architecture**
- Implemented `TTSService` as singleton with proper initialization lifecycle
- Added reactive providers for language configuration changes
- Created `TTSMessageController` for per-message playback state management
- Added text preprocessing to handle markdown formatting and special characters

**State Management** 
- Extended storage service with TTS language persistence methods
- Added Riverpod providers for TTS configuration and state tracking
- Implemented timing safeguards to prevent race conditions during initialization

### Bug Fixes

- Fixed RenderFlex overflow in authentication page causing unexpected errors. This is unrelated with the assistant feature, but please let me know if this is correct! But I had the `Unexpected Error` screen in my phone after submitting the service URL.

### User Flow

When the Assistant is triggered via Android Assistant, the app opens, activates voice input, captures speech, sends the message, and plays the AI response via TTS in the user's configured language. Manual TTS controls remain available for regular chat interactions.