### PR TITLE
Make release workflow and script GitButler-compatible

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,8 @@
 name: Release
 
+# GitButler-compatible release workflow
+# Triggered automatically when you push a tag (v*) through GitButler
+# Can also be manually triggered to rebuild an existing release
 on:
   push:
     tags:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: conduit
 description: Open-source mobile client for Open-WebUI
-version: 2.1.9+34
+version: 2.1.8+33
 publish_to: 'none'
 
 environment:


### PR DESCRIPTION
Make the GitHub Actions release workflow and release script compatible with GitButler-driven releases. Update the workflow metadata and comments to indicate GitButler triggers, add user-friendly messaging and links when dispatching the workflow, and remove the local git-clean check since GitButler manages git state. Modify the script so it only updates pubspec.yaml and instructs the user to commit and push the version bump and tag via GitButler (including next-step instructions), rather than committing and pushing automatically.