### PR TITLE
feat: Add support for nested folders

### DIFF
--- a/lib/core/utils/folder_hierarchy.dart
+++ b/lib/core/utils/folder_hierarchy.dart
@@ -1,0 +1,129 @@
+import '../models/folder.dart';
+
+/// Represents a folder node in the hierarchy tree
+class FolderNode {
+  FolderNode({
+    required this.folder,
+    this.children = const [],
+    this.depth = 0,
+  });
+
+  final Folder folder;
+  final List<FolderNode> children;
+  final int depth;
+
+  FolderNode copyWith({
+    Folder? folder,
+    List<FolderNode>? children,
+    int? depth,
+  }) {
+    return FolderNode(
+      folder: folder ?? this.folder,
+      children: children ?? this.children,
+      depth: depth ?? this.depth,
+    );
+  }
+}
+
+/// Builds a hierarchical tree structure from a flat list of folders
+class FolderHierarchy {
+  FolderHierarchy(List<Folder> folders) {
+    _buildHierarchy(folders);
+  }
+
+  final List<FolderNode> _rootNodes = [];
+  final Map<String, FolderNode> _nodeMap = {};
+
+  /// Get root-level folders (folders with no parent)
+  List<FolderNode> get rootNodes => _rootNodes;
+
+  /// Get all folders in a flattened list with depth information
+  List<FolderNode> get flattenedNodes {
+    final result = <FolderNode>[];
+    void addNodesRecursively(List<FolderNode> nodes) {
+      for (final node in nodes) {
+        result.add(node);
+        addNodesRecursively(node.children);
+      }
+    }
+
+    addNodesRecursively(_rootNodes);
+    return result;
+  }
+
+  /// Find a folder node by ID
+  FolderNode? findNode(String folderId) {
+    return _nodeMap[folderId];
+  }
+
+  /// Build the hierarchy from a flat list
+  void _buildHierarchy(List<Folder> folders) {
+    _rootNodes.clear();
+    _nodeMap.clear();
+
+    // First pass: Create nodes for all folders
+    for (final folder in folders) {
+      _nodeMap[folder.id] = FolderNode(folder: folder);
+    }
+
+    // Second pass: Build parent-child relationships
+    final childrenMap = <String, List<FolderNode>>{};
+
+    for (final folder in folders) {
+      final node = _nodeMap[folder.id]!;
+      if (folder.parentId == null || folder.parentId!.isEmpty) {
+        // Root level folder
+        _rootNodes.add(node);
+      } else {
+        // Child folder - add to parent's children list
+        childrenMap.putIfAbsent(folder.parentId!, () => []).add(node);
+      }
+    }
+
+    // Third pass: Update children and depths recursively
+    void updateDepthsRecursively(FolderNode node, int depth) {
+      final updatedNode = node.copyWith(
+        depth: depth,
+        children: childrenMap[node.folder.id] ?? const [],
+      );
+      _nodeMap[node.folder.id] = updatedNode;
+
+      for (final child in updatedNode.children) {
+        updateDepthsRecursively(child, depth + 1);
+      }
+    }
+
+    // Start with root nodes at depth 0
+    final updatedRoots = <FolderNode>[];
+    for (final root in _rootNodes) {
+      updateDepthsRecursively(root, 0);
+      updatedRoots.add(_nodeMap[root.folder.id]!);
+    }
+    _rootNodes
+      ..clear()
+      ..addAll(updatedRoots);
+  }
+
+  /// Check if a folder has any children
+  bool hasChildren(String folderId) {
+    final node = _nodeMap[folderId];
+    return node != null && node.children.isNotEmpty;
+  }
+
+  /// Get all child folder IDs recursively
+  List<String> getDescendantIds(String folderId) {
+    final node = _nodeMap[folderId];
+    if (node == null) return [];
+
+    final result = <String>[];
+    void collectIds(FolderNode n) {
+      for (final child in n.children) {
+        result.add(child.folder.id);
+        collectIds(child);
+      }
+    }
+
+    collectIds(node);
+    return result;
+  }
+}

