### PR TITLE
fix: Enable URL launching for websearch sources

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -29,6 +29,14 @@
         <intent>
             <action android:name="android.intent.action.TTS_SERVICE" />
         </intent>
+        <intent>
+            <action android:name="android.intent.action.VIEW" />
+            <data android:scheme="https" />
+        </intent>
+        <intent>
+            <action android:name="android.intent.action.VIEW" />
+            <data android:scheme="http" />
+        </intent>
     </queries>
 
     <!-- Custom Application class creates notification channels at startup to prevent

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -68,6 +68,11 @@
 	<string>group.app.cogwheel.conduit</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
+	<key>LSApplicationQueriesSchemes</key>
+	<array>
+		<string>http</string>
+		<string>https</string>
+	</array>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>NSAppTransportSecurity</key>


### PR DESCRIPTION
Add platform-specific configuration to allow url_launcher to open external URLs from websearch sources.

- Android: Add VIEW intent queries for http/https schemes (required for API 30+)
- iOS: Add LSApplicationQueriesSchemes for http/https (required for canLaunchUrl)

Fixes #357