### PR TITLE
feat(terminal): full-screen mode, touch key toolbar, and copy/paste

### DIFF
--- a/lib/features/terminal/widgets/terminal_clipboard_actions.dart
+++ b/lib/features/terminal/widgets/terminal_clipboard_actions.dart
@@ -1,0 +1,55 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:xterm/xterm.dart';
+
+import '../../../l10n/app_localizations.dart';
+import '../../../shared/utils/utf16_sanitizer.dart';
+
+void _showTerminalSnackBar(BuildContext context, String message) {
+  ScaffoldMessenger.maybeOf(
+    context,
+  )?.showSnackBar(SnackBar(content: Text(sanitizeUtf16(message))));
+}
+
+/// Copies the current xterm selection to the system clipboard, surfacing a
+/// snackbar (via [context]) when there is nothing selected.
+Future<void> copyTerminalSelection(
+  BuildContext context,
+  Terminal terminal,
+  TerminalController controller,
+) async {
+  final l10n = AppLocalizations.of(context)!;
+  final selection = controller.selection;
+  if (selection == null) {
+    _showTerminalSnackBar(context, l10n.terminalNothingToCopy);
+    return;
+  }
+
+  final text = terminal.buffer.getText(selection);
+  await Clipboard.setData(ClipboardData(text: sanitizeUtf16(text)));
+  controller.clearSelection();
+  if (context.mounted) {
+    _showTerminalSnackBar(context, l10n.terminalCopied);
+  }
+}
+
+/// Pastes clipboard text into the terminal (bracketed-paste aware). When the
+/// terminal is not [connected], surfaces a snackbar instead of swallowing the
+/// keystrokes.
+Future<void> pasteIntoTerminal(
+  BuildContext context,
+  Terminal terminal, {
+  required bool connected,
+}) async {
+  final l10n = AppLocalizations.of(context)!;
+  if (!connected) {
+    _showTerminalSnackBar(context, l10n.terminalPasteWhileDisconnected);
+    return;
+  }
+
+  final data = await Clipboard.getData(Clipboard.kTextPlain);
+  final text = data?.text;
+  if (text != null && text.isNotEmpty) {
+    terminal.paste(text);
+  }
+}

