### PR TITLE
feat(auth): improve iOS text field styling and header input UX

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,24 @@
+{
+  "hooks": {
+    "Notification": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "curl -sf -X POST -H \"Content-Type: application/json\" -H \"X-Emdash-Token: $EMDASH_HOOK_TOKEN\" -H \"X-Emdash-Pty-Id: $EMDASH_PTY_ID\" -H \"X-Emdash-Event-Type: notification\" -d @- \"http://127.0.0.1:$EMDASH_HOOK_PORT/hook\" || true"
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "curl -sf -X POST -H \"Content-Type: application/json\" -H \"X-Emdash-Token: $EMDASH_HOOK_TOKEN\" -H \"X-Emdash-Pty-Id: $EMDASH_PTY_ID\" -H \"X-Emdash-Event-Type: stop\" -d @- \"http://127.0.0.1:$EMDASH_HOOK_PORT/hook\" || true"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/lib/features/auth/views/authentication_page.dart
+++ b/lib/features/auth/views/authentication_page.dart
@@ -679,6 +679,13 @@ class _AuthenticationPageState extends ConsumerState<AuthenticationPage> {
           ),
           onSubmitted: (_) => _signIn(),
           autofillHints: const [AutofillHints.password],
+          cupertinoDecoration: BoxDecoration(
+            color: CupertinoColors.tertiarySystemBackground,
+            border: Border.all(
+              color: context.conduitTheme.inputBorder,
+            ),
+            borderRadius: BorderRadius.circular(8),
+          ),
         ),
         const SizedBox(height: Spacing.sm),
         Text(
@@ -712,6 +719,13 @@ class _AuthenticationPageState extends ConsumerState<AuthenticationPage> {
               color: context.conduitTheme.iconSecondary,
             ),
             autofillHints: const [AutofillHints.username, AutofillHints.email],
+            cupertinoDecoration: BoxDecoration(
+              color: CupertinoColors.tertiarySystemBackground,
+              border: Border.all(
+                color: context.conduitTheme.inputBorder,
+              ),
+              borderRadius: BorderRadius.circular(8),
+            ),
           ),
           const SizedBox(height: Spacing.lg),
           AdaptiveTextFormField(
@@ -751,6 +765,13 @@ class _AuthenticationPageState extends ConsumerState<AuthenticationPage> {
             ),
             onSubmitted: (_) => _signIn(),
             autofillHints: const [AutofillHints.password],
+            cupertinoDecoration: BoxDecoration(
+              color: CupertinoColors.tertiarySystemBackground,
+              border: Border.all(
+                color: context.conduitTheme.inputBorder,
+              ),
+              borderRadius: BorderRadius.circular(8),
+            ),
           ),
         ],
       ),
@@ -776,6 +797,13 @@ class _AuthenticationPageState extends ConsumerState<AuthenticationPage> {
               color: context.conduitTheme.iconSecondary,
             ),
             autofillHints: const [AutofillHints.username],
+            cupertinoDecoration: BoxDecoration(
+              color: CupertinoColors.tertiarySystemBackground,
+              border: Border.all(
+                color: context.conduitTheme.inputBorder,
+              ),
+              borderRadius: BorderRadius.circular(8),
+            ),
           ),
           const SizedBox(height: Spacing.lg),
           AdaptiveTextFormField(
@@ -815,6 +843,13 @@ class _AuthenticationPageState extends ConsumerState<AuthenticationPage> {
             ),
             onSubmitted: (_) => _signIn(),
             autofillHints: const [AutofillHints.password],
+            cupertinoDecoration: BoxDecoration(
+              color: CupertinoColors.tertiarySystemBackground,
+              border: Border.all(
+                color: context.conduitTheme.inputBorder,
+              ),
+              borderRadius: BorderRadius.circular(8),
+            ),
           ),
           const SizedBox(height: Spacing.sm),
           Text(

--- a/lib/features/auth/views/server_connection_page.dart
+++ b/lib/features/auth/views/server_connection_page.dart
@@ -38,6 +38,7 @@ class _ServerConnectionPageState extends ConsumerState<ServerConnectionPage> {
   final Map<String, String> _customHeaders = {};
   final TextEditingController _headerKeyController = TextEditingController();
   final TextEditingController _headerValueController = TextEditingController();
+  final FocusNode _headerValueFocusNode = FocusNode();
 
   String? _connectionError;
   bool _isConnecting = false;
@@ -64,6 +65,7 @@ class _ServerConnectionPageState extends ConsumerState<ServerConnectionPage> {
     _urlController.dispose();
     _headerKeyController.dispose();
     _headerValueController.dispose();
+    _headerValueFocusNode.dispose();
     super.dispose();
   }
 
@@ -721,6 +723,13 @@ class _ServerConnectionPageState extends ConsumerState<ServerConnectionPage> {
             color: context.conduitTheme.iconSecondary,
           ),
           autofillHints: const [AutofillHints.url],
+          cupertinoDecoration: BoxDecoration(
+            color: CupertinoColors.tertiarySystemBackground,
+            border: Border.all(
+              color: context.conduitTheme.inputBorder,
+            ),
+            borderRadius: BorderRadius.circular(8),
+          ),
         ),
 
         if (_connectionError != null) ...[
@@ -928,23 +937,6 @@ class _ServerConnectionPageState extends ConsumerState<ServerConnectionPage> {
                         ),
                       ),
                     ),