--- a/lib/features/navigation/widgets/chats_drawer.dart
+++ b/lib/features/navigation/widgets/chats_drawer.dart
@@ -383,6 +383,9 @@ class _ChatsDrawerState extends ConsumerState<ChatsDrawer> {
                         final hasItems = convs.isNotEmpty;
                         final hasChildren = node.children.isNotEmpty;
 
+                        // Count both conversations and subfolders
+                        final totalCount = convs.length + node.children.length;
+
                         // Add folder header with proper indentation
                         out.add(
                           SliverPadding(
@@ -394,7 +397,7 @@ class _ChatsDrawerState extends ConsumerState<ChatsDrawer> {
                               child: _buildFolderHeader(
                                 folder.id,
                                 folder.name,
-                                convs.length,
+                                totalCount,
                                 defaultExpanded: folder.isExpanded,
                                 depth: depth,
                                 hasChildren: hasChildren,
@@ -634,6 +637,9 @@ class _ChatsDrawerState extends ConsumerState<ChatsDrawer> {
                     final hasItems = convs.isNotEmpty;
                     final hasChildren = node.children.isNotEmpty;
 
+                    // Count both conversations and subfolders
+                    final totalCount = convs.length + node.children.length;
+
                     out.add(
                       SliverPadding(
                         padding: EdgeInsets.only(
@@ -644,7 +650,7 @@ class _ChatsDrawerState extends ConsumerState<ChatsDrawer> {
                           child: _buildFolderHeader(
                             folder.id,
                             folder.name,
-                            convs.length,
+                            totalCount,
                             defaultExpanded: folder.isExpanded,
                             depth: depth,
                             hasChildren: hasChildren,

--- a/lib/features/navigation/widgets/chats_drawer.dart
+++ b/lib/features/navigation/widgets/chats_drawer.dart
@@ -940,10 +940,6 @@ class _ChatsDrawerState extends ConsumerState<ChatsDrawer> {
             current[folderId] = next;
             ref.read(_expandedFoldersProvider.notifier).set(current);
           },
-          onLongPress: () {
-            HapticFeedback.selectionClick();
-            _showFolderContextMenu(context, folderId, name);
-          },
           overlayColor: WidgetStateProperty.resolveWith(overlayForStates),
           child: ConstrainedBox(
             constraints: const BoxConstraints(
@@ -994,6 +990,37 @@ class _ChatsDrawerState extends ConsumerState<ChatsDrawer> {
                         style: AppTypography.standard.copyWith(
                           color: theme.textSecondary,
                         ),
+                      ),
+                      const SizedBox(width: Spacing.sm),
+                      Builder(
+                        builder: (buttonContext) {
+                          return IconButton(
+                            iconSize: IconSize.sm,
+                            visualDensity: const VisualDensity(
+                              horizontal: -2,
+                              vertical: -2,
+                            ),
+                            padding: EdgeInsets.zero,
+                            constraints: const BoxConstraints(
+                              minWidth: TouchTarget.listItem,
+                              minHeight: TouchTarget.listItem,
+                            ),
+                            icon: Icon(
+                              Platform.isIOS
+                                  ? CupertinoIcons.ellipsis
+                                  : Icons.more_vert_rounded,
+                              color: theme.iconSecondary,
+                            ),
+                            onPressed: () {
+                              _showFolderContextMenu(
+                                buttonContext,
+                                folderId,
+                                name,
+                              );
+                            },
+                            tooltip: AppLocalizations.of(context)!.more,
+                          );
+                        },
                       ),
                       const SizedBox(width: Spacing.xs),
                       Icon(

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -734,6 +734,10 @@
   "@newFolder": {
     "description": "Action to create a new folder."
   },
+  "newSubfolder": "New Subfolder",
+  "@newSubfolder": {
+    "description": "Action to create a new subfolder inside a folder."
+  },
   "folderName": "Folder name",
   "@folderName": {
     "description": "Label for entering a folder's name."


### PR DESCRIPTION
## Summary
Implements full support for nested folders with intuitive drag-and-drop interface and visual hierarchy.

## Changes
- ✅ **Hierarchical folder display** with visual indentation for nested structure
- ✅ **Create subfolders** via context menu on any folder
- ✅ **Drag-and-drop folders** into other folders to create nesting
- ✅ **Drag conversations** into nested folders
- ✅ **Circular reference prevention** - can't drop folder into itself or descendants
- ✅ **Smart folder counts** - shows both conversations AND subfolders
- ✅ **Auto-expand behavior** - parent folders expand when items are added

## Technical Implementation
- Created `FolderHierarchy` utility class to build tree structure from flat folder list
- Recursive rendering algorithm for nested folder display with depth-based indentation
- Dual `DragTarget` system for both conversation and folder drops
- Removed long-press context menu in favor of explicit menu button to enable drag gestures
- Leverages existing `parentId` field in Folder model (API already supported nesting)

## UI/UX Improvements
- Folders show "⋮" menu button for accessing New Subfolder, Rename, Delete
- Long-press on folder now initiates drag instead of showing menu
- Visual hover feedback when dragging over valid drop targets
- Folders automatically expand when new items are nested inside
- Indentation scales with depth for clear hierarchy visualization

## Testing
- Empty folders with subfolders now show correct count (e.g., "2" instead of "0")
- Drag-and-drop prevents invalid nesting (circular references)
- Parent folders expand automatically to show newly created/moved subfolders

Closes #81