### PR TITLE
feat(notes): rich-text editing with Fleather

### DIFF
--- a/lib/features/notes/providers/notes_providers.dart
+++ b/lib/features/notes/providers/notes_providers.dart
@@ -40,6 +40,20 @@ List<Note> _sortNotes(Iterable<Note> notes) {
 
 Note _noteFromRow(NoteRow row) => Note.fromJson(noteRowToServer(row));
 
+/// Reads a note straight from the local Drift row, with no server fetch.
+///
+/// Use this after a sync ([SyncEngine.requestPull]) when you need the
+/// reconciled local state and must NOT let a stale/behind server copy clobber
+/// not-yet-pushed local content (e.g. the note editor's pull-to-refresh).
+/// Returns null when the row is missing or tombstoned.
+Future<Note?> readLocalNote(AppDatabase db, String id, {String? userId}) async {
+  final row = userId == null || userId.isEmpty
+      ? await db.notesDao.getNote(id)
+      : await db.notesDao.getNoteForUser(id, userId: userId);
+  if (row == null || row.deleted) return null;
+  return _noteFromRow(row);
+}
+
 Note _noteFromListEntry(NoteListEntry entry) {
   final meta = entry.previewMarkdown.isEmpty
       ? null

--- a/lib/features/notes/utils/note_document_codec.dart
+++ b/lib/features/notes/utils/note_document_codec.dart
@@ -1,0 +1,78 @@
+import 'package:fleather/fleather.dart';
+import 'package:parchment/codecs.dart';
+
+import '../../../core/utils/debug_logger.dart';
+
+/// Conversion helpers between a note's canonical markdown (`content.md`, the
+/// interchange format shared with the Open WebUI web client) and the
+/// [ParchmentDocument] model edited by Fleather.
+///
+/// Markdown stays the source of truth: notes are stored as `content.md` (+ a
+/// derived `content.html`) and `content.json` is left null so notes authored or
+/// edited on the web (TipTap) remain fully compatible. These helpers wrap the
+/// `parchment` codecs and centralise the best-effort failure handling, since
+/// decoding is lossy and may choke on markdown constructs the codec does not
+/// model (e.g. web-authored content or AI-enhanced output).
+
+/// Decodes [markdown] into a [ParchmentDocument].
+///
+/// Falls back to a plain-text document (and ultimately an empty document) if the
+/// markdown cannot be parsed, so the editor never fails to open a note.
+ParchmentDocument documentFromMarkdown(String markdown) {
+  if (markdown.trim().isEmpty) {
+    return ParchmentDocument();
+  }
+  try {
+    return parchmentMarkdown.decode(markdown);
+  } catch (e, st) {
+    DebugLogger.error(
+      'Failed to decode note markdown to document; falling back to plain text',
+      scope: 'notes/codec',
+      error: e,
+      stackTrace: st,
+    );
+    return _plainTextDocument(markdown);
+  }
+}
+
+/// Encodes [document] back to markdown for `content.md`.
+String markdownFromDocument(ParchmentDocument document) {
+  try {
+    return parchmentMarkdown.encode(document);
+  } catch (e, st) {
+    DebugLogger.error(
+      'Failed to encode note document to markdown; falling back to plain text',
+      scope: 'notes/codec',
+      error: e,
+      stackTrace: st,
+    );
+    return document.toPlainText();
+  }
+}
+
+/// Encodes [document] to HTML for `content.html`.
+///
+/// Returns an empty string on failure; `content.md` remains the source of truth,
+/// so a missing HTML representation is non-fatal.
+String htmlFromDocument(ParchmentDocument document) {
+  try {
+    return parchmentHtml.encode(document);
+  } catch (e, st) {
+    DebugLogger.error(
+      'Failed to encode note document to HTML',
+      scope: 'notes/codec',
+      error: e,
+      stackTrace: st,
+    );
+    return '';
+  }
+}
+
+/// Builds a document containing [text] as a single unformatted block.
+///
+/// A Parchment delta must always end with a line break, so one is appended when
+/// missing.
+ParchmentDocument _plainTextDocument(String text) {
+  final normalized = text.endsWith('\n') ? text : '$text\n';
+  return ParchmentDocument.fromDelta(Delta()..insert(normalized));
+}

--- a/lib/features/notes/views/note_editor_page.dart
+++ b/lib/features/notes/views/note_editor_page.dart
@@ -1516,15 +1516,21 @@ class _NoteEditorPageState extends ConsumerState<NoteEditorPage> {
       // safe here (avoids pulling auth providers into the editor just for the
       // user id).
       final note = await readLocalNote(db, widget.noteId);
+      if (!mounted || note == null) return;
+      // If the user typed while the sync/read was in flight, do NOT overwrite
+      // their in-progress edits: those keystroke(s) re-set `_hasChanges` and
+      // queued a fresh debounce. Bail out and leave the editor as-is so that
+      // debounce saves them — overwriting here would discard them silently.
+      // (No await between this check and the setState below, so nothing can
+      // sneak in.)
+      if (_hasChanges) return;
       // Keep the detail cache consistent with what we just loaded.
       ref.invalidate(noteByIdProvider(widget.noteId));
-      if (!mounted || note == null) return;
       setState(() {
         _note = note;
         _titleController.text = note.title;
         _installContentDocument(documentFromMarkdown(note.markdownContent));
         _savedMarkdown = _contentMarkdown;
-        _hasChanges = false;
         _updateWordCount();
       });
     } catch (e) {

--- a/lib/features/notes/views/note_editor_page.dart
+++ b/lib/features/notes/views/note_editor_page.dart
@@ -6,6 +6,7 @@ import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:conduit/core/services/haptic_service.dart';
+import 'package:fleather/fleather.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:intl/intl.dart';
@@ -30,6 +31,7 @@ import '../../../shared/widgets/themed_dialogs.dart';
 import '../../../shared/widgets/themed_sheets.dart';
 import '../../chat/services/voice_input_service.dart';
 import '../providers/notes_providers.dart';
+import '../utils/note_document_codec.dart';
 import '../widgets/audio_player_dialog.dart';
 import '../widgets/audio_recording_overlay.dart';
 import '../widgets/note_file_attachment.dart';
@@ -46,7 +48,7 @@ class NoteEditorPage extends ConsumerStatefulWidget {
 
 class _NoteEditorPageState extends ConsumerState<NoteEditorPage> {
   final TextEditingController _titleController = TextEditingController();
-  final TextEditingController _contentController = TextEditingController();
+  FleatherController? _contentController;
   final FocusNode _titleFocusNode = FocusNode(debugLabel: 'note_title');
   final FocusNode _contentFocusNode = FocusNode(debugLabel: 'note_content');
   final ScrollController _scrollController = ScrollController();
@@ -64,32 +66,74 @@ class _NoteEditorPageState extends ConsumerState<NoteEditorPage> {
   // Voice input
   VoiceInputService? _voiceService;
   StreamSubscription<String>? _voiceSub;
-  String _voiceBaseText = '';
+  // Index in the document where the in-progress dictation run is inserted, and
+  // the length of that run, so each (cumulative) transcript update replaces the
+  // previous one without disturbing the rest of the document.
+  int? _dictationAnchor;
+  int _dictationLength = 0;
+
+  // Markdown snapshot of the last saved/loaded document, used to detect real
+  // edits. Compared against the re-encoded current document so opening a note
+  // never registers as a spurious change from non-semantic markdown
+  // normalisation.
+  String _savedMarkdown = '';
 
   static final _whitespacePattern = RegExp(r'\s+');
-  static final _boldPattern = RegExp(r'\*\*(.+?)\*\*');
-  static final _italicPattern = RegExp(r'\*(.+?)\*');
   int _cachedWordCount = 0;
 
+  /// Plain text of the current document (empty when no note is loaded).
+  String get _contentPlainText =>
+      _contentController?.document.toPlainText().trimRight() ?? '';
+
+  /// Markdown encoding of the current document.
+  String get _contentMarkdown {
+    final controller = _contentController;
+    return controller == null ? '' : markdownFromDocument(controller.document);
+  }
+
   void _updateWordCount() {
-    final text = _contentController.text.trim();
+    final text = _contentPlainText.trim();
     _cachedWordCount = text.isEmpty ? 0 : text.split(_whitespacePattern).length;
   }
 
-  int get _charCount => _contentController.text.length;
+  int get _charCount => _contentPlainText.length;
 
   @override
   void initState() {
     super.initState();
     _loadNote();
     _titleController.addListener(_onContentChanged);
-    _contentController.addListener(_onContentChanged);
+    // The content controller is created once the note is loaded; its listener
+    // is wired up in [_installContentDocument].
     // Rebuild when title focus changes to show/hide the generate title button
     _titleFocusNode.addListener(_onTitleFocusChanged);
+    // Rebuild to show/hide the formatting toolbar as the editor gains/loses
+    // focus.
+    _contentFocusNode.addListener(_onContentFocusChanged);
   }
 
   void _onTitleFocusChanged() {
     if (mounted) setState(() {});
+  }
+
+  void _onContentFocusChanged() {
+    if (mounted) setState(() {});
+  }
+
+  /// Replaces the content editor's controller with one backed by [document],
+  /// disposing the previous controller. Used on initial load and whenever the
+  /// whole document is swapped (e.g. AI enhancement).
+  ///
+  /// Does not touch [_savedMarkdown]: callers that load already-persisted
+  /// content reset the baseline themselves, while callers that introduce new
+  /// content (enhancement) leave it so the change is detected and auto-saved.
+  void _installContentDocument(ParchmentDocument document) {
+    final previous = _contentController;
+    final controller = FleatherController(document: document);
+    controller.addListener(_onContentChanged);
+    _contentController = controller;
+    previous?.removeListener(_onContentChanged);
+    previous?.dispose();
   }
 
   @override
@@ -98,9 +142,10 @@ class _NoteEditorPageState extends ConsumerState<NoteEditorPage> {
     _voiceSub?.cancel();
     _voiceService?.stopListening();
     _titleController.dispose();
-    _contentController.dispose();
+    _contentController?.dispose();
     _titleFocusNode.removeListener(_onTitleFocusChanged);
     _titleFocusNode.dispose();
+    _contentFocusNode.removeListener(_onContentFocusChanged);
     _contentFocusNode.dispose();
     _scrollController.dispose();
     super.dispose();
@@ -126,7 +171,8 @@ class _NoteEditorPageState extends ConsumerState<NoteEditorPage> {
         setState(() {
           _note = note;
           _titleController.text = note.title;
-          _contentController.text = note.markdownContent;
+          _installContentDocument(documentFromMarkdown(note.markdownContent));
+          _savedMarkdown = _contentMarkdown;
           _updateWordCount();
           _isLoading = false;
           _hasChanges = false;
@@ -178,10 +224,11 @@ class _NoteEditorPageState extends ConsumerState<NoteEditorPage> {
   void _onContentChanged() {
     if (!mounted || _isLoading) return;
 
-    // Check if content actually changed from the saved note
+    // Check if content actually changed from the saved note. Compare the
+    // re-encoded markdown against the snapshot taken on load/save so that
+    // markdown normalisation on open never registers as an edit.
     final titleChanged = _note != null && _titleController.text != _note!.title;
-    final contentChanged =
-        _note != null && _contentController.text != _note!.markdownContent;
+    final contentChanged = _note != null && _contentMarkdown != _savedMarkdown;
     final hasRealChanges = titleChanged || contentChanged;
 
     if (hasRealChanges != _hasChanges) {
@@ -212,15 +259,15 @@ class _NoteEditorPageState extends ConsumerState<NoteEditorPage> {
   /// entries while the editor was open — spreading the editor's stale copy here
   /// would revert them on the next save).
   Map<String, dynamic> _composeUpdatedNoteData({
-    required String markdown,
     List<Map<String, dynamic>>? files,
   }) {
+    final document = _contentController?.document;
+    final markdown = document != null ? markdownFromDocument(document) : '';
+    final html = document != null ? htmlFromDocument(document) : '';
+    // `json` (TipTap) is intentionally left null: markdown stays the canonical
+    // interchange format so notes remain editable on the Open WebUI web client.
     final data = <String, dynamic>{
-      'content': <String, dynamic>{
-        'json': null,
-        'html': _markdownToHtml(markdown),
-        'md': markdown,
-      },
+      'content': <String, dynamic>{'json': null, 'html': html, 'md': markdown},
     };
     if (files != null) {
       data['files'] = files;
@@ -279,11 +326,11 @@ class _NoteEditorPageState extends ConsumerState<NoteEditorPage> {
 
     try {
       final title = _titleController.text.trim();
-      final content = _contentController.text;
 
       // Preserve existing note data (versions, attached files) — only the
       // content changes here.
-      final data = _composeUpdatedNoteData(markdown: content);
+      final savedMarkdown = _contentMarkdown;
+      final data = _composeUpdatedNoteData();
 
       final resolvedTitle = title.isEmpty
           ? AppLocalizations.of(context)!.untitled
@@ -304,6 +351,7 @@ class _NoteEditorPageState extends ConsumerState<NoteEditorPage> {
         if (updatedNote != null) {
           setState(() {
             _note = updatedNote;
+            _savedMarkdown = savedMarkdown;
             _isSaving = false;
             _hasChanges = false;
           });
@@ -321,46 +369,6 @@ class _NoteEditorPageState extends ConsumerState<NoteEditorPage> {
         _showError(e.toString());
       }
     }
-  }
-
-  String _markdownToHtml(String markdown) {
-    final paragraphs = markdown.split('\n\n');
-    final html = paragraphs
-        .map((p) {
-          if (p.trim().isEmpty) return '';
-          if (p.startsWith('# ')) {
-            return '<h1>${_escapeHtml(p.substring(2))}</h1>';
-          }
-          if (p.startsWith('## ')) {
-            return '<h2>${_escapeHtml(p.substring(3))}</h2>';
-          }
-          if (p.startsWith('### ')) {
-            return '<h3>${_escapeHtml(p.substring(4))}</h3>';
-          }
-          // Escape entire paragraph first to prevent XSS, then apply
-          // markdown formatting replacements on the escaped text.
-          var text = _escapeHtml(p);
-          text = text.replaceAllMapped(
-            _boldPattern,
-            (m) => '<strong>${m.group(1)!}</strong>',
-          );
-          text = text.replaceAllMapped(
-            _italicPattern,
-            (m) => '<em>${m.group(1)!}</em>',
-          );
-          return '<p>$text</p>';
-        })
-        .join('\n');
-    return html;
-  }
-
-  String _escapeHtml(String text) {
-    return text
-        .replaceAll('&', '&amp;')
-        .replaceAll('<', '&lt;')
-        .replaceAll('>', '&gt;')
-        .replaceAll('"', '&quot;')
-        .replaceAll("'", '&#39;');
   }
 
   void _showError(String message) {
@@ -423,7 +431,7 @@ class _NoteEditorPageState extends ConsumerState<NoteEditorPage> {
   // AI title generation
   Future<void> _generateTitle() async {
     if (_note == null || _isGeneratingTitle) return;
-    final content = _contentController.text.trim();
+    final content = _contentMarkdown.trim();
     if (content.isEmpty) {
       _showError(AppLocalizations.of(context)!.noContentToGenerateTitle);
       return;
@@ -467,7 +475,7 @@ class _NoteEditorPageState extends ConsumerState<NoteEditorPage> {
   // AI content enhancement
   Future<void> _enhanceContent() async {
     if (_note == null || _isEnhancing) return;
-    final content = _contentController.text.trim();
+    final content = _contentMarkdown.trim();
     if (content.isEmpty) {
       _showError(AppLocalizations.of(context)!.noContentToEnhance);
       return;
@@ -494,7 +502,12 @@ class _NoteEditorPageState extends ConsumerState<NoteEditorPage> {
         modelId: modelId,
       );
       if (mounted && enhancedContent != null && enhancedContent.isNotEmpty) {
-        _contentController.text = enhancedContent;
+        setState(() {
+          _installContentDocument(documentFromMarkdown(enhancedContent));
+        });
+        // Installing a fresh document resets the saved-markdown snapshot, so
+        // re-run change detection to flag the enhancement for auto-save.
+        _onContentChanged();
         ConduitHaptics.mediumImpact();
         AdaptiveSnackBar.show(
           context,
@@ -537,9 +550,24 @@ class _NoteEditorPageState extends ConsumerState<NoteEditorPage> {
       final stream = await _voiceService!.beginListening();
       if (!mounted) return;
 
+      // Anchor the dictation run at the current selection, or the end of the
+      // document when there is no selection. The trailing line-break of a
+      // Parchment document is not editable, so clamp before it.
+      final controller = _contentController;
+      final selection = controller?.selection;
+      final docEnd = controller == null
+          ? 0
+          : (controller.document.length - 1).clamp(0, controller.document.length);
+      _dictationAnchor =
+          (selection != null && selection.isValid && !selection.isCollapsed)
+          ? selection.start
+          : (selection != null && selection.isValid
+                ? selection.baseOffset.clamp(0, docEnd)
+                : docEnd);
+      _dictationLength = 0;
+
       setState(() {
         _isRecording = true;
-        _voiceBaseText = _contentController.text;
       });
 
       ConduitHaptics.lightImpact();
@@ -548,13 +576,7 @@ class _NoteEditorPageState extends ConsumerState<NoteEditorPage> {
       _voiceSub = stream.listen(
         (text) {
           if (!mounted) return;
-          final updated = _voiceBaseText.isEmpty
-              ? text
-              : '${_voiceBaseText.trimRight()} $text';
-          _contentController.value = TextEditingValue(
-            text: updated,
-            selection: TextSelection.collapsed(offset: updated.length),
-          );
+          _applyDictationText(text);
         },
         onDone: () {
           if (!mounted) return;
@@ -576,10 +598,36 @@ class _NoteEditorPageState extends ConsumerState<NoteEditorPage> {
   Future<void> _stopDictation() async {
     await _voiceService?.stopListening();
     _voiceSub?.cancel();
+    _dictationAnchor = null;
+    _dictationLength = 0;
     if (mounted) {
       setState(() => _isRecording = false);
       ConduitHaptics.selectionClick();
     }
+  }
+
+  /// Applies the latest (cumulative) dictation [transcript] by replacing the
+  /// previously inserted run at [_dictationAnchor] with the new text, leaving
+  /// the rest of the document — and its formatting — untouched.
+  void _applyDictationText(String transcript) {
+    final controller = _contentController;
+    final anchor = _dictationAnchor;
+    if (controller == null || anchor == null) return;
+
+    final plain = controller.document.toPlainText();
+    final needsLeadingSpace =
+        anchor > 0 &&
+        anchor <= plain.length &&
+        !_whitespacePattern.hasMatch(plain[anchor - 1]);
+    final insert = needsLeadingSpace ? ' $transcript' : transcript;
+
+    controller.replaceText(
+      anchor,
+      _dictationLength,
+      insert,
+      selection: TextSelection.collapsed(offset: anchor + insert.length),
+    );
+    _dictationLength = insert.length;
   }
 
   /// Shows a bottom sheet to choose between dictation and audio recording.
@@ -784,10 +832,7 @@ class _NoteEditorPageState extends ConsumerState<NoteEditorPage> {
       ];
 
       // Update note with the file attachment
-      final data = _composeUpdatedNoteData(
-        markdown: _contentController.text,
-        files: updatedFiles,
-      );
+      final data = _composeUpdatedNoteData(files: updatedFiles);
 
       final resolvedTitle = _titleController.text.isEmpty
           ? l10n.untitled
@@ -842,7 +887,7 @@ class _NoteEditorPageState extends ConsumerState<NoteEditorPage> {
 
   void _copyToClipboard() {
     final l10n = AppLocalizations.of(context)!;
-    final content = _contentController.text;
+    final content = _contentMarkdown;
     Clipboard.setData(ClipboardData(text: content));
     ConduitHaptics.selectionClick();
     AdaptiveSnackBar.show(
@@ -895,14 +940,53 @@ class _NoteEditorPageState extends ConsumerState<NoteEditorPage> {
                   child: Center(child: _buildFloatingMetadataBar(context)),
                 ),
               ),
-            if (!_isLoading && _note != null)
+            if (!_isLoading && _note != null && !_contentFocusNode.hasFocus)
               Positioned(
                 left: Spacing.md,
                 right: Spacing.md,
                 bottom: Spacing.md + MediaQuery.of(context).padding.bottom,
                 child: _buildFloatingActionsRow(context),
               ),
+            // Formatting toolbar — shown above the keyboard while the content
+            // editor is focused (in place of the floating actions row).
+            if (!_isLoading && _note != null && _contentFocusNode.hasFocus)
+              Positioned(
+                left: 0,
+                right: 0,
+                bottom: MediaQuery.viewInsetsOf(context).bottom,
+                child: _buildFormattingToolbar(context),
+              ),
           ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildFormattingToolbar(BuildContext context) {
+    final theme = context.conduitTheme;
+    final controller = _contentController;
+    if (controller == null) return const SizedBox.shrink();
+    return Material(
+      color: theme.surfaceContainer,
+      child: SafeArea(
+        top: false,
+        child: Container(
+          decoration: BoxDecoration(
+            border: Border(
+              top: BorderSide(color: theme.cardBorder, width: BorderWidth.thin),
+            ),
+          ),
+          child: FleatherTheme(
+            data: _buildFleatherTheme(context),
+            // Hide formatting that markdown cannot round-trip (underline and
+            // colours), since markdown stays the canonical stored format.
+            child: FleatherToolbar.basic(
+              controller: controller,
+              hideUnderLineButton: true,
+              hideBackgroundColor: true,
+              hideForegroundColor: true,
+            ),
+          ),
         ),
       ),
     );
@@ -1270,8 +1354,6 @@ class _NoteEditorPageState extends ConsumerState<NoteEditorPage> {
   }
 
   Widget _buildEditor(BuildContext context) {
-    final theme = context.conduitTheme;
-    final l10n = AppLocalizations.of(context)!;
     final topPadding = MediaQuery.of(context).padding.top;
     // App bar height: kTextTabBarHeight + metadata bar (~40)
     final appBarHeight = kTextTabBarHeight + 40;
@@ -1303,32 +1385,80 @@ class _NoteEditorPageState extends ConsumerState<NoteEditorPage> {
               const SizedBox(height: Spacing.lg),
             ],
             // Content editor
-            AdaptiveTextField(
-              controller: _contentController,
-              focusNode: _contentFocusNode,
-              style: AppTypography.bodyLargeStyle.copyWith(
-                color: theme.textPrimary,
-                height: 1.8,
-              ),
-              placeholder: l10n.writeNote,
-              maxLines: null,
-              minLines: 20,
-              textCapitalization: TextCapitalization.sentences,
-              keyboardType: TextInputType.multiline,
-              padding: EdgeInsets.zero,
-              cupertinoDecoration: const BoxDecoration(),
-              decoration: context.conduitInputStyles
-                  .borderless(hint: l10n.writeNote)
-                  .copyWith(
-                    hintStyle: AppTypography.bodyLargeStyle.copyWith(
-                      color: theme.textSecondary.withValues(alpha: 0.35),
-                      height: 1.8,
-                    ),
-                    contentPadding: EdgeInsets.zero,
-                  ),
-            ),
+            _buildContentEditor(context),
           ],
         ),
+      ),
+    );
+  }
+
+  Widget _buildContentEditor(BuildContext context) {
+    final theme = context.conduitTheme;
+    final l10n = AppLocalizations.of(context)!;
+    final controller = _contentController;
+    if (controller == null) {
+      return const SizedBox.shrink();
+    }
+
+    final editor = FleatherEditor(
+      controller: controller,
+      focusNode: _contentFocusNode,
+      // Lives inside the page's SingleChildScrollView; the editor must not
+      // scroll independently so the whole note grows with the content.
+      scrollable: false,
+      expands: false,
+      padding: EdgeInsets.zero,
+      minHeight: 20 * 1.8 * AppTypography.bodyLarge,
+      textCapitalization: TextCapitalization.sentences,
+    );
+
+    // Fleather has no built-in placeholder, so overlay a hint while the
+    // document is empty.
+    final showPlaceholder = _contentPlainText.isEmpty;
+    return FleatherTheme(
+      data: _buildFleatherTheme(context),
+      child: Stack(
+        children: [
+          if (showPlaceholder)
+            Positioned(
+              left: 0,
+              top: 0,
+              right: 0,
+              child: IgnorePointer(
+                child: Text(
+                  l10n.writeNote,
+                  style: AppTypography.bodyLargeStyle.copyWith(
+                    color: theme.textSecondary.withValues(alpha: 0.35),
+                    height: 1.8,
+                  ),
+                ),
+              ),
+            ),
+          editor,
+        ],
+      ),
+    );
+  }
+
+  /// Builds a Fleather theme derived from the app's typography and colours so
+  /// the rich-text editor matches the rest of the note UI.
+  FleatherThemeData _buildFleatherTheme(BuildContext context) {
+    final theme = context.conduitTheme;
+    final base = AppTypography.bodyLargeStyle.copyWith(
+      color: theme.textPrimary,
+      height: 1.8,
+    );
+    final fallback = FleatherThemeData.fallback(context);
+    return fallback.copyWith(
+      paragraph: TextBlockTheme(
+        style: base,
+        spacing: const VerticalSpacing(top: 0, bottom: 6),
+      ),
+      bold: const TextStyle(fontWeight: FontWeight.bold),
+      italic: const TextStyle(fontStyle: FontStyle.italic),
+      link: TextStyle(
+        color: theme.buttonPrimary,
+        decoration: TextDecoration.underline,
       ),
     );
   }
@@ -1379,10 +1509,7 @@ class _NoteEditorPageState extends ConsumerState<NoteEditorPage> {
           .where((f) => f['id']?.toString() != fileId)
           .toList();
 
-      final data = _composeUpdatedNoteData(
-        markdown: _contentController.text,
-        files: updatedFiles,
-      );
+      final data = _composeUpdatedNoteData(files: updatedFiles);
 
       final resolvedTitle = _titleController.text.isEmpty
           ? l10n.untitled

--- a/lib/features/notes/views/note_editor_page.dart
+++ b/lib/features/notes/views/note_editor_page.dart
@@ -17,6 +17,7 @@ import '../../../core/database/database_provider.dart';
 import '../../../core/models/note.dart';
 import '../../../core/providers/app_providers.dart';
 import '../../../core/services/ios_native_dropdown_bridge.dart';
+import '../../../core/sync/sync_engine.dart';
 import '../../../core/widgets/error_boundary.dart';
 import '../../../shared/theme/conduit_input_styles.dart';
 import '../../../shared/theme/theme_extensions.dart';
@@ -329,23 +330,36 @@ class _NoteEditorPageState extends ConsumerState<NoteEditorPage> {
     required Map<String, dynamic> data,
   }) async {
     if (!_isCurrentNoteSession(api: api, db: db)) return null;
+    Note? note;
     if (db != null) {
-      return durableUpdateNote(
+      note = await durableUpdateNote(
         ref,
         db,
         id: widget.noteId,
         title: title,
         data: data,
       );
+    } else {
+      // Session confirmed current, so the live API equals the captured one.
+      final currentApi = ref.read(apiServiceProvider);
+      if (currentApi == null) return null;
+      note = Note.fromJson(
+        await currentApi.updateNote(widget.noteId, title: title, data: data),
+      );
+      if (mounted && _isCurrentNoteSession(api: api, db: db)) {
+        ref.read(notesListProvider.notifier).updateNote(note, sourceDb: db);
+      }
     }
-    // Session confirmed current, so the live API equals the captured one.
-    final currentApi = ref.read(apiServiceProvider);
-    if (currentApi == null) return null;
-    final note = Note.fromJson(
-      await currentApi.updateNote(widget.noteId, title: title, data: data),
-    );
-    if (mounted && _isCurrentNoteSession(api: api, db: db)) {
-      ref.read(notesListProvider.notifier).updateNote(note, sourceDb: db);
+    // `noteByIdProvider` is keepAlive, so without this it keeps serving the
+    // note as it was when first opened (e.g. empty for a freshly created note)
+    // and reopening the note in the same app session shows stale/empty content
+    // until a full restart. Invalidate so the next open re-reads what we just
+    // saved. Cover the remapped server id too, in case a `local:` id resolved.
+    if (note != null) {
+      ref.invalidate(noteByIdProvider(widget.noteId));
+      if (note.id != widget.noteId) {
+        ref.invalidate(noteByIdProvider(note.id));
+      }
     }
     return note;
   }
@@ -1430,32 +1444,92 @@ class _NoteEditorPageState extends ConsumerState<NoteEditorPage> {
     return GestureDetector(
       onTap: () => _contentFocusNode.requestFocus(),
       behavior: HitTestBehavior.opaque,
-      child: SingleChildScrollView(
-        controller: _scrollController,
-        padding: EdgeInsets.fromLTRB(
-          Spacing.inputPadding,
-          topPadding + appBarHeight + Spacing.sm, // Space for floating app bar
-          Spacing.inputPadding,
-          120, // Extra padding for floating buttons
-        ),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            // File attachments section (if any)
-            if (files.isNotEmpty) ...[
-              NoteFilesSection(
-                files: files,
-                onPlayFile: _playAudioFile,
-                onDeleteFile: _removeFile,
-              ),
-              const SizedBox(height: Spacing.lg),
+      child: RefreshIndicator.adaptive(
+        onRefresh: _refreshNote,
+        edgeOffset: topPadding + appBarHeight + Spacing.sm,
+        child: SingleChildScrollView(
+          controller: _scrollController,
+          // Always scrollable so pull-to-refresh works even when the note is
+          // short enough to fit on screen.
+          physics: const AlwaysScrollableScrollPhysics(),
+          padding: EdgeInsets.fromLTRB(
+            Spacing.inputPadding,
+            topPadding +
+                appBarHeight +
+                Spacing.sm, // Space for floating app bar
+            Spacing.inputPadding,
+            120, // Extra padding for floating buttons
+          ),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              // File attachments section (if any)
+              if (files.isNotEmpty) ...[
+                NoteFilesSection(
+                  files: files,
+                  onPlayFile: _playAudioFile,
+                  onDeleteFile: _removeFile,
+                ),
+                const SizedBox(height: Spacing.lg),
+              ],
+              // Content editor
+              _buildContentEditor(context),
             ],
-            // Content editor
-            _buildContentEditor(context),
-          ],
+          ),
         ),
       ),
     );
+  }
+
+  /// Pull-to-refresh handler: syncs the note with the server, then reloads it
+  /// into the editor.
+  ///
+  /// Order matters. We first flush any pending local edit, then run a full sync
+  /// cycle (push the outbox + pull the server) before re-reading. Re-reading
+  /// without syncing would let the detail fetch return a server copy that is
+  /// behind a not-yet-synced local edit and clobber it with stale/empty content.
+  Future<void> _refreshNote() async {
+    if (_hasChanges) {
+      _saveDebounce?.cancel();
+      await _autoSave();
+    }
+    if (!mounted) return;
+
+    // Push local changes and pull remote ones so the local row reflects both
+    // sides. Mirrors the notes-list pull-to-refresh.
+    final db = ref.read(appDatabaseProvider);
+    if (db == null) return;
+    try {
+      await ref
+          .read(syncEngineProvider.notifier)
+          .requestPull(reason: 'note-editor-refresh');
+    } catch (_) {
+      // Best-effort; still reload from the (at least locally-current) row below.
+    }
+    if (!mounted) return;
+
+    // Re-read from the reconciled LOCAL row, not a fresh server fetch: the pull
+    // has already merged remote edits into it, and reading the row avoids a
+    // server copy that's behind a not-yet-pushed local edit clobbering it.
+    try {
+      // The note is already open in the current session, so an id-scoped read is
+      // safe here (avoids pulling auth providers into the editor just for the
+      // user id).
+      final note = await readLocalNote(db, widget.noteId);
+      // Keep the detail cache consistent with what we just loaded.
+      ref.invalidate(noteByIdProvider(widget.noteId));
+      if (!mounted || note == null) return;
+      setState(() {
+        _note = note;
+        _titleController.text = note.title;
+        _installContentDocument(documentFromMarkdown(note.markdownContent));
+        _savedMarkdown = _contentMarkdown;
+        _hasChanges = false;
+        _updateWordCount();
+      });
+    } catch (e) {
+      if (mounted) _showError(e.toString());
+    }
   }
 
   Widget _buildContentEditor(BuildContext context) {

--- a/lib/features/notes/views/note_editor_page.dart
+++ b/lib/features/notes/views/note_editor_page.dart
@@ -81,6 +81,11 @@ class _NoteEditorPageState extends ConsumerState<NoteEditorPage> {
   static final _whitespacePattern = RegExp(r'\s+');
   int _cachedWordCount = 0;
 
+  // Cached Fleather theme. Derived from the app theme via the inherited
+  // context, so it is (re)computed in didChangeDependencies rather than on
+  // every build — the editor and toolbar both consume it each frame.
+  FleatherThemeData? _fleatherTheme;
+
   /// Plain text of the current document (empty when no note is loaded).
   String get _contentPlainText =>
       _contentController?.document.toPlainText().trimRight() ?? '';
@@ -118,6 +123,12 @@ class _NoteEditorPageState extends ConsumerState<NoteEditorPage> {
 
   void _onContentFocusChanged() {
     if (mounted) setState(() {});
+  }
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    _fleatherTheme = _buildFleatherTheme(context);
   }
 
   /// Replaces the content editor's controller with one backed by [document],
@@ -222,22 +233,16 @@ class _NoteEditorPageState extends ConsumerState<NoteEditorPage> {
   }
 
   void _onContentChanged() {
-    if (!mounted || _isLoading) return;
+    if (!mounted || _isLoading || _note == null) return;
 
-    // Check if content actually changed from the saved note. Compare the
-    // re-encoded markdown against the snapshot taken on load/save so that
-    // markdown normalisation on open never registers as an edit.
-    final titleChanged = _note != null && _titleController.text != _note!.title;
-    final contentChanged = _note != null && _contentMarkdown != _savedMarkdown;
-    final hasRealChanges = titleChanged || contentChanged;
-
-    if (hasRealChanges != _hasChanges) {
-      setState(() => _hasChanges = hasRealChanges);
+    // Optimistically flag the note dirty so the unsaved indicator reacts
+    // immediately. The authoritative comparison — which re-encodes the document
+    // to markdown — is deferred to the debounced auto-save so we never run a
+    // full delta->markdown traversal on every keystroke.
+    if (!_hasChanges) {
+      setState(() => _hasChanges = true);
     }
-
-    if (hasRealChanges) {
-      _debounceSave();
-    }
+    _debounceSave();
     _updateWordCount();
   }
 
@@ -247,7 +252,20 @@ class _NoteEditorPageState extends ConsumerState<NoteEditorPage> {
   }
 
   Future<void> _autoSave() async {
-    if (_note == null || !_hasChanges) return;
+    final note = _note;
+    if (note == null) return;
+
+    // Authoritative dirty check: compare the re-encoded markdown against the
+    // snapshot taken on load/save so markdown normalisation on open never
+    // registers as an edit, and a no-op edit never hits the server.
+    final titleChanged = _titleController.text != note.title;
+    final contentChanged = _contentMarkdown != _savedMarkdown;
+    if (!titleChanged && !contentChanged) {
+      if (mounted && _hasChanges) {
+        setState(() => _hasChanges = false);
+      }
+      return;
+    }
     await _saveNote(showFeedback: false);
   }
 
@@ -505,8 +523,9 @@ class _NoteEditorPageState extends ConsumerState<NoteEditorPage> {
         setState(() {
           _installContentDocument(documentFromMarkdown(enhancedContent));
         });
-        // Installing a fresh document resets the saved-markdown snapshot, so
-        // re-run change detection to flag the enhancement for auto-save.
+        // _installContentDocument deliberately leaves _savedMarkdown untouched,
+        // so the enhanced content now differs from the saved baseline; re-run
+        // change detection to flag the enhancement for auto-save.
         _onContentChanged();
         ConduitHaptics.mediumImpact();
         AdaptiveSnackBar.show(
@@ -831,7 +850,9 @@ class _NoteEditorPageState extends ConsumerState<NoteEditorPage> {
         },
       ];
 
-      // Update note with the file attachment
+      // Update note with the file attachment. Snapshot the markdown that gets
+      // persisted so the dirty baseline stays in sync with what was saved.
+      final savedMarkdown = _contentMarkdown;
       final data = _composeUpdatedNoteData(files: updatedFiles);
 
       final resolvedTitle = _titleController.text.isEmpty
@@ -853,6 +874,7 @@ class _NoteEditorPageState extends ConsumerState<NoteEditorPage> {
         if (updatedNote != null) {
           setState(() {
             _note = updatedNote;
+            _savedMarkdown = savedMarkdown;
             _isUploadingAudio = false;
             _hasChanges = false;
           });
@@ -977,7 +999,7 @@ class _NoteEditorPageState extends ConsumerState<NoteEditorPage> {
             ),
           ),
           child: FleatherTheme(
-            data: _buildFleatherTheme(context),
+            data: _fleatherTheme ??= _buildFleatherTheme(context),
             // Hide formatting that markdown cannot round-trip (underline and
             // colours), since markdown stays the canonical stored format.
             child: FleatherToolbar.basic(
@@ -1416,7 +1438,7 @@ class _NoteEditorPageState extends ConsumerState<NoteEditorPage> {
     // document is empty.
     final showPlaceholder = _contentPlainText.isEmpty;
     return FleatherTheme(
-      data: _buildFleatherTheme(context),
+      data: _fleatherTheme ??= _buildFleatherTheme(context),
       child: Stack(
         children: [
           if (showPlaceholder)
@@ -1509,6 +1531,9 @@ class _NoteEditorPageState extends ConsumerState<NoteEditorPage> {
           .where((f) => f['id']?.toString() != fileId)
           .toList();
 
+      // Snapshot the markdown that gets persisted so the dirty baseline stays
+      // in sync with what was saved.
+      final savedMarkdown = _contentMarkdown;
       final data = _composeUpdatedNoteData(files: updatedFiles);
 
       final resolvedTitle = _titleController.text.isEmpty
@@ -1530,6 +1555,7 @@ class _NoteEditorPageState extends ConsumerState<NoteEditorPage> {
         if (updatedNote != null) {
           setState(() {
             _note = updatedNote;
+            _savedMarkdown = savedMarkdown;
             _isSaving = false;
             _hasChanges = false;
           });

--- a/lib/features/notes/views/note_editor_page.dart
+++ b/lib/features/notes/views/note_editor_page.dart
@@ -122,7 +122,15 @@ class _NoteEditorPageState extends ConsumerState<NoteEditorPage> {
   }
 
   void _onContentFocusChanged() {
-    if (mounted) setState(() {});
+    if (!mounted) return;
+    // When the editor loses focus (e.g. the user taps away or starts
+    // navigating elsewhere), flush any pending edit immediately instead of
+    // waiting out the debounce, so a quick format-then-leave isn't dropped.
+    if (!_contentFocusNode.hasFocus && _hasChanges) {
+      _saveDebounce?.cancel();
+      unawaited(_autoSave());
+    }
+    setState(() {});
   }
 
   @override
@@ -249,6 +257,18 @@ class _NoteEditorPageState extends ConsumerState<NoteEditorPage> {
   void _debounceSave() {
     _saveDebounce?.cancel();
     _saveDebounce = Timer(const Duration(milliseconds: 800), _autoSave);
+  }
+
+  /// Handles a back-navigation attempt. Reached only when [canPop] was false,
+  /// i.e. there is a pending edit: flush it while still mounted (so the durable
+  /// write doesn't race teardown), then pop programmatically.
+  Future<void> _onEditorPopInvoked(bool didPop, Object? result) async {
+    if (didPop) return;
+    _saveDebounce?.cancel();
+    await _autoSave();
+    if (mounted && Navigator.of(context).canPop()) {
+      Navigator.of(context).pop(result);
+    }
   }
 
   Future<void> _autoSave() async {
@@ -576,7 +596,10 @@ class _NoteEditorPageState extends ConsumerState<NoteEditorPage> {
       final selection = controller?.selection;
       final docEnd = controller == null
           ? 0
-          : (controller.document.length - 1).clamp(0, controller.document.length);
+          : (controller.document.length - 1).clamp(
+              0,
+              controller.document.length,
+            );
       _dictationAnchor =
           (selection != null && selection.isValid && !selection.isCollapsed)
           ? selection.start
@@ -935,50 +958,63 @@ class _NoteEditorPageState extends ConsumerState<NoteEditorPage> {
       return const AdaptiveRouteShell(body: SizedBox.shrink());
     }
 
-    return ErrorBoundary(
-      child: AdaptiveRouteShell(
-        backgroundColor: context.conduitTheme.surfaceBackground,
-        extendBodyBehindAppBar: true,
-        appBar: _buildAdaptiveNoteEditorAppBar(context),
-        body: Stack(
-          children: [
-            Positioned.fill(child: _buildMainContent(context)),
-            Positioned(
-              left: 0,
-              right: 0,
-              top: 0,
-              child: ConduitChromeGradientFade.top(
-                contentHeight:
-                    MediaQuery.viewPaddingOf(context).top + kTextTabBarHeight,
-              ),
-            ),
-            if (!_isLoading && _note != null)
+    return PopScope(
+      // Allow the back gesture/animation to proceed normally when there is
+      // nothing to save. When an edit is still pending (within the auto-save
+      // debounce), intercept the pop, flush the save while the widget is still
+      // mounted (so the durable write completes without racing teardown), then
+      // pop programmatically.
+      canPop: !_hasChanges,
+      onPopInvokedWithResult: _onEditorPopInvoked,
+      child: ErrorBoundary(
+        child: AdaptiveRouteShell(
+          backgroundColor: context.conduitTheme.surfaceBackground,
+          extendBodyBehindAppBar: true,
+          appBar: _buildAdaptiveNoteEditorAppBar(context),
+          body: Stack(
+            children: [
+              Positioned.fill(child: _buildMainContent(context)),
               Positioned(
-                top: MediaQuery.of(context).padding.top + kTextTabBarHeight,
                 left: 0,
                 right: 0,
-                child: Padding(
-                  padding: const EdgeInsets.only(bottom: Spacing.xs),
-                  child: Center(child: _buildFloatingMetadataBar(context)),
+                top: 0,
+                child: ConduitChromeGradientFade.top(
+                  contentHeight:
+                      MediaQuery.viewPaddingOf(context).top + kTextTabBarHeight,
                 ),
               ),
-            if (!_isLoading && _note != null && !_contentFocusNode.hasFocus)
-              Positioned(
-                left: Spacing.md,
-                right: Spacing.md,
-                bottom: Spacing.md + MediaQuery.of(context).padding.bottom,
-                child: _buildFloatingActionsRow(context),
-              ),
-            // Formatting toolbar — shown above the keyboard while the content
-            // editor is focused (in place of the floating actions row).
-            if (!_isLoading && _note != null && _contentFocusNode.hasFocus)
-              Positioned(
-                left: 0,
-                right: 0,
-                bottom: MediaQuery.viewInsetsOf(context).bottom,
-                child: _buildFormattingToolbar(context),
-              ),
-          ],
+              if (!_isLoading && _note != null)
+                Positioned(
+                  top: MediaQuery.of(context).padding.top + kTextTabBarHeight,
+                  left: 0,
+                  right: 0,
+                  child: Padding(
+                    padding: const EdgeInsets.only(bottom: Spacing.xs),
+                    child: Center(child: _buildFloatingMetadataBar(context)),
+                  ),
+                ),
+              if (!_isLoading && _note != null && !_contentFocusNode.hasFocus)
+                Positioned(
+                  left: Spacing.md,
+                  right: Spacing.md,
+                  bottom: Spacing.md + MediaQuery.of(context).padding.bottom,
+                  child: _buildFloatingActionsRow(context),
+                ),
+              // Formatting toolbar — shown above the keyboard while the content
+              // editor is focused (in place of the floating actions row). The
+              // scaffold uses resizeToAvoidBottomInset, so the body is already
+              // laid out above the keyboard; anchoring at bottom: 0 sits the
+              // toolbar directly on top of it (anchoring at viewInsets.bottom
+              // would double-count the inset and push it up to the stats row).
+              if (!_isLoading && _note != null && _contentFocusNode.hasFocus)
+                Positioned(
+                  left: 0,
+                  right: 0,
+                  bottom: 0,
+                  child: _buildFormattingToolbar(context),
+                ),
+            ],
+          ),
         ),
       ),
     );
@@ -1000,13 +1036,21 @@ class _NoteEditorPageState extends ConsumerState<NoteEditorPage> {
           ),
           child: FleatherTheme(
             data: _fleatherTheme ??= _buildFleatherTheme(context),
-            // Hide formatting that markdown cannot round-trip (underline and
-            // colours), since markdown stays the canonical stored format.
+            // Markdown is the canonical stored format, so hide every control
+            // whose result markdown can't represent — otherwise the user
+            // applies formatting that silently vanishes on save/reopen.
+            // Dropped: underline, text/background colour, alignment,
+            // indentation, and text direction. Kept: bold, italic,
+            // strikethrough, inline code, headings, lists (incl. checkboxes),
+            // code blocks, quotes, links, and horizontal rules.
             child: FleatherToolbar.basic(
               controller: controller,
               hideUnderLineButton: true,
               hideBackgroundColor: true,
               hideForegroundColor: true,
+              hideAlignment: true,
+              hideIndentation: true,
+              hideDirection: true,
             ),
           ),
         ),

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -329,6 +329,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.7.13"
+  diff_match_patch:
+    dependency: transitive
+    description:
+      name: diff_match_patch
+      sha256: "2efc9e6e8f449d0abe15be240e2c2a3bcd977c8d126cfd70598aee60af35c0a4"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.4.1"
   dio:
     dependency: "direct main"
     description:
@@ -457,6 +465,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.1.1"
+  fleather:
+    dependency: "direct main"
+    description:
+      name: fleather
+      sha256: b2edca833fd58f46fca91a3976952f1cd61dd28e7414e0812b44e1e8363d5ac8
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.27.0"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -1327,6 +1343,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.1.0"
+  parchment:
+    dependency: "direct main"
+    description:
+      name: parchment
+      sha256: "1af4dd4a39034452aecabac2baf4cb2a5248fc4467b6ba48cd5e11e533e00875"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.27.0"
+  parchment_delta:
+    dependency: transitive
+    description:
+      name: parchment_delta
+      sha256: "8b360d0138eb591c7fe193670e2d05466e482792af9c5b4d3f568c5c61530f08"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.0"
   path:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -99,7 +99,10 @@ dependencies:
       ref: 7a897c8ef022966758ac1f7a8d96c0a14b260c9c
   drift: ^2.34.0
   drift_flutter: ^0.3.0
-  
+  fleather: ^1.27.0
+  # Document model + markdown/HTML codecs backing the Fleather note editor.
+  parchment: ^1.27.0
+
 dev_dependencies:
   flutter_test:
     sdk: flutter

--- a/test/features/notes/utils/note_document_codec_test.dart
+++ b/test/features/notes/utils/note_document_codec_test.dart
@@ -1,0 +1,83 @@
+import 'package:checks/checks.dart';
+import 'package:conduit/features/notes/utils/note_document_codec.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('documentFromMarkdown', () {
+    test('returns an empty document for blank input', () {
+      check(documentFromMarkdown('').toPlainText().trim()).isEmpty();
+      check(documentFromMarkdown('   \n  ').toPlainText().trim()).isEmpty();
+    });
+
+    test('preserves plain paragraph text', () {
+      final doc = documentFromMarkdown('Just some plain text');
+      check(doc.toPlainText()).contains('Just some plain text');
+    });
+
+    test('never throws on unusual input', () {
+      // Unbalanced markers / stray syntax must fall back gracefully.
+      for (final input in ['**unterminated', '> ', '[x](', '```', '#']) {
+        check(documentFromMarkdown(input).toPlainText()).isNotNull();
+      }
+    });
+  });
+
+  group('markdown round-trips', () {
+    String roundTrip(String md) =>
+        markdownFromDocument(documentFromMarkdown(md));
+
+    test('headings survive', () {
+      check(roundTrip('# Heading one')).contains('# Heading one');
+    });
+
+    test('bold survives', () {
+      check(roundTrip('Some **bold** text')).contains('**bold**');
+    });
+
+    test('italic survives', () {
+      final out = roundTrip('Some *italic* text');
+      check(out.contains('*italic*') || out.contains('_italic_')).isTrue();
+    });
+
+    test('strikethrough survives', () {
+      check(roundTrip('A ~~struck~~ word')).contains('~~struck~~');
+    });
+
+    test('inline code survives', () {
+      check(roundTrip('Call `foo()` now')).contains('`foo()`');
+    });
+
+    test('bullet lists survive', () {
+      final out = roundTrip('- first\n- second');
+      check(out).contains('first');
+      check(out).contains('second');
+      // The encoder may emit either '-' or '*' bullet markers.
+      check(out.contains('- ') || out.contains('* ')).isTrue();
+    });
+
+    test('block quotes survive', () {
+      check(roundTrip('> quoted line')).contains('> quoted line');
+    });
+
+    test('links survive', () {
+      check(roundTrip('See [docs](https://example.com)'))
+          .contains('[docs](https://example.com)');
+    });
+  });
+
+  group('htmlFromDocument', () {
+    test('emits HTML tags for formatted content', () {
+      final html = htmlFromDocument(documentFromMarkdown('# Title'));
+      check(html.toLowerCase()).contains('<h1');
+    });
+
+    test('emits paragraph markup for plain text', () {
+      final html = htmlFromDocument(documentFromMarkdown('hello world'));
+      check(html.toLowerCase()).contains('hello world');
+    });
+
+    test('returns a string for empty documents', () {
+      check(htmlFromDocument(documentFromMarkdown(''))).isA<String>();
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Replaces the plain-text note editor with **[Fleather](https://pub.dev/packages/fleather)**, a WYSIWYG rich-text editor built on the Parchment/Delta document model.

**Markdown stays the canonical stored format.** On save the document is encoded to `content.md` + a derived `content.html` via the `parchment` codecs, and `content.json` (TipTap) is left null — so notes created or edited here remain fully editable on the Open WebUI web client, and web-authored notes open with formatting intact. This replaces the old hand-rolled markdown→HTML converter that only handled h1–h3/bold/italic.

## Changes

- **deps:** add `fleather` + `parchment` (`^1.27.0`).
- **`note_document_codec.dart` (new):** `documentFromMarkdown` / `markdownFromDocument` / `htmlFromDocument`, wrapping the parchment codecs with best-effort fallback (blank → empty doc, malformed → plain text) so the editor never fails to open a note.
- **`note_editor_page.dart`:** `TextEditingController` → `FleatherController`; `FleatherEditor` inside the existing scroll view with a placeholder overlay and a `FleatherToolbar.basic` shown above the keyboard while editing. Word/char counts, dirty detection, auto-save, AI-enhance (swaps the document), and dictation (anchored `replaceText` preserving surrounding formatting) all rewired off the document. Removed the old `_markdownToHtml`/`_escapeHtml`.
- Underline/colour toolbar buttons are hidden since markdown can't round-trip them.
- **tests:** codec round-trip + fallback unit tests.

## Server format

The Open WebUI notes API stores `data.content = {json, html, md}` and **merges** inbound `data` patches onto the existing row, preserving `versions`/`files`; search runs over `content.md`. Keeping `md` accurate is the priority, which this PR does.

## Verification

- `flutter analyze` — clean.
- `flutter test` — **2156 tests pass** (incl. 14 new codec tests).

## Review notes

- The dictation rework assumes the voice stream emits a **cumulative** transcript (as the previous code did by rebuilding from a base-text snapshot each event). If it actually emits incremental fragments, dictation needs a small tweak — worth confirming during the manual run.
- Formatting that markdown can't represent (text colour, underline) is intentionally dropped on round-trip; toolbar buttons for those are hidden.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary

* **New Features**
  * Introduced a Fleather-based rich-text note editor with formatting toolbar, placeholder, improved back-navigation, and pull-to-refresh.
  * Updated voice dictation to insert into rich-text without breaking formatting.
  * AI title/content enhancements now apply to rich-text notes.
* **Bug Fixes**
  * Reduced false “unsaved changes” by using canonical markdown snapshots.
  * More reliable saving and copy by converting editor content to canonical markdown/HTML with safe fallbacks.
  * Improved note content reloading after refresh/sync to reflect the latest saved state.
* **Tests**
  * Added coverage for markdown↔document and HTML conversion utilities, including edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Replaces the plain-text `TextEditingController` with a `FleatherController` (Fleather/Parchment WYSIWYG editor), keeping markdown as the canonical storage format by encoding to `content.md` + `content.html` on every save. A new `note_document_codec.dart` centralises markdown↔`ParchmentDocument` conversion with best-effort fallbacks so the editor never fails to open a note.

- **Editor mechanics:** `PopScope` intercepts back-navigation to flush pending saves; pull-to-refresh follows a flush → sync → read-local order to avoid clobbering in-flight edits; the Fleather theme is cached in `didChangeDependencies`; the formatting toolbar hides controls whose output markdown cannot represent.
- **Dictation:** rewired to anchor-based `replaceText` so each cumulative transcript update replaces only the in-progress dictation run, leaving surrounding formatting intact.
- **State tracking:** `_savedMarkdown` (re-encoded markdown on load/save) replaces direct text comparison, absorbing codec normalisation so opening a note never registers as a spurious change; previously flagged `_savedMarkdown` staleness after file-attachment saves is resolved.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge. The editor rewrite is well-structured, the pull-to-refresh race condition is correctly guarded, and all previously flagged stale-baseline issues are resolved.

The logic for flush-on-back (PopScope), pull-to-refresh ordering, and _savedMarkdown tracking is sound. The only notes are minor: markdownFromDocument runs twice per save (redundant but inexpensive at debounce frequency), and a focus-loss auto-save could theoretically overlap with a PopScope-triggered auto-save — neither causes data loss or corruption.

note_editor_page.dart — the _onContentFocusChanged unawaited auto-save and the missing _isSaving entry guard in _saveNote are worth a quick second look.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| lib/features/notes/views/note_editor_page.dart | Core editor rewrite: replaces TextEditingController with FleatherController, adds PopScope flush-on-back, pull-to-refresh with correct flush→sync→read-local ordering, anchor-based dictation, and caches the Fleather theme in didChangeDependencies. Previously flagged _savedMarkdown staleness in file-attachment saves is fixed. |
| lib/features/notes/utils/note_document_codec.dart | New codec helpers wrapping parchment's markdown/HTML codecs with best-effort fallback (blank → empty doc, decode failure → plain-text doc, encode failure → toPlainText()). Logic is clean and well-documented. |
| lib/features/notes/providers/notes_providers.dart | Adds readLocalNote helper that reads directly from the local Drift row, bypassing any server fetch — used by the editor's pull-to-refresh to avoid clobbering not-yet-pushed local edits with a stale server copy. |
| test/features/notes/utils/note_document_codec_test.dart | New unit tests covering empty/blank inputs, plain text, fallback on malformed markdown, round-trips for headings/bold/italic/strikethrough/inline-code/bullets/blockquotes/links, and HTML output. |
| pubspec.yaml | Adds fleather ^1.27.0 and parchment ^1.27.0 as direct dependencies, with a comment explaining parchment's role. |

</details>


</details>


<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[User edits note] --> B[_onContentChanged\noptimistic: _hasChanges = true]
    B --> C[_debounceSave 800ms]
    C --> D[_autoSave\nauthoritative dirty check\n_contentMarkdown vs _savedMarkdown]
    D -- no real change --> E[_hasChanges = false\nno API call]
    D -- changed --> F[_saveNote\nmarkdownFromDocument\nhtmlFromDocument]
    F --> G[API/Drift write\n_savedMarkdown = savedMarkdown\n_hasChanges = false]
    H[User swipes Back\n_hasChanges = true] --> I{canPop = !_hasChanges}
    I -- false: intercept --> J[_onEditorPopInvoked\ncancel debounce\nawait _autoSave]
    J --> K[pop after save]
    L[Pull-to-refresh] --> M{_hasChanges?}
    M -- yes --> N[flush via _autoSave]
    N --> O[requestPull sync]
    M -- no --> O
    O --> P{_hasChanges again?}
    P -- yes --> Q[bail: leave in-flight edits]
    P -- no --> R[readLocalNote\ninstall document\n_savedMarkdown reset]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[User edits note] --> B[_onContentChanged\noptimistic: _hasChanges = true]
    B --> C[_debounceSave 800ms]
    C --> D[_autoSave\nauthoritative dirty check\n_contentMarkdown vs _savedMarkdown]
    D -- no real change --> E[_hasChanges = false\nno API call]
    D -- changed --> F[_saveNote\nmarkdownFromDocument\nhtmlFromDocument]
    F --> G[API/Drift write\n_savedMarkdown = savedMarkdown\n_hasChanges = false]
    H[User swipes Back\n_hasChanges = true] --> I{canPop = !_hasChanges}
    I -- false: intercept --> J[_onEditorPopInvoked\ncancel debounce\nawait _autoSave]
    J --> K[pop after save]
    L[Pull-to-refresh] --> M{_hasChanges?}
    M -- yes --> N[flush via _autoSave]
    N --> O[requestPull sync]
    M -- no --> O
    O --> P{_hasChanges again?}
    P -- yes --> Q[bail: leave in-flight edits]
    P -- no --> R[readLocalNote\ninstall document\n_savedMarkdown reset]
```

</a>
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `lib/features/notes/views/note_editor_page.dart`, line 854-858 ([link](https://github.com/cogwheel0/conduit/blob/38820bbe3594cd7afdc1dfe72b46f0bc7e8fce03/lib/features/notes/views/note_editor_page.dart#L854-L858)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **`_savedMarkdown` not updated after file-attachment saves**

   `_uploadAudioFile` and `_removeFile` both call `_composeUpdatedNoteData()` (which includes the current markdown) and successfully persist the note, but their `setState` blocks only set `_hasChanges = false` without advancing `_savedMarkdown` to match what was just saved. After either operation, `_savedMarkdown` still holds the pre-save baseline.

   The next time `_onContentChanged` fires — a title edit, another keystroke, or a toolbar tap — `_contentMarkdown != _savedMarkdown` is true even though no real content change occurred since the last server write. This triggers a debounced auto-save and re-lights the dirty indicator, sending a redundant API call with content that was already persisted. The same pattern applies in `_removeFile` (line 1534).

   The fix is to capture `_contentMarkdown` before each `await _persistNoteUpdate(...)` and assign it to `_savedMarkdown` inside the success `setState`, identical to what `_saveNote` already does.
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (7): Last reviewed commit: ["fix(notes): don&#39;t discard edits made dur..."](https://github.com/cogwheel0/conduit/commit/f17243629877830d8e6762c4f0de6d2bbefcaad7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38686986)</sub>

<!-- /greptile_comment -->