-                  ConduitIconButton(
-                    icon: Platform.isIOS
-                        ? CupertinoIcons.plus
-                        : Icons.add_rounded,
-                    onPressed: _customHeaders.length >= 10
-                        ? null
-                        : _addCustomHeader,
-                    tooltip: _customHeaders.length >= 10
-                        ? l10n.maximumHeadersReached
-                        : l10n.addHeader,
-                    backgroundColor: _customHeaders.length >= 10
-                        ? theme.surfaceContainer
-                        : theme.buttonPrimary,
-                    iconColor: _customHeaders.length >= 10
-                        ? theme.textDisabled
-                        : theme.buttonPrimaryText,
-                  ),
                 ],
               ),
               const SizedBox(height: Spacing.md),
@@ -960,6 +952,17 @@ class _ServerConnectionPageState extends ConsumerState<ServerConnectionPage> {
                         value ?? _headerKeyController.text,
                       ),
                       keyboardType: TextInputType.text,
+                      textInputAction: TextInputAction.next,
+                      onSubmitted: (_) =>
+                          _headerValueFocusNode.requestFocus(),
+                      cupertinoDecoration: BoxDecoration(
+                        color: CupertinoColors
+                            .tertiarySystemBackground,
+                        border: Border.all(
+                          color: theme.inputBorder,
+                        ),
+                        borderRadius: BorderRadius.circular(8),
+                      ),
                     ),
                   ),
                   const SizedBox(width: Spacing.sm),
@@ -967,13 +970,51 @@ class _ServerConnectionPageState extends ConsumerState<ServerConnectionPage> {
                     child: AdaptiveTextFormField(
                       placeholder: l10n.headerValueHint,
                       controller: _headerValueController,
+                      focusNode: _headerValueFocusNode,
                       validator: (value) => _validateHeaderValue(
                         value ?? _headerValueController.text,
                       ),
                       keyboardType: TextInputType.text,
+                      textInputAction: TextInputAction.done,
+                      onSubmitted: (_) => _addCustomHeader(),
+                      cupertinoDecoration: BoxDecoration(
+                        color: CupertinoColors
+                            .tertiarySystemBackground,
+                        border: Border.all(
+                          color: theme.inputBorder,
+                        ),
+                        borderRadius: BorderRadius.circular(8),
+                      ),
                     ),
                   ),
                 ],
+              ),
+              const SizedBox(height: Spacing.sm),
+              Center(
+                child: GestureDetector(
+                  onTap: _customHeaders.length >= 10
+                      ? null
+                      : _addCustomHeader,
+                  child: Container(
+                    width: TouchTarget.minimum,
+                    height: TouchTarget.minimum,
+                    decoration: BoxDecoration(
+                      color: _customHeaders.length >= 10
+                          ? theme.surfaceContainer
+                          : theme.buttonPrimary,
+                      shape: BoxShape.circle,
+                    ),
+                    child: Icon(
+                      Platform.isIOS
+                          ? CupertinoIcons.plus
+                          : Icons.add_rounded,
+                      color: _customHeaders.length >= 10
+                          ? theme.textDisabled
+                          : theme.buttonPrimaryText,
+                      size: IconSize.medium,
+                    ),
+                  ),
+                ),
               ),
 
               // Header list

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1042,10 +1042,10 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: "12956d0ad8390bbcc63ca2e1469c0619946ccb52809807067a7020d57e647aa6"
+      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.18"
+    version: "0.12.19"
   material_color_utilities:
     dependency: transitive
     description:
@@ -1832,26 +1832,26 @@ packages:
     dependency: transitive
     description:
       name: test
-      sha256: "54c516bbb7cee2754d327ad4fca637f78abfc3cbcc5ace83b3eda117e42cd71a"
+      sha256: "280d6d890011ca966ad08df7e8a4ddfab0fb3aa49f96ed6de56e3521347a9ae7"
       url: "https://pub.dev"
     source: hosted
-    version: "1.29.0"
+    version: "1.30.0"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: "93167629bfc610f71560ab9312acdda4959de4df6fac7492c89ff0d3886f6636"
+      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.9"
+    version: "0.7.10"
   test_core:
     dependency: transitive
     description:
       name: test_core
-      sha256: "394f07d21f0f2255ec9e3989f21e54d3c7dc0e6e9dbce160e5a9c1a6be0e2943"
+      sha256: "0381bd1585d1a924763c308100f2138205252fb90c9d4eeaf28489ee65ccde51"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.15"
+    version: "0.6.16"
   timezone:
     dependency: transitive
     description:


### PR DESCRIPTION
## Summary
- Add `cupertinoDecoration` to all `AdaptiveTextFormField` widgets across authentication and server connection pages for consistent iOS styling with bordered, rounded inputs
- Improve custom headers input flow: add keyboard navigation (tab from key to value, submit on done) via `FocusNode` and `textInputAction`
- Move the "add header" button below the input row as a centered circular button for better layout

## Test plan
- [ ] Verify text fields render correctly on iOS with the new Cupertino decoration (border, background, radius)
- [ ] Verify Android text fields are unaffected
- [ ] Test custom header keyboard flow: typing in key field and pressing next focuses value field, pressing done in value field adds the header
- [ ] Verify add-header button appearance and disabled state when 10 headers reached