### PR TITLE
fix(ios): prevent infinite recursion in paste bridge swizzling

### DIFF
--- a/ios/Runner/NativePasteBridge.swift
+++ b/ios/Runner/NativePasteBridge.swift
@@ -26,15 +26,16 @@ final class NativePasteBridge {
         guard !didSwizzle else { return }
         didSwizzle = true
 
-        [
-            "FlutterTextInputView",
-            "FlutterSecureTextInputView",
-        ].forEach { className in
-            guard let targetClass = NSClassFromString(className) else { return }
-            swizzlePaste(for: targetClass)
-            swizzleCanPerformAction(for: targetClass)
-            swizzlePasteConfiguration(for: targetClass)
-        }
+        // Only swizzle the base class. FlutterSecureTextInputView inherits
+        // from FlutterTextInputView, so the swizzle applies automatically.
+        // Swizzling both causes infinite recursion: the subclass swizzle
+        // sees the parent's already-swizzled Method, making the exchange
+        // a no-op and leaving conduit_canPerformAction pointing at itself.
+        guard let targetClass = NSClassFromString("FlutterTextInputView")
+        else { return }
+        swizzlePaste(for: targetClass)
+        swizzleCanPerformAction(for: targetClass)
+        swizzlePasteConfiguration(for: targetClass)
     }
 
     private static func swizzlePaste(for targetClass: AnyClass) {


### PR DESCRIPTION
## Summary

- Only swizzle the base `FlutterTextInputView` class instead of both it and `FlutterSecureTextInputView`
- `FlutterSecureTextInputView` inherits from `FlutterTextInputView`, so the swizzle applies automatically via inheritance
- Swizzling both caused infinite recursion: the subclass swizzle saw the parent's already-swizzled method, making the exchange a no-op and leaving `conduit_canPerformAction` pointing at itself

## Test Plan

- Verify paste (text and images) works in regular text fields
- Verify paste works in secure/password text fields
- Confirm no crashes from infinite recursion when interacting with the paste menu