### PR TITLE
fix(auth): recover saved server when active id is missing

### DIFF
--- a/lib/core/providers/app_providers.dart
+++ b/lib/core/providers/app_providers.dart
@@ -174,12 +174,32 @@ Future<ServerConfig?> activeServer(Ref ref) async {
   final configs = await ref.watch(serverConfigsProvider.future);
   final activeId = await storage.getActiveServerId();
 
-  if (activeId == null || configs.isEmpty) return null;
+  if (configs.isEmpty) return null;
 
+  if (activeId != null) {
+    for (final config in configs) {
+      if (config.id == activeId) {
+        return config;
+      }
+    }
+  }
+
+  final fallback = _recoverActiveServerConfig(configs);
+  if (fallback == null) return null;
+
+  await storage.setActiveServerId(fallback.id);
+  return fallback.isActive ? fallback : fallback.copyWith(isActive: true);
+}
+
+ServerConfig? _recoverActiveServerConfig(List<ServerConfig> configs) {
   for (final config in configs) {
-    if (config.id == activeId) {
+    if (config.isActive) {
       return config;
     }
+  }
+
+  if (configs.length == 1) {
+    return configs.first;
   }
 
   return null;

--- a/test/core/providers/active_server_provider_test.dart
+++ b/test/core/providers/active_server_provider_test.dart
@@ -1,0 +1,81 @@
+import 'package:conduit/core/models/server_config.dart';
+import 'package:conduit/core/providers/app_providers.dart';
+import 'package:conduit/core/services/optimized_storage_service.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+
+class _MockOptimizedStorageService extends Mock
+    implements OptimizedStorageService {}
+
+void main() {
+  group('activeServerProvider', () {
+    test(
+      'recovers a single saved server when active server id is missing',
+      () async {
+        final storage = _MockOptimizedStorageService();
+        final server = _server('server-1', isActive: false);
+
+        when(
+          () => storage.getServerConfigs(),
+        ).thenAnswer((_) async => [server]);
+        when(() => storage.getActiveServerId()).thenAnswer((_) async => null);
+        when(
+          () => storage.setActiveServerId(server.id),
+        ).thenAnswer((_) async {});
+
+        final container = ProviderContainer(
+          overrides: [
+            optimizedStorageServiceProvider.overrideWithValue(storage),
+          ],
+        );
+        addTearDown(container.dispose);
+
+        final active = await container.read(activeServerProvider.future);
+
+        expect(active?.id, server.id);
+        expect(active?.isActive, isTrue);
+        verify(() => storage.setActiveServerId(server.id)).called(1);
+      },
+    );
+
+    test(
+      'recovers the config marked active when active server id is missing',
+      () async {
+        final storage = _MockOptimizedStorageService();
+        final inactive = _server('server-1', isActive: false);
+        final activeServer = _server('server-2', isActive: true);
+
+        when(
+          () => storage.getServerConfigs(),
+        ).thenAnswer((_) async => [inactive, activeServer]);
+        when(() => storage.getActiveServerId()).thenAnswer((_) async => null);
+        when(
+          () => storage.setActiveServerId(activeServer.id),
+        ).thenAnswer((_) async {});
+
+        final container = ProviderContainer(
+          overrides: [
+            optimizedStorageServiceProvider.overrideWithValue(storage),
+          ],
+        );
+        addTearDown(container.dispose);
+
+        final active = await container.read(activeServerProvider.future);
+
+        expect(active?.id, activeServer.id);
+        expect(active?.isActive, isTrue);
+        verify(() => storage.setActiveServerId(activeServer.id)).called(1);
+      },
+    );
+  });
+}
+
+ServerConfig _server(String id, {required bool isActive}) {
+  return ServerConfig(
+    id: id,
+    name: 'Test server $id',
+    url: 'https://$id.example.com',
+    isActive: isActive,
+  );
+}


### PR DESCRIPTION
## Summary
- Recover the active server from saved configs when the stored active server id is missing or stale
- Prefer an explicitly `isActive` saved config; if there is only one saved server, restore it automatically
- Persist the recovered active server id so subsequent launches go straight to sign-in instead of server setup

## Test Plan
- `dart format lib/core/providers/app_providers.dart test/core/providers/active_server_provider_test.dart`
- `flutter pub run build_runner build --delete-conflicting-outputs`
- `flutter test test/core/providers/active_server_provider_test.dart`

## Context
This fixes the app appearing to forget server details even though the server config itself is still saved. The previous provider returned `null` whenever `active_server_id` was absent, causing the router to send users back to the server connection flow.
