### PR TITLE
Add LDAP to publicEndpoints

### DIFF
--- a/lib/core/auth/api_auth_interceptor.dart
+++ b/lib/core/auth/api_auth_interceptor.dart
@@ -16,6 +16,7 @@ class ApiAuthInterceptor extends Interceptor {
   // Public endpoints that don't require authentication
   static const Set<String> _publicEndpoints = {
     '/health',
+    '/api/v1/auths/ldap',
     '/api/v1/auths/signin',
     '/api/v1/auths/signup',
     '/api/v1/auths/signup/enabled',


### PR DESCRIPTION
Without having LDAP in publicEndpoints, LDAP authentication fails with
"We couldn't sign you in. Check your credentials and server settings."

Not sure if this is just a dirty fix.