### PR TITLE
fix(streaming): acknowledge channel RPC to prevent 60s timeout

### DIFF
--- a/lib/core/services/streaming_helper.dart
+++ b/lib/core/services/streaming_helper.dart
@@ -1336,6 +1336,11 @@ ActiveSocketStream attachUnifiedChunkedStreaming({
         if (channel is String && channel.isNotEmpty) {
           channelLineHandlerFactory(channel);
         }
+        // Acknowledge the RPC call so the server can proceed immediately.
+        // Without this, sio.call() waits for the 60s timeout (issue #378).
+        if (ack != null) {
+          ack({'status': true});
+        }
       } else if (type == 'execute:tool' && payload != null) {
         // Show an executing tile immediately; also surface any inline files/result
         try {


### PR DESCRIPTION
## Summary

Fixes an issue where OpenRouter pipe routing would stall for 60 seconds before streaming began.

- The server uses `sio.call()` (an RPC-style emit) when sending the `channel` event, which expects an acknowledgment callback
- Without calling `ack()`, the server blocks until the 60-second timeout expires before proceeding
- This adds the missing acknowledgment response so the server can continue immediately

Fixes #378

<!-- emdash-issue-footer:start -->
Fixes #378
<!-- emdash-issue-footer:end -->