### PR TITLE
refactor(persistence): move caches + attachment queue from Hive to Drift (PR-2)

### DIFF
--- a/lib/core/database/app_database.dart
+++ b/lib/core/database/app_database.dart
@@ -2,6 +2,8 @@ import 'package:drift/drift.dart';
 import 'package:drift_flutter/drift_flutter.dart';
 import 'package:path_provider/path_provider.dart';
 
+import 'daos/app_cache_dao.dart';
+import 'daos/attachment_queue_dao.dart';
 import 'daos/chats_dao.dart';
 import 'daos/folders_dao.dart';
 import 'daos/messages_dao.dart';
@@ -10,6 +12,8 @@ import 'daos/outbox_dao.dart';
 import 'daos/search_dao.dart';
 import 'daos/sync_meta_dao.dart';
 import 'fts/fts_ddl.dart';
+import 'tables/app_cache.dart';
+import 'tables/attachment_queue.dart';
 import 'tables/chats.dart';
 import 'tables/folders.dart';
 import 'tables/messages.dart';
@@ -21,13 +25,23 @@ part 'app_database.g.dart';
 
 /// Conduit's per-server local database (CDT-RFC-001).
 ///
-/// Current schema version 5 includes sync metadata, chats, messages, folders,
-/// outbox operations, notes, and the shared chat/note FTS substrate.
+/// Current schema version 6 includes sync metadata, chats, messages, folders,
+/// outbox operations, notes, the shared chat/note FTS substrate, and (v6) the
+/// per-server app cache + attachment upload queue.
 ///
 /// One database file exists per [ServerConfig]; lifecycle (open/close/delete
 /// on server switch or removal) is owned by [DatabaseManager].
 @DriftDatabase(
-  tables: [SyncMeta, Chats, Messages, Folders, OutboxOps, Notes],
+  tables: [
+    SyncMeta,
+    Chats,
+    Messages,
+    Folders,
+    OutboxOps,
+    Notes,
+    AppCache,
+    AttachmentQueue,
+  ],
   daos: [
     ChatsDao,
     MessagesDao,
@@ -36,6 +50,8 @@ part 'app_database.g.dart';
     OutboxDao,
     SearchDao,
     NotesDao,
+    AppCacheDao,
+    AttachmentQueueDao,
   ],
 )
 class AppDatabase extends _$AppDatabase {
@@ -57,7 +73,7 @@ class AppDatabase extends _$AppDatabase {
   }
 
   @override
-  int get schemaVersion => 5;
+  int get schemaVersion => 6;
 
   @override
   MigrationStrategy get migration => MigrationStrategy(
@@ -106,6 +122,11 @@ class AppDatabase extends _$AppDatabase {
         await m.createTable(notes);
         await _createNoteIndexes();
         await _ensureNotesFts(backfill: true);
+      }
+      if (from < 6) {
+        // Hive removal PR-2: per-server app cache + attachment queue tables.
+        await m.createTable(appCache);
+        await m.createTable(attachmentQueue);
       }
     },
     beforeOpen: (details) async {

--- a/lib/core/database/daos/app_cache_dao.dart
+++ b/lib/core/database/daos/app_cache_dao.dart
@@ -1,0 +1,34 @@
+import 'package:drift/drift.dart';
+
+import '../app_database.dart';
+import '../tables/app_cache.dart';
+
+part 'app_cache_dao.g.dart';
+
+/// Accessor for the per-server [AppCache] key-value table (offline-fallback
+/// caches: local user, avatar, backend config, tools, default model, models).
+@DriftAccessor(tables: [AppCache])
+class AppCacheDao extends DatabaseAccessor<AppDatabase> with _$AppCacheDaoMixin {
+  AppCacheDao(super.db);
+
+  Future<String?> getValue(String key) async {
+    final row = await (select(
+      appCache,
+    )..where((t) => t.key.equals(key))).getSingleOrNull();
+    return row?.value;
+  }
+
+  Future<void> setValue(String key, String value, {int updatedAt = 0}) {
+    return into(appCache).insertOnConflictUpdate(
+      AppCacheCompanion.insert(key: key, value: value, updatedAt: Value(updatedAt)),
+    );
+  }
+
+  Future<void> deleteKey(String key) {
+    return (delete(appCache)..where((t) => t.key.equals(key))).go();
+  }
+
+  Future<void> deleteKeys(Iterable<String> keys) {
+    return (delete(appCache)..where((t) => t.key.isIn(keys))).go();
+  }
+}

--- a/lib/core/database/daos/attachment_queue_dao.dart
+++ b/lib/core/database/daos/attachment_queue_dao.dart
@@ -1,0 +1,32 @@
+import 'package:drift/drift.dart';
+
+import '../app_database.dart';
+import '../tables/attachment_queue.dart';
+
+part 'attachment_queue_dao.g.dart';
+
+/// Accessor for the per-server [AttachmentQueue] table.
+@DriftAccessor(tables: [AttachmentQueue])
+class AttachmentQueueDao extends DatabaseAccessor<AppDatabase>
+    with _$AttachmentQueueDaoMixin {
+  AttachmentQueueDao(super.db);
+
+  /// All queued attachments, oldest first.
+  Future<List<AttachmentQueueData>> getAll() {
+    return (select(
+      attachmentQueue,
+    )..orderBy([(t) => OrderingTerm.asc(t.enqueuedAt)])).get();
+  }
+
+  Future<void> upsert(AttachmentQueueCompanion row) {
+    return into(attachmentQueue).insertOnConflictUpdate(row);
+  }
+
+  Future<void> deleteById(String id) {
+    return (delete(attachmentQueue)..where((t) => t.id.equals(id))).go();
+  }
+
+  Future<void> clearAll() {
+    return delete(attachmentQueue).go();
+  }
+}

--- a/lib/core/database/tables/app_cache.dart
+++ b/lib/core/database/tables/app_cache.dart
@@ -1,0 +1,20 @@
+import 'package:drift/drift.dart';
+
+/// Per-server key-value cache for non-sync app data that was previously held in
+/// the Hive `caches` box (local user, avatar, backend config, tools, default
+/// model, models). The database is already per-server, so no `serverId` column
+/// is needed — the file IS the server scope.
+///
+/// Values are JSON strings (or a plain string for the avatar URL). These are
+/// offline-fallback caches: re-fetched from the network when stale, so losing
+/// a non-active server's cache on migration is acceptable.
+class AppCache extends Table {
+  TextColumn get key => text()();
+  TextColumn get value => text()();
+
+  /// Epoch milliseconds of the last write (advisory; not used for invalidation).
+  IntColumn get updatedAt => integer().withDefault(const Constant(0))();
+
+  @override
+  Set<Column> get primaryKey => {key};
+}

--- a/lib/core/database/tables/attachment_queue.dart
+++ b/lib/core/database/tables/attachment_queue.dart
@@ -1,0 +1,27 @@
+import 'package:drift/drift.dart';
+
+/// Per-server durable queue of pending attachment uploads (previously the Hive
+/// `attachment_queue` box). One row per queued attachment; the active server's
+/// database owns its queue, so uploads always target the active server.
+///
+/// Mirrors the legacy `QueuedAttachment` model. `status` is the
+/// `QueuedAttachmentStatus` name; `enqueuedAt`/`nextRetryAt` are epoch millis.
+class AttachmentQueue extends Table {
+  TextColumn get id => text()();
+  TextColumn get filePath => text()();
+  TextColumn get fileName => text()();
+  IntColumn get fileSize => integer()();
+  TextColumn get mimeType => text().nullable()();
+  TextColumn get checksum => text().nullable()();
+
+  TextColumn get status => text()();
+  IntColumn get retryCount => integer().withDefault(const Constant(0))();
+  IntColumn get nextRetryAt => integer().nullable()();
+  TextColumn get lastError => text().nullable()();
+  TextColumn get fileId => text().nullable()();
+
+  IntColumn get enqueuedAt => integer()();
+
+  @override
+  Set<Column> get primaryKey => {id};
+}

--- a/lib/core/providers/app_providers.dart
+++ b/lib/core/providers/app_providers.dart
@@ -511,10 +511,12 @@ final attachmentUploadQueueProvider = Provider<AttachmentUploadQueue?>((ref) {
   if (api == null) return null;
 
   final queue = AttachmentUploadQueue();
-  // Initialize once; subsequent calls are no-ops due to singleton
+  // Re-runs when the API (and thus active server) changes, reloading the queue
+  // from the active server's Drift table.
   queue.initialize(
     onUpload: (filePath, fileName, {cancelToken}) =>
         api.uploadFile(filePath, fileName, cancelToken: cancelToken),
+    database: () => ref.read(appDatabaseProvider),
   );
 
   return queue;

--- a/lib/core/providers/storage_providers.dart
+++ b/lib/core/providers/storage_providers.dart
@@ -1,6 +1,7 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 
+import '../database/database_provider.dart';
 import '../persistence/persistence_providers.dart';
 import '../services/optimized_storage_service.dart';
 import '../services/worker_manager.dart';
@@ -33,5 +34,8 @@ final optimizedStorageServiceProvider = Provider<OptimizedStorageService>((
     secureStorage: ref.watch(secureStorageProvider),
     boxes: ref.watch(hiveBoxesProvider),
     workerManager: ref.watch(workerManagerProvider),
+    // Lazy read (NOT watch) so structured caches resolve the active server's
+    // Drift DB at call time without creating a build-time dependency cycle.
+    database: () => ref.read(appDatabaseProvider),
   );
 });

--- a/lib/core/services/attachment_upload_queue.dart
+++ b/lib/core/services/attachment_upload_queue.dart
@@ -1,9 +1,9 @@
 import 'dart:async';
-import 'dart:convert';
 import 'dart:math';
 import 'package:dio/dio.dart';
-import 'package:hive_ce/hive.dart';
-import '../persistence/hive_boxes.dart';
+import 'package:drift/drift.dart' show Value;
+import '../database/app_database.dart';
+import '../database/daos/attachment_queue_dao.dart';
 import '../utils/debug_logger.dart';
 
 /// Status of a queued attachment upload
@@ -119,8 +119,10 @@ class AttachmentUploadQueue {
   static const Duration _baseRetryDelay = Duration(seconds: 5);
   static const Duration _maxRetryDelay = Duration(minutes: 5);
 
-  late final Box<dynamic> _queueBox;
-  bool _initialized = false;
+  /// Resolves the active server's Drift database. Re-supplied on each
+  /// [initialize] (the owning provider re-runs on server switch), so the queue
+  /// reloads and persists against the active server's `attachment_queue` table.
+  AppDatabase? Function()? _databaseResolver;
   final List<QueuedAttachment> _queue = [];
   Timer? _retryTimer;
   bool _isProcessing = false;
@@ -138,21 +140,22 @@ class AttachmentUploadQueue {
 
   Future<void> initialize({
     required UploadCallback onUpload,
+    required AppDatabase? Function() database,
     AttachmentsEventCallback? onQueueChanged,
   }) async {
     _onUpload = onUpload;
     _onQueueChanged = onQueueChanged;
-    if (!_initialized) {
-      _queueBox = Hive.box<dynamic>(HiveBoxNames.attachmentQueue);
-      _initialized = true;
-    }
+    _databaseResolver = database;
     await _load();
     _startPeriodicProcessing();
     DebugLogger.log(
-      'AttachmentUploadQueue initialized with \${_queue.length} items',
+      'AttachmentUploadQueue initialized with ${_queue.length} items',
       scope: 'attachments/queue',
     );
   }
+
+  AttachmentQueueDao? get _attachmentDao =>
+      _databaseResolver?.call()?.attachmentQueueDao;
 
   Future<String> enqueue({
     required String filePath,
@@ -376,33 +379,69 @@ class AttachmentUploadQueue {
 
   // Utilities
   Future<void> _load() async {
-    final stored = _queueBox.get(HiveStoreKeys.attachmentQueueEntries);
-    if (stored == null) {
-      return;
-    }
-
-    List<dynamic> rawList;
-    if (stored is String && stored.isNotEmpty) {
-      rawList = (jsonDecode(stored) as List<dynamic>);
-    } else if (stored is List) {
-      rawList = stored;
-    } else {
-      return;
-    }
-
-    _queue
-      ..clear()
-      ..addAll(
-        rawList.map(
-          (item) =>
-              QueuedAttachment.fromJson(Map<String, dynamic>.from(item as Map)),
-        ),
-      );
+    _queue.clear();
+    final dao = _attachmentDao;
+    if (dao == null) return;
+    final rows = await dao.getAll();
+    _queue.addAll(rows.map(_rowToModel));
   }
 
   Future<void> _save() async {
-    final list = _queue.map((e) => e.toJson()).toList(growable: false);
-    await _queueBox.put(HiveStoreKeys.attachmentQueueEntries, list);
+    final db = _databaseResolver?.call();
+    if (db == null) return;
+    // The in-memory list is the source of truth; mirror it wholesale.
+    final snapshot = List<QueuedAttachment>.from(_queue);
+    await db.transaction(() async {
+      await db.attachmentQueueDao.clearAll();
+      for (final item in snapshot) {
+        await db.attachmentQueueDao.upsert(_modelToCompanion(item));
+      }
+    });
+  }
+
+  static QueuedAttachment _rowToModel(AttachmentQueueData row) {
+    return QueuedAttachment(
+      id: row.id,
+      filePath: row.filePath,
+      fileName: row.fileName,
+      fileSize: row.fileSize,
+      mimeType: row.mimeType,
+      checksum: row.checksum,
+      enqueuedAt: DateTime.fromMillisecondsSinceEpoch(row.enqueuedAt),
+      retryCount: row.retryCount,
+      nextRetryAt: row.nextRetryAt != null
+          ? DateTime.fromMillisecondsSinceEpoch(row.nextRetryAt!)
+          : null,
+      status: QueuedAttachmentStatus.values.firstWhere(
+        (e) => e.name == row.status,
+        orElse: () => QueuedAttachmentStatus.pending,
+      ),
+      lastError: row.lastError,
+      fileId: row.fileId,
+    );
+  }
+
+  /// Maps a legacy Hive attachment-queue JSON entry to a Drift row companion.
+  /// Used by the one-time Hive → Drift migration.
+  static AttachmentQueueCompanion companionFromLegacyJson(
+    Map<String, dynamic> json,
+  ) => _modelToCompanion(QueuedAttachment.fromJson(json));
+
+  static AttachmentQueueCompanion _modelToCompanion(QueuedAttachment item) {
+    return AttachmentQueueCompanion.insert(
+      id: item.id,
+      filePath: item.filePath,
+      fileName: item.fileName,
+      fileSize: item.fileSize,
+      mimeType: Value(item.mimeType),
+      checksum: Value(item.checksum),
+      status: item.status.name,
+      retryCount: Value(item.retryCount),
+      nextRetryAt: Value(item.nextRetryAt?.millisecondsSinceEpoch),
+      lastError: Value(item.lastError),
+      fileId: Value(item.fileId),
+      enqueuedAt: item.enqueuedAt.millisecondsSinceEpoch,
+    );
   }
 
   void _notify() {

--- a/lib/core/services/media_upload_controller.dart
+++ b/lib/core/services/media_upload_controller.dart
@@ -7,6 +7,7 @@ import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 import '../../features/chat/services/file_attachment_service.dart';
 import '../../features/chat/widgets/enhanced_image_attachment.dart';
+import '../database/database_provider.dart';
 import '../models/file_info.dart';
 import '../providers/app_providers.dart';
 import '../utils/debug_logger.dart';
@@ -100,6 +101,7 @@ class MediaUploadController {
     await uploader.initialize(
       onUpload: (path, name, {cancelToken}) =>
           api.uploadFile(path, name, cancelToken: cancelToken),
+      database: () => _ref.read(appDatabaseProvider),
     );
 
     // For images: convert unsupported formats to JPEG for compatibility.

--- a/lib/core/services/optimized_storage_service.dart
+++ b/lib/core/services/optimized_storage_service.dart
@@ -10,6 +10,8 @@ import '../models/server_config.dart';
 import '../models/user.dart';
 import '../models/tool.dart';
 import '../models/socket_transport_availability.dart';
+import '../database/app_database.dart';
+import '../database/daos/app_cache_dao.dart';
 import '../persistence/hive_boxes.dart';
 import '../persistence/persistence_keys.dart';
 import '../persistence/preferences_store.dart';
@@ -26,13 +28,36 @@ class OptimizedStorageService {
     required FlutterSecureStorage secureStorage,
     required HiveBoxes boxes,
     required WorkerManager workerManager,
+    AppDatabase? Function()? database,
   }) : _cachesBox = boxes.caches,
        _attachmentQueueBox = boxes.attachmentQueue,
        _metadataBox = boxes.metadata,
+       _database = database,
        _secureCredentialStorage = SecureCredentialStorage(
          instance: secureStorage,
        ),
        _workerManager = workerManager;
+
+  /// Resolves the active server's Drift database (PR-2: structured caches live
+  /// in the per-server DB, not the Hive caches box). Null in reviewer mode / no
+  /// active server / tests without a DB — callers fall back to defaults.
+  final AppDatabase? Function()? _database;
+
+  AppCacheDao? get _appCacheDao => _database?.call()?.appCacheDao;
+
+  Future<String?> _readCacheValue(String key) async =>
+      await _appCacheDao?.getValue(key);
+
+  Future<void> _writeCacheValue(String key, String value) async {
+    await _appCacheDao?.setValue(
+      key,
+      value,
+      updatedAt: DateTime.now().millisecondsSinceEpoch,
+    );
+  }
+
+  Future<void> _deleteCacheValue(String key) async =>
+      await _appCacheDao?.deleteKey(key);
 
   final Box<dynamic> _cachesBox;
   final Box<dynamic> _attachmentQueueBox;
@@ -67,6 +92,17 @@ class OptimizedStorageService {
   static const String _localModelsKey = HiveStoreKeys.localModels;
   static const String _localFoldersKey = HiveStoreKeys.localFolders;
   static const String _reviewerModeKey = PreferenceKeys.reviewerMode;
+
+  /// The Drift app-cache keys (everything moved off the Hive `caches` box in
+  /// PR-2 except transport options, which live in shared_preferences).
+  static const List<String> _allCacheKeys = [
+    _localUserKey,
+    _localUserAvatarKey,
+    _localBackendConfigKey,
+    _localToolsKey,
+    _localDefaultModelKey,
+    _localModelsKey,
+  ];
   // Longer TTLs to reduce secure storage churn for OpenWebUI sessions.
   static const Duration _authTokenTtl = Duration(hours: 12);
   static const Duration _serverIdTtl = Duration(days: 7);
@@ -524,7 +560,7 @@ class OptimizedStorageService {
     return _readNullableSafely(
       errorMessage: 'Failed to retrieve local user',
       read: () async {
-        final stored = _cachesBox.get(_localUserKey);
+        final stored = await _readCacheValue(_localUserKey);
         if (stored == null) return null;
         return _decodeJsonObject(stored, User.fromJson);
       },
@@ -536,12 +572,11 @@ class OptimizedStorageService {
       errorMessage: 'Failed to save local user',
       write: () async {
         if (user == null) {
-          await _cachesBox.delete(_localUserKey);
-          await _cachesBox.delete(_localUserAvatarKey);
+          await _deleteCacheValue(_localUserKey);
+          await _deleteCacheValue(_localUserAvatarKey);
           return;
         }
-        final serialized = jsonEncode(user.toJson());
-        await _cachesBox.put(_localUserKey, serialized);
+        await _writeCacheValue(_localUserKey, jsonEncode(user.toJson()));
       },
     );
   }
@@ -550,8 +585,8 @@ class OptimizedStorageService {
     return _readNullableSafely(
       errorMessage: 'Failed to retrieve local user avatar',
       read: () async {
-        final stored = _cachesBox.get(_localUserAvatarKey);
-        if (stored is String && stored.isNotEmpty) {
+        final stored = await _readCacheValue(_localUserAvatarKey);
+        if (stored != null && stored.isNotEmpty) {
           return stored;
         }
         return null;
@@ -564,10 +599,10 @@ class OptimizedStorageService {
       errorMessage: 'Failed to save local user avatar',
       write: () async {
         if (avatarUrl == null || avatarUrl.isEmpty) {
-          await _cachesBox.delete(_localUserAvatarKey);
+          await _deleteCacheValue(_localUserAvatarKey);
           return;
         }
-        await _cachesBox.put(_localUserAvatarKey, avatarUrl);
+        await _writeCacheValue(_localUserAvatarKey, avatarUrl);
       },
     );
   }
@@ -575,10 +610,11 @@ class OptimizedStorageService {
   Future<BackendConfig?> getLocalBackendConfig() {
     return _readNullableSafely(
       errorMessage: 'Failed to retrieve local backend config',
-      read: () => _readServerScopedJsonObject(
-        key: _localBackendConfigKey,
-        fromJson: BackendConfig.fromJson,
-      ),
+      read: () async {
+        final stored = await _readCacheValue(_localBackendConfigKey);
+        if (stored == null) return null;
+        return _decodeJsonObject(stored, BackendConfig.fromJson);
+      },
     );
   }
 
@@ -587,13 +623,12 @@ class OptimizedStorageService {
       errorMessage: 'Failed to save local backend config',
       write: () async {
         if (config == null) {
-          await _cachesBox.delete(_localBackendConfigKey);
+          await _deleteCacheValue(_localBackendConfigKey);
           return;
         }
-        await _saveServerScopedJsonObject(
+        await _writeCacheValue(
           _localBackendConfigKey,
-          config,
-          toJson: (value) => value.toJson(),
+          jsonEncode(normalizeJsonLikeValue(config.toJson())),
         );
       },
     );
@@ -651,26 +686,55 @@ class OptimizedStorageService {
     return _readTransportOptionsForActiveServer();
   }
 
+  /// Decodes a stored JSON-list cache value off the UI isolate (lists can be
+  /// large, e.g. models). Empty when [stored] is null.
+  Future<List<Map<String, dynamic>>> _decodeCacheJsonList(
+    String? stored, {
+    required String debugLabel,
+  }) async {
+    if (stored == null || stored.isEmpty) {
+      return const <Map<String, dynamic>>[];
+    }
+    return _workerManager
+        .schedule<Map<String, dynamic>, List<Map<String, dynamic>>>(
+          _decodeStoredJsonListWorker,
+          {'stored': stored},
+          debugLabel: debugLabel,
+        );
+  }
+
+  Future<void> _writeCacheJsonList<T>(
+    String key,
+    Iterable<T> items, {
+    required Map<String, dynamic> Function(T item) toJson,
+  }) async {
+    final normalized = items
+        .map((item) => normalizeJsonLikeMap(toJson(item)))
+        .toList(growable: false);
+    await _writeCacheValue(key, jsonEncode(normalized));
+  }
+
   Future<List<Model>> getLocalModels() {
     return _readSafely(
       errorMessage: 'Failed to retrieve local models',
       fallback: List<Model>.empty(growable: false),
-      read: () => _readServerScopedJsonList(
-        key: _localModelsKey,
-        decodeDebugLabel: 'decode_local_models',
-        fromJson: Model.fromJson,
-      ),
+      read: () async {
+        final parsed = await _decodeCacheJsonList(
+          await _readCacheValue(_localModelsKey),
+          debugLabel: 'decode_local_models',
+        );
+        return parsed.map(Model.fromJson).toList(growable: false);
+      },
     );
   }
 
   Future<void> saveLocalModels(List<Model> models) {
     return _writeSafely(
       errorMessage: 'Failed to save local models',
-      write: () => _saveServerScopedJsonList(
+      write: () => _writeCacheJsonList(
         _localModelsKey,
-        items: models,
+        models,
         toJson: (model) => model.toJson(),
-        encodeDebugLabel: 'encode_local_models',
       ),
     );
   }
@@ -679,22 +743,23 @@ class OptimizedStorageService {
     return _readSafely(
       errorMessage: 'Failed to retrieve local tools',
       fallback: List<Tool>.empty(growable: false),
-      read: () => _readServerScopedJsonList(
-        key: _localToolsKey,
-        decodeDebugLabel: 'decode_local_tools',
-        fromJson: Tool.fromJson,
-      ),
+      read: () async {
+        final parsed = await _decodeCacheJsonList(
+          await _readCacheValue(_localToolsKey),
+          debugLabel: 'decode_local_tools',
+        );
+        return parsed.map(Tool.fromJson).toList(growable: false);
+      },
     );
   }
 
   Future<void> saveLocalTools(List<Tool> tools) {
     return _writeSafely(
       errorMessage: 'Failed to save local tools',
-      write: () => _saveServerScopedJsonList(
+      write: () => _writeCacheJsonList(
         _localToolsKey,
-        items: tools,
+        tools,
         toJson: (tool) => tool.toJson(),
-        encodeDebugLabel: 'encode_local_tools',
       ),
     );
   }
@@ -703,13 +768,11 @@ class OptimizedStorageService {
     return _readNullableSafely(
       errorMessage: 'Failed to retrieve local default model',
       read: () async {
-        final parsed = await _readServerScopedJsonObject(
-          key: _localDefaultModelKey,
-          fromJson: Model.fromJson,
-        );
-        if (parsed == null) return null;
+        final stored = await _readCacheValue(_localDefaultModelKey);
+        if (stored == null) return null;
+        final parsedModel = _decodeJsonObject(stored, Model.fromJson);
+        if (parsedModel == null) return null;
 
-        final parsedModel = parsed;
         final cachedModels = await getLocalModels();
         final hasMatch = cachedModels.any(
           (model) =>
@@ -729,13 +792,12 @@ class OptimizedStorageService {
       errorMessage: 'Failed to save local default model',
       write: () async {
         if (model == null) {
-          await _cachesBox.delete(_localDefaultModelKey);
+          await _deleteCacheValue(_localDefaultModelKey);
           return;
         }
-        await _saveServerScopedJsonObject(
+        await _writeCacheValue(
           _localDefaultModelKey,
-          model,
-          toJson: (value) => value.toJson(),
+          jsonEncode(normalizeJsonLikeValue(model.toJson())),
         );
       },
     );
@@ -744,8 +806,26 @@ class OptimizedStorageService {
   // ---------------------------------------------------------------------------
   // Batch operations
   // ---------------------------------------------------------------------------
-  Future<void> _clearUserScopedCacheEntries() {
-    return Future.wait([
+  Future<void> _clearUserScopedCacheEntries() async {
+    // Active store: the per-server Drift app cache.
+    final dao = _appCacheDao;
+    if (dao != null) {
+      await dao.deleteKeys(<String>[
+        _localUserKey,
+        _localUserAvatarKey,
+        _localBackendConfigKey,
+        _localToolsKey,
+        _localDefaultModelKey,
+        _localModelsKey,
+      ]);
+    }
+    // Transport options moved to shared_preferences (PR-1).
+    final activeServerId = _rawStoredActiveServerId();
+    if (activeServerId != null && activeServerId.isNotEmpty) {
+      await PreferencesStore.remove(_transportOptionsKey(activeServerId));
+    }
+    // Legacy Hive caches-box cleanup for installs that predate the Drift cache.
+    await Future.wait([
       _cachesBox.delete(_localUserKey),
       _cachesBox.delete(_localUserAvatarKey),
       _cachesBox.delete(_localBackendConfigKey),
@@ -797,6 +877,7 @@ class OptimizedStorageService {
 
   Future<void> clearAll() async {
     try {
+      final db = _database?.call();
       await Future.wait([
         _secureCredentialStorage.clearAll(),
         // Preserve the migration gate so a wipe doesn't re-import stale Hive
@@ -804,6 +885,9 @@ class OptimizedStorageService {
         PreferencesStore.clear(
           preserve: const {PreferenceKeys.hiveToPrefsMigrationV1},
         ),
+        // Active stores (Drift, per active server) + legacy Hive boxes.
+        if (db != null) db.appCacheDao.deleteKeys(_allCacheKeys),
+        if (db != null) db.attachmentQueueDao.clearAll(),
         _cachesBox.clear(),
         _attachmentQueueBox.clear(),
       ]);
@@ -832,120 +916,6 @@ class OptimizedStorageService {
 
   Future<bool> isSecureStorageAvailable() async {
     return _secureCredentialStorage.isSecureStorageAvailable();
-  }
-
-  // ---------------------------------------------------------------------------
-  // Server scoping helpers
-  // ---------------------------------------------------------------------------
-  bool _isServerScopedPayload(Object? stored) =>
-      stored is Map && stored.containsKey('data');
-
-  (Object?, String?) _unwrapServerScoped(Object? stored) {
-    if (_isServerScopedPayload(stored)) {
-      final scoped = stored as Map<Object?, Object?>;
-      final serverId = scoped['serverId'];
-      return (scoped['data'], serverId is String ? serverId : null);
-    }
-    return (stored, null);
-  }
-
-  Future<Map<String, Object?>> _wrapServerScoped(Object? data) async {
-    return _wrapServerScopedForServerId(data, await getActiveServerId());
-  }
-
-  Map<String, Object?> _wrapServerScopedForServerId(
-    Object? data,
-    String? serverId,
-  ) {
-    return {'data': data, 'serverId': _normalizeServerId(serverId)};
-  }
-
-  Object? _resolveServerScopedPayload(
-    Object? stored, {
-    required String? activeServerId,
-  }) {
-    if (stored == null) {
-      return null;
-    }
-
-    final (payload, ownerServerId) = _unwrapServerScoped(stored);
-    if (!_matchesActiveServer(activeServerId, ownerServerId)) {
-      return null;
-    }
-    return payload;
-  }
-
-  Future<Object?> _getServerScopedPayload({required String key}) async {
-    final stored = _cachesBox.get(key);
-    final activeServerId = await getActiveServerId();
-    return _resolveServerScopedPayload(stored, activeServerId: activeServerId);
-  }
-
-  Future<List<T>> _readServerScopedJsonList<T>({
-    required String key,
-    required String decodeDebugLabel,
-    required T Function(Map<String, dynamic> json) fromJson,
-  }) async {
-    final payload = await _getServerScopedPayload(key: key);
-    if (payload == null) {
-      return List<T>.empty(growable: false);
-    }
-
-    final parsed = await _workerManager
-        .schedule<Map<String, dynamic>, List<Map<String, dynamic>>>(
-          _decodeStoredJsonListWorker,
-          {'stored': payload},
-          debugLabel: decodeDebugLabel,
-        );
-    return parsed.map(fromJson).toList(growable: false);
-  }
-
-  Future<void> _saveServerScopedJsonList<T>(
-    String key, {
-    required Iterable<T> items,
-    required Map<String, dynamic> Function(T item) toJson,
-    required String encodeDebugLabel,
-  }) async {
-    final _ = encodeDebugLabel;
-    final normalizedItems = items
-        .map((item) => normalizeJsonLikeMap(toJson(item)))
-        .toList(growable: false);
-    await _putServerScopedCacheValue(key, normalizedItems);
-  }
-
-  Future<void> _putServerScopedCacheValue(String key, Object? value) async {
-    await _cachesBox.put(key, await _wrapServerScoped(value));
-  }
-
-  Future<void> _saveServerScopedJsonObject<T>(
-    String key,
-    T value, {
-    required Object? Function(T value) toJson,
-  }) async {
-    await _putServerScopedCacheValue(
-      key,
-      normalizeJsonLikeValue(toJson(value)),
-    );
-  }
-
-  Future<T?> _readServerScopedJsonObject<T>({
-    required String key,
-    required T? Function(Map<String, dynamic> json) fromJson,
-  }) async {
-    final payload = await _getServerScopedPayload(key: key);
-    if (payload == null) {
-      return null;
-    }
-    return _decodeJsonObject(payload, fromJson);
-  }
-
-  bool _matchesActiveServer(String? activeServerId, String? ownerServerId) {
-    final normalizedActive = _normalizeServerId(activeServerId);
-    final normalizedOwner = _normalizeServerId(ownerServerId);
-    if (normalizedOwner == null) {
-      return normalizedActive == null;
-    }
-    return normalizedActive == normalizedOwner;
   }
 
   String? _normalizeServerId(String? serverId) {

--- a/lib/core/sync/hive_cache_migrator.dart
+++ b/lib/core/sync/hive_cache_migrator.dart
@@ -1,0 +1,85 @@
+import 'dart:convert';
+
+import '../database/app_database.dart';
+import '../persistence/hive_boxes.dart';
+import '../utils/debug_logger.dart';
+
+/// One-time, per-server migration of the structured caches in the Hive `caches`
+/// box (local user, avatar, backend config, tools, default model, models) into
+/// the active server's Drift `app_cache` table — PR-2 of the Hive removal.
+///
+/// Gated by the per-server `sync_meta` flag `hive_caches_migrated` and mirrors
+/// [OutboxTaskQueueMigrator]'s idempotency: copy → set flag → delete the Hive
+/// keys, abort (flag unset) on any error so the next sync cycle retries.
+///
+/// Only the ACTIVE server's scoped values migrate (the Hive box is global with
+/// per-value `{data, serverId}` wrappers, but only the active server's Drift DB
+/// is open). Other servers' caches are dropped — they are re-fetchable
+/// offline-fallback caches (CDT-RFC-001 / plan D4). User/avatar were stored
+/// unwrapped (global) and migrate into the active server's DB.
+class HiveCacheMigrator {
+  HiveCacheMigrator({
+    required AppDatabase db,
+    required HiveBoxes hiveBoxes,
+    required Future<String?> Function() resolveActiveServerId,
+  }) : _db = db,
+       _boxes = hiveBoxes,
+       _resolveActiveServerId = resolveActiveServerId;
+
+  final AppDatabase _db;
+  final HiveBoxes _boxes;
+  final Future<String?> Function() _resolveActiveServerId;
+
+  static const String _flagKey = 'hive_caches_migrated';
+
+  static const List<String> _keys = [
+    HiveStoreKeys.localUser,
+    HiveStoreKeys.localUserAvatar,
+    HiveStoreKeys.localBackendConfig,
+    HiveStoreKeys.localTools,
+    HiveStoreKeys.localDefaultModel,
+    HiveStoreKeys.localModels,
+  ];
+
+  Future<void> migrateIfNeeded() async {
+    if (await _db.syncMetaDao.getValue(_flagKey) == '1') return;
+
+    final activeServerId = _normalize(await _resolveActiveServerId());
+    final box = _boxes.caches;
+
+    for (final key in _keys) {
+      final raw = box.get(key);
+      if (raw == null) continue;
+      final json = _toCacheJson(raw, activeServerId);
+      if (json == null) continue;
+      await _db.appCacheDao.setValue(key, json);
+    }
+
+    // Flag last (idempotency), then delete the migrated Hive keys.
+    await _db.syncMetaDao.setValue(_flagKey, '1');
+    await Future.wait(_keys.map(box.delete));
+
+    DebugLogger.log(
+      'Hive caches → Drift migration completed',
+      scope: 'persistence/migration',
+    );
+  }
+
+  /// Converts a stored Hive caches value into the JSON string `app_cache`
+  /// expects, or null to skip (a different server's scoped value, or empty).
+  String? _toCacheJson(Object raw, String? activeServerId) {
+    Object? data = raw;
+    if (raw is Map && raw.containsKey('data')) {
+      final owner = raw['serverId'];
+      final ownerId = _normalize(owner is String ? owner : null);
+      if (ownerId != activeServerId) return null; // other server's cache
+      data = raw['data'];
+    }
+    if (data == null) return null;
+    // user/avatar were stored as a plain string (JSON or URL); the wrapped
+    // caches' `data` is a Map/List that needs encoding.
+    return data is String ? data : jsonEncode(data);
+  }
+
+  String? _normalize(String? id) => (id == null || id.isEmpty) ? null : id;
+}

--- a/lib/core/sync/hive_cache_migrator.dart
+++ b/lib/core/sync/hive_cache_migrator.dart
@@ -2,6 +2,7 @@ import 'dart:convert';
 
 import '../database/app_database.dart';
 import '../persistence/hive_boxes.dart';
+import '../services/attachment_upload_queue.dart';
 import '../utils/debug_logger.dart';
 
 /// One-time, per-server migration of the structured caches in the Hive `caches`
@@ -31,6 +32,7 @@ class HiveCacheMigrator {
   final Future<String?> Function() _resolveActiveServerId;
 
   static const String _flagKey = 'hive_caches_migrated';
+  static const String _attachmentFlagKey = 'hive_attachment_queue_migrated';
 
   static const List<String> _keys = [
     HiveStoreKeys.localUser,
@@ -42,6 +44,11 @@ class HiveCacheMigrator {
   ];
 
   Future<void> migrateIfNeeded() async {
+    await _migrateCaches();
+    await _migrateAttachmentQueue();
+  }
+
+  Future<void> _migrateCaches() async {
     if (await _db.syncMetaDao.getValue(_flagKey) == '1') return;
 
     final activeServerId = _normalize(await _resolveActiveServerId());
@@ -63,6 +70,50 @@ class HiveCacheMigrator {
       'Hive caches → Drift migration completed',
       scope: 'persistence/migration',
     );
+  }
+
+  /// The Hive attachment queue is GLOBAL (one box), so it migrates into the
+  /// ACTIVE server's table at migration time (its uploads already targeted the
+  /// active server's API). Gated separately from the caches.
+  Future<void> _migrateAttachmentQueue() async {
+    if (await _db.syncMetaDao.getValue(_attachmentFlagKey) == '1') return;
+
+    final stored = _boxes.attachmentQueue.get(
+      HiveStoreKeys.attachmentQueueEntries,
+    );
+    final entries = _coerceJsonList(stored);
+    if (entries.isNotEmpty) {
+      await _db.transaction(() async {
+        for (final entry in entries) {
+          await _db.attachmentQueueDao.upsert(
+            AttachmentUploadQueue.companionFromLegacyJson(entry),
+          );
+        }
+      });
+    }
+
+    await _db.syncMetaDao.setValue(_attachmentFlagKey, '1');
+    await _boxes.attachmentQueue.delete(HiveStoreKeys.attachmentQueueEntries);
+
+    DebugLogger.log(
+      'Hive attachment queue → Drift migration completed',
+      scope: 'persistence/migration',
+    );
+  }
+
+  List<Map<String, dynamic>> _coerceJsonList(Object? stored) {
+    List<dynamic>? raw;
+    if (stored is String && stored.isNotEmpty) {
+      final decoded = jsonDecode(stored);
+      if (decoded is List) raw = decoded;
+    } else if (stored is List) {
+      raw = stored;
+    }
+    if (raw == null) return const <Map<String, dynamic>>[];
+    return raw
+        .whereType<Map>()
+        .map((e) => Map<String, dynamic>.from(e))
+        .toList(growable: false);
   }
 
   /// Converts a stored Hive caches value into the JSON string `app_cache`

--- a/lib/core/sync/sync_engine.dart
+++ b/lib/core/sync/sync_engine.dart
@@ -20,6 +20,7 @@ import 'deletion_reconcile.dart';
 import 'id_remapper.dart';
 import 'note_adapter.dart';
 import 'note_deletion_reconcile.dart';
+import 'hive_cache_migrator.dart';
 import 'note_sync.dart';
 import 'outbox_drainer.dart';
 import 'outbox_task_queue_migrator.dart';
@@ -465,6 +466,20 @@ class SyncEngine extends _$SyncEngine {
     );
   }
 
+  /// Engine-internal: the one-time per-server Hive caches → Drift `app_cache`
+  /// migration (PR-2 of the Hive removal). Built lazily so it sees the current
+  /// active DB; internally idempotent + per-server flag-gated.
+  HiveCacheMigrator? _buildCacheMigrator() {
+    final db = _boundDb;
+    if (db == null) return null;
+    return HiveCacheMigrator(
+      db: db,
+      hiveBoxes: ref.read(hiveBoxesProvider),
+      resolveActiveServerId: () =>
+          ref.read(optimizedStorageServiceProvider).getActiveServerId(),
+    );
+  }
+
   /// §9 step 2 / §11: convert the legacy Hive task queue into rows+ops EXACTLY
   /// ONCE per process, BEFORE any drain entry point can consume the outbox.
   Future<void> _migrateLegacyTaskQueueIfNeeded() {
@@ -487,6 +502,7 @@ class SyncEngine extends _$SyncEngine {
   Future<void> _runLegacyTaskQueueMigration(int migrationEpoch) async {
     try {
       await _buildMigrator()?.migrateIfNeeded();
+      await _buildCacheMigrator()?.migrateIfNeeded();
       if (migrationEpoch == _sessionEpoch) {
         _migrated = true;
       }

--- a/test/core/sync/hive_cache_migrator_test.dart
+++ b/test/core/sync/hive_cache_migrator_test.dart
@@ -106,6 +106,33 @@ void main() {
     check(caches.containsKey(HiveStoreKeys.localBackendConfig)).isFalse();
   });
 
+  test('migrates the Hive attachment queue into the Drift table', () async {
+    await attachmentQueue.put(HiveStoreKeys.attachmentQueueEntries, [
+      {
+        'id': 'a1',
+        'filePath': '/tmp/a.png',
+        'fileName': 'a.png',
+        'fileSize': 10,
+        'status': 'pending',
+        'retryCount': 0,
+        'enqueuedAt': DateTime.utc(2026).toIso8601String(),
+      },
+    ]);
+
+    await migrator().migrateIfNeeded();
+
+    final rows = await db.attachmentQueueDao.getAll();
+    check(rows.length).equals(1);
+    check(rows.single.id).equals('a1');
+    check(rows.single.fileName).equals('a.png');
+    check(
+      await db.syncMetaDao.getValue('hive_attachment_queue_migrated'),
+    ).equals('1');
+    check(
+      attachmentQueue.containsKey(HiveStoreKeys.attachmentQueueEntries),
+    ).isFalse();
+  });
+
   test('is gated: a second run does not re-import deleted keys', () async {
     await caches.put(HiveStoreKeys.localUserAvatar, 'https://x/a.png');
     await migrator().migrateIfNeeded();

--- a/test/core/sync/hive_cache_migrator_test.dart
+++ b/test/core/sync/hive_cache_migrator_test.dart
@@ -1,0 +1,123 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:checks/checks.dart';
+import 'package:conduit/core/database/app_database.dart';
+import 'package:conduit/core/persistence/hive_boxes.dart';
+import 'package:conduit/core/sync/hive_cache_migrator.dart';
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hive_ce/hive.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late AppDatabase db;
+  late Directory tempDir;
+  late Box<dynamic> preferences;
+  late Box<dynamic> caches;
+  late Box<dynamic> attachmentQueue;
+  late Box<dynamic> metadata;
+
+  HiveBoxes boxes() => HiveBoxes(
+    preferences: preferences,
+    caches: caches,
+    attachmentQueue: attachmentQueue,
+    metadata: metadata,
+  );
+
+  HiveCacheMigrator migrator({String? activeServerId = 'server-a'}) =>
+      HiveCacheMigrator(
+        db: db,
+        hiveBoxes: boxes(),
+        resolveActiveServerId: () async => activeServerId,
+      );
+
+  setUp(() async {
+    db = AppDatabase(NativeDatabase.memory());
+    tempDir = await Directory.systemTemp.createTemp('hive-cache-migrator-test');
+    Hive.init(tempDir.path);
+    preferences = await Hive.openBox<dynamic>(HiveBoxNames.preferences);
+    caches = await Hive.openBox<dynamic>(HiveBoxNames.caches);
+    attachmentQueue = await Hive.openBox<dynamic>(HiveBoxNames.attachmentQueue);
+    metadata = await Hive.openBox<dynamic>(HiveBoxNames.metadata);
+  });
+
+  tearDown(() async {
+    await db.close();
+    await Hive.close();
+    if (await tempDir.exists()) {
+      await tempDir.delete(recursive: true);
+    }
+  });
+
+  test('migrates active-server caches into Drift app_cache', () async {
+    // Unwrapped (global) string values.
+    await caches.put(
+      HiveStoreKeys.localUser,
+      jsonEncode({'id': 'u1', 'name': 'User'}),
+    );
+    await caches.put(HiveStoreKeys.localUserAvatar, 'https://x/a.png');
+    // Server-scoped wrapped values for the active server.
+    await caches.put(HiveStoreKeys.localBackendConfig, {
+      'data': {'version': '1.2.3'},
+      'serverId': 'server-a',
+    });
+    await caches.put(HiveStoreKeys.localModels, {
+      'data': [
+        {'id': 'm1'},
+      ],
+      'serverId': 'server-a',
+    });
+    // A different server's scoped value must be skipped.
+    await caches.put(HiveStoreKeys.localTools, {
+      'data': [
+        {'id': 't1'},
+      ],
+      'serverId': 'server-b',
+    });
+
+    await migrator().migrateIfNeeded();
+
+    check(
+      await db.appCacheDao.getValue(HiveStoreKeys.localUser),
+    ).equals(jsonEncode({'id': 'u1', 'name': 'User'}));
+    check(
+      await db.appCacheDao.getValue(HiveStoreKeys.localUserAvatar),
+    ).equals('https://x/a.png');
+    check(
+      jsonDecode(
+            (await db.appCacheDao.getValue(HiveStoreKeys.localBackendConfig))!,
+          )
+          as Map,
+    ).deepEquals({'version': '1.2.3'});
+    check(
+      jsonDecode((await db.appCacheDao.getValue(HiveStoreKeys.localModels))!)
+          as List,
+    ).deepEquals([
+      {'id': 'm1'},
+    ]);
+    // Other server's cache dropped.
+    check(await db.appCacheDao.getValue(HiveStoreKeys.localTools)).isNull();
+
+    // Flag set; migrated Hive keys deleted.
+    check(await db.syncMetaDao.getValue('hive_caches_migrated')).equals('1');
+    check(caches.containsKey(HiveStoreKeys.localUser)).isFalse();
+    check(caches.containsKey(HiveStoreKeys.localBackendConfig)).isFalse();
+  });
+
+  test('is gated: a second run does not re-import deleted keys', () async {
+    await caches.put(HiveStoreKeys.localUserAvatar, 'https://x/a.png');
+    await migrator().migrateIfNeeded();
+
+    // Simulate the user clearing the avatar after migration; a second run must
+    // not resurrect it from Hive (gate already set).
+    await db.appCacheDao.deleteKey(HiveStoreKeys.localUserAvatar);
+    await caches.put(HiveStoreKeys.localUserAvatar, 'https://x/a.png');
+    await migrator().migrateIfNeeded();
+
+    check(
+      await db.appCacheDao.getValue(HiveStoreKeys.localUserAvatar),
+    ).isNull();
+  });
+}


### PR DESCRIPTION
**Stack: PR-2 of 3** removing Hive. ⚠️ **Stacked on #516 (PR-1)** — review/merge that first; this PR's diff is against the PR-1 branch.

Moves the remaining Hive *data* boxes (`caches_v1`, `attachment_queue_v1`) onto per-server Drift tables. After this, the only Hive box left is `metadata` (the migration-version gate).

## PR-2a — structured caches → Drift (`5dd86693`)
- New per-server Drift tables `app_cache` + `attachment_queue` (schema **v5→6**) + DAOs.
- `local_user/avatar/backend_config/tools/default_model/models` now read/write the Drift `app_cache` via a lazy `AppDatabase?` resolver injected into `OptimizedStorageService` (`() => ref.read(appDatabaseProvider)` — a read, **not** a watch, so no build-time dependency cycle). Null DB (reviewer mode / no active server) falls back to defaults. The dead `_wrapServerScoped` cluster is removed (the per-server DB IS the scope).
- `HiveCacheMigrator` (one-time, per-server, `sync_meta`-gated) runs in the SyncEngine beside `OutboxTaskQueueMigrator`; copies the active server's caches forward, drops other servers' (re-fetchable).
- `clearAll`/`clearUserScoped` updated for Drift + the per-server transport-options prefs key.

## PR-2b — attachment upload queue → Drift (`f197a637`)
- `AttachmentUploadQueue` re-pointed onto the per-server `attachment_queue` table via the same lazy resolver; in-memory queue mirrored to the table on each mutation.
- Both `initialize()` callers re-run on active-server change → each server now has an **isolated** queue (previously one global Hive list — a latent cross-server bug, now fixed).
- `HiveCacheMigrator` also migrates the legacy global queue into the active server's table (separate `sync_meta` gate).

## Verification
- `flutter analyze` clean; full suite green (2142 tests) incl. new caches/attachment migrator tests + a Drift v5→6 schema bump validated by existing DB tests.
- Hive remains installed (read-only) for the migrators; **PR-3** drops the dependency (release-gated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR moves the Hive `caches_v1` and `attachment_queue_v1` boxes into per-server Drift tables (`app_cache` + `attachment_queue`) as part of a 3-PR Hive removal sequence, including a one-time `HiveCacheMigrator` gated by `sync_meta` flags.

- **Schema v5→6**: Two new tables added with correct `from < 6` migration guard; `HiveCacheMigrator` handles the one-time copy of active-server cache values and the global attachment queue, both idempotent and flag-gated via `sync_meta`.
- **`OptimizedStorageService`**: The server-scoped Hive wrapper cluster (`_wrapServerScoped` etc.) is cleanly removed; all structured cache reads/writes go through a lazy `AppCacheDao` resolver that returns `null` in reviewer mode or before a server is active.
- **`AttachmentUploadQueue`**: Switched to a clear-all-then-reinsert transaction strategy for durability; `initialize()` is not awaited in `app_providers.dart`, and since `_load()` now performs a real async `dao.getAll()` (vs. the formerly synchronous Hive read), there is a brief window in which a concurrent `enqueue()` call can mix a fresh item with stale pre-clear DB rows that `_save()` had already removed.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge; migration is idempotent and flag-gated, all structured cache paths are covered, and the test suite validates both migrators end-to-end.

The migration logic is sound, schema versioning is correct, and the lazy resolver pattern avoids provider cycles cleanly. The one new concern — a narrow async gap in `_load()` that didn't exist with the old synchronous Hive read — requires an unlikely timing condition (user enqueues a file during the milliseconds of a single DB read on initialization) and the consequence (stale rows temporarily re-appearing in memory) self-corrects on the next `_save()` or `initialize()` call.

`lib/core/providers/app_providers.dart` and `lib/core/services/attachment_upload_queue.dart` around the non-awaited `initialize()` / async `_load()` interaction.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| lib/core/database/app_database.dart | Schema bumped 5→6, `AppCache` and `AttachmentQueue` tables added with correct `from < 6` migration guard. |
| lib/core/database/daos/app_cache_dao.dart | New DAO with getValue/setValue/deleteKey/deleteKeys — clean, minimal interface with upsert semantics. |
| lib/core/database/daos/attachment_queue_dao.dart | New DAO for attachment queue; getAll() ordered by enqueuedAt, upsert/deleteById/clearAll all correct. |
| lib/core/services/attachment_upload_queue.dart | Migrated to Drift-backed `_save()`/`_load()`; `_load()` now has a real async gap (not present with synchronous Hive reads) — see inline comment on app_providers.dart where `initialize()` is not awaited. |
| lib/core/services/optimized_storage_service.dart | Server-scoped Hive wrappers removed; all structured cache reads/writes routed through lazy `_appCacheDao`. `_decodeCacheJsonList` correctly passes a String to the worker (which already handles both String and List). |
| lib/core/sync/hive_cache_migrator.dart | One-time migrator for caches + attachment queue; idempotent flag-gated; correctly filters cross-server scoped values; attachment migration wrapped in transaction. |
| lib/core/sync/sync_engine.dart | Cache migrator added in sequence after outbox migrator in `_runLegacyTaskQueueMigration()`; exception handling and `_migrated` gate preserved correctly. |
| test/core/sync/hive_cache_migrator_test.dart | Good coverage: active-server caches migrate, other-server caches are dropped, attachment queue migrates, idempotency gate verified. |
| lib/core/providers/app_providers.dart | `initialize()` not awaited before returning queue; creates an async gap in `_load()` that didn't exist with synchronous Hive reads. |
| lib/core/providers/storage_providers.dart | Lazy `database` resolver injected into `OptimizedStorageService` using `ref.read` (not watch) to avoid build-time cycle — correct pattern. |
| lib/core/services/media_upload_controller.dart | `initialize()` is awaited here, so no `_load()` race; correctly passes the lazy DB resolver. |

</details>


</details>


<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant App as App Launch / Server Switch
    participant Prov as attachmentUploadQueueProvider
    participant AUQ as AttachmentUploadQueue (singleton)
    participant SE as SyncEngine
    participant HCM as HiveCacheMigrator
    participant DB as Drift AppDatabase

    App->>Prov: rebuild (API changed)
    Prov->>AUQ: initialize(onUpload, database) — NOT awaited
    AUQ->>AUQ: _queue.clear()
    AUQ->>DB: dao.getAll() [async — yields here]
    Note over AUQ,DB: window: enqueue() can run here
    Prov-->>App: return queue (initialize still in flight)

    App->>SE: sync cycle
    SE->>SE: _migrateLegacyTaskQueueIfNeeded()
    SE->>SE: _buildMigrator().migrateIfNeeded() [outbox]
    SE->>HCM: _buildCacheMigrator().migrateIfNeeded()
    HCM->>DB: syncMetaDao.getValue(hive_caches_migrated)?
    alt flag not set
        HCM->>DB: appCacheDao.setValue(key, json) x N
        HCM->>DB: syncMetaDao.setValue(hive_caches_migrated, 1)
        HCM->>DB: transaction attachmentQueueDao.upsert x M
        HCM->>DB: syncMetaDao.setValue(hive_attachment_queue_migrated, 1)
    else flag already set
        HCM-->>SE: return (no-op)
    end
    SE->>SE: "_migrated = true"

    DB-->>AUQ: getAll() resolves with rows
    AUQ->>AUQ: _queue.addAll(rows)
    AUQ->>AUQ: _startPeriodicProcessing()
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant App as App Launch / Server Switch
    participant Prov as attachmentUploadQueueProvider
    participant AUQ as AttachmentUploadQueue (singleton)
    participant SE as SyncEngine
    participant HCM as HiveCacheMigrator
    participant DB as Drift AppDatabase

    App->>Prov: rebuild (API changed)
    Prov->>AUQ: initialize(onUpload, database) — NOT awaited
    AUQ->>AUQ: _queue.clear()
    AUQ->>DB: dao.getAll() [async — yields here]
    Note over AUQ,DB: window: enqueue() can run here
    Prov-->>App: return queue (initialize still in flight)

    App->>SE: sync cycle
    SE->>SE: _migrateLegacyTaskQueueIfNeeded()
    SE->>SE: _buildMigrator().migrateIfNeeded() [outbox]
    SE->>HCM: _buildCacheMigrator().migrateIfNeeded()
    HCM->>DB: syncMetaDao.getValue(hive_caches_migrated)?
    alt flag not set
        HCM->>DB: appCacheDao.setValue(key, json) x N
        HCM->>DB: syncMetaDao.setValue(hive_caches_migrated, 1)
        HCM->>DB: transaction attachmentQueueDao.upsert x M
        HCM->>DB: syncMetaDao.setValue(hive_attachment_queue_migrated, 1)
    else flag already set
        HCM-->>SE: return (no-op)
    end
    SE->>SE: "_migrated = true"

    DB-->>AUQ: getAll() resolves with rows
    AUQ->>AUQ: _queue.addAll(rows)
    AUQ->>AUQ: _startPeriodicProcessing()
```

</a>
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `lib/core/services/media_upload_controller.dart`, line 96-105 ([link](https://github.com/cogwheel0/conduit/blob/f197a6372fea6a3a5e9a0efcab573655f9440583/lib/core/services/media_upload_controller.dart#L96-L105)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **`initialize()` called on every upload, widening the empty-queue window**

   `_uploadInner()` calls `initialize()` on the singleton every time a file upload starts, regardless of whether the resolver has changed. Each call clears `_queue` and schedules an async `dao.getAll()` reload. With the old synchronous Hive read, this clear-and-refill was practically instantaneous; with the new async Drift read there is a real inter-await window where `_queue` is empty. If a concurrent upload or the 10-second periodic timer fires into that window, `processQueue()` iterates an empty list and skips all pending items (they will retry on the next tick, so data is not lost, but it is an unnecessary gap).

   The `_initialized` guard was intentionally removed for the server-switch re-initialization case. A lightweight check like "skip `_load()` if the resolver instance is unchanged" would avoid the spurious reload and narrow the race back down without breaking the server-switch path.

2. `lib/core/sync/hive_cache_migrator.dart`, line 934-956 ([link](https://github.com/cogwheel0/conduit/blob/f197a6372fea6a3a5e9a0efcab573655f9440583/lib/core/sync/hive_cache_migrator.dart#L934-L956)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Cache migration writes are not in a single transaction**

   Each key in `_keys` is written to Drift with its own `await _db.appCacheDao.setValue(...)` call outside any wrapping transaction. If a crash or DB error occurs mid-loop, some keys land in Drift but the flag is never set. On retry the partially-migrated keys are overwritten via `insertOnConflictUpdate` (safe), so correctness is preserved. This is fine as-is, but wrapping the loop + flag write in a single `_db.transaction()` would make the "all-or-nothing" intent explicit and eliminate the partial-migration state entirely (analogous to how `_migrateAttachmentQueue` uses a transaction around its inserts).

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (2): Last reviewed commit: ["refactor(persistence): move attachment u..."](https://github.com/cogwheel0/conduit/commit/43efd32739b5500653b799f4b6262e0878bd207e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38667209)</sub>

<!-- /greptile_comment -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added per-server app cache to enhance offline functionality and improve data accessibility
  * Introduced attachment upload queue with automatic retry logic to increase upload reliability and reduce data loss

* **Improvements**
  * Updated local storage backend infrastructure for improved performance and consistency

<!-- end of auto-generated comment: release notes by coderabbit.ai -->