### PR TITLE
feat: Make navigation drawer retractable on tablets

### DIFF
--- a/lib/features/chat/views/chat_page.dart
+++ b/lib/features/chat/views/chat_page.dart
@@ -1331,41 +1331,39 @@ class _ChatPageState extends ConsumerState<ChatPage> {
                           ),
                           onPressed: _clearSelection,
                         )
-                      : (isTablet
-                            ? null // Hide menu button on tablets (drawer is always visible)
-                            : Builder(
-                                builder: (ctx) => Padding(
-                                  padding: const EdgeInsets.only(
-                                    left: Spacing.inputPadding,
-                                  ),
-                                  child: IconButton(
-                                    onPressed: () {
-                                      // Suppress auto-focus and dismiss keyboard, then open drawer
-                                      try {
-                                        ref
-                                            .read(
-                                              composerAutofocusEnabledProvider
-                                                  .notifier,
-                                            )
-                                            .set(false);
-                                        FocusManager.instance.primaryFocus
-                                            ?.unfocus();
-                                        SystemChannels.textInput.invokeMethod(
-                                          'TextInput.hide',
-                                        );
-                                      } catch (_) {}
-                                      ResponsiveDrawerLayout.of(ctx)?.open();
-                                    },
-                                    icon: Icon(
-                                      Platform.isIOS
-                                          ? CupertinoIcons.line_horizontal_3
-                                          : Icons.menu,
-                                      color: context.conduitTheme.textPrimary,
-                                      size: IconSize.appBar,
-                                    ),
-                                  ),
-                                ),
-                              )),
+                      : Builder(
+                          builder: (ctx) => Padding(
+                            padding: const EdgeInsets.only(
+                              left: Spacing.inputPadding,
+                            ),
+                            child: IconButton(
+                              onPressed: () {
+                                // Suppress auto-focus and dismiss keyboard, then toggle drawer
+                                try {
+                                  ref
+                                      .read(
+                                        composerAutofocusEnabledProvider
+                                            .notifier,
+                                      )
+                                      .set(false);
+                                  FocusManager.instance.primaryFocus
+                                      ?.unfocus();
+                                  SystemChannels.textInput.invokeMethod(
+                                    'TextInput.hide',
+                                  );
+                                } catch (_) {}
+                                ResponsiveDrawerLayout.of(ctx)?.toggle();
+                              },
+                              icon: Icon(
+                                Platform.isIOS
+                                    ? CupertinoIcons.line_horizontal_3
+                                    : Icons.menu,
+                                color: context.conduitTheme.textPrimary,
+                                size: IconSize.appBar,
+                              ),
+                            ),
+                          ),
+                        ),
                   title: _isSelectionMode
                       ? Text(
                           '${_selectedMessageIds.length} selected',

--- a/lib/features/chat/widgets/modern_chat_input.dart
+++ b/lib/features/chat/widgets/modern_chat_input.dart
@@ -4,6 +4,7 @@ import 'package:flutter/services.dart';
 import '../../../shared/theme/theme_extensions.dart';
 // app_theme not required here; using theme extension tokens
 import '../../../shared/widgets/sheet_handle.dart';
+import '../../../shared/widgets/responsive_drawer_layout.dart';
 
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
@@ -136,6 +137,18 @@ class _ModernChatInputState extends ConsumerState<ModernChatInput>
         try {
           ref.read(composerHasFocusProvider.notifier).set(hasFocus);
         } catch (_) {}
+
+        // Auto-collapse drawer on tablets when input is focused
+        if (hasFocus) {
+          try {
+            final mediaQuery = MediaQuery.of(context);
+            final isTablet = mediaQuery.size.shortestSide >= 600;
+            if (isTablet) {
+              // Close drawer using public API
+              ResponsiveDrawerLayout.of(context)?.close();
+            }
+          } catch (_) {}
+        }
       });
     });
 


### PR DESCRIPTION
Resolves issue #150 where the navigation drawer was permanently visible on tablet devices, consuming approximately half the screen.

Changes:
- Modified ResponsiveDrawerLayout to support collapsible drawer on tablets with animated overlay
- Removed early returns in gesture handlers to enable swipe-to-close/open on tablets
- Added menu button in AppBar for tablets to toggle drawer visibility
- Implemented auto-collapse when chat input is focused on tablets for better UX
- Changed tablet layout from side-by-side to overlay with gesture support

The drawer now supports:
- Button press to toggle (menu icon in AppBar)
- Swipe gestures (drag to open/close)
- Auto-collapse when typing in chat input
- Smooth animations with scrim overlay

This provides an intuitive and flowing UX on tablet devices while maintaining full chat visibility.

![Screenshot_20251120_031526](https://github.com/user-attachments/assets/3c818f40-05c6-4f0a-9549-8c8e468dba7e)

![Screenshot_20251120_031523](https://github.com/user-attachments/assets/7e7672ec-805a-452e-80ce-e2dcdd0ddace)