--- a/lib/features/terminal/widgets/terminal_connection_badge.dart
+++ b/lib/features/terminal/widgets/terminal_connection_badge.dart
@@ -1,0 +1,49 @@
+import 'package:flutter/material.dart';
+
+import '../../../l10n/app_localizations.dart';
+import '../../../shared/theme/theme_extensions.dart';
+import '../models/terminal_models.dart';
+
+/// Pill badge that reflects the terminal connection status. Shared by the
+/// inline pane header and the full-screen terminal page.
+class TerminalConnectionBadge extends StatelessWidget {
+  const TerminalConnectionBadge({super.key, required this.state});
+
+  final TerminalConnectionState state;
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context)!;
+    final theme = context.conduitTheme;
+
+    final label = switch (state.status) {
+      TerminalConnectionStatus.connected => l10n.terminalConnectedStatus,
+      TerminalConnectionStatus.connecting => l10n.terminalConnectingStatus,
+      TerminalConnectionStatus.error => l10n.errorMessage,
+      TerminalConnectionStatus.disconnected => l10n.terminalDisconnectedStatus,
+    };
+    final color = switch (state.status) {
+      TerminalConnectionStatus.connected => const Color(0xFF16A34A),
+      TerminalConnectionStatus.connecting => theme.buttonPrimary,
+      TerminalConnectionStatus.error => theme.error,
+      TerminalConnectionStatus.disconnected => theme.textSecondary,
+    };
+
+    return DecoratedBox(
+      decoration: BoxDecoration(
+        color: color.withValues(alpha: 0.14),
+        borderRadius: BorderRadius.circular(AppBorderRadius.pill),
+      ),
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: Spacing.sm, vertical: 6),
+        child: Text(
+          label,
+          style: AppTypography.labelSmallStyle.copyWith(
+            color: color,
+            fontWeight: FontWeight.w700,
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/terminal/widgets/terminal_console_surface.dart
+++ b/lib/features/terminal/widgets/terminal_console_surface.dart
@@ -1,0 +1,149 @@
+import 'package:flutter/widgets.dart';
+import 'package:xterm/xterm.dart';
+
+import '../../../shared/theme/theme_extensions.dart';
+import '../../../shared/utils/utf16_sanitizer.dart';
+import 'terminal_key_toolbar.dart';
+
+/// Terminal console body shared by the inline sidebar pane and the full-screen
+/// page: the xterm [TerminalView] plus the [TerminalKeyToolbar] accessory row.
+///
+/// The [terminal]/[controller] are owned elsewhere and passed by reference, so
+/// only one [TerminalConsoleSurface] should be mounted against a given
+/// [terminal] at a time (xterm drives resize/focus from the live view).
+class TerminalConsoleSurface extends StatelessWidget {
+  const TerminalConsoleSurface({
+    super.key,
+    required this.terminal,
+    required this.controller,
+    required this.connected,
+    this.overlayMessage,
+    this.autofocus = true,
+    this.roundedBottom = true,
+  });
+
+  final Terminal terminal;
+  final TerminalController controller;
+  final bool connected;
+  final String? overlayMessage;
+  final bool autofocus;
+  final bool roundedBottom;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = context.conduitTheme;
+    final message = overlayMessage;
+
+    Widget content = Column(
+      children: [
+        Expanded(
+          child: Stack(
+            children: [
+              Positioned.fill(
+                child: DecoratedBox(
+                  decoration: BoxDecoration(color: theme.codeBackground),
+                  child: MediaQuery.removePadding(
+                    context: context,
+                    removeTop: true,
+                    child: TerminalView(
+                      terminal,
+                      controller: controller,
+                      autofocus: autofocus,
+                      padding: const EdgeInsets.symmetric(
+                        horizontal: Spacing.sm,
+                        vertical: Spacing.xs,
+                      ),
+                      theme: buildTerminalTheme(context),
+                      textStyle: TerminalStyle.fromTextStyle(
+                        AppTypography.codeStyle.copyWith(fontSize: 12),
+                      ),
+                      backgroundOpacity: 1,
+                      deleteDetection: true,
+                    ),
+                  ),
+                ),
+              ),
+              if (message != null) _TerminalOverlayMessage(message: message),
+            ],
+          ),
+        ),
+        if (message == null)
+          TerminalKeyToolbar(
+            terminal: terminal,
+            controller: controller,
+            connected: connected,
+          ),
+      ],
+    );
+
+    if (roundedBottom) {
+      content = ClipRRect(
+        borderRadius: const BorderRadius.vertical(
+          bottom: Radius.circular(AppBorderRadius.standard),
+        ),
+        child: content,
+      );
+    }
+
+    return content;
+  }
+}
+
+TerminalTheme buildTerminalTheme(BuildContext context) {
+  final theme = context.conduitTheme;
+  return TerminalTheme(
+    cursor: theme.codeText,
+    selection: theme.buttonPrimary.withValues(alpha: 0.25),
+    foreground: theme.codeText,
+    background: theme.codeBackground,
+    black: const Color(0xFF000000),
+    white: const Color(0xFFE5E5E5),
+    red: const Color(0xFFCD3131),
+    green: const Color(0xFF0DBC79),
+    yellow: const Color(0xFFE5E510),
+    blue: const Color(0xFF2472C8),
+    magenta: const Color(0xFFBC3FBC),
+    cyan: const Color(0xFF11A8CD),
+    brightBlack: const Color(0xFF666666),
+    brightRed: const Color(0xFFF14C4C),
+    brightGreen: const Color(0xFF23D18B),
+    brightYellow: const Color(0xFFF5F543),
+    brightBlue: const Color(0xFF3B8EEA),
+    brightMagenta: const Color(0xFFD670D6),
+    brightCyan: const Color(0xFF29B8DB),
+    brightWhite: const Color(0xFFFFFFFF),
+    searchHitBackground: theme.buttonPrimary.withValues(alpha: 0.35),
+    searchHitBackgroundCurrent: theme.buttonPrimary.withValues(alpha: 0.55),
+    searchHitForeground: theme.textPrimary,
+  );
+}
+
+class _TerminalOverlayMessage extends StatelessWidget {
+  const _TerminalOverlayMessage({required this.message});
+
+  final String message;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = context.conduitTheme;
+    return Positioned.fill(
+      child: DecoratedBox(
+        decoration: BoxDecoration(
+          color: theme.codeBackground.withValues(alpha: 0.88),
+        ),
+        child: Center(
+          child: Padding(
+            padding: const EdgeInsets.all(Spacing.lg),
+            child: Text(
+              sanitizeUtf16(message),
+              textAlign: TextAlign.center,
+              style: AppTypography.bodyMediumStyle.copyWith(
+                color: theme.codeText,
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/terminal/widgets/terminal_fullscreen_page.dart
+++ b/lib/features/terminal/widgets/terminal_fullscreen_page.dart
@@ -1,0 +1,65 @@
+import 'package:adaptive_platform_ui/adaptive_platform_ui.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:xterm/xterm.dart';
+
+import '../../../l10n/app_localizations.dart';
+import '../../../shared/theme/theme_extensions.dart';
+import '../../../shared/widgets/adaptive_route_shell.dart';
+import '../providers/terminal_providers.dart';
+import 'terminal_connection_badge.dart';
+import 'terminal_console_surface.dart';
+
+/// Full-screen presentation of the terminal console. The [terminal] and
+/// [controller] are owned by the sidebar `TerminalTab` and passed by reference;
+/// while this page is on screen the inline pane renders a placeholder so only
+/// one `TerminalView` is mounted against the shared session at a time.
+class TerminalFullscreenPage extends ConsumerWidget {
+  const TerminalFullscreenPage({
+    super.key,
+    required this.terminal,
+    required this.controller,
+  });
+
+  final Terminal terminal;
+  final TerminalController controller;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final l10n = AppLocalizations.of(context)!;
+    final theme = context.conduitTheme;
+    final connectionState = ref.watch(terminalConnectionStateProvider);
+
+    return AdaptiveRouteShell(
+      backgroundColor: theme.surfaceBackground,
+      bodySafeArea: true,
+      appBar: AdaptiveAppBar(title: l10n.terminal),
+      body: Column(
+        children: [
+          Padding(
+            padding: const EdgeInsets.fromLTRB(
+              Spacing.md,
+              Spacing.sm,
+              Spacing.md,
+              Spacing.sm,
+            ),
+            child: Row(
+              children: [
+                const Spacer(),
+                TerminalConnectionBadge(state: connectionState),
+              ],
+            ),
+          ),
+          Expanded(
+            child: TerminalConsoleSurface(
+              terminal: terminal,
+              controller: controller,
+              connected: connectionState.isConnected,
+              roundedBottom: false,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/features/terminal/widgets/terminal_key_toolbar.dart
+++ b/lib/features/terminal/widgets/terminal_key_toolbar.dart
@@ -1,0 +1,168 @@
+import 'dart:async';
+import 'dart:io';
+
+import 'package:adaptive_platform_ui/adaptive_platform_ui.dart';
+import 'package:flutter/material.dart';
+import 'package:xterm/xterm.dart';
+
+import '../../../l10n/app_localizations.dart';
+import '../../../shared/theme/theme_extensions.dart';
+import 'terminal_clipboard_actions.dart';
+
+/// Accessory toolbar of touch-friendly keys for the terminal: command history
+/// (Up/Down), shell completion (Tab), copy/paste, and Ctrl-C. Operates
+/// directly on the shared [terminal]/[controller]; any key routes through the
+/// terminal's `onOutput` callback and out to the remote PTY.
+class TerminalKeyToolbar extends StatelessWidget {
+  const TerminalKeyToolbar({
+    super.key,
+    required this.terminal,
+    required this.controller,
+    required this.connected,
+  });
+
+  final Terminal terminal;
+  final TerminalController controller;
+  final bool connected;
+
+  void _sendKey(TerminalKey key, {bool ctrl = false}) {
+    terminal.keyInput(key, ctrl: ctrl);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context)!;
+    final theme = context.conduitTheme;
+
+    return DecoratedBox(
+      decoration: BoxDecoration(
+        color: theme.surfaceBackground,
+        border: Border(top: BorderSide(color: theme.cardBorder)),
+      ),
+      child: Padding(
+        padding: const EdgeInsets.symmetric(
+          horizontal: Spacing.sm,
+          vertical: Spacing.xs,
+        ),
+        child: Row(
+          children: [
+            Expanded(
+              child: _ToolbarKey(
+                icon: Icons.keyboard_arrow_up_rounded,
+                tooltip: l10n.terminalKeyUp,
+                onPressed: connected
+                    ? () => _sendKey(TerminalKey.arrowUp)
+                    : null,
+              ),
+            ),
+            const SizedBox(width: Spacing.xs),
+            Expanded(
+              child: _ToolbarKey(
+                icon: Icons.keyboard_arrow_down_rounded,
+                tooltip: l10n.terminalKeyDown,
+                onPressed: connected
+                    ? () => _sendKey(TerminalKey.arrowDown)
+                    : null,
+              ),
+            ),
+            const SizedBox(width: Spacing.xs),
+            Expanded(
+              child: _ToolbarKey(
+                label: l10n.terminalKeyTab,
+                tooltip: l10n.terminalKeyTab,
+                onPressed: connected ? () => _sendKey(TerminalKey.tab) : null,
+              ),
+            ),
+            const SizedBox(width: Spacing.sm),
+            Expanded(
+              child: _ToolbarKey(
+                icon: Icons.copy_rounded,
+                tooltip: l10n.terminalCopyAction,
+                onPressed: () => unawaited(
+                  copyTerminalSelection(context, terminal, controller),
+                ),
+              ),
+            ),
+            const SizedBox(width: Spacing.xs),
+            Expanded(
+              child: _ToolbarKey(
+                icon: Icons.paste_rounded,
+                tooltip: l10n.terminalPasteAction,
+                onPressed: () => unawaited(
+                  pasteIntoTerminal(context, terminal, connected: connected),
+                ),
+              ),
+            ),
+            const SizedBox(width: Spacing.sm),
+            Expanded(
+              child: _ToolbarKey(
+                icon: Icons.block_rounded,
+                tooltip: l10n.terminalKeyCtrlC,
+                onPressed: connected
+                    ? () => _sendKey(TerminalKey.keyC, ctrl: true)
+                    : null,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _ToolbarKey extends StatelessWidget {
+  const _ToolbarKey({
+    required this.tooltip,
+    required this.onPressed,
+    this.icon,
+    this.label,
+  }) : assert(icon != null || label != null);
+
+  final String tooltip;
+  final VoidCallback? onPressed;
+  final IconData? icon;
+  final String? label;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = context.conduitTheme;
+    final enabled = onPressed != null;
+    final foreground = enabled ? theme.iconSecondary : theme.iconDisabled;
+
+    final Widget child = icon != null
+        ? Icon(icon, size: IconSize.sm, color: foreground)
+        : Text(
+            label!,
+            style: AppTypography.labelStyle.copyWith(
+              color: foreground,
+              fontWeight: FontWeight.w600,
+            ),
+          );
+
+    return AdaptiveTooltip(
+      message: tooltip,
+      child: Semantics(
+        button: true,
+        enabled: enabled,
+        label: tooltip,
+        child: AdaptiveButton.child(
+          onPressed: onPressed,
+          enabled: enabled,
+          style: Platform.isAndroid
+              ? AdaptiveButtonStyle.filled
+              : AdaptiveButtonStyle.glass,
+          color: Platform.isAndroid ? theme.surfaceContainerHighest : null,
+          size: AdaptiveButtonSize.small,
+          minSize: const Size(TouchTarget.minimum, TouchTarget.minimum),
+          padding: const EdgeInsets.symmetric(
+            horizontal: Spacing.sm,
+            vertical: Spacing.xxs,
+          ),
+          borderRadius: BorderRadius.circular(AppBorderRadius.small),
+          useSmoothRectangleBorder: false,
+          child: child,
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/terminal/widgets/terminal_tab.dart
+++ b/lib/features/terminal/widgets/terminal_tab.dart
@@ -17,6 +17,7 @@ import 'package:xterm/xterm.dart';
 
 import '../../../l10n/app_localizations.dart';
 import '../../../shared/theme/theme_extensions.dart';
+import '../../../shared/utils/platform_page_route.dart';
 import '../../../shared/utils/platform_scroll_physics.dart';
 import '../../../shared/utils/ui_utils.dart';
 import '../../../shared/utils/utf16_sanitizer.dart';
@@ -29,6 +30,9 @@ import '../../tools/providers/tools_providers.dart';
 import '../models/terminal_models.dart';
 import '../providers/terminal_providers.dart';
 import '../services/terminal_service.dart';
+import 'terminal_connection_badge.dart';
+import 'terminal_console_surface.dart';
+import 'terminal_fullscreen_page.dart';
 
 class TerminalTab extends ConsumerStatefulWidget {
   const TerminalTab({super.key, this.isActive = true});
@@ -59,6 +63,8 @@ class _TerminalTabState extends ConsumerState<TerminalTab>
   bool _loadingFiles = false;
   bool _loadingPorts = false;
   bool _terminalSupported = true;
+  bool _fullscreen = false;
+  bool _portsCollapsed = true;
   String? _syncKey;
   int _syncGeneration = 0;
   int _connectionGeneration = 0;
@@ -549,6 +555,30 @@ class _TerminalTabState extends ConsumerState<TerminalTab>
     channel.sink.add(jsonEncode(const <String, dynamic>{'type': 'ping'}));
   }
 
+  Future<void> _openFullscreen() async {
+    if (_fullscreen) {
+      return;
+    }
+    // Swap the inline TerminalView for a placeholder while full screen is open
+    // so only one TerminalView is ever mounted against the shared session.
+    setState(() => _fullscreen = true);
+    try {
+      await Navigator.of(context, rootNavigator: true).push(
+        buildPlatformPageRoute<void>(
+          fullscreenDialog: true,
+          builder: (_) => TerminalFullscreenPage(
+            terminal: _terminal,
+            controller: _terminalController,
+          ),
+        ),
+      );
+    } finally {
+      if (mounted) {
+        setState(() => _fullscreen = false);
+      }
+    }
+  }
+
   Future<void> _loadDirectory(
     TerminalService service,
     TerminalServerInfo server, {
@@ -963,35 +993,6 @@ class _TerminalTabState extends ConsumerState<TerminalTab>
     )?.showSnackBar(SnackBar(content: Text(sanitizeUtf16(message))));
   }
 
-  TerminalTheme _terminalTheme(BuildContext context) {
-    final theme = context.conduitTheme;
-    return TerminalTheme(
-      cursor: theme.codeText,
-      selection: theme.buttonPrimary.withValues(alpha: 0.25),
-      foreground: theme.codeText,
-      background: theme.codeBackground,
-      black: const Color(0xFF000000),
-      white: const Color(0xFFE5E5E5),
-      red: const Color(0xFFCD3131),
-      green: const Color(0xFF0DBC79),
-      yellow: const Color(0xFFE5E510),
-      blue: const Color(0xFF2472C8),
-      magenta: const Color(0xFFBC3FBC),
-      cyan: const Color(0xFF11A8CD),
-      brightBlack: const Color(0xFF666666),
-      brightRed: const Color(0xFFF14C4C),
-      brightGreen: const Color(0xFF23D18B),
-      brightYellow: const Color(0xFFF5F543),
-      brightBlue: const Color(0xFF3B8EEA),
-      brightMagenta: const Color(0xFFD670D6),
-      brightCyan: const Color(0xFF29B8DB),
-      brightWhite: const Color(0xFFFFFFFF),
-      searchHitBackground: theme.buttonPrimary.withValues(alpha: 0.35),
-      searchHitBackgroundCurrent: theme.buttonPrimary.withValues(alpha: 0.55),
-      searchHitForeground: theme.textPrimary,
-    );
-  }
-
   @override
   Widget build(BuildContext context) {
     super.build(context);
@@ -1082,8 +1083,53 @@ class _TerminalTabState extends ConsumerState<TerminalTab>
             ),
           ),
           const SizedBox(height: Spacing.md),
-          _buildPortsSection(l10n: l10n, theme: theme, ports: ports),
+          _buildPortsToggleHeader(l10n: l10n, theme: theme, ports: ports),
+          if (!_portsCollapsed) ...[
+            const SizedBox(height: Spacing.xs),
+            _buildPortsSection(l10n: l10n, ports: ports),
+          ],
         ],
+      ),
+    );
+  }
+
+  Widget _buildPortsToggleHeader({
+    required AppLocalizations l10n,
+    required ConduitThemeExtension theme,
+    required List<TerminalListeningPort> ports,
+  }) {
+    final labelStyle = AppTypography.labelStyle.copyWith(
+      color: theme.textSecondary,
+      fontWeight: FontWeight.w700,
+    );
+    return Semantics(
+      button: true,
+      child: GestureDetector(
+        behavior: HitTestBehavior.opaque,
+        onTap: () => setState(() => _portsCollapsed = !_portsCollapsed),
+        child: Padding(
+          padding: const EdgeInsets.symmetric(vertical: Spacing.xxs),
+          child: Row(
+            children: [
+              Icon(
+                _portsCollapsed
+                    ? Icons.chevron_right_rounded
+                    : Icons.expand_more_rounded,
+                size: IconSize.medium,
+                color: theme.iconSecondary,
+              ),
+              const SizedBox(width: Spacing.xs),
+              Text(l10n.terminalPortsToggle, style: labelStyle),
+              if (ports.isNotEmpty) ...[
+                const SizedBox(width: Spacing.xs),
+                Text(
+                  '(${ports.length})',
+                  style: labelStyle.copyWith(fontWeight: FontWeight.w500),
+                ),
+              ],
+            ],
+          ),
+        ),
       ),
     );
   }
@@ -1160,14 +1206,8 @@ class _TerminalTabState extends ConsumerState<TerminalTab>
 
   Widget _buildPortsSection({
     required AppLocalizations l10n,
-    required ConduitThemeExtension theme,
     required List<TerminalListeningPort> ports,
   }) {
-    final labelStyle = AppTypography.labelStyle.copyWith(
-      color: theme.textSecondary,
-      fontWeight: FontWeight.w700,
-    );
-
     return ConstrainedBox(
       constraints: const BoxConstraints(maxHeight: 180),
       child: CustomScrollView(
@@ -1175,10 +1215,6 @@ class _TerminalTabState extends ConsumerState<TerminalTab>
         shrinkWrap: true,
         physics: platformAlwaysScrollablePhysics(context),
         slivers: [
-          SliverToBoxAdapter(
-            child: Text(l10n.terminalPortsSectionLabel, style: labelStyle),
-          ),
-          const SliverToBoxAdapter(child: SizedBox(height: Spacing.xs)),
           if (_loadingPorts)
             const SliverToBoxAdapter(
               child: Padding(
@@ -1239,26 +1275,7 @@ class _TerminalTabState extends ConsumerState<TerminalTab>
                     ),
                   ),
                 ),
-                _ConnectionBadge(
-                  label: switch (connectionState.status) {
-                    TerminalConnectionStatus.connected =>
-                      l10n.terminalConnectedStatus,
-                    TerminalConnectionStatus.connecting =>
-                      l10n.terminalConnectingStatus,
-                    TerminalConnectionStatus.error => l10n.errorMessage,
-                    TerminalConnectionStatus.disconnected =>
-                      l10n.terminalDisconnectedStatus,
-                  },
-                  color: switch (connectionState.status) {
-                    TerminalConnectionStatus.connected => const Color(
-                      0xFF16A34A,
-                    ),
-                    TerminalConnectionStatus.connecting => theme.buttonPrimary,
-                    TerminalConnectionStatus.error => theme.error,
-                    TerminalConnectionStatus.disconnected =>
-                      theme.textSecondary,
-                  },
-                ),
+                TerminalConnectionBadge(state: connectionState),
                 if (selectedServer != null) ...[
                   const SizedBox(width: Spacing.xs),
                   if (connectionState.isConnected ||
@@ -1289,48 +1306,81 @@ class _TerminalTabState extends ConsumerState<TerminalTab>
                               ),
                             ),
                     ),
+                  const SizedBox(width: Spacing.xs),
+                  _buildAdaptiveIconActionButton(
+                    tooltip: l10n.terminalExpandAction,
+                    iosIcon: CupertinoIcons.fullscreen,
+                    materialIcon: Icons.fullscreen_rounded,
+                    compact: true,
+                    onPressed: _terminalSupported
+                        ? () => unawaited(_openFullscreen())
+                        : null,
+                  ),
                 ],
               ],
             ),
           ),
           Expanded(
-            child: ClipRRect(
-              borderRadius: const BorderRadius.vertical(
-                bottom: Radius.circular(AppBorderRadius.standard),
-              ),
-              child: Stack(
-                children: [
-                  Positioned.fill(
-                    child: DecoratedBox(
-                      decoration: BoxDecoration(color: theme.codeBackground),
-                      child: MediaQuery.removePadding(
-                        context: context,
-                        removeTop: true,
-                        child: TerminalView(
-                          _terminal,
-                          controller: _terminalController,
-                          autofocus: true,
-                          theme: _terminalTheme(context),
-                          textStyle: TerminalStyle.fromTextStyle(
-                            AppTypography.codeStyle.copyWith(fontSize: 12),
-                          ),
-                          backgroundOpacity: 1,
-                          deleteDetection: true,
-                        ),
+            child: _fullscreen
+                ? _buildFullscreenPlaceholder(l10n)
+                : TerminalConsoleSurface(
+                    terminal: _terminal,
+                    controller: _terminalController,
+                    connected: connectionState.isConnected,
+                    overlayMessage: noServersConfigured
+                        ? l10n.terminalNoServersConfigured
+                        : selectedServer == null
+                        ? l10n.terminalSelectServer
+                        : !_terminalSupported
+                        ? l10n.terminalFeatureDisabled
+                        : null,
+                  ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildFullscreenPlaceholder(AppLocalizations l10n) {
+    final theme = context.conduitTheme;
+    return ClipRRect(
+      borderRadius: const BorderRadius.vertical(
+        bottom: Radius.circular(AppBorderRadius.standard),
+      ),
+      child: SizedBox.expand(
+        child: GestureDetector(
+          behavior: HitTestBehavior.opaque,
+          onTap: () => unawaited(_openFullscreen()),
+          child: ColoredBox(
+            color: theme.codeBackground,
+            child: Center(
+              child: Padding(
+                padding: const EdgeInsets.all(Spacing.lg),
+                child: Column(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    Icon(
+                      UiUtils.platformIcon(
+                        ios: CupertinoIcons.fullscreen,
+                        android: Icons.fullscreen_rounded,
+                      ),
+                      color: theme.codeText,
+                      size: IconSize.medium,
+                    ),
+                    const SizedBox(height: Spacing.sm),
+                    Text(
+                      l10n.terminalReopenFullscreen,
+                      textAlign: TextAlign.center,
+                      style: AppTypography.bodyMediumStyle.copyWith(
+                        color: theme.codeText,
                       ),
                     ),
-                  ),
-                  if (noServersConfigured)
-                    _OverlayMessage(message: l10n.terminalNoServersConfigured)
-                  else if (selectedServer == null)
-                    _OverlayMessage(message: l10n.terminalSelectServer)
-                  else if (!_terminalSupported)
-                    _OverlayMessage(message: l10n.terminalFeatureDisabled),
-                ],
+                  ],
+                ),
               ),
             ),
           ),
-        ],
+        ),
       ),
     );
   }
@@ -1474,59 +1524,62 @@ class _TerminalTabState extends ConsumerState<TerminalTab>
 
     return ConduitCard(
       padding: EdgeInsets.zero,
-      child: AdaptiveListTile(
-        hideBottomDivider: true,
-        backgroundColor: Colors.transparent,
-        padding: const EdgeInsets.symmetric(
-          horizontal: Spacing.md,
-          vertical: Spacing.sm,
-        ),
-        onTap: () => _openEntry(entry),
-        leading: Icon(
-          entry.isDirectory
-              ? UiUtils.folderIcon
-              : UiUtils.platformIcon(
-                  ios: CupertinoIcons.doc,
-                  android: Icons.insert_drive_file_outlined,
+      child: Material(
+        type: MaterialType.transparency,
+        child: AdaptiveListTile(
+          hideBottomDivider: true,
+          backgroundColor: Colors.transparent,
+          padding: const EdgeInsets.symmetric(
+            horizontal: Spacing.md,
+            vertical: Spacing.sm,
+          ),
+          onTap: () => _openEntry(entry),
+          leading: Icon(
+            entry.isDirectory
+                ? UiUtils.folderIcon
+                : UiUtils.platformIcon(
+                    ios: CupertinoIcons.doc,
+                    android: Icons.insert_drive_file_outlined,
+                  ),
+          ),
+          title: Text(
+            sanitizeUtf16(entry.displayName),
+            maxLines: 1,
+            overflow: TextOverflow.ellipsis,
+          ),
+          subtitle: subtitle.isEmpty
+              ? null
+              : Text(
+                  sanitizeUtf16(subtitle),
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
                 ),
-        ),
-        title: Text(
-          sanitizeUtf16(entry.displayName),
-          maxLines: 1,
-          overflow: TextOverflow.ellipsis,
-        ),
-        subtitle: subtitle.isEmpty
-            ? null
-            : Text(
-                sanitizeUtf16(subtitle),
-                maxLines: 1,
-                overflow: TextOverflow.ellipsis,
+          trailing: AdaptiveTooltip(
+            message: l10n.more,
+            child: AdaptivePopupMenuButton.icon<String>(
+              icon: conduitAdaptivePopupMenuIcon(
+                iosSymbol: 'ellipsis',
+                materialIcon: Icons.more_horiz_rounded,
               ),
-        trailing: AdaptiveTooltip(
-          message: l10n.more,
-          child: AdaptivePopupMenuButton.icon<String>(
-            icon: conduitAdaptivePopupMenuIcon(
-              iosSymbol: 'ellipsis',
-              materialIcon: Icons.more_horiz_rounded,
+              items: _buildEntryMenuItems(l10n: l10n, entry: entry),
+              onSelected: (_, selected) async {
+                switch (selected.value) {
+                  case 'download':
+                    await _downloadEntry(entry);
+                    break;
+                  case 'rename':
+                    await _renameEntry(entry);
+                    break;
+                  case 'delete':
+                    await _deleteEntry(entry);
+                    break;
+                  case null:
+                    return;
+                }
+              },
+              buttonStyle: PopupButtonStyle.glass,
+              size: TouchTarget.medium,
             ),
-            items: _buildEntryMenuItems(l10n: l10n, entry: entry),
-            onSelected: (_, selected) async {
-              switch (selected.value) {
-                case 'download':
-                  await _downloadEntry(entry);
-                  break;
-                case 'rename':
-                  await _renameEntry(entry);
-                  break;
-                case 'delete':
-                  await _deleteEntry(entry);
-                  break;
-                case null:
-                  return;
-              }
-            },
-            buttonStyle: PopupButtonStyle.glass,
-            size: TouchTarget.medium,
           ),
         ),
       ),
@@ -1544,29 +1597,32 @@ class _TerminalTabState extends ConsumerState<TerminalTab>
     ];
     return ConduitCard(
       padding: EdgeInsets.zero,
-      child: AdaptiveListTile(
-        hideBottomDivider: true,
-        backgroundColor: Colors.transparent,
-        padding: const EdgeInsets.symmetric(
-          horizontal: Spacing.md,
-          vertical: Spacing.sm,
-        ),
-        onTap: () => _openPortInBrowser(port),
-        leading: Icon(
-          UiUtils.platformIcon(
-            ios: CupertinoIcons.globe,
-            android: Icons.lan_outlined,
+      child: Material(
+        type: MaterialType.transparency,
+        child: AdaptiveListTile(
+          hideBottomDivider: true,
+          backgroundColor: Colors.transparent,
+          padding: const EdgeInsets.symmetric(
+            horizontal: Spacing.md,
+            vertical: Spacing.sm,
           ),
-        ),
-        title: Text('localhost:${port.port}'),
-        subtitle: subtitleParts.isEmpty
-            ? null
-            : Text(sanitizeUtf16(subtitleParts.join(' • '))),
-        trailing: _buildAdaptiveIconActionButton(
-          tooltip: l10n.terminalOpenInBrowserAction,
-          iosIcon: CupertinoIcons.arrow_up_right,
-          materialIcon: Icons.open_in_new_rounded,
-          onPressed: () => _openPortInBrowser(port),
+          onTap: () => _openPortInBrowser(port),
+          leading: Icon(
+            UiUtils.platformIcon(
+              ios: CupertinoIcons.globe,
+              android: Icons.lan_outlined,
+            ),
+          ),
+          title: Text('localhost:${port.port}'),
+          subtitle: subtitleParts.isEmpty
+              ? null
+              : Text(sanitizeUtf16(subtitleParts.join(' • '))),
+          trailing: _buildAdaptiveIconActionButton(
+            tooltip: l10n.terminalOpenInBrowserAction,
+            iosIcon: CupertinoIcons.arrow_up_right,
+            materialIcon: Icons.open_in_new_rounded,
+            onPressed: () => _openPortInBrowser(port),
+          ),
         ),
       ),
     );
@@ -1659,62 +1715,3 @@ class _TerminalTabState extends ConsumerState<TerminalTab>
   }
 }
 
-class _OverlayMessage extends StatelessWidget {
-  const _OverlayMessage({required this.message});
-
-  final String message;
-
-  @override
-  Widget build(BuildContext context) {
-    final theme = context.conduitTheme;
-    return Positioned.fill(
-      child: DecoratedBox(
-        decoration: BoxDecoration(
-          color: theme.codeBackground.withValues(alpha: 0.88),
-        ),
-        child: Center(
-          child: Padding(
-            padding: const EdgeInsets.all(Spacing.lg),
-            child: Text(
-              sanitizeUtf16(message),
-              textAlign: TextAlign.center,
-              style: AppTypography.bodyMediumStyle.copyWith(
-                color: theme.codeText,
-              ),
-            ),
-          ),
-        ),
-      ),
-    );
-  }
-}
-
-class _ConnectionBadge extends StatelessWidget {
-  const _ConnectionBadge({required this.label, required this.color});
-
-  final String label;
-  final Color color;
-
-  @override
-  Widget build(BuildContext context) {
-    return DecoratedBox(
-      decoration: BoxDecoration(
-        color: color.withValues(alpha: 0.14),
-        borderRadius: BorderRadius.circular(AppBorderRadius.pill),
-      ),
-      child: Padding(
-        padding: const EdgeInsets.symmetric(
-          horizontal: Spacing.sm,
-          vertical: 6,
-        ),
-        child: Text(
-          label,
-          style: AppTypography.labelSmallStyle.copyWith(
-            color: color,
-            fontWeight: FontWeight.w700,
-          ),
-        ),
-      ),
-    );
-  }
-}

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -2221,6 +2221,58 @@
   "@terminalFolderCreateFailed": {
     "description": "Error message shown when creating a new terminal folder fails."
   },
+  "terminalExpandAction": "Full screen",
+  "@terminalExpandAction": {
+    "description": "Tooltip for the button that opens the terminal in a full-screen page."
+  },
+  "terminalReopenFullscreen": "Opened in full screen — tap to reopen",
+  "@terminalReopenFullscreen": {
+    "description": "Placeholder shown in the inline terminal pane while the full-screen terminal page is open."
+  },
+  "terminalKeyTab": "Tab",
+  "@terminalKeyTab": {
+    "description": "Label for the toolbar button that sends a Tab key to trigger shell completion."
+  },
+  "terminalKeyUp": "Up",
+  "@terminalKeyUp": {
+    "description": "Label for the toolbar button that sends the Up arrow key to navigate command history."
+  },
+  "terminalKeyDown": "Down",
+  "@terminalKeyDown": {
+    "description": "Label for the toolbar button that sends the Down arrow key to navigate command history."
+  },
+  "terminalKeyEscape": "Esc",
+  "@terminalKeyEscape": {
+    "description": "Label for the toolbar button that sends the Escape key."
+  },
+  "terminalKeyCtrlC": "Ctrl-C",
+  "@terminalKeyCtrlC": {
+    "description": "Label for the toolbar button that sends Ctrl-C to interrupt the running process."
+  },
+  "terminalCopyAction": "Copy",
+  "@terminalCopyAction": {
+    "description": "Tooltip for the button that copies the current terminal selection to the clipboard."
+  },
+  "terminalPasteAction": "Paste",
+  "@terminalPasteAction": {
+    "description": "Tooltip for the button that pastes clipboard contents into the terminal."
+  },
+  "terminalNothingToCopy": "Nothing selected to copy",
+  "@terminalNothingToCopy": {
+    "description": "Message shown when the user taps Copy but no terminal text is selected."
+  },
+  "terminalCopied": "Copied to clipboard",
+  "@terminalCopied": {
+    "description": "Confirmation shown after copying the terminal selection to the clipboard."
+  },
+  "terminalPasteWhileDisconnected": "Connect to paste",
+  "@terminalPasteWhileDisconnected": {
+    "description": "Message shown when the user tries to paste while the terminal is disconnected."
+  },
+  "terminalPortsToggle": "Listening ports",
+  "@terminalPortsToggle": {
+    "description": "Label for the collapsible header that shows or hides the listening ports list."
+  },
   "closeSidebar": "Close sidebar",
   "@closeSidebar": {
     "description": "Tooltip for the sidebar close button"

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -2241,10 +2241,6 @@
   "@terminalKeyDown": {
     "description": "Label for the toolbar button that sends the Down arrow key to navigate command history."
   },
-  "terminalKeyEscape": "Esc",
-  "@terminalKeyEscape": {
-    "description": "Label for the toolbar button that sends the Escape key."
-  },
   "terminalKeyCtrlC": "Ctrl-C",
   "@terminalKeyCtrlC": {
     "description": "Label for the toolbar button that sends Ctrl-C to interrupt the running process."

--- a/test/features/terminal/widgets/terminal_clipboard_actions_test.dart
+++ b/test/features/terminal/widgets/terminal_clipboard_actions_test.dart
@@ -1,0 +1,121 @@
+import 'package:conduit/features/terminal/widgets/terminal_clipboard_actions.dart';
+import 'package:conduit/l10n/app_localizations.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:xterm/xterm.dart';
+
+void main() {
+  group('terminal clipboard actions', () {
+    late List<MethodCall> platformCalls;
+    String? clipboardText;
+
+    setUp(() {
+      platformCalls = <MethodCall>[];
+      clipboardText = null;
+      TestWidgetsFlutterBinding.ensureInitialized();
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(SystemChannels.platform, (call) async {
+            platformCalls.add(call);
+            if (call.method == 'Clipboard.getData') {
+              return <String, dynamic>{'text': clipboardText};
+            }
+            return null;
+          });
+    });
+
+    tearDown(() {
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(SystemChannels.platform, null);
+    });
+
+    testWidgets('copy with no selection surfaces a snackbar and writes nothing', (
+      tester,
+    ) async {
+      final terminal = Terminal();
+      final controller = TerminalController();
+      final context = await _pumpContext(tester);
+
+      await copyTerminalSelection(context, terminal, controller);
+      await tester.pump();
+
+      expect(find.text('Nothing selected to copy'), findsOneWidget);
+      expect(
+        platformCalls.where((c) => c.method == 'Clipboard.setData'),
+        isEmpty,
+      );
+    });
+
+    testWidgets('copy with a selection writes to the clipboard and clears it', (
+      tester,
+    ) async {
+      final terminal = Terminal()..resize(80, 24);
+      terminal.write('hello world');
+      final controller = TerminalController();
+      controller.setSelection(
+        terminal.buffer.createAnchor(0, 0),
+        terminal.buffer.createAnchor(5, 0),
+      );
+      final expected = terminal.buffer.getText(controller.selection!);
+
+      final context = await _pumpContext(tester);
+      await copyTerminalSelection(context, terminal, controller);
+      await tester.pump();
+
+      final setData = platformCalls.firstWhere(
+        (c) => c.method == 'Clipboard.setData',
+      );
+      expect((setData.arguments as Map)['text'], expected);
+      expect(controller.selection, isNull);
+      expect(find.text('Copied to clipboard'), findsOneWidget);
+    });
+
+    testWidgets('paste while disconnected surfaces a snackbar and does not paste', (
+      tester,
+    ) async {
+      final outputs = <String>[];
+      final terminal = Terminal(onOutput: outputs.add);
+      clipboardText = 'echo hi';
+      final context = await _pumpContext(tester);
+
+      await pasteIntoTerminal(context, terminal, connected: false);
+      await tester.pump();
+
+      expect(find.text('Connect to paste'), findsOneWidget);
+      expect(outputs, isEmpty);
+    });
+
+    testWidgets('paste while connected sends clipboard text to the terminal', (
+      tester,
+    ) async {
+      final outputs = <String>[];
+      final terminal = Terminal(onOutput: outputs.add);
+      clipboardText = 'echo hi';
+      final context = await _pumpContext(tester);
+
+      await pasteIntoTerminal(context, terminal, connected: true);
+      await tester.pump();
+
+      expect(outputs.join(), contains('echo hi'));
+    });
+  });
+}
+
+Future<BuildContext> _pumpContext(WidgetTester tester) async {
+  late BuildContext captured;
+  await tester.pumpWidget(
+    MaterialApp(
+      localizationsDelegates: AppLocalizations.localizationsDelegates,
+      supportedLocales: AppLocalizations.supportedLocales,
+      home: Scaffold(
+        body: Builder(
+          builder: (context) {
+            captured = context;
+            return const SizedBox.shrink();
+          },
+        ),
+      ),
+    ),
+  );
+  return captured;
+}

--- a/test/features/terminal/widgets/terminal_key_toolbar_test.dart
+++ b/test/features/terminal/widgets/terminal_key_toolbar_test.dart
@@ -1,0 +1,93 @@
+import 'package:conduit/features/terminal/widgets/terminal_key_toolbar.dart';
+import 'package:conduit/l10n/app_localizations.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:xterm/xterm.dart';
+
+void main() {
+  group('TerminalKeyToolbar', () {
+    setUp(() {
+      TestWidgetsFlutterBinding.ensureInitialized();
+      // Keep paste's clipboard read deterministic for the "enabled" checks.
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(SystemChannels.platform, (call) async {
+            if (call.method == 'Clipboard.getData') {
+              return <String, dynamic>{'text': ''};
+            }
+            return null;
+          });
+    });
+
+    tearDown(() {
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(SystemChannels.platform, null);
+    });
+
+    testWidgets('key taps route control codes to the terminal when connected', (
+      tester,
+    ) async {
+      final outputs = <String>[];
+      final terminal = Terminal(onOutput: outputs.add);
+      await _pumpToolbar(tester, terminal: terminal, connected: true);
+
+      const tab = '\t';
+      final etx = String.fromCharCode(3); // Ctrl-C
+
+      await tester.tap(find.text('Tab'));
+      await tester.pump();
+      expect(outputs, contains(tab));
+
+      outputs.clear();
+      await tester.tap(find.byIcon(Icons.block_rounded));
+      await tester.pump();
+      expect(outputs, contains(etx));
+    });
+
+    testWidgets('key taps are inert while disconnected', (tester) async {
+      final outputs = <String>[];
+      final terminal = Terminal(onOutput: outputs.add);
+      await _pumpToolbar(tester, terminal: terminal, connected: false);
+
+      await tester.tap(find.text('Tab'));
+      await tester.tap(find.byIcon(Icons.keyboard_arrow_up_rounded));
+      await tester.tap(find.byIcon(Icons.block_rounded));
+      await tester.pump();
+
+      expect(outputs, isEmpty);
+    });
+
+    testWidgets('copy stays enabled while disconnected', (tester) async {
+      final terminal = Terminal();
+      await _pumpToolbar(tester, terminal: terminal, connected: false);
+
+      // Copy is not gated on the connection; with no selection it surfaces the
+      // "nothing to copy" snackbar, proving the button is still interactive.
+      await tester.tap(find.byIcon(Icons.copy_rounded));
+      await tester.pump();
+
+      expect(find.text('Nothing selected to copy'), findsOneWidget);
+    });
+  });
+}
+
+Future<void> _pumpToolbar(
+  WidgetTester tester, {
+  required Terminal terminal,
+  required bool connected,
+}) async {
+  final controller = TerminalController();
+  await tester.pumpWidget(
+    MaterialApp(
+      localizationsDelegates: AppLocalizations.localizationsDelegates,
+      supportedLocales: AppLocalizations.supportedLocales,
+      home: Scaffold(
+        body: TerminalKeyToolbar(
+          terminal: terminal,
+          controller: controller,
+          connected: connected,
+        ),
+      ),
+    ),
+  );
+}

--- a/test/features/terminal/widgets/terminal_tab_test.dart
+++ b/test/features/terminal/widgets/terminal_tab_test.dart
@@ -303,8 +303,14 @@ void main() {
       await tester.pumpAndSettle();
 
       expect(find.text('Listening ports'), findsOneWidget);
-      expect(find.text('localhost:3000'), findsOneWidget);
       expect(find.text('alpha.txt'), findsNothing);
+
+      // Ports are collapsed by default to give the terminal more room; expand
+      // the section to reveal the listening ports list.
+      expect(find.text('localhost:3000'), findsNothing);
+      await tester.tap(find.text('Listening ports'));
+      await tester.pumpAndSettle();
+      expect(find.text('localhost:3000'), findsOneWidget);
     });
 
     testWidgets('ignores stale file loads after switching terminal servers', (


### PR DESCRIPTION
## Summary

Makes the in-app terminal far more usable on touch devices. Adds a full-screen presentation, a touch-friendly accessory key toolbar (history, Tab, Ctrl-C), copy/paste support, a shared connection-status badge, and a collapsible "listening ports" section. Also extracts the console rendering into a reusable surface shared by the inline pane and the full-screen page, and fixes a Material assertion in the file/port list tiles.

https://github.com/user-attachments/assets/85eb6a1f-1cc6-431b-9448-a0fd76fa48a2


## Features

- **Full-screen terminal** (`terminal_fullscreen_page.dart`) — opens via a full-screen dialog; the inline pane shows a tap-to-reopen placeholder so only one `TerminalView` is ever mounted against the shared session at a time.
- **Touch key toolbar** (`terminal_key_toolbar.dart`) — full-width accessory row: **Up · Down · Tab · Copy · Paste · Ctrl-C** (icon). Buttons scale evenly; key actions are gated on the connection state, copy/paste remain available.
- **Copy / paste** (`terminal_clipboard_actions.dart`) — copy the xterm selection to the system clipboard (UTF-16 sanitized) with a "nothing selected" affordance; bracketed-paste-aware paste with a "connect to paste" guard while disconnected.
- **Connection-status badge** (`terminal_connection_badge.dart`) — shared pill badge (connected / connecting / error / disconnected) used by both the inline header and the full-screen page.
- **Shared console surface** (`terminal_console_surface.dart`) — extracts the `TerminalView` + toolbar + overlay stack into one reusable widget; adds small interior padding so command text isn't flush against the edges.
- **Collapsible listening-ports section** in `terminal_tab.dart`, collapsed by default to give the terminal more room.

## Fixes

- **`ListTile` Material assertion** — the file/port tiles rendered an `AdaptiveListTile` (Material `ListTile`) directly inside `ConduitCard`'s colored `DecoratedBox`, tripping Flutter's "background/ink may be invisible" assertion on the Material platform. Each tile is now wrapped in a transparent `Material` so it has a proper Material ancestor (no visual change).

## Tests

- `terminal_clipboard_actions_test.dart` — copy with/without a selection, paste while connected/disconnected (mocks the `Clipboard` platform channel).
- `terminal_key_toolbar_test.dart` — key taps route correct control codes (`Tab` to tab, `Ctrl-C` to ETX) when connected, are inert when disconnected, and copy stays interactive while disconnected.
- Updated `terminal_tab_test.dart` for the now-collapsed ports section.

## Localization

New `app_en.arb` keys: `terminalExpandAction`, `terminalReopenFullscreen`, `terminalPortsToggle`, `terminalKeyTab/Up/Down/Escape/CtrlC`, `terminalCopyAction`, `terminalPasteAction`, `terminalNothingToCopy`, `terminalCopied`, `terminalPasteWhileDisconnected`.

## Test plan

- [ ] `flutter test test/features/terminal/` passes (21 tests green locally)
- [ ] Inline terminal: open full-screen, confirm placeholder + reopen
- [ ] Toolbar keys send correct sequences; Ctrl-C interrupts a running command
- [ ] Copy a selection / paste into the shell; verify disconnected guards
- [ ] Expand/collapse listening ports; tap a port to open in browser

🤖 Generated with [Claude Code](https://claude.com/claude-code)
