### PR TITLE
check-xcode

### DIFF
--- a/.github/workflows/check-xcode.yml
+++ b/.github/workflows/check-xcode.yml
@@ -1,0 +1,26 @@
+name: Check Xcode Versions
+
+on:
+  workflow_dispatch:
+
+jobs:
+  check-xcode:
+    runs-on: macos-latest
+
+    steps:
+      - name: Show current Xcode
+        run: |
+          echo "Current Xcode:"
+          xcodebuild -version
+          echo ""
+          echo "Developer directory:"
+          xcode-select -p
+
+      - name: List installed Xcodes
+        run: |
+          echo "Installed Xcodes:"
+          ls -1 /Applications | grep Xcode || true
+
+      - name: Show available SDKs
+        run: |
+          xcodebuild -showsdks


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Added GitHub Actions workflow for checking and reporting installed Xcode versions, developer directory path, and available SDKs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

- Adds a manually triggered GitHub Actions workflow for checking Xcode details on macOS runners.
- Prints the selected Xcode version and developer directory.
- Lists installed Xcode applications and available SDKs.

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The workflow is low-risk but can mislead release-environment debugging until it mirrors the release job's Xcode selection.

The change is small and isolated to a manual GitHub Actions workflow, and the mismatch with the release workflow was confirmed against the repository workflow files.

.github/workflows/check-xcode.yml
</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- I ran the generated workflow parity validation script against the repository's check-xcode and release workflow YAML files.
- The validation script reported a parity mismatch, showing that check-xcode's first steps run xcodebuild and xcode-select without a preceding maxim-lobanov/setup-xcode latest-stable step, while the release build uses maxim-lobanov/setup-xcode@v1 with latest-stable before the iOS build.
- I inspected the repro artifacts produced by the parity validation script to verify the mismatch details.
- Before the change, the base commit log showed a fatal: path ... not in ... error for .github/workflows/check-xcode.yml and the absence validation passed.
- After the change, the head workflow YAML and all targeted contract checks passed, including manual\_dispatch, macOS runner, installed-Xcodes diagnostic, and SDK diagnostic.

<a href="https://app.greptile.com/trex/runs/11398999/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=1"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=1" height="32"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["check-xcode"](https://github.com/cogwheel0/conduit/commit/633f207c03adb2114f5749f9be8b5353c78ef470) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38147246)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->