### PR TITLE
feat(chat): regenerate variants and support

### DIFF
--- a/lib/core/models/chat_message.dart
+++ b/lib/core/models/chat_message.dart
@@ -30,10 +30,38 @@ sealed class ChatMessage with _$ChatMessage {
     @Default(<ChatSourceReference>[])
     List<ChatSourceReference> sources,
     Map<String, dynamic>? usage,
+    // Previous generated versions of this assistant message (OpenWebUI-style)
+    @JsonKey(includeFromJson: false, includeToJson: false)
+    @Default(<ChatMessageVersion>[])
+    List<ChatMessageVersion> versions,
   }) = _ChatMessage;
 
   factory ChatMessage.fromJson(Map<String, dynamic> json) =>
       _$ChatMessageFromJson(json);
+}
+
+@freezed
+abstract class ChatMessageVersion with _$ChatMessageVersion {
+  const factory ChatMessageVersion({
+    required String id,
+    required String content,
+    required DateTime timestamp,
+    String? model,
+    List<Map<String, dynamic>>? files,
+    @JsonKey(
+      name: 'sources',
+      fromJson: _sourceRefsFromJson,
+      toJson: _sourceRefsToJson,
+    )
+    @Default(<ChatSourceReference>[])
+    List<ChatSourceReference> sources,
+    @Default(<String>[]) List<String> followUps,
+    @Default(<ChatCodeExecution>[]) List<ChatCodeExecution> codeExecutions,
+    Map<String, dynamic>? usage,
+  }) = _ChatMessageVersion;
+
+  factory ChatMessageVersion.fromJson(Map<String, dynamic> json) =>
+      _$ChatMessageVersionFromJson(json);
 }
 
 @freezed

--- a/lib/features/chat/views/chat_page.dart
+++ b/lib/features/chat/views/chat_page.dart
@@ -902,6 +902,13 @@ class _ChatPageState extends ConsumerState<ChatPage> {
                 }
               }
 
+              // Hide archived assistant variants in the linear view
+              final isArchivedVariant =
+                  !isUser && (message.metadata?['archivedVariant'] == true);
+              if (isArchivedVariant) {
+                return const SizedBox.shrink();
+              }
+
               final showFollowUps =
                   !isUser && !hasUserBubbleBelow && !hasAssistantBubbleBelow;
 
@@ -990,8 +997,14 @@ class _ChatPageState extends ConsumerState<ChatPage> {
         return;
       }
 
-      // Remove the assistant message we want to regenerate
-      ref.read(chatMessagesProvider.notifier).removeLastMessage();
+      // Mark previous assistant as archived for UI; keep it for server history
+      ref.read(chatMessagesProvider.notifier).updateLastMessageWithFunction((
+        m,
+      ) {
+        final meta = Map<String, dynamic>.from(m.metadata ?? const {});
+        meta['archivedVariant'] = true;
+        return m.copyWith(metadata: meta, isStreaming: false);
+      });
 
       // Regenerate response for the previous user message (without duplicating it)
       final userMessage = messages[messageIndex - 1];


### PR DESCRIPTION
Hide archived assistant variants in the linear chat view and track
previous assistant as versions so regenerated responses do not
duplicate or lose history. When regenerating, mark the previous assistant
message with an archivedVariant flag for the UI and keep it in server
history. Add a ChatMessageVersion model and a versions field to
ChatMessage to store prior generated variants. Implement
archiveLastAssistantAsVersion in chat providers to snapshot the last
assistant message into versions and reset the message for a fresh
streamed generation. Finalize flow updates to attach an adjacent archived
assistant as a version when needed so the UI can present a switcher
between current and past variants. These changes prevent duplicate
messages, preserve previous responses, and enable variant switching.