### PR TITLE
feat: Add ability to start conversations inside folders

### DIFF
--- a/lib/core/services/api_service.dart
+++ b/lib/core/services/api_service.dart
@@ -598,6 +598,7 @@ class ApiService {
     required List<ChatMessage> messages,
     String? model,
     String? systemPrompt,
+    String? folderId,
   }) async {
     _traceApi('Creating new conversation on OpenWebUI server');
     _traceApi('Title: $title, Messages: ${messages.length}');
@@ -675,7 +676,7 @@ class ApiService {
         'tags': [],
         'timestamp': DateTime.now().millisecondsSinceEpoch,
       },
-      'folder_id': null,
+      'folder_id': folderId,
     };
 
     _traceApi('Sending chat data with proper parent-child structure');

--- a/lib/features/chat/views/chat_page.dart
+++ b/lib/features/chat/views/chat_page.dart
@@ -1469,8 +1469,130 @@ class _ChatPageState extends ConsumerState<ChatPage> {
                                           const SizedBox(height: Spacing.xs),
                                         ],
                                       )
-                                    : const SizedBox.shrink(
-                                        key: ValueKey<String>('empty-title'),
+                                    : Builder(
+                                        key: const ValueKey<String>(
+                                          'empty-title',
+                                        ),
+                                        builder: (context) {
+                                          final selectedFolderId = ref.watch(
+                                            selectedFolderForNewChatProvider,
+                                          );
+                                          if (selectedFolderId == null) {
+                                            return const SizedBox.shrink();
+                                          }
+
+                                          // Get folder name
+                                          final foldersAsync = ref.watch(
+                                            foldersProvider,
+                                          );
+                                          final folderName = foldersAsync
+                                              .maybeWhen(
+                                            data: (folders) {
+                                              final folder = folders.firstWhere(
+                                                (f) => f.id == selectedFolderId,
+                                                orElse: () => folders.first,
+                                              );
+                                              return folder.name;
+                                            },
+                                            orElse: () => null,
+                                          );
+
+                                          if (folderName == null) {
+                                            return const SizedBox.shrink();
+                                          }
+
+                                          return Padding(
+                                            padding: const EdgeInsets.symmetric(
+                                              horizontal: Spacing.md,
+                                            ),
+                                            child: Container(
+                                              padding: const EdgeInsets
+                                                  .symmetric(
+                                                horizontal: Spacing.sm,
+                                                vertical: Spacing.xxs,
+                                              ),
+                                              decoration: BoxDecoration(
+                                                color: context
+                                                    .conduitTheme
+                                                    .buttonPrimary
+                                                    .withValues(alpha: 0.1),
+                                                borderRadius: BorderRadius
+                                                    .circular(
+                                                  AppBorderRadius.badge,
+                                                ),
+                                                border: Border.all(
+                                                  color: context
+                                                      .conduitTheme
+                                                      .buttonPrimary
+                                                      .withValues(alpha: 0.3),
+                                                  width: BorderWidth.thin,
+                                                ),
+                                              ),
+                                              child: Row(
+                                                mainAxisSize: MainAxisSize.min,
+                                                children: [
+                                                  Icon(
+                                                    Platform.isIOS
+                                                        ? CupertinoIcons.folder
+                                                        : Icons.folder,
+                                                    color: context
+                                                        .conduitTheme
+                                                        .buttonPrimary,
+                                                    size: IconSize.xs,
+                                                  ),
+                                                  const SizedBox(
+                                                    width: Spacing.xs,
+                                                  ),
+                                                  Flexible(
+                                                    child: Text(
+                                                      folderName,
+                                                      style: AppTypography
+                                                          .bodySmallStyle
+                                                          .copyWith(
+                                                        color: context
+                                                            .conduitTheme
+                                                            .buttonPrimary,
+                                                        fontWeight:
+                                                            FontWeight.w500,
+                                                      ),
+                                                      maxLines: 1,
+                                                      overflow: TextOverflow
+                                                          .ellipsis,
+                                                    ),
+                                                  ),
+                                                  const SizedBox(
+                                                    width: Spacing.xs,
+                                                  ),
+                                                  GestureDetector(
+                                                    onTap: () {
+                                                      ref
+                                                          .read(
+                                                            selectedFolderForNewChatProvider
+                                                                .notifier,
+                                                          )
+                                                          .clear();
+                                                      HapticFeedback
+                                                          .lightImpact();
+                                                    },
+                                                    child: Icon(
+                                                      Platform.isIOS
+                                                          ? CupertinoIcons
+                                                              .xmark_circle_fill
+                                                          : Icons.cancel,
+                                                      color: context
+                                                          .conduitTheme
+                                                          .buttonPrimary
+                                                          .withValues(
+                                                        alpha: 0.7,
+                                                      ),
+                                                      size: IconSize.xs,
+                                                    ),
+                                                  ),
+                                                ],
+                                              ),
+                                            ),
+                                          );
+                                        },
                                       ),
                               ),
                               Transform.translate(

--- a/lib/features/navigation/widgets/chats_drawer.dart
+++ b/lib/features/navigation/widgets/chats_drawer.dart
@@ -756,6 +756,27 @@ class _ChatsDrawerState extends ConsumerState<ChatsDrawer> {
     );
   }
 
