### PR TITLE
feat: add temporary chats feature

### DIFF
--- a/lib/core/persistence/persistence_keys.dart
+++ b/lib/core/persistence/persistence_keys.dart
@@ -31,6 +31,10 @@ final class PreferenceKeys {
   static const String voiceSilenceDuration = 'voice_silence_duration';
   static const String androidAssistantTrigger = 'android_assistant_trigger';
 
+  // Temporary chat settings
+  static const String temporaryChat = 'temporary_chat_enabled';
+  static const String temporaryChatDefault = 'temporary_chat_default';
+
   // Drawer section collapsed states
   static const String drawerShowPinned = 'drawer_show_pinned';
   static const String drawerShowFolders = 'drawer_show_folders';

--- a/lib/core/providers/app_providers.dart
+++ b/lib/core/providers/app_providers.dart
@@ -1909,6 +1909,7 @@ final filteredConversationsProvider = Provider<List<Conversation>>((ref) {
         return conversations.maybeWhen(
           data: (convs) => convs.where((conv) {
             return !conv.archived &&
+                !conv.id.startsWith('local:') &&
                 (conv.title.toLowerCase().contains(query.toLowerCase()) ||
                     conv.messages.any(
                       (msg) => msg.content.toLowerCase().contains(
@@ -1924,6 +1925,7 @@ final filteredConversationsProvider = Provider<List<Conversation>>((ref) {
         return conversations.maybeWhen(
           data: (convs) => convs.where((conv) {
             return !conv.archived &&
+                !conv.id.startsWith('local:') &&
                 (conv.title.toLowerCase().contains(query.toLowerCase()) ||
                     conv.messages.any(
                       (msg) => msg.content.toLowerCase().contains(
@@ -1944,8 +1946,8 @@ final filteredConversationsProvider = Provider<List<Conversation>>((ref) {
       if (ref.watch(reviewerModeProvider)) {
         return convs; // Already filtered above for demo
       }
-      // Filter out archived conversations (they should be in a separate view)
-      final filtered = convs.where((conv) => !conv.archived).toList();
+      // Filter out archived and temporary conversations
+      final filtered = convs.where((conv) => !conv.archived && !conv.id.startsWith('local:')).toList();
 
       // Sort: pinned conversations first, then by updated date
       filtered.sort((a, b) {
@@ -2014,6 +2016,25 @@ class ReviewerMode extends _$ReviewerMode {
   }
 
   Future<void> toggle() => setEnabled(!state);
+}
+
+// Temporary chat mode provider - when enabled, chats use local: prefix and skip server persistence
+@Riverpod(keepAlive: true)
+class TemporaryChatEnabled extends _$TemporaryChatEnabled {
+  @override
+  bool build() {
+    // Initialize from default setting preference
+    final defaultSetting = ref.watch(
+      appSettingsProvider.select((s) => s.temporaryChatDefault),
+    );
+    return defaultSetting;
+  }
+
+  void setEnabled(bool enabled) {
+    state = enabled;
+  }
+
+  void toggle() => setEnabled(!state);
 }
 
 // User Settings providers

--- a/lib/core/services/settings_service.dart
+++ b/lib/core/services/settings_service.dart
@@ -174,6 +174,7 @@ class SettingsService {
       _voiceSilenceDurationKey: settings.voiceSilenceDuration,
       _androidAssistantTriggerKey:
           settings.androidAssistantTrigger.storageValue,
+      PreferenceKeys.temporaryChatDefault: settings.temporaryChatDefault,
     };
 
     await box.putAll(updates);
@@ -336,6 +337,10 @@ class SettingsService {
     return _preferencesBox().put(_sendOnEnterKey, value);
   }
 
+  static Future<void> setTemporaryChatDefault(bool value) {
+    return _preferencesBox().put(PreferenceKeys.temporaryChatDefault, value);
+  }
+
   static Future<int> getVoiceSilenceDuration() {
     final value = _preferencesBox().get(_voiceSilenceDurationKey) as int?;
     return Future.value((value ?? 2000).clamp(300, 3000));
@@ -438,6 +443,7 @@ class SettingsService {
       ),
       voiceSilenceDuration: (box.get(_voiceSilenceDurationKey) as int? ?? 2000)
           .clamp(300, 3000),
+      temporaryChatDefault: (box.get(PreferenceKeys.temporaryChatDefault) as bool?) ?? false,
     );
   }
 }
@@ -472,6 +478,7 @@ class AppSettings {
   final String? ttsServerVoiceName;
   final AndroidAssistantTrigger androidAssistantTrigger;
   final int voiceSilenceDuration;
+  final bool temporaryChatDefault;
   const AppSettings({
     this.reduceMotion = false,
     this.animationSpeed = 1.0,
@@ -496,6 +503,7 @@ class AppSettings {
     this.ttsServerVoiceName,
     this.androidAssistantTrigger = AndroidAssistantTrigger.overlay,
     this.voiceSilenceDuration = 2000,
+    this.temporaryChatDefault = false,
   });
 
   AppSettings copyWith({
@@ -522,6 +530,7 @@ class AppSettings {
     Object? ttsServerVoiceName = const _DefaultValue(),
     int? voiceSilenceDuration,
     AndroidAssistantTrigger? androidAssistantTrigger,
+    bool? temporaryChatDefault,
   }) {
     return AppSettings(
       reduceMotion: reduceMotion ?? this.reduceMotion,
@@ -556,6 +565,7 @@ class AppSettings {
       androidAssistantTrigger:
           androidAssistantTrigger ?? this.androidAssistantTrigger,
       voiceSilenceDuration: voiceSilenceDuration ?? this.voiceSilenceDuration,
+      temporaryChatDefault: temporaryChatDefault ?? this.temporaryChatDefault,
     );
   }
 
@@ -584,6 +594,7 @@ class AppSettings {
         other.ttsServerVoiceName == ttsServerVoiceName &&
         other.androidAssistantTrigger == androidAssistantTrigger &&
         other.voiceSilenceDuration == voiceSilenceDuration &&
+        other.temporaryChatDefault == temporaryChatDefault &&
         _listEquals(other.quickPills, quickPills);
     // socketTransportMode intentionally not included in == to avoid frequent rebuilds
   }
@@ -613,6 +624,7 @@ class AppSettings {
       ttsServerVoiceName,
       androidAssistantTrigger,
       voiceSilenceDuration,
+      temporaryChatDefault,
       Object.hashAllUnordered(quickPills),
     ]);
   }
@@ -736,6 +748,11 @@ class AppSettingsNotifier extends _$AppSettingsNotifier {
   Future<void> setSendOnEnter(bool value) async {
     state = state.copyWith(sendOnEnter: value);
     await SettingsService.setSendOnEnter(value);
+  }
+
+  Future<void> setTemporaryChatDefault(bool value) async {
+    state = state.copyWith(temporaryChatDefault: value);
+    await SettingsService.setTemporaryChatDefault(value);
   }
 
   Future<void> setSttPreference(SttPreference preference) async {

--- a/lib/features/chat/views/chat_page.dart
+++ b/lib/features/chat/views/chat_page.dart
@@ -874,6 +874,62 @@ class _ChatPageState extends ConsumerState<ChatPage> {
     return FloatingAppBarPill(isCircular: isCircular, child: child);
   }
 
+  Widget _buildTemporaryChatToggle(BuildContext context) {
+    final isTemporary = ref.watch(temporaryChatEnabledProvider);
+    final conduitTheme = context.conduitTheme;
+
+    return Tooltip(
+      message: isTemporary
+          ? 'Temporary chat ON - not saved'
+          : 'Temporary chat OFF - saved to history',
+      child: GestureDetector(
+        onTap: () => ref.read(temporaryChatEnabledProvider.notifier).toggle(),
+        child: _buildAppBarPill(
+          context: context,
+          isCircular: true,
+          child: Icon(
+            isTemporary
+                ? (Platform.isIOS ? CupertinoIcons.eye_slash : Icons.visibility_off)
+                : (Platform.isIOS ? CupertinoIcons.eye : Icons.visibility),
+            color: isTemporary ? conduitTheme.warning : conduitTheme.textPrimary,
+            size: IconSize.appBar,
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildSaveChatButton(BuildContext context) {
+    final conduitTheme = context.conduitTheme;
+
+    return Tooltip(
+      message: 'Save chat to history',
+      child: GestureDetector(
+        onTap: () async {
+          final conversation = ref.read(activeConversationProvider);
+          if (conversation != null) {
+            final messenger = ScaffoldMessenger.of(context);
+            final saved = await saveTemporaryChat(ref, conversation);
+            if (saved != null && mounted) {
+              messenger.showSnackBar(
+                const SnackBar(content: Text('Chat saved to history')),
+              );
+            }
+          }
+        },
+        child: _buildAppBarPill(
+          context: context,
+          isCircular: true,
+          child: Icon(
+            Platform.isIOS ? CupertinoIcons.floppy_disk : Icons.save,
+            color: conduitTheme.buttonPrimary,
+            size: IconSize.appBar,
+          ),
+        ),
+      ),
+    );
+  }
+
   Widget _buildMessagesList(ThemeData theme) {
     // Use select to watch only the messages list to reduce rebuilds
     final messages = ref.watch(
@@ -1915,6 +1971,17 @@ class _ChatPageState extends ConsumerState<ChatPage> {
                         ),
                   actions: [
                     if (!_isSelectionMode) ...[
+                      // Temporary chat toggle
+                      Padding(
+                        padding: const EdgeInsets.only(right: Spacing.sm),
+                        child: _buildTemporaryChatToggle(context),
+                      ),
+                      // Save button (only for temporary chats)
+                      if (ref.watch(activeConversationProvider)?.id.startsWith('local:') == true)
+                        Padding(
+                          padding: const EdgeInsets.only(right: Spacing.sm),
+                          child: _buildSaveChatButton(context),
+                        ),
                       Padding(
                         padding: const EdgeInsets.only(
                           right: Spacing.inputPadding,

--- a/lib/features/profile/views/app_customization_page.dart
+++ b/lib/features/profile/views/app_customization_page.dart
@@ -476,6 +476,25 @@ class AppCustomizationPage extends ConsumerWidget {
               .read(appSettingsProvider.notifier)
               .setSendOnEnter(!settings.sendOnEnter),
         ),
+        const SizedBox(height: Spacing.sm),
+        _CustomizationTile(
+          leading: _buildIconBadge(
+            context,
+            Platform.isIOS ? CupertinoIcons.eye_slash : Icons.visibility_off,
+            color: theme.warning,
+          ),
+          title: 'Temporary chats by default',
+          subtitle: 'New chats will not be saved to history unless you tap Save',
+          trailing: Switch.adaptive(
+            value: settings.temporaryChatDefault,
+            onChanged: (value) =>
+                ref.read(appSettingsProvider.notifier).setTemporaryChatDefault(value),
+          ),
+          showChevron: false,
+          onTap: () => ref
+              .read(appSettingsProvider.notifier)
+              .setTemporaryChatDefault(!settings.temporaryChatDefault),
+        ),
         if (Platform.isAndroid) ...[
           const SizedBox(height: Spacing.sm),
           _CustomizationTile(


### PR DESCRIPTION
Add temporary chats functionality matching Open WebUI's behavior. Temporary chats use 'local:' prefix and skip server persistence, allowing users to have private conversations that aren't saved.

Features:
- Toggle button in chat AppBar (eye icon) to enable/disable temporary mode
- "Temporary chats by default" setting in app customization page
- Save button to convert temporary chat to permanent
- Temporary chats filtered from sidebar conversation list
- All server sync operations skip temporary chats to prevent errors

Implementation:
- Add temporaryChatEnabled provider for session state
- Add temporaryChatDefault setting for default behavior
- Modify chat ID generation to use 'local:' prefix when enabled
- Skip api.createConversation() for temporary chats
- Add guards in streaming_helper.dart and chat_providers.dart:
  - Skip task monitoring
  - Skip message sync
  - Skip conversation refresh
  - Skip chat completed notifications
- Add isTemporaryConversation() helper function

The Open WebUI backend already supports the 'local:' prefix convention, so this is a frontend-only implementation.

Tested on Pixel 4 with Android 13.