### PR TITLE
feat(hermes): Hermes-only mode — run with no Open WebUI server

### DIFF
--- a/lib/core/persistence/persistence_keys.dart
+++ b/lib/core/persistence/persistence_keys.dart
@@ -54,6 +54,10 @@ final class PreferenceKeys {
   static const String hermesBaseUrl = 'hermes_base_url_v1';
   static const String hermesShowJobs = 'hermes_show_jobs_v1';
 
+  /// Which backend onboarding completed against ('owui' | 'hermes' | unset).
+  /// Read synchronously by the router for boot-deterministic routing.
+  static const String preferredBackend = 'preferred_backend_v1';
+
   // Drawer section collapsed states
   static const String drawerShowPinned = 'drawer_show_pinned';
   static const String drawerShowFolders = 'drawer_show_folders';

--- a/lib/core/providers/app_providers.dart
+++ b/lib/core/providers/app_providers.dart
@@ -652,6 +652,11 @@ class Models extends _$Models {
     }
 
     if (!ref.watch(isAuthenticatedProvider2)) {
+      // Hermes-only mode: no OpenWebUI auth, but a usable Hermes agent — surface
+      // just the synthetic Hermes model so the picker/composer work.
+      if (ref.watch(hermesConfigProvider).isUsable) {
+        return _withHermes(const <Model>[]);
+      }
       DebugLogger.log('skip-unauthed', scope: 'models');
       _persistModelsAsync(const <Model>[]);
       return const [];
@@ -1859,6 +1864,21 @@ Future<Model?> defaultModel(Ref ref) async {
 
   final api = ref.watch(apiServiceProvider);
   if (api == null) {
+    // Hermes-only mode: auto-select the synthetic Hermes agent model.
+    if (ref.read(hermesConfigProvider).isUsable) {
+      final models = await ref.read(modelsProvider.future);
+      Model? hermes;
+      for (final model in models) {
+        if (isHermesModel(model)) {
+          hermes = model;
+          break;
+        }
+      }
+      if (hermes != null && !ref.read(isManualModelSelectionProvider)) {
+        ref.read(selectedModelProvider.notifier).set(hermes);
+      }
+      return hermes;
+    }
     DebugLogger.warning('no-api', scope: 'models/default');
     return null;
   }

--- a/lib/core/providers/backend_mode_providers.dart
+++ b/lib/core/providers/backend_mode_providers.dart
@@ -1,0 +1,40 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../persistence/persistence_keys.dart';
+import '../persistence/preferences_store.dart';
+
+/// Which backend the user has onboarded against. Drives boot-deterministic
+/// routing so a Hermes-only install never bounces to the OpenWebUI server
+/// connection screen while async state (active server / Hermes secrets) loads.
+enum PreferredBackend { unset, owui, hermes }
+
+/// Synchronous, persisted preferred-backend signal. Read by the router.
+///
+/// Unlike the derived `hermesOnlyModeProvider`, this resolves synchronously at
+/// boot from shared preferences (mirroring `reviewerModeProvider`'s role) so the
+/// first `redirect()` is correct without waiting on async providers.
+class PreferredBackendController extends Notifier<PreferredBackend> {
+  @override
+  PreferredBackend build() => _parse(
+    PreferencesStore.getString(PreferenceKeys.preferredBackend),
+  );
+
+  Future<void> set(PreferredBackend backend) async {
+    state = backend;
+    await PreferencesStore.put(
+      PreferenceKeys.preferredBackend,
+      backend.name,
+    );
+  }
+
+  static PreferredBackend _parse(String? raw) => switch (raw) {
+    'owui' => PreferredBackend.owui,
+    'hermes' => PreferredBackend.hermes,
+    _ => PreferredBackend.unset,
+  };
+}
+
+final preferredBackendProvider =
+    NotifierProvider<PreferredBackendController, PreferredBackend>(
+      PreferredBackendController.new,
+    );

--- a/lib/core/router/app_router.dart
+++ b/lib/core/router/app_router.dart
@@ -7,11 +7,15 @@ import 'package:go_router/go_router.dart';
 
 import '../auth/auth_state_manager.dart';
 import '../providers/app_providers.dart';
+import '../providers/backend_mode_providers.dart';
+import '../../features/hermes/models/hermes_config.dart';
+import '../../features/hermes/providers/hermes_providers.dart';
 import '../services/navigation_service.dart';
 import '../services/performance_profiler.dart';
 import '../utils/debug_logger.dart';
 import '../../features/auth/providers/unified_auth_providers.dart';
 import '../../features/auth/views/authentication_page.dart';
+import '../../features/auth/views/backend_chooser_page.dart';
 import '../../features/auth/views/connect_signin_page.dart';
 import '../../features/auth/views/connection_issue_page.dart';
 import '../../features/auth/views/proxy_auth_page.dart';
@@ -49,6 +53,10 @@ class RouterNotifier extends ChangeNotifier {
         authNavigationStateProvider,
         _onStateChanged,
       ),
+      // Hermes-only routing: re-evaluate when the preferred backend changes or
+      // the Hermes config becomes usable (secrets finish loading).
+      ref.listen<PreferredBackend>(preferredBackendProvider, _onStateChanged),
+      ref.listen<HermesConfig>(hermesConfigProvider, _onStateChanged),
     ];
   }
 
@@ -87,9 +95,23 @@ class RouterNotifier extends ChangeNotifier {
       return Routes.chat;
     }
 
+    // Onboarding screens (backend chooser + Hermes setup) always render.
+    if (location == Routes.backendChooser ||
+        location == Routes.hermesSettings) {
+      return null;
+    }
+
+    final preferredBackend = ref.read(preferredBackendProvider);
+    final hermesUsable = ref.read(hermesConfigProvider).isUsable;
+    final prefersHermes = preferredBackend == PreferredBackend.hermes;
+
     if (activeServerAsync.isLoading) {
       // Avoid redirect loops: do not override explicit auth routes while loading
       if (_isAuthLocation(location)) return null;
+      // Hermes-only user: don't flash the OWUI splash→serverConnection path.
+      if (prefersHermes && hermesUsable) {
+        return location == Routes.chat ? null : Routes.chat;
+      }
       // Keep splash during server loading otherwise
       return location == Routes.splash ? null : Routes.splash;
     }
@@ -100,11 +122,26 @@ class RouterNotifier extends ChangeNotifier {
 
     final activeServer = activeServerAsync.asData?.value;
     final hasActiveServer = activeServer != null;
+
+    // Hermes-only mode: onboarded to Hermes with no OWUI server → straight to
+    // chat, bypassing OWUI server/auth entirely (mirrors reviewer mode).
+    if (prefersHermes && !hasActiveServer) {
+      if (hermesUsable) {
+        return location == Routes.chat ? null : Routes.chat;
+      }
+      // Not usable yet. If Hermes is still enabled, the API key secret is just
+      // loading → hold on splash (the hermesConfigProvider subscription re-runs
+      // this once it resolves). If disabled (config cleared), fall through to
+      // the chooser so the user is never stranded.
+      if (ref.read(hermesConfigProvider).enabled) {
+        return location == Routes.splash ? null : Routes.splash;
+      }
+    }
+
     if (!hasActiveServer) {
-      // No server configured - redirect to server connection
+      // No server configured - redirect to onboarding chooser.
       // Exception: allow staying on server connection, authentication,
       // proxy auth, and SSO pages during the connection/auth flow.
-      // But always redirect away from connection issue page (user logged out)
       if (location == Routes.serverConnection ||
           location == Routes.authentication ||
           location == Routes.proxyAuth ||
@@ -112,7 +149,7 @@ class RouterNotifier extends ChangeNotifier {
           location == Routes.login) {
         return null;
       }
-      return Routes.serverConnection;
+      return Routes.backendChooser;
     }
 
     final authState = ref.read(authNavigationStateProvider);
@@ -261,6 +298,12 @@ final goRouterProvider = Provider<GoRouter>((ref) {
           _buildPlatformPage(state: state, child: const ConnectAndSignInPage()),
     ),
     GoRoute(
+      path: Routes.backendChooser,
+      name: RouteNames.backendChooser,
+      pageBuilder: (context, state) =>
+          _buildPlatformPage(state: state, child: const BackendChooserPage()),
+    ),
+    GoRoute(
       path: Routes.serverConnection,
       name: RouteNames.serverConnection,
       pageBuilder: (context, state) =>
@@ -367,8 +410,10 @@ final goRouterProvider = Provider<GoRouter>((ref) {
     GoRoute(
       path: Routes.hermesSettings,
       name: RouteNames.hermesSettings,
-      pageBuilder: (context, state) =>
-          _buildPlatformPage(state: state, child: const HermesSettingsPage()),
+      pageBuilder: (context, state) => _buildPlatformPage(
+        state: state,
+        child: HermesSettingsPage(isOnboarding: state.extra == true),
+      ),
     ),
     GoRoute(
       path: Routes.hermesJobs,

--- a/lib/core/router/app_router.dart
+++ b/lib/core/router/app_router.dart
@@ -126,6 +126,10 @@ class RouterNotifier extends ChangeNotifier {
     // Hermes-only mode: onboarded to Hermes with no OWUI server → straight to
     // chat, bypassing OWUI server/auth entirely (mirrors reviewer mode).
     if (prefersHermes && !hasActiveServer) {
+      // Let a Hermes-only user reach the OWUI connect/auth flow so they can add
+      // an Open WebUI server (bidirectional switching). Once connected,
+      // preferredBackend flips to owui and this branch no longer applies.
+      if (_isAuthLocation(location)) return null;
       if (hermesUsable) {
         return location == Routes.chat ? null : Routes.chat;
       }

--- a/lib/core/services/native_sheet_hydration_service.dart
+++ b/lib/core/services/native_sheet_hydration_service.dart
@@ -181,10 +181,13 @@ class NativeSheetHydrationService {
     String detailId = NativeSheetRoutes.about,
   }) async {
     try {
-      final packageInfoFuture = _ref.read(packageInfoProvider.future);
-      final aboutFuture = _ref.read(serverAboutInfoProvider.future);
-      final packageInfo = await packageInfoFuture;
-      final about = await aboutFuture;
+      // Hermes-only has no Open WebUI server, so skip the server lookup and omit
+      // the server name/version rows entirely.
+      final hermesOnly = _ref.read(hermesOnlyModeProvider);
+      final packageInfo = await _ref.read(packageInfoProvider.future);
+      final about = hermesOnly
+          ? null
+          : await _ref.read(serverAboutInfoProvider.future);
       if (!context.mounted) return;
 
       final appVersionLabel = packageInfo.buildNumber.isEmpty
@@ -211,20 +214,22 @@ class NativeSheetHydrationService {
               sfSymbol: 'app.badge',
               kind: NativeSheetItemKind.info,
             ),
-            NativeSheetItemConfig(
-              id: 'server-name',
-              title: l10n.serverNameLabel,
-              subtitle: serverName,
-              sfSymbol: 'server.rack',
-              kind: NativeSheetItemKind.info,
-            ),
-            NativeSheetItemConfig(
-              id: 'server-version',
-              title: l10n.serverVersionLabel,
-              subtitle: serverVersion,
-              sfSymbol: 'number',
-              kind: NativeSheetItemKind.info,
-            ),
+            if (!hermesOnly)
+              NativeSheetItemConfig(
+                id: 'server-name',
+                title: l10n.serverNameLabel,
+                subtitle: serverName,
+                sfSymbol: 'server.rack',
+                kind: NativeSheetItemKind.info,
+              ),
+            if (!hermesOnly)
+              NativeSheetItemConfig(
+                id: 'server-version',
+                title: l10n.serverVersionLabel,
+                subtitle: serverVersion,
+                sfSymbol: 'number',
+                kind: NativeSheetItemKind.info,
+              ),
             NativeSheetItemConfig(
               id: 'github',
               title: l10n.githubRepository,

--- a/lib/core/services/navigation_service.dart
+++ b/lib/core/services/navigation_service.dart
@@ -121,6 +121,7 @@ class Routes {
   static const String chat = '/chat';
   static const String folder = '/folder/:id';
   static const String login = '/login';
+  static const String backendChooser = '/backend-chooser';
   static const String serverConnection = '/server-connection';
   static const String connectionIssue = '/connection-issue';
   static const String authentication = '/authentication';
@@ -148,6 +149,7 @@ class RouteNames {
   static const String chat = 'chat';
   static const String folder = 'folder';
   static const String login = 'login';
+  static const String backendChooser = 'backend-chooser';
   static const String serverConnection = 'server-connection';
   static const String connectionIssue = 'connection-issue';
   static const String authentication = 'authentication';

--- a/lib/features/auth/views/authentication_page.dart
+++ b/lib/features/auth/views/authentication_page.dart
@@ -9,6 +9,7 @@ import 'package:go_router/go_router.dart';
 import '../../../core/models/backend_config.dart';
 import '../../../core/models/server_config.dart';
 import '../../../core/providers/app_providers.dart';
+import '../../../core/providers/backend_mode_providers.dart';
 import '../../../core/services/input_validation_service.dart';
 import '../../../core/services/navigation_service.dart';
 import '../../../core/widgets/error_boundary.dart';
@@ -225,6 +226,9 @@ class _AuthenticationPageState extends ConsumerState<AuthenticationPage> {
     final storage = ref.read(optimizedStorageServiceProvider);
     await storage.saveServerConfigs([config]);
     await storage.setActiveServerId(config.id);
+    await ref
+        .read(preferredBackendProvider.notifier)
+        .set(PreferredBackend.owui);
     ref.invalidate(serverConfigsProvider);
     ref.invalidate(activeServerProvider);
     ref.invalidate(apiServiceProvider);

--- a/lib/features/auth/views/backend_chooser_page.dart
+++ b/lib/features/auth/views/backend_chooser_page.dart
@@ -1,0 +1,148 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+
+import '../../../core/services/navigation_service.dart';
+import '../../../shared/theme/theme_extensions.dart';
+import '../../../shared/widgets/adaptive_route_shell.dart';
+
+/// First-run screen letting a fresh install choose its backend: a self-hosted
+/// Open WebUI server, or a Hermes Agent (used exclusively, no Open WebUI).
+class BackendChooserPage extends ConsumerWidget {
+  const BackendChooserPage({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final theme = context.conduitTheme;
+    final safePadding = MediaQuery.of(context).padding;
+
+    return AdaptiveRouteShell(
+      backgroundColor: theme.surfaceBackground,
+      body: SingleChildScrollView(
+        child: Center(
+          child: ConstrainedBox(
+            constraints: const BoxConstraints(maxWidth: 480),
+            child: Padding(
+              padding: EdgeInsets.only(
+                left: Spacing.pagePadding,
+                right: Spacing.pagePadding,
+                top: safePadding.top + Spacing.xxl,
+                bottom: Spacing.xxl,
+              ),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.stretch,
+                children: [
+                  Text(
+                    'Welcome to Conduit',
+                    textAlign: TextAlign.center,
+                    style: AppTypography.headlineLargeStyle.copyWith(
+                      color: theme.textPrimary,
+                      fontWeight: FontWeight.w700,
+                    ),
+                  ),
+                  const SizedBox(height: Spacing.sm),
+                  Text(
+                    'Choose how you want to connect.',
+                    textAlign: TextAlign.center,
+                    style: AppTypography.bodyMediumStyle.copyWith(
+                      color: theme.textSecondary,
+                    ),
+                  ),
+                  const SizedBox(height: Spacing.xxl),
+                  _ChooserCard(
+                    icon: Icons.dns_outlined,
+                    title: 'Connect to Open WebUI',
+                    subtitle:
+                        'Use your self-hosted Open WebUI server with full chat, '
+                        'notes, and more.',
+                    onTap: () => context.go(Routes.serverConnection),
+                  ),
+                  const SizedBox(height: Spacing.md),
+                  _ChooserCard(
+                    icon: Icons.smart_toy_outlined,
+                    title: 'Use a Hermes Agent',
+                    subtitle:
+                        'Connect directly to a self-hosted Hermes agent — no '
+                        'Open WebUI server needed.',
+                    onTap: () =>
+                        context.go(Routes.hermesSettings, extra: true),
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _ChooserCard extends StatelessWidget {
+  const _ChooserCard({
+    required this.icon,
+    required this.title,
+    required this.subtitle,
+    required this.onTap,
+  });
+
+  final IconData icon;
+  final String title;
+  final String subtitle;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = context.conduitTheme;
+    return Material(
+      color: Colors.transparent,
+      child: InkWell(
+        onTap: onTap,
+        borderRadius: BorderRadius.circular(AppBorderRadius.card),
+        child: Container(
+          padding: const EdgeInsets.all(Spacing.lg),
+          decoration: BoxDecoration(
+            color: theme.cardBackground,
+            borderRadius: BorderRadius.circular(AppBorderRadius.card),
+            border: Border.all(color: theme.cardBorder),
+          ),
+          child: Row(
+            children: [
+              Container(
+                width: 44,
+                height: 44,
+                decoration: BoxDecoration(
+                  color: theme.buttonPrimary.withValues(alpha: 0.12),
+                  borderRadius: BorderRadius.circular(AppBorderRadius.md),
+                ),
+                child: Icon(icon, color: theme.buttonPrimary),
+              ),
+              const SizedBox(width: Spacing.md),
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      title,
+                      style: AppTypography.standard.copyWith(
+                        color: theme.textPrimary,
+                        fontWeight: FontWeight.w600,
+                      ),
+                    ),
+                    const SizedBox(height: Spacing.xxs),
+                    Text(
+                      subtitle,
+                      style: AppTypography.bodySmallStyle.copyWith(
+                        color: theme.textSecondary,
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+              Icon(Icons.chevron_right, color: theme.iconSecondary),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/auth/views/server_connection_page.dart
+++ b/lib/features/auth/views/server_connection_page.dart
@@ -17,6 +17,7 @@ import 'package:conduit/l10n/app_localizations.dart';
 import '../../../core/auth/webview_cookie_helper.dart';
 import '../../../core/models/server_config.dart';
 import '../../../core/providers/app_providers.dart';
+import '../../../core/providers/backend_mode_providers.dart';
 import '../../../core/services/api_service.dart';
 import '../../../core/services/worker_manager.dart';
 import '../../../core/services/input_validation_service.dart';
@@ -434,6 +435,9 @@ class _ServerConnectionPageState extends ConsumerState<ServerConnectionPage> {
     final storage = ref.read(optimizedStorageServiceProvider);
     await storage.saveServerConfigs([config]);
     await storage.setActiveServerId(config.id);
+    await ref
+        .read(preferredBackendProvider.notifier)
+        .set(PreferredBackend.owui);
     ref.invalidate(serverConfigsProvider);
     ref.invalidate(activeServerProvider);
   }

--- a/lib/features/chat/providers/chat_providers.dart
+++ b/lib/features/chat/providers/chat_providers.dart
@@ -3923,7 +3923,12 @@ Future<void> regenerateMessage(
   final api = ref.read(apiServiceProvider);
   final selectedModel = ref.read(selectedModelProvider);
 
-  if ((!reviewerMode && api == null) || selectedModel == null) {
+  // The OpenWebUI API may be null in Hermes-only mode; Hermes models route to
+  // the Hermes transport and don't need it.
+  if ((!reviewerMode &&
+          api == null &&
+          !(selectedModel != null && isHermesModel(selectedModel))) ||
+      selectedModel == null) {
     throw Exception('No API service or model selected');
   }
 
@@ -5336,7 +5341,12 @@ Future<void> _sendMessageInternal(
   final api = ref.read(apiServiceProvider);
   final selectedModel = ref.read(selectedModelProvider);
 
-  if ((!reviewerMode && api == null) || selectedModel == null) {
+  // The OpenWebUI API may be null in Hermes-only mode; Hermes models route to
+  // the Hermes transport and don't need it.
+  if ((!reviewerMode &&
+          api == null &&
+          !(selectedModel != null && isHermesModel(selectedModel))) ||
+      selectedModel == null) {
     throw Exception('No API service or model selected');
   }
 

--- a/lib/features/chat/providers/chat_providers.dart
+++ b/lib/features/chat/providers/chat_providers.dart
@@ -3912,6 +3912,24 @@ List<Map<String, dynamic>> _contextAttachmentsToFiles(
   }).toList();
 }
 
+/// Whether a send/regenerate should be blocked given the current backend state.
+///
+/// A send needs one of: an OpenWebUI [api], reviewer mode, or a Hermes model
+/// (which routes to the direct Hermes transport and doesn't use [api]). A null
+/// [selectedModel] always blocks. Extracted so the Hermes-only relaxation is
+/// unit-testable independent of the large send pipelines.
+@visibleForTesting
+bool isSendBlocked({
+  required bool reviewerMode,
+  required Object? api,
+  required Model? selectedModel,
+}) {
+  if (selectedModel == null) return true;
+  if (reviewerMode) return false;
+  if (api != null) return false;
+  return !isHermesModel(selectedModel);
+}
+
 // Regenerate message function that doesn't duplicate user message
 Future<void> regenerateMessage(
   dynamic ref,
@@ -3925,10 +3943,11 @@ Future<void> regenerateMessage(
 
   // The OpenWebUI API may be null in Hermes-only mode; Hermes models route to
   // the Hermes transport and don't need it.
-  if ((!reviewerMode &&
-          api == null &&
-          !(selectedModel != null && isHermesModel(selectedModel))) ||
-      selectedModel == null) {
+  if (isSendBlocked(
+    reviewerMode: reviewerMode,
+    api: api,
+    selectedModel: selectedModel,
+  )) {
     throw Exception('No API service or model selected');
   }
 
@@ -5343,10 +5362,11 @@ Future<void> _sendMessageInternal(
 
   // The OpenWebUI API may be null in Hermes-only mode; Hermes models route to
   // the Hermes transport and don't need it.
-  if ((!reviewerMode &&
-          api == null &&
-          !(selectedModel != null && isHermesModel(selectedModel))) ||
-      selectedModel == null) {
+  if (isSendBlocked(
+    reviewerMode: reviewerMode,
+    api: api,
+    selectedModel: selectedModel,
+  )) {
     throw Exception('No API service or model selected');
   }
 

--- a/lib/features/chat/widgets/modern_chat_input.dart
+++ b/lib/features/chat/widgets/modern_chat_input.dart
@@ -1792,6 +1792,13 @@ class _ModernChatInputState extends ConsumerState<ModernChatInput>
       return const <IosKeyboardAttachmentActionConfig>[];
     }
 
+    // Hermes is a single-agent backend with no OWUI tools/web-search/attachments;
+    // suppress the OWUI keyboard-accessory actions for it.
+    final selectedModel = ref.read(selectedModelProvider);
+    if (selectedModel != null && isHermesModel(selectedModel)) {
+      return const <IosKeyboardAttachmentActionConfig>[];
+    }
+
     return buildComposerOverflowItems(
       l10n: l10n,
       attachmentAvailability: _overflowAttachmentAvailability,
@@ -2035,6 +2042,12 @@ class _ModernChatInputState extends ConsumerState<ModernChatInput>
       selectedModelProvider.select(modelSupportsTerminal),
     );
     final terminalActive = selectedTerminalId != null && terminalModelSupported;
+    // Hermes is a single-agent backend with no OWUI tools/web-search/image-gen/
+    // attachments; it uses its own `/` skills. Hide the OWUI composer affordances
+    // (the "+" overflow button and the quick pills) when a Hermes model is active.
+    final bool isHermesComposer = ref.watch(
+      selectedModelProvider.select((m) => m != null && isHermesModel(m)),
+    );
     final nativeAttachmentActions = _nativeKeyboardAttachmentActions(
       l10n: l10n,
       webSearchAvailable: webSearchAvailable,
@@ -2071,6 +2084,7 @@ class _ModernChatInputState extends ConsumerState<ModernChatInput>
     final List<Widget> quickPills = <Widget>[];
 
     for (final id in selectedQuickPills) {
+      if (isHermesComposer) break; // Hermes has no OWUI quick pills.
       if (id == 'web' && showWebPill && webSearchAvailable) {
         final String label = AppLocalizations.of(context)!.web;
         final IconData icon = Platform.isIOS
@@ -2267,17 +2281,19 @@ class _ModernChatInputState extends ConsumerState<ModernChatInput>
           ),
           child: Row(
             children: [
-              _buildOverflowButton(
-                tooltip: l10n.more,
-                webSearchActive: webSearchEnabled,
-                imageGenerationActive: imageGenEnabled,
-                toolsActive: selectedToolIds.isNotEmpty,
-                terminalActive: terminalActive,
-                filtersActive: selectedFilterIds.isNotEmpty,
-                dense: true,
-                nativeActions: nativeAttachmentActions,
-              ),
-              const SizedBox(width: Spacing.xs),
+              if (!isHermesComposer) ...[
+                _buildOverflowButton(
+                  tooltip: l10n.more,
+                  webSearchActive: webSearchEnabled,
+                  imageGenerationActive: imageGenEnabled,
+                  toolsActive: selectedToolIds.isNotEmpty,
+                  terminalActive: terminalActive,
+                  filtersActive: selectedFilterIds.isNotEmpty,
+                  dense: true,
+                  nativeActions: nativeAttachmentActions,
+                ),
+                const SizedBox(width: Spacing.xs),
+              ],
               Expanded(
                 child: ClipRect(
                   child: SingleChildScrollView(
@@ -2427,16 +2443,18 @@ class _ModernChatInputState extends ConsumerState<ModernChatInput>
             Row(
               crossAxisAlignment: CrossAxisAlignment.end,
               children: [
-                _buildOverflowButton(
-                  tooltip: l10n.more,
-                  webSearchActive: webSearchEnabled,
-                  imageGenerationActive: imageGenEnabled,
-                  toolsActive: selectedToolIds.isNotEmpty,
-                  terminalActive: terminalActive,
-                  filtersActive: selectedFilterIds.isNotEmpty,
-                  nativeActions: nativeAttachmentActions,
-                ),
-                const SizedBox(width: Spacing.sm),
+                if (!isHermesComposer) ...[
+                  _buildOverflowButton(
+                    tooltip: l10n.more,
+                    webSearchActive: webSearchEnabled,
+                    imageGenerationActive: imageGenEnabled,
+                    toolsActive: selectedToolIds.isNotEmpty,
+                    terminalActive: terminalActive,
+                    filtersActive: selectedFilterIds.isNotEmpty,
+                    nativeActions: nativeAttachmentActions,
+                  ),
+                  const SizedBox(width: Spacing.sm),
+                ],
                 Expanded(
                   child: _wrapIosSurfaceShadow(
                     textFieldShell,

--- a/lib/features/hermes/providers/hermes_providers.dart
+++ b/lib/features/hermes/providers/hermes_providers.dart
@@ -7,6 +7,8 @@ import 'package:uuid/uuid.dart';
 import '../../../core/models/prompt.dart';
 import '../../../core/persistence/persistence_keys.dart';
 import '../../../core/persistence/preferences_store.dart';
+import '../../../core/providers/app_providers.dart'
+    show activeServerProvider, reviewerModeProvider;
 import '../../../core/providers/storage_providers.dart';
 import '../../../core/services/secure_credential_storage.dart';
 import '../models/hermes_capabilities.dart';
@@ -115,6 +117,16 @@ final hermesConfigProvider =
 final hermesEnabledProvider = Provider<bool>(
   (ref) => ref.watch(hermesConfigProvider).enabled,
 );
+
+/// True when the app is running as a Hermes-only client: Hermes is fully
+/// configured AND there is no OpenWebUI server. Drives UI gating (hide OWUI
+/// tabs/affordances, make Hermes home). Reviewer mode takes precedence.
+final hermesOnlyModeProvider = Provider<bool>((ref) {
+  if (ref.watch(reviewerModeProvider)) return false;
+  if (!ref.watch(hermesConfigProvider).isUsable) return false;
+  final activeServer = ref.watch(activeServerProvider).asData?.value;
+  return activeServer == null;
+});
 
 /// The Hermes client, or null when Hermes is disabled / not fully configured.
 final hermesApiServiceProvider = Provider<HermesApiService?>((ref) {
@@ -281,7 +293,11 @@ class HermesJobsController extends AsyncNotifier<List<HermesJob>> {
     ref.invalidateSelf();
   }
 
-  Future<void> edit(String id, {String? prompt, String? schedule}) async {
+  Future<void> edit(
+    String id, {
+    String? prompt,
+    String? schedule,
+  }) async {
     final service = _service;
     if (service == null) return;
     await service.updateJob(id, prompt: prompt, schedule: schedule);

--- a/lib/features/hermes/views/hermes_settings_page.dart
+++ b/lib/features/hermes/views/hermes_settings_page.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
+import '../../../core/providers/backend_mode_providers.dart';
 import '../../../core/services/navigation_service.dart';
 import '../../../shared/theme/theme_extensions.dart';
 import '../../../shared/widgets/conduit_components.dart';
@@ -14,7 +15,11 @@ import '../providers/hermes_providers.dart';
 /// Settings for the optional direct Hermes Agent backend: enable toggle, server
 /// URL, API key, long-term memory key, and a connection test.
 class HermesSettingsPage extends ConsumerStatefulWidget {
-  const HermesSettingsPage({super.key});
+  const HermesSettingsPage({super.key, this.isOnboarding = false});
+
+  /// When true, the page is shown as a first-run setup step: the enable toggle
+  /// is implicit, and a "Finish setup" button completes onboarding into the app.
+  final bool isOnboarding;
 
   @override
   ConsumerState<HermesSettingsPage> createState() => _HermesSettingsPageState();
@@ -31,6 +36,21 @@ class _HermesSettingsPageState extends ConsumerState<HermesSettingsPage> {
     super.initState();
     final config = ref.read(hermesConfigProvider);
     _urlController = TextEditingController(text: config.baseUrl);
+    if (widget.isOnboarding) {
+      // Onboarding implies enabling; the toggle is hidden in this mode.
+      ref.read(hermesConfigProvider.notifier).setEnabled(true);
+    }
+  }
+
+  Future<void> _finishOnboarding() async {
+    final notifier = ref.read(hermesConfigProvider.notifier);
+    await notifier.setEnabled(true);
+    await notifier.ensureSessionKey();
+    await ref
+        .read(preferredBackendProvider.notifier)
+        .set(PreferredBackend.hermes);
+    if (!mounted) return;
+    context.go(Routes.chat);
   }
 
   @override
@@ -72,29 +92,43 @@ class _HermesSettingsPageState extends ConsumerState<HermesSettingsPage> {
     return SettingsPageScaffold(
       title: 'Hermes Agent',
       children: [
-        CustomizationTile(
-          leading: _badge(context, Icons.smart_toy_outlined),
-          title: 'Enable Hermes Agent',
-          subtitle:
-              'Connect directly to your self-hosted Hermes agent and use it '
-              'as a model in the picker.',
-          trailing: AdaptiveSwitch(
-            value: config.enabled,
-            onChanged: (value) => notifier.setEnabled(value),
-          ),
-          showChevron: false,
-          onTap: () => notifier.setEnabled(!config.enabled),
-        ),
-        if (config.enabled && _capabilities.jobs) ...[
-          const SizedBox(height: Spacing.sm),
+        if (widget.isOnboarding)
+          Padding(
+            padding: const EdgeInsets.only(bottom: Spacing.lg),
+            child: Text(
+              'Enter your self-hosted Hermes agent\'s address and API key to '
+              'start using it. You can add an Open WebUI server later in '
+              'settings.',
+              style: AppTypography.bodyMediumStyle.copyWith(
+                color: theme.textSecondary,
+              ),
+            ),
+          )
+        else ...[
           CustomizationTile(
-            leading: _badge(context, Icons.schedule),
-            title: 'Scheduled Agents',
-            subtitle: 'Run prompts on a cron schedule.',
-            onTap: () => context.pushNamed(RouteNames.hermesJobs),
+            leading: _badge(context, Icons.smart_toy_outlined),
+            title: 'Enable Hermes Agent',
+            subtitle:
+                'Connect directly to your self-hosted Hermes agent and use it '
+                'as a model in the picker.',
+            trailing: AdaptiveSwitch(
+              value: config.enabled,
+              onChanged: (value) => notifier.setEnabled(value),
+            ),
+            showChevron: false,
+            onTap: () => notifier.setEnabled(!config.enabled),
           ),
+          if (config.enabled && _capabilities.jobs) ...[
+            const SizedBox(height: Spacing.sm),
+            CustomizationTile(
+              leading: _badge(context, Icons.schedule),
+              title: 'Scheduled Agents',
+              subtitle: 'Run prompts on a cron schedule.',
+              onTap: () => context.pushNamed(RouteNames.hermesJobs),
+            ),
+          ],
+          const SizedBox(height: Spacing.lg),
         ],
-        const SizedBox(height: Spacing.lg),
         ConduitInput(
           label: 'Server URL',
           hint: 'http://192.168.1.10:8642',
@@ -158,6 +192,15 @@ class _HermesSettingsPageState extends ConsumerState<HermesSettingsPage> {
               ),
           ],
         ),
+        if (widget.isOnboarding) ...[
+          const SizedBox(height: Spacing.lg),
+          ConduitButton(
+            text: 'Finish setup',
+            icon: Icons.check,
+            isFullWidth: true,
+            onPressed: config.isUsable ? _finishOnboarding : null,
+          ),
+        ],
         if (config.isUsable) ...[
           const SizedBox(height: Spacing.xl),
           _capabilitiesSection(),

--- a/lib/features/hermes/views/hermes_settings_page.dart
+++ b/lib/features/hermes/views/hermes_settings_page.dart
@@ -59,6 +59,19 @@ class _HermesSettingsPageState extends ConsumerState<HermesSettingsPage> {
     super.dispose();
   }
 
+  /// Toggle the Hermes backend. When disabling a Hermes-only backend (no OWUI
+  /// server, so the preference is still 'hermes'), reset the preference to
+  /// 'unset' so the backend chooser is shown rather than leaving a stale value.
+  Future<void> _setHermesEnabled(bool value) async {
+    await ref.read(hermesConfigProvider.notifier).setEnabled(value);
+    if (!value &&
+        ref.read(preferredBackendProvider) == PreferredBackend.hermes) {
+      await ref
+          .read(preferredBackendProvider.notifier)
+          .set(PreferredBackend.unset);
+    }
+  }
+
   Future<void> _testConnection() async {
     final service = ref.read(hermesApiServiceProvider);
     if (service == null) {
@@ -113,10 +126,10 @@ class _HermesSettingsPageState extends ConsumerState<HermesSettingsPage> {
                 'as a model in the picker.',
             trailing: AdaptiveSwitch(
               value: config.enabled,
-              onChanged: (value) => notifier.setEnabled(value),
+              onChanged: (value) => _setHermesEnabled(value),
             ),
             showChevron: false,
-            onTap: () => notifier.setEnabled(!config.enabled),
+            onTap: () => _setHermesEnabled(!config.enabled),
           ),
           if (config.enabled && _capabilities.jobs) ...[
             const SizedBox(height: Spacing.sm),

--- a/lib/features/navigation/utils/sidebar_create_action.dart
+++ b/lib/features/navigation/utils/sidebar_create_action.dart
@@ -29,6 +29,7 @@ class SidebarCreateActionSpec {
 SidebarCreateActionSpec? sidebarCreateActionForActiveTab(WidgetRef ref) {
   final kind = _resolveSidebarCreateActionKind(
     tabIndex: ref.watch(sidebarActiveTabProvider),
+    hermesOnly: ref.watch(hermesOnlyModeProvider),
     hermesOn: ref.watch(hermesEnabledProvider),
     notesOn: ref.watch(notesFeatureEnabledProvider),
     terminalOn: _watchTerminalTabVisible(ref),
@@ -57,6 +58,7 @@ SidebarCreateActionSpec? sidebarCreateActionForActiveTab(WidgetRef ref) {
 Future<void> runSidebarCreateAction(BuildContext context, WidgetRef ref) async {
   final kind = _resolveSidebarCreateActionKind(
     tabIndex: ref.read(sidebarActiveTabProvider),
+    hermesOnly: ref.read(hermesOnlyModeProvider),
     hermesOn: ref.read(hermesEnabledProvider),
     notesOn: ref.read(notesFeatureEnabledProvider),
     terminalOn: _readTerminalTabVisible(ref),
@@ -82,11 +84,18 @@ Future<void> runSidebarCreateAction(BuildContext context, WidgetRef ref) async {
 
 _SidebarCreateActionKind? _resolveSidebarCreateActionKind({
   required int tabIndex,
+  required bool hermesOnly,
   required bool hermesOn,
   required bool notesOn,
   required bool terminalOn,
   required bool channelsOn,
 }) {
+  // Hermes-only: the Hermes tab is the only tab, so "+" always starts a new
+  // Hermes chat.
+  if (hermesOnly) {
+    return _SidebarCreateActionKind.hermesChat;
+  }
+
   var currentIndex = 0;
   if (tabIndex == currentIndex) {
     return _SidebarCreateActionKind.chat;

--- a/lib/features/navigation/widgets/sidebar_page.dart
+++ b/lib/features/navigation/widgets/sidebar_page.dart
@@ -471,14 +471,18 @@ class _SidebarPageState extends ConsumerState<SidebarPage> {
   @override
   Widget build(BuildContext context) {
     final localizations = AppLocalizations.of(context)!;
+    // Hermes-only mode hides every OpenWebUI surface; the Hermes tab is home.
+    final hermesOnly = ref.watch(hermesOnlyModeProvider);
     final hermesEnabled = ref.watch(hermesEnabledProvider);
-    final notesEnabled = ref.watch(notesFeatureEnabledProvider);
-    final channelsEnabled = ref.watch(channelsFeatureEnabledProvider);
+    final notesEnabled = !hermesOnly && ref.watch(notesFeatureEnabledProvider);
+    final channelsEnabled =
+        !hermesOnly && ref.watch(channelsFeatureEnabledProvider);
     // Live when the server list resolves; cached last-known value when offline
     // (so a terminal-disabled server doesn't surface the tab offline).
-    final showTerminalTab = ref.watch(terminalTabVisibleProvider);
+    final showTerminalTab =
+        !hermesOnly && ref.watch(terminalTabVisibleProvider);
     final visibleTabIds = <_SidebarTabId>[
-      _SidebarTabId.chats,
+      if (!hermesOnly) _SidebarTabId.chats,
       if (hermesEnabled) _SidebarTabId.hermes,
       if (notesEnabled) _SidebarTabId.notes,
       if (showTerminalTab) _SidebarTabId.terminal,
@@ -492,11 +496,12 @@ class _SidebarPageState extends ConsumerState<SidebarPage> {
     final isTerminalTabSelected =
         visibleTabIds[activeIndex] == _SidebarTabId.terminal;
     final tabDefinitions = <_SidebarTabDefinition>[
-      _SidebarTabDefinition(
-        id: _SidebarTabId.chats,
-        label: localizations.sidebarChatsTab,
-        body: const ChatsDrawer(),
-      ),
+      if (!hermesOnly)
+        _SidebarTabDefinition(
+          id: _SidebarTabId.chats,
+          label: localizations.sidebarChatsTab,
+          body: const ChatsDrawer(),
+        ),
       if (hermesEnabled)
         const _SidebarTabDefinition(
           id: _SidebarTabId.hermes,

--- a/lib/features/navigation/widgets/sidebar_user_pill.dart
+++ b/lib/features/navigation/widgets/sidebar_user_pill.dart
@@ -5,6 +5,7 @@ import 'dart:typed_data';
 import 'package:adaptive_platform_ui/adaptive_platform_ui.dart';
 import 'package:conduit/l10n/app_localizations.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart' show rootBundle;
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
@@ -25,6 +26,19 @@ import '../../../shared/widgets/user_avatar.dart';
 import '../../auth/providers/unified_auth_providers.dart';
 import '../../terminal/providers/terminal_providers.dart';
 import '../providers/sidebar_providers.dart';
+
+/// Cached bytes of the Hermes agent icon, used as the native profile-sheet
+/// avatar in Hermes-only mode (loaded once, then reused).
+Uint8List? _hermesAvatarBytesCache;
+Future<Uint8List?> _loadHermesAvatarBytes() async {
+  if (_hermesAvatarBytesCache != null) return _hermesAvatarBytesCache;
+  try {
+    final data = await rootBundle.load('assets/icons/hermes_agent.png');
+    return _hermesAvatarBytesCache = data.buffer.asUint8List();
+  } catch (_) {
+    return null;
+  }
+}
 
 /// Resolves the best available current user for sidebar UI.
 dynamic resolveSidebarUser(WidgetRef ref) {
@@ -109,6 +123,12 @@ class SidebarProfileAppBarLeading extends ConsumerWidget {
           if (!context.mounted) return;
 
           if (Platform.isIOS) {
+            // Pre-load the Hermes avatar bytes (the config builder is sync, and
+            // avatarBytes must be supplied up front).
+            final hermesAvatarBytes = ref.read(hermesOnlyModeProvider)
+                ? await _loadHermesAvatarBytes()
+                : null;
+            if (!context.mounted) return;
             final config = _buildNativeProfileSheetConfig(
               context: context,
               ref: ref,
@@ -116,6 +136,7 @@ class SidebarProfileAppBarLeading extends ConsumerWidget {
               api: api,
               displayName: displayName,
               initials: initial,
+              hermesAvatarBytes: hermesAvatarBytes,
             );
             final presented = await NativeSheetBridge.instance
                 .presentProfileMenu(config);
@@ -151,6 +172,7 @@ class SidebarProfileAppBarLeading extends ConsumerWidget {
     required dynamic api,
     required String displayName,
     required String initials,
+    Uint8List? hermesAvatarBytes,
   }) {
     final l10n = AppLocalizations.of(context)!;
     // In Hermes-only mode there's no Open WebUI account, so hide the OWUI
@@ -177,18 +199,25 @@ class SidebarProfileAppBarLeading extends ConsumerWidget {
 
     return NativeProfileSheetConfig(
       profileMenuTitle: settingsTitle,
-      profile: NativeProfileSheetUser(
-        displayName: displayName,
-        email: email,
-        initials: initials,
-        avatarUrl: avatarBytes == null ? avatarUrl : null,
-        avatarBytes: avatarBytes,
-        avatarHeaders: buildImageHeadersFromWidgetRef(ref) ?? const {},
-        bio: accountProfile?.bio,
-        gender: accountProfile?.gender,
-        dateOfBirth: accountProfile?.dateOfBirth,
-        profileImageUrl: accountProfile?.profileImageUrl,
-      ),
+      profile: hermesOnly
+          ? NativeProfileSheetUser(
+              displayName: 'Hermes Agent',
+              email: _hermesHostLabel(ref),
+              initials: 'HA',
+              avatarBytes: hermesAvatarBytes,
+            )
+          : NativeProfileSheetUser(
+              displayName: displayName,
+              email: email,
+              initials: initials,
+              avatarUrl: avatarBytes == null ? avatarUrl : null,
+              avatarBytes: avatarBytes,
+              avatarHeaders: buildImageHeadersFromWidgetRef(ref) ?? const {},
+              bio: accountProfile?.bio,
+              gender: accountProfile?.gender,
+              dateOfBirth: accountProfile?.dateOfBirth,
+              profileImageUrl: accountProfile?.profileImageUrl,
+            ),
       editProfileLabel: l10n.edit,
       editProfileSheet: NativeEditProfileSheetConfig(
         title: l10n.profileDetails,
@@ -431,6 +460,14 @@ class SidebarProfileAppBarLeading extends ConsumerWidget {
         ),
       ],
     );
+  }
+
+  /// Header subtitle for the Hermes-only profile sheet: the configured agent's
+  /// host, falling back to a generic label.
+  String _hermesHostLabel(WidgetRef ref) {
+    final baseUrl = ref.read(hermesConfigProvider).baseUrl;
+    final host = Uri.tryParse(baseUrl)?.host;
+    return host != null && host.isNotEmpty ? host : 'Self-hosted agent';
   }
 
   Uint8List? _decodeDataImage(String? dataUrl) {

--- a/lib/features/navigation/widgets/sidebar_user_pill.dart
+++ b/lib/features/navigation/widgets/sidebar_user_pill.dart
@@ -38,6 +38,8 @@ dynamic resolveSidebarUser(WidgetRef ref) {
 
 /// Localized search hint for the active sidebar tab.
 String sidebarSearchHintForActiveTab(WidgetRef ref, AppLocalizations l10n) {
+  // Hermes-only: the Hermes tab is the only tab.
+  if (ref.watch(hermesOnlyModeProvider)) return l10n.searchConversations;
   final tabIndex = ref.watch(sidebarActiveTabProvider);
   final hermesOn = ref.watch(hermesEnabledProvider);
   final notesOn = ref.watch(notesFeatureEnabledProvider);

--- a/lib/features/navigation/widgets/sidebar_user_pill.dart
+++ b/lib/features/navigation/widgets/sidebar_user_pill.dart
@@ -153,6 +153,10 @@ class SidebarProfileAppBarLeading extends ConsumerWidget {
     required String initials,
   }) {
     final l10n = AppLocalizations.of(context)!;
+    // In Hermes-only mode there's no Open WebUI account, so hide the OWUI
+    // account-specific sections (profile, memory, data connection, password,
+    // sign-out) and instead surface a "Connect to Open WebUI" switch entry.
+    final hermesOnly = ref.read(hermesOnlyModeProvider);
     final avatarUrl = resolveUserAvatarUrlForUser(api, user);
     final avatarBytes = _decodeDataImage(avatarUrl);
     final email = _extractEmail(user) ?? l10n.noEmailLabel;
@@ -214,16 +218,17 @@ class SidebarProfileAppBarLeading extends ConsumerWidget {
       ),
       menuItems: const [],
       sections: [
-        NativeSheetSectionConfig(
-          items: [
-            NativeSheetItemConfig(
-              id: NativeSheetRoutes.profile,
-              title: displayName,
-              subtitle: email,
-              sfSymbol: 'person.crop.circle',
-            ),
-          ],
-        ),
+        if (!hermesOnly)
+          NativeSheetSectionConfig(
+            items: [
+              NativeSheetItemConfig(
+                id: NativeSheetRoutes.profile,
+                title: displayName,
+                subtitle: email,
+                sfSymbol: 'person.crop.circle',
+              ),
+            ],
+          ),
         NativeSheetSectionConfig(
           items: [
             NativeSheetItemConfig(
@@ -241,26 +246,37 @@ class SidebarProfileAppBarLeading extends ConsumerWidget {
               title: l10n.voice,
               sfSymbol: 'waveform',
             ),
-            NativeSheetItemConfig(
-              id: NativeSheetRoutes.aiMemory,
-              title: aiMemoryTitle,
-              sfSymbol: 'wand.and.stars',
-            ),
-            NativeSheetItemConfig(
-              id: NativeSheetRoutes.notificationSettings,
-              title: l10n.notificationsTitle,
-              sfSymbol: 'bell',
-            ),
-            NativeSheetItemConfig(
-              id: NativeSheetRoutes.dataConnection,
-              title: dataConnectionTitle,
-              sfSymbol: 'network',
-            ),
+            if (!hermesOnly)
+              NativeSheetItemConfig(
+                id: NativeSheetRoutes.aiMemory,
+                title: aiMemoryTitle,
+                sfSymbol: 'wand.and.stars',
+              ),
+            // Notifications are OWUI-socket-derived, so hide them in Hermes-only.
+            if (!hermesOnly)
+              NativeSheetItemConfig(
+                id: NativeSheetRoutes.notificationSettings,
+                title: l10n.notificationsTitle,
+                sfSymbol: 'bell',
+              ),
+            if (!hermesOnly)
+              NativeSheetItemConfig(
+                id: NativeSheetRoutes.dataConnection,
+                title: dataConnectionTitle,
+                sfSymbol: 'network',
+              ),
             const NativeSheetItemConfig(
               id: NativeSheetRoutes.hermes,
               title: 'Hermes Agent',
               sfSymbol: 'sparkles',
             ),
+            if (hermesOnly)
+              const NativeSheetItemConfig(
+                id: 'add-owui-server',
+                title: 'Connect to Open WebUI',
+                subtitle: 'Add a self-hosted Open WebUI server',
+                sfSymbol: 'plus.circle',
+              ),
           ],
         ),
         NativeSheetSectionConfig(
@@ -292,75 +308,78 @@ class SidebarProfileAppBarLeading extends ConsumerWidget {
             ),
           ],
         ),
-        NativeSheetSectionConfig(
-          items: [
-            NativeSheetItemConfig(
-              id: 'sign-out',
-              title: l10n.signOut,
-              subtitle: l10n.endYourSession,
-              sfSymbol: 'rectangle.portrait.and.arrow.right',
-              destructive: true,
-            ),
-          ],
-        ),
+        if (!hermesOnly)
+          NativeSheetSectionConfig(
+            items: [
+              NativeSheetItemConfig(
+                id: 'sign-out',
+                title: l10n.signOut,
+                subtitle: l10n.endYourSession,
+                sfSymbol: 'rectangle.portrait.and.arrow.right',
+                destructive: true,
+              ),
+            ],
+          ),
       ],
       detailSheets: [
-        NativeSheetDetailConfig(
-          id: NativeSheetRoutes.profile,
-          title: profileTitle,
-          sections: [
-            NativeSheetSectionConfig(
-              footer: l10n.accountSettingsSubtitle,
-              items: [
-                NativeSheetItemConfig(
-                  id: 'profile-photo',
-                  title: l10n.editPhoto,
-                  sfSymbol: 'person.crop.circle',
-                ),
-              ],
-            ),
-            NativeSheetSectionConfig(
-              items: [
-                NativeSheetItemConfig(
-                  id: 'profile-name',
-                  title: l10n.name,
-                  subtitle: profileSummary,
-                  sfSymbol: 'person.text.rectangle',
-                ),
-                NativeSheetItemConfig(
-                  id: 'profile-about',
-                  title: l10n.bioLabel,
-                  subtitle: accountProfile?.bio?.trim().isNotEmpty == true
-                      ? accountProfile!.bio!.trim()
-                      : l10n.notSet,
-                  sfSymbol: 'text.bubble',
-                ),
-                NativeSheetItemConfig(
-                  id: 'profile-details',
-                  title: l10n.profileDetails,
-                  subtitle: l10n.genderLabel,
-                  sfSymbol: 'person.crop.circle',
-                ),
-              ],
-            ),
-            NativeSheetSectionConfig(
-              title: l10n.accountSettingsTitle,
-              items: [
-                NativeSheetItemConfig(
-                  id: 'password',
-                  title: l10n.changePasswordTitle,
-                  subtitle: l10n.passwordChangesLabel,
-                  sfSymbol: 'lock',
-                ),
-              ],
-            ),
-          ],
-        ),
-        buildNativePasswordDetail(
-          l10n,
-          passwordChangeEnabled: true,
-          subtitle: l10n.passwordFieldsRequired,
-        ),
+        if (!hermesOnly)
+          NativeSheetDetailConfig(
+            id: NativeSheetRoutes.profile,
+            title: profileTitle,
+            sections: [
+              NativeSheetSectionConfig(
+                footer: l10n.accountSettingsSubtitle,
+                items: [
+                  NativeSheetItemConfig(
+                    id: 'profile-photo',
+                    title: l10n.editPhoto,
+                    sfSymbol: 'person.crop.circle',
+                  ),
+                ],
+              ),
+              NativeSheetSectionConfig(
+                items: [
+                  NativeSheetItemConfig(
+                    id: 'profile-name',
+                    title: l10n.name,
+                    subtitle: profileSummary,
+                    sfSymbol: 'person.text.rectangle',
+                  ),
+                  NativeSheetItemConfig(
+                    id: 'profile-about',
+                    title: l10n.bioLabel,
+                    subtitle: accountProfile?.bio?.trim().isNotEmpty == true
+                        ? accountProfile!.bio!.trim()
+                        : l10n.notSet,
+                    sfSymbol: 'text.bubble',
+                  ),
+                  NativeSheetItemConfig(
+                    id: 'profile-details',
+                    title: l10n.profileDetails,
+                    subtitle: l10n.genderLabel,
+                    sfSymbol: 'person.crop.circle',
+                  ),
+                ],
+              ),
+              NativeSheetSectionConfig(
+                title: l10n.accountSettingsTitle,
+                items: [
+                  NativeSheetItemConfig(
+                    id: 'password',
+                    title: l10n.changePasswordTitle,
+                    subtitle: l10n.passwordChangesLabel,
+                    sfSymbol: 'lock',
+                  ),
+                ],
+              ),
+            ],
+          ),
+        if (!hermesOnly)
+          buildNativePasswordDetail(
+            l10n,
+            passwordChangeEnabled: true,
+            subtitle: l10n.passwordFieldsRequired,
+          ),
         buildNativeLoadingDetail(
           l10n: l10n,
           id: NativeSheetRoutes.appearance,

--- a/lib/features/profile/views/profile_page.dart
+++ b/lib/features/profile/views/profile_page.dart
@@ -15,6 +15,7 @@ import '../../../shared/utils/ui_utils.dart';
 import '../../../shared/widgets/themed_dialogs.dart';
 import '../../../core/providers/app_providers.dart';
 import '../../../core/services/navigation_service.dart';
+import '../../hermes/providers/hermes_providers.dart';
 import '../../auth/providers/unified_auth_providers.dart';
 import '../../../core/services/api_service.dart';
 import '../../../core/models/user.dart' as models;
@@ -326,6 +327,9 @@ class ProfilePage extends ConsumerWidget {
   }
 
   Widget _buildAccountSection(BuildContext context, WidgetRef ref) {
+    // In Hermes-only mode there's no Open WebUI account to sign out of; instead
+    // surface a "Connect to Open WebUI" entry so the user can add a server.
+    final hermesOnly = ref.watch(hermesOnlyModeProvider);
     final items = [
       _buildAccountOption(
         context,
@@ -387,18 +391,32 @@ class ProfilePage extends ConsumerWidget {
           context.pushNamed(RouteNames.hermesSettings);
         },
       ),
-      _buildAboutTile(context),
-      _buildAccountOption(
-        context,
-        icon: UiUtils.platformIcon(
-          ios: CupertinoIcons.square_arrow_left,
-          android: Icons.logout,
+      if (hermesOnly)
+        _buildAccountOption(
+          context,
+          icon: UiUtils.platformIcon(
+            ios: CupertinoIcons.add_circled,
+            android: Icons.add_circle_outline,
+          ),
+          title: 'Connect to Open WebUI',
+          subtitle: 'Add a self-hosted Open WebUI server',
+          onTap: () {
+            context.goNamed(RouteNames.serverConnection);
+          },
         ),
-        title: AppLocalizations.of(context)!.signOut,
-        subtitle: AppLocalizations.of(context)!.endYourSession,
-        onTap: () => _signOut(context, ref),
-        showChevron: false,
-      ),
+      _buildAboutTile(context),
+      if (!hermesOnly)
+        _buildAccountOption(
+          context,
+          icon: UiUtils.platformIcon(
+            ios: CupertinoIcons.square_arrow_left,
+            android: Icons.logout,
+          ),
+          title: AppLocalizations.of(context)!.signOut,
+          subtitle: AppLocalizations.of(context)!.endYourSession,
+          onTap: () => _signOut(context, ref),
+          showChevron: false,
+        ),
     ];
 
     return Column(

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -18,6 +18,7 @@ import 'core/persistence/preferences_store.dart';
 import 'core/router/app_router.dart';
 import 'core/services/native_sheet_bridge.dart';
 import 'core/services/native_sheet_hydration_service.dart';
+import 'core/services/navigation_service.dart';
 import 'core/services/performance_profiler.dart';
 import 'core/services/carplay_service.dart';
 import 'core/services/settings_service.dart';
@@ -332,6 +333,15 @@ class _ConduitAppState extends ConsumerState<ConduitApp> {
   ) async {
     final value = event.value;
     try {
+      // Hermes-only: "Connect to Open WebUI" switch entry. Dismiss the native
+      // sheet and route into the OWUI connect flow (the router allows the
+      // serverConnection route for Hermes-only users).
+      if (event.id == 'add-owui-server') {
+        await NativeSheetBridge.instance.dismiss();
+        await NavigationService.navigateTo(Routes.serverConnection);
+        return;
+      }
+
       if (event.id.startsWith('tts-voice-pick:')) {
         await _handleNativeTtsVoicePick(event);
         return;

--- a/test/core/providers/backend_mode_providers_test.dart
+++ b/test/core/providers/backend_mode_providers_test.dart
@@ -1,0 +1,88 @@
+import 'package:checks/checks.dart';
+import 'package:conduit/core/persistence/persistence_keys.dart';
+import 'package:conduit/core/persistence/preferences_store.dart';
+import 'package:conduit/core/providers/backend_mode_providers.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+/// Unit tests for the synchronous, persisted [preferredBackendProvider] that the
+/// router reads for boot-deterministic Hermes-only routing.
+void main() {
+  setUp(() async {
+    SharedPreferences.setMockInitialValues({});
+    PreferencesStore.debugReset();
+    PreferencesStore.debugOverride(await SharedPreferences.getInstance());
+  });
+
+  tearDown(() {
+    PreferencesStore.debugReset();
+  });
+
+  ProviderContainer makeContainer() {
+    final container = ProviderContainer();
+    addTearDown(container.dispose);
+    return container;
+  }
+
+  group('preferredBackendProvider', () {
+    test('defaults to unset when nothing is persisted', () {
+      final container = makeContainer();
+      check(
+        container.read(preferredBackendProvider),
+      ).equals(PreferredBackend.unset);
+    });
+
+    test('parses a persisted owui value at build time', () async {
+      await PreferencesStore.put(PreferenceKeys.preferredBackend, 'owui');
+      final container = makeContainer();
+      check(
+        container.read(preferredBackendProvider),
+      ).equals(PreferredBackend.owui);
+    });
+
+    test('parses a persisted hermes value at build time', () async {
+      await PreferencesStore.put(PreferenceKeys.preferredBackend, 'hermes');
+      final container = makeContainer();
+      check(
+        container.read(preferredBackendProvider),
+      ).equals(PreferredBackend.hermes);
+    });
+
+    test('falls back to unset for an unrecognized persisted value', () async {
+      await PreferencesStore.put(PreferenceKeys.preferredBackend, 'garbage');
+      final container = makeContainer();
+      check(
+        container.read(preferredBackendProvider),
+      ).equals(PreferredBackend.unset);
+    });
+
+    test('set() updates state and persists the enum name', () async {
+      final container = makeContainer();
+      await container
+          .read(preferredBackendProvider.notifier)
+          .set(PreferredBackend.hermes);
+
+      check(
+        container.read(preferredBackendProvider),
+      ).equals(PreferredBackend.hermes);
+      check(
+        PreferencesStore.getString(PreferenceKeys.preferredBackend),
+      ).equals('hermes');
+    });
+
+    test('set() round-trips through a fresh container (persistence)', () async {
+      final first = makeContainer();
+      await first
+          .read(preferredBackendProvider.notifier)
+          .set(PreferredBackend.owui);
+
+      // A new container rebuilds the controller from persisted prefs.
+      final second = ProviderContainer();
+      addTearDown(second.dispose);
+      check(
+        second.read(preferredBackendProvider),
+      ).equals(PreferredBackend.owui);
+    });
+  });
+}

--- a/test/features/chat/send_guard_test.dart
+++ b/test/features/chat/send_guard_test.dart
@@ -1,0 +1,68 @@
+import 'package:checks/checks.dart';
+import 'package:conduit/core/models/model.dart';
+import 'package:conduit/core/services/api_service.dart';
+import 'package:conduit/features/chat/providers/chat_providers.dart';
+import 'package:conduit/features/hermes/models/hermes_model.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+/// Stand-in for a non-null [ApiService] (we only care about non-null identity).
+class _FakeApiService extends Fake implements ApiService {}
+
+const _owuiModel = Model(id: 'gpt-4', name: 'GPT-4');
+final _hermesModel = hermesSyntheticModel();
+
+/// Unit tests for the extracted send/regenerate guard. The Hermes-only
+/// relaxation lets a Hermes model send with no OpenWebUI [api].
+void main() {
+  group('isSendBlocked', () {
+    test('blocks when no model is selected', () {
+      check(
+        isSendBlocked(reviewerMode: false, api: null, selectedModel: null),
+      ).isTrue();
+      // ...even with an api present.
+      check(
+        isSendBlocked(
+          reviewerMode: false,
+          api: _FakeApiService(),
+          selectedModel: null,
+        ),
+      ).isTrue();
+    });
+
+    test('blocks an OWUI model when the api is null and not reviewer', () {
+      check(
+        isSendBlocked(
+          reviewerMode: false,
+          api: null,
+          selectedModel: _owuiModel,
+        ),
+      ).isTrue();
+    });
+
+    test('allows an OWUI model when the api is present', () {
+      check(
+        isSendBlocked(
+          reviewerMode: false,
+          api: _FakeApiService(),
+          selectedModel: _owuiModel,
+        ),
+      ).isFalse();
+    });
+
+    test('allows any model in reviewer mode even with a null api', () {
+      check(
+        isSendBlocked(reviewerMode: true, api: null, selectedModel: _owuiModel),
+      ).isFalse();
+    });
+
+    test('allows a Hermes model with a null api (the relaxation)', () {
+      check(
+        isSendBlocked(
+          reviewerMode: false,
+          api: null,
+          selectedModel: _hermesModel,
+        ),
+      ).isFalse();
+    });
+  });
+}

--- a/test/features/hermes/hermes_model_surfacing_test.dart
+++ b/test/features/hermes/hermes_model_surfacing_test.dart
@@ -1,0 +1,81 @@
+import 'package:checks/checks.dart';
+import 'package:conduit/core/providers/app_providers.dart';
+import 'package:conduit/core/services/optimized_storage_service.dart';
+import 'package:conduit/features/auth/providers/unified_auth_providers.dart';
+import 'package:conduit/features/hermes/models/hermes_config.dart';
+import 'package:conduit/features/hermes/models/hermes_model.dart';
+import 'package:conduit/features/hermes/providers/hermes_providers.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+/// A [HermesConfigController] stand-in yielding a fixed config without touching
+/// shared preferences or secure storage.
+class _FakeHermesConfigController extends HermesConfigController {
+  _FakeHermesConfigController(this._config);
+
+  final HermesConfig _config;
+
+  @override
+  HermesConfig build() => _config;
+}
+
+/// `defaultModelProvider` reads the storage service at the top but never calls a
+/// method on it before the Hermes-only branch returns, so an empty fake is fine.
+class _FakeOptimizedStorageService extends Fake
+    implements OptimizedStorageService {}
+
+const _usableHermes = HermesConfig(
+  enabled: true,
+  baseUrl: 'https://hermes.example/v1',
+  apiKey: 'secret-key',
+);
+
+void main() {
+  group('Hermes model surfacing without an OWUI server', () {
+    test('modelsProvider surfaces only the synthetic Hermes model', () async {
+      final container = ProviderContainer(
+        overrides: [
+          reviewerModeProvider.overrideWithValue(false),
+          isAuthenticatedProvider2.overrideWithValue(false),
+          hermesConfigProvider.overrideWith(
+            () => _FakeHermesConfigController(_usableHermes),
+          ),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      final models = await container.read(modelsProvider.future);
+      check(models).length.equals(1);
+      check(isHermesModel(models.first)).isTrue();
+    });
+
+    test(
+      'defaultModelProvider auto-selects Hermes when there is no api',
+      () async {
+        final container = ProviderContainer(
+          overrides: [
+            reviewerModeProvider.overrideWithValue(false),
+            isAuthenticatedProvider2.overrideWithValue(false),
+            apiServiceProvider.overrideWithValue(null),
+            optimizedStorageServiceProvider.overrideWithValue(
+              _FakeOptimizedStorageService(),
+            ),
+            hermesConfigProvider.overrideWith(
+              () => _FakeHermesConfigController(_usableHermes),
+            ),
+          ],
+        );
+        addTearDown(container.dispose);
+
+        final model = await container.read(defaultModelProvider.future);
+        check(model).isNotNull();
+        check(isHermesModel(model!)).isTrue();
+
+        // The auto-select wrote through to the selected-model provider.
+        final selected = container.read(selectedModelProvider);
+        check(selected).isNotNull();
+        check(isHermesModel(selected!)).isTrue();
+      },
+    );
+  });
+}

--- a/test/features/hermes/hermes_only_mode_test.dart
+++ b/test/features/hermes/hermes_only_mode_test.dart
@@ -1,0 +1,106 @@
+import 'package:checks/checks.dart';
+import 'package:conduit/core/models/server_config.dart';
+import 'package:conduit/core/providers/app_providers.dart';
+import 'package:conduit/features/hermes/models/hermes_config.dart';
+import 'package:conduit/features/hermes/providers/hermes_providers.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+/// A [HermesConfigController] stand-in that yields a fixed config without
+/// touching shared preferences or secure storage (the real `build()` loads
+/// secrets asynchronously, which is unavailable in a plain unit test).
+class _FakeHermesConfigController extends HermesConfigController {
+  _FakeHermesConfigController(this._config);
+
+  final HermesConfig _config;
+
+  @override
+  HermesConfig build() => _config;
+}
+
+const _usableHermes = HermesConfig(
+  enabled: true,
+  baseUrl: 'https://hermes.example/v1',
+  apiKey: 'secret-key',
+);
+
+const _disabledHermes = HermesConfig(enabled: false);
+
+// Enabled but missing the API key → not usable.
+const _incompleteHermes = HermesConfig(
+  enabled: true,
+  baseUrl: 'https://hermes.example/v1',
+);
+
+const _server = ServerConfig(
+  id: 'srv-1',
+  name: 'Example',
+  url: 'https://owui.example',
+);
+
+void main() {
+  /// Builds a container wired for [hermesOnlyModeProvider] with all three of its
+  /// inputs overridden.
+  Future<ProviderContainer> makeContainer({
+    required HermesConfig hermesConfig,
+    required ServerConfig? activeServer,
+    bool reviewerMode = false,
+  }) async {
+    final container = ProviderContainer(
+      overrides: [
+        reviewerModeProvider.overrideWithValue(reviewerMode),
+        hermesConfigProvider.overrideWith(
+          () => _FakeHermesConfigController(hermesConfig),
+        ),
+        activeServerProvider.overrideWith((ref) async => activeServer),
+      ],
+    );
+    addTearDown(container.dispose);
+    // Settle the active-server future so the derived provider reads AsyncData.
+    await container.read(activeServerProvider.future);
+    return container;
+  }
+
+  group('hermesOnlyModeProvider', () {
+    test('true when Hermes is usable and there is no OWUI server', () async {
+      final container = await makeContainer(
+        hermesConfig: _usableHermes,
+        activeServer: null,
+      );
+      check(container.read(hermesOnlyModeProvider)).isTrue();
+    });
+
+    test('false when an OWUI server is active', () async {
+      final container = await makeContainer(
+        hermesConfig: _usableHermes,
+        activeServer: _server,
+      );
+      check(container.read(hermesOnlyModeProvider)).isFalse();
+    });
+
+    test('false when Hermes is disabled', () async {
+      final container = await makeContainer(
+        hermesConfig: _disabledHermes,
+        activeServer: null,
+      );
+      check(container.read(hermesOnlyModeProvider)).isFalse();
+    });
+
+    test('false when Hermes is enabled but not usable (no key)', () async {
+      final container = await makeContainer(
+        hermesConfig: _incompleteHermes,
+        activeServer: null,
+      );
+      check(container.read(hermesOnlyModeProvider)).isFalse();
+    });
+
+    test('reviewer mode takes precedence over Hermes-only', () async {
+      final container = await makeContainer(
+        hermesConfig: _usableHermes,
+        activeServer: null,
+        reviewerMode: true,
+      );
+      check(container.read(hermesOnlyModeProvider)).isFalse();
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Makes Open WebUI **optional** so a user can install the app and use a self-hosted **Hermes Agent exclusively** — no OWUI server at all. The mode is **derived from what's configured** and is **switchable anytime**; first run shows a backend chooser.

Stacked on `feat/hermes-agent` (#521) — review that one first; this PR's diff is the Hermes-only delta.

## Design — two signals

- **`preferredBackendProvider`** (`lib/core/providers/backend_mode_providers.dart`) — a **synchronous**, persisted `Notifier<PreferredBackend>` (`unset | owui | hermes`). Read by the **router only**, for boot determinism — mirrors `reviewerModeProvider`'s synchronous role. On cold boot the router runs `redirect()` while `activeServerProvider` is still loading and Hermes secrets are still loading, so a purely-derived gate would bounce a Hermes-only user to server-connection. The flag avoids that; real gating stays derived.
- **`hermesOnlyModeProvider`** (derived, in `hermes_providers.dart`) — `!reviewerMode && hermesConfig.isUsable && activeServer == null`. Drives **UI gating**; widgets rebuild as it settles.

## What's included

- **Onboarding:** new `BackendChooserPage` (Connect to Open WebUI / Use a Hermes Agent) + `Routes.backendChooser`. Reuses `HermesSettingsPage(isOnboarding: true)` with a "Finish setup" button that validates `isUsable`, sets `preferredBackend = hermes`, and enters the app.
- **Router:** Hermes-only short-circuits straight to `chat` before any OWUI server/auth branch; holds `splash` (not server-connection) while Hermes secrets load; first run → chooser. Disabled-Hermes safety net avoids a stuck splash.
- **Models:** `Models.build` / `defaultModelProvider` surface + auto-select the synthetic Hermes model when there's no OWUI API. Send guard relaxed (extracted to a pure `isSendBlocked()` helper) to allow `api == null` for Hermes models.
- **UI gating:** hide chats/notes/terminal/channels across the 3 synchronized tab sites — Hermes becomes the home tab. `preferredBackend = owui` is set on successful OWUI connect.
- **Composer gating:** when a Hermes model is active, hide the OWUI affordances — the "+" overflow button, quick pills, and the iOS keyboard-accessory actions (Hermes has no OWUI tools/web-search/image-gen/attachments and uses its own `/` skills).
- **iOS native settings sheet** (100% data-driven from Dart, no Swift changes): gate the OWUI account sections (profile, AI memory, data connection, password + profile detail sheets, sign-out) on Hermes-only; render a **Hermes-branded profile header** (name "Hermes Agent", agent host, `hermes_agent.png` avatar); the About detail skips the server lookup so it no longer errors with no server.
- **Bidirectional switching:** a "Connect to Open WebUI" entry in both the native sheet (routed via a control event in `main.dart`) and the Flutter profile page; the router reaches the OWUI connect/auth routes for a Hermes-only user; `preferredBackend` resets to `unset` when a Hermes-only backend is disabled.

## Verification

- `flutter analyze` clean; `flutter test` (2218) passing — incl. unit tests for `preferredBackend` parse/persistence, `hermesOnlyMode` derivation (usable/no-server, server-present, disabled, incomplete, reviewer precedence), `isSendBlocked` (the send-guard relaxation), and `modelsProvider`/`defaultModelProvider` Hermes surfacing + auto-select when `api == null`.
- **On-device E2E** (erased iOS simulator, fresh install, live Hermes server): backend chooser → "Use a Hermes Agent" → enter URL/key (capabilities + toolsets load) → Finish → lands in Hermes-only chat (header "Hermes Agent", no model dropdown) → sidebar shows **only** the Hermes tab → kill/relaunch boots **straight** into Hermes chat (boot determinism) → send created a new **server-side session** with no OWUI backend.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add Hermes-only mode to run without an Open WebUI server
> - Introduces a `preferredBackendProvider` that persists whether the user has chosen Open WebUI or a Hermes Agent as their backend, read synchronously at boot.
> - Adds a `/backend-chooser` onboarding screen that lets first-time users pick between the two backends, replacing the previous direct redirect to `/server-connection`.
> - When Hermes is the preferred backend and no Open WebUI server is configured, the router sends users directly to `/chat`; the sidebar hides Chats, Notes, Terminal, and Channels tabs; and the profile sheet replaces account options with a 'Connect to Open WebUI' entry.
> - `modelsProvider` and `defaultModelProvider` now surface and auto-select a synthetic Hermes model when no OpenWebUI API is available, and message send/regenerate are unblocked for Hermes models without an API.
> - The Hermes settings page gains an onboarding mode (triggered via `GoRouter` `state.extra`) that auto-enables Hermes, hides the toggle, and routes to chat on completion.
> - Behavioral Change: users with no configured server are now redirected to `/backend-chooser` instead of `/server-connection`.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 821a735. 17 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->