+  void _startNewChatInFolder(String folderId, String folderName) {
+    // Set the selected folder for new conversations
+    ref.read(chat.selectedFolderForNewChatProvider.notifier).set(folderId);
+
+    // Clear the current conversation to start fresh
+    ref.read(chat.chatMessagesProvider.notifier).clearMessages();
+    ref.read(activeConversationProvider.notifier).clear();
+
+    // Close the drawer
+    ResponsiveDrawerLayout.of(context)?.close();
+
+    // Provide haptic feedback
+    HapticFeedback.lightImpact();
+
+    DebugLogger.log(
+      'new-chat-in-folder',
+      scope: 'drawer',
+      data: {'folderId': folderId, 'folderName': folderName},
+    );
+  }
+
   Future<void> _promptCreateFolder() async {
     final name = await ThemedDialogs.promptTextInput(
       context,
@@ -929,6 +950,25 @@ class _ChatsDrawerState extends ConsumerState<ChatsDrawer> {
                           ),
                         ),
                         const SizedBox(width: Spacing.xs),
+                        IconButton(
+                          visualDensity: VisualDensity.compact,
+                          padding: EdgeInsets.zero,
+                          constraints: const BoxConstraints(
+                            minWidth: TouchTarget.listItem,
+                            minHeight: TouchTarget.listItem,
+                          ),
+                          tooltip: AppLocalizations.of(context)!.newChat,
+                          icon: Icon(
+                            Platform.isIOS
+                                ? CupertinoIcons.plus_circle
+                                : Icons.add_circle_outline,
+                            color: theme.iconPrimary,
+                            size: IconSize.listItem,
+                          ),
+                          onPressed: () {
+                            _startNewChatInFolder(folderId, name);
+                          },
+                        ),
                         Icon(
                           isExpanded
                               ? (Platform.isIOS


### PR DESCRIPTION
This commit implements the feature requested in issue #140, allowing users to create conversations directly within folders instead of having to create them first and then move them.

Changes:
- Added folderId parameter to createConversation API method
- Created selectedFolderForNewChat provider to track which folder is selected
- Added "New Chat" button (+ icon) to each folder header in the drawer
- Updated chat creation flow to use the selected folder when creating conversations
- Added visual indicator in chat page showing selected folder for new chats
- Indicator includes folder icon, name, and close button to deselect

Usage:
1. Click the + icon on any folder in the drawer
2. The folder is now selected (shown in app bar when no conversation is active)
3. Send a message to create a new conversation in that folder
4. Click the X on the folder indicator to deselect

Fixes #140

<img width="1768" height="2208" alt="image" src="https://github.com/user-attachments/assets/e3852d04-3ed9-4588-90b5-bdc87eb2729d" />
