### PR TITLE
Open WebUI streaming parity: modelName, optimistic state, fade caching, socket resume

### DIFF
--- a/lib/core/models/chat_message.dart
+++ b/lib/core/models/chat_message.dart
@@ -147,6 +147,7 @@ abstract class ChatMessageVersion with _$ChatMessageVersion {
     required String content,
     required DateTime timestamp,
     String? model,
+    String? modelName,
     List<Map<String, dynamic>>? files,
     List<Map<String, dynamic>>? output,
     List<Map<String, dynamic>>? embeds,

--- a/lib/core/providers/app_providers.dart
+++ b/lib/core/providers/app_providers.dart
@@ -3921,6 +3921,12 @@ class ActiveChatsSync extends _$ActiveChatsSync {
     _reconnectSub?.cancel();
     _reconnectSub = null;
     if (socket == null) {
+      // Logout / session teardown: the socket the spinners were derived from is
+      // gone. Drop the whole set so a stale `generating` indicator cannot
+      // survive into the next session (the new socket re-arms the cold-open
+      // fetch below to repopulate authoritative state).
+      ref.read(activeChatIdsProvider.notifier).setAll(const <String>{});
+      _initialFetchDone = false;
       return;
     }
 

--- a/lib/core/providers/app_providers.dart
+++ b/lib/core/providers/app_providers.dart
@@ -3852,19 +3852,44 @@ class ActiveChatIds extends _$ActiveChatIds {
   @override
   Set<String> build() => const <String>{};
 
+  // Monotonic activation tokens so a delayed, conditional clear can detect that
+  // a chat was (re)activated after the clear was scheduled and skip itself.
+  int _seq = 0;
+  final Map<String, int> _activationToken = {};
+
   /// Mark a chat as active (background task running).
   void setActive(String chatId) {
+    _activationToken[chatId] = ++_seq;
+    if (state.contains(chatId)) return;
     state = {...state, chatId};
   }
 
   /// Mark a chat as inactive (background task completed).
   void setInactive(String chatId) {
-    final next = {...state}..remove(chatId);
-    state = next;
+    _activationToken.remove(chatId);
+    if (!state.contains(chatId)) return;
+    state = {...state}..remove(chatId);
+  }
+
+  /// The current activation token for [chatId], or null if not active. Capture
+  /// this before an async task-registry check, then pass it to
+  /// [setInactiveIfUnchanged] so a racing [setActive] cannot be clobbered.
+  int? activationToken(String chatId) => _activationToken[chatId];
+
+  /// Clear [chatId] only if it has not been (re)activated since [token] was
+  /// captured — guards an async optimistic clear against a racing setActive
+  /// (e.g. a new stream starting for the same chat before the lookup resolves).
+  void setInactiveIfUnchanged(String chatId, int? token) {
+    if (_activationToken[chatId] != token) return;
+    setInactive(chatId);
   }
 
   /// Bulk-initialize from a server response.
   void setAll(Set<String> chatIds) {
+    _seq++;
+    _activationToken
+      ..clear()
+      ..addEntries([for (final id in chatIds) MapEntry(id, _seq)]);
     state = chatIds;
   }
 }

--- a/lib/core/services/chat_completion_transport.dart
+++ b/lib/core/services/chat_completion_transport.dart
@@ -53,6 +53,31 @@ final class ChatCompletionSession {
     abort: abort,
   );
 
+  /// Socket-only resume of an in-flight chat that is still generating on the
+  /// server (mirrors Open WebUI reopening a streaming chat).
+  ///
+  /// A named, intent-revealing alias for the socket-only [taskSocket] shape:
+  /// [byteStream] is `null` (no HTTP body to forward — the existing taskSocket
+  /// dispatch closes the HTTP side immediately and waits for the socket `done`)
+  /// and [abort] is `null` (resume does not own an HTTP request to cancel;
+  /// cancellation goes through the task registry via `taskId`).
+  ///
+  /// [sessionId] is intentionally `null` so the streaming helper's session
+  /// matching stays permissive and binds the server's (possibly foreign)
+  /// `message_id` to the local [messageId] on the first `chat:completion`.
+  factory ChatCompletionSession.resumeSocket({
+    required String messageId,
+    String? sessionId,
+    String? conversationId,
+    String? taskId,
+  }) => ChatCompletionSession._(
+    transport: ChatCompletionTransport.taskSocket,
+    messageId: messageId,
+    sessionId: sessionId,
+    conversationId: conversationId,
+    taskId: taskId,
+  );
+
   /// Direct JSON completion (non-streamed).
   factory ChatCompletionSession.jsonCompletion({
     required String messageId,

--- a/lib/core/services/chat_completion_transport.dart
+++ b/lib/core/services/chat_completion_transport.dart
@@ -67,13 +67,14 @@ final class ChatCompletionSession {
   /// `message_id` to the local [messageId] on the first `chat:completion`.
   factory ChatCompletionSession.resumeSocket({
     required String messageId,
-    String? sessionId,
     String? conversationId,
     String? taskId,
   }) => ChatCompletionSession._(
     transport: ChatCompletionTransport.taskSocket,
     messageId: messageId,
-    sessionId: sessionId,
+    // Always null: resume must keep session matching permissive so a foreign
+    // server-assigned message_id can still bind. No caller may override it.
+    sessionId: null,
     conversationId: conversationId,
     taskId: taskId,
   );

--- a/lib/core/services/conversation_parsing.dart
+++ b/lib/core/services/conversation_parsing.dart
@@ -316,12 +316,14 @@ Map<String, dynamic>? _parseSiblingAsVersion(
       : msgData['codeExecutions'] ?? msgData['code_executions'];
   final rawUsage = _coerceJsonMap(historyMsg?['usage'] ?? msgData['usage']);
   final errorData = _extractErrorData(msgData, historyMsg);
+  final modelName = _extractOpenWebUiModelName(msgData, historyMsg);
 
   return <String, dynamic>{
     'id': (msgData['id'] ?? _uuid.v4()).toString(),
     'content': contentString,
     'timestamp': _parseTimestamp(msgData['timestamp']).toIso8601String(),
     if (msgData['model'] != null) 'model': msgData['model'].toString(),
+    'modelName': ?modelName,
     'files': ?files,
     if (embeds.isNotEmpty) 'embeds': embeds,
     'sources': _parseSourcesField(sourcesRaw),
@@ -420,7 +422,44 @@ Map<String, dynamic>? _extractOpenWebUiMessageMetadata(
     }
   }
 
+  final modelName = _extractOpenWebUiModelName(msgData, historyMsg);
+  if (modelName != null) {
+    metadata['modelName'] = modelName;
+  }
+
+  final modelIdx = _extractOpenWebUiModelIdx(msgData, historyMsg);
+  if (modelIdx != null) {
+    metadata['modelIdx'] = modelIdx;
+  }
+
   return metadata.isEmpty ? null : metadata;
+}
+
+String? _extractOpenWebUiModelName(
+  Map<String, dynamic> msgData,
+  Map<String, dynamic>? historyMsg,
+) {
+  final raw =
+      historyMsg?['modelName'] ??
+      historyMsg?['model_name'] ??
+      msgData['modelName'] ??
+      msgData['model_name'];
+  final value = raw?.toString().trim();
+  return value == null || value.isEmpty ? null : value;
+}
+
+int? _extractOpenWebUiModelIdx(
+  Map<String, dynamic> msgData,
+  Map<String, dynamic>? historyMsg,
+) {
+  final raw =
+      historyMsg?['modelIdx'] ??
+      historyMsg?['model_idx'] ??
+      msgData['modelIdx'] ??
+      msgData['model_idx'];
+  if (raw is int) return raw;
+  if (raw is num) return raw.toInt();
+  return int.tryParse(raw?.toString() ?? '');
 }
 
 Map<String, dynamic> _parseOpenWebUIMessageToJson(

--- a/lib/core/services/conversation_parsing.dart
+++ b/lib/core/services/conversation_parsing.dart
@@ -322,7 +322,8 @@ Map<String, dynamic>? _parseSiblingAsVersion(
     'id': (msgData['id'] ?? _uuid.v4()).toString(),
     'content': contentString,
     'timestamp': _parseTimestamp(msgData['timestamp']).toIso8601String(),
-    if (msgData['model'] != null) 'model': msgData['model'].toString(),
+    if ((msgData['model'] ?? historyMsg?['model']) != null)
+      'model': (msgData['model'] ?? historyMsg?['model']).toString(),
     'modelName': ?modelName,
     'files': ?files,
     if (embeds.isNotEmpty) 'embeds': embeds,
@@ -595,7 +596,7 @@ Map<String, dynamic> _parseOpenWebUIMessageToJson(
     'role': role,
     'content': contentString,
     'timestamp': _parseTimestamp(msgData['timestamp']).toIso8601String(),
-    'model': msgData['model']?.toString(),
+    'model': (msgData['model'] ?? historyMsg?['model'])?.toString(),
     'isStreaming': _safeBool(msgData['isStreaming']) ?? false,
     'attachmentIds': ?attachmentIds,
     'files': ?files,

--- a/lib/core/services/conversation_parsing.dart
+++ b/lib/core/services/conversation_parsing.dart
@@ -427,11 +427,6 @@ Map<String, dynamic>? _extractOpenWebUiMessageMetadata(
     metadata['modelName'] = modelName;
   }
 
-  final modelIdx = _extractOpenWebUiModelIdx(msgData, historyMsg);
-  if (modelIdx != null) {
-    metadata['modelIdx'] = modelIdx;
-  }
-
   return metadata.isEmpty ? null : metadata;
 }
 
@@ -446,20 +441,6 @@ String? _extractOpenWebUiModelName(
       msgData['model_name'];
   final value = raw?.toString().trim();
   return value == null || value.isEmpty ? null : value;
-}
-
-int? _extractOpenWebUiModelIdx(
-  Map<String, dynamic> msgData,
-  Map<String, dynamic>? historyMsg,
-) {
-  final raw =
-      historyMsg?['modelIdx'] ??
-      historyMsg?['model_idx'] ??
-      msgData['modelIdx'] ??
-      msgData['model_idx'];
-  if (raw is int) return raw;
-  if (raw is num) return raw.toInt();
-  return int.tryParse(raw?.toString() ?? '');
 }
 
 Map<String, dynamic> _parseOpenWebUIMessageToJson(

--- a/lib/core/services/conversation_parsing.dart
+++ b/lib/core/services/conversation_parsing.dart
@@ -434,13 +434,20 @@ String? _extractOpenWebUiModelName(
   Map<String, dynamic> msgData,
   Map<String, dynamic>? historyMsg,
 ) {
-  final raw =
-      historyMsg?['modelName'] ??
-      historyMsg?['model_name'] ??
-      msgData['modelName'] ??
-      msgData['model_name'];
-  final value = raw?.toString().trim();
-  return value == null || value.isEmpty ? null : value;
+  // Walk candidates in priority order, skipping null AND empty/whitespace
+  // values so an empty `modelName` does not shadow a populated `model_name`.
+  for (final candidate in [
+    historyMsg?['modelName'],
+    historyMsg?['model_name'],
+    msgData['modelName'],
+    msgData['model_name'],
+  ]) {
+    final value = candidate?.toString().trim();
+    if (value != null && value.isNotEmpty) {
+      return value;
+    }
+  }
+  return null;
 }
 
 Map<String, dynamic> _parseOpenWebUIMessageToJson(

--- a/lib/core/services/streaming_helper.dart
+++ b/lib/core/services/streaming_helper.dart
@@ -2360,6 +2360,15 @@ ActiveChatStream attachUnifiedChunkedStreaming({
       }
     }
 
+    // Paired removal so the sidebar `generating` spinner clears on a normal
+    // success finalize even if the backend's `chat:active{false}` is dropped or
+    // late (it only fires when the LAST task for the chat finishes). Keeps the
+    // success path symmetric with the cancel + error branches and mirrors the
+    // optimistic START at the completion-POST dispatch site.
+    if (activeConversationId != null && activeConversationId.isNotEmpty) {
+      onChatActiveChanged?.call(activeConversationId, false);
+    }
+
     wrappedFinishStreaming();
   }
 
@@ -2675,6 +2684,13 @@ ActiveChatStream attachUnifiedChunkedStreaming({
             isStreaming: false,
           ),
         );
+        // Paired removal so the sidebar `generating` spinner clears on a
+        // stop/cancel even if the backend's `chat:active{false}` is dropped
+        // (it only fires when the LAST task for the chat finishes). Mirrors the
+        // optimistic START at the completion-POST dispatch site.
+        if (activeConversationId != null && activeConversationId.isNotEmpty) {
+          onChatActiveChanged?.call(activeConversationId, false);
+        }
         disposeSocketSubscriptions();
         wrappedFinishStreaming();
       } else if (type == 'chat:message:follow_ups' && payload != null) {
@@ -2887,6 +2903,12 @@ ActiveChatStream attachUnifiedChunkedStreaming({
             );
           });
         } catch (_) {}
+        // Paired removal: a terminal error means no `chat:active{false}` may
+        // arrive for this chat, so clear the sidebar spinner directly instead
+        // of stranding it (mirrors the cancel branch + the optimistic START).
+        if (activeConversationId != null && activeConversationId.isNotEmpty) {
+          onChatActiveChanged?.call(activeConversationId, false);
+        }
         // Ensure UI exits streaming state
         wrappedFinishStreaming();
       } else if ((type == 'chat:message:delta' || type == 'message') &&

--- a/lib/core/services/streaming_helper.dart
+++ b/lib/core/services/streaming_helper.dart
@@ -2482,6 +2482,19 @@ ActiveChatStream attachUnifiedChunkedStreaming({
       final messageId = ev['message_id']?.toString();
       final incomingSessionId = extractEventSessionId(ev);
 
+      // Chat-scope guard: on the shared user socket, an event for a different
+      // chat must never bind to or write this stream's message (critical for
+      // resume, where session matching is permissive and a foreign message_id
+      // may bind). Events with no chat_id fall through to message-level checks.
+      final eventChatId = ev['chat_id']?.toString();
+      if (eventChatId != null &&
+          eventChatId.isNotEmpty &&
+          activeConversationId != null &&
+          activeConversationId.isNotEmpty &&
+          eventChatId != activeConversationId) {
+        return;
+      }
+
       if (isObsoleteStream) {
         return;
       }

--- a/lib/core/services/streaming_helper.dart
+++ b/lib/core/services/streaming_helper.dart
@@ -1570,7 +1570,9 @@ ActiveChatStream attachUnifiedChunkedStreaming({
           // Preserve existing usage if server doesn't have it yet (issue #274)
           // Usage is captured from streaming but may not be persisted on server
           final effectiveUsage = assistant.usage ?? current.usage;
-          final nextFollowUps = List<String>.from(assistant.followUps);
+          final nextFollowUps = assistant.followUps.isNotEmpty
+              ? List<String>.from(assistant.followUps)
+              : current.followUps;
           final nextStatusHistory = assistant.statusHistory.isNotEmpty
               ? assistant.statusHistory
               : current.isStreaming

--- a/lib/core/services/streaming_helper.dart
+++ b/lib/core/services/streaming_helper.dart
@@ -2316,6 +2316,14 @@ ActiveChatStream attachUnifiedChunkedStreaming({
         if (finishAfterRecovery &&
             !isObsoleteStream &&
             currentAssistantTargetId() == assistantMessageId) {
+          // Paired sidebar-spinner removal, mirroring the synchronous done
+          // path: this branch finalizes via wrappedFinishStreaming() after the
+          // early return at the top of handleCompletionDone, so without this
+          // the `generating` indicator would strand on the delayed-recovery
+          // path.
+          if (activeConversationId != null && activeConversationId.isNotEmpty) {
+            onChatActiveChanged?.call(activeConversationId, false);
+          }
           wrappedFinishStreaming();
         }
       }

--- a/lib/core/services/streaming_helper.dart
+++ b/lib/core/services/streaming_helper.dart
@@ -426,6 +426,10 @@ ActiveChatStream attachUnifiedChunkedStreaming({
   /// Called when a `chat:active` event is received, indicating a background
   /// task has started (active=true) or completed (active=false).
   void Function(String? chatId, bool active)? onChatActiveChanged,
+  // Fired when a foreign server-assigned message_id is bound to the local
+  // assistant (notably during socket resume). Lets the caller's poll fallback
+  // resolve server messages by the bound id if the socket later dies.
+  void Function(String remoteMessageId)? onRemoteMessageBound,
   required void Function() completeStreamingUi,
   required void Function() finishStreaming,
   required List<ChatMessage> Function() getMessages,
@@ -543,6 +547,7 @@ ActiveChatStream attachUnifiedChunkedStreaming({
       return;
     }
     boundRemoteMessageId = candidateId;
+    onRemoteMessageBound?.call(candidateId);
     DebugLogger.log(
       'Binding $source server message $candidateId '
       'to local assistant $assistantMessageId',
@@ -642,6 +647,7 @@ ActiveChatStream attachUnifiedChunkedStreaming({
 
     if (boundRemoteMessageId == null) {
       boundRemoteMessageId = incomingMessageId;
+      onRemoteMessageBound?.call(incomingMessageId);
       DebugLogger.log(
         'Binding $eventType server message $incomingMessageId '
         'to local assistant $assistantMessageId',

--- a/lib/core/services/streaming_helper.dart
+++ b/lib/core/services/streaming_helper.dart
@@ -595,6 +595,33 @@ ActiveChatStream attachUnifiedChunkedStreaming({
     return candidate;
   }
 
+  /// Extracts an id that [SocketService] may deliver at the envelope level OR
+  /// nested under `data` / `data.data`. Mirrors the session-id walk above so
+  /// chat/message scoping cannot be bypassed by a nested-id event.
+  String? extractNestedEventId(
+    Map<String, dynamic> event,
+    String snakeKey,
+    String camelKey,
+  ) {
+    String? candidate =
+        event[snakeKey]?.toString() ?? event[camelKey]?.toString();
+    final data = event['data'];
+    if (candidate == null && data is Map) {
+      candidate = data[snakeKey]?.toString() ?? data[camelKey]?.toString();
+      final inner = data['data'];
+      if (candidate == null && inner is Map) {
+        candidate = inner[snakeKey]?.toString() ?? inner[camelKey]?.toString();
+      }
+    }
+    return candidate;
+  }
+
+  String? extractEventMessageId(Map<String, dynamic> event) =>
+      extractNestedEventId(event, 'message_id', 'messageId');
+
+  String? extractEventChatId(Map<String, dynamic> event) =>
+      extractNestedEventId(event, 'chat_id', 'chatId');
+
   bool streamHasBeenSuperseded() {
     final currentTargetId = currentAssistantTargetId();
     return currentTargetId != null && currentTargetId != assistantMessageId;
@@ -2479,14 +2506,17 @@ ActiveChatStream attachUnifiedChunkedStreaming({
       final type = data['type'];
 
       final payload = data['data'];
-      final messageId = ev['message_id']?.toString();
+      // Read ids the same way SocketService delivers them — envelope level OR
+      // nested under data / data.data — so a nested message_id still binds and
+      // a nested chat_id can't bypass the chat-scope guard below.
+      final messageId = extractEventMessageId(ev);
       final incomingSessionId = extractEventSessionId(ev);
 
       // Chat-scope guard: on the shared user socket, an event for a different
       // chat must never bind to or write this stream's message (critical for
       // resume, where session matching is permissive and a foreign message_id
       // may bind). Events with no chat_id fall through to message-level checks.
-      final eventChatId = ev['chat_id']?.toString();
+      final eventChatId = extractEventChatId(ev);
       if (eventChatId != null &&
           eventChatId.isNotEmpty &&
           activeConversationId != null &&

--- a/lib/features/chat/providers/chat_providers.dart
+++ b/lib/features/chat/providers/chat_providers.dart
@@ -1696,6 +1696,20 @@ class ChatMessagesNotifier extends Notifier<List<ChatMessage>> {
     _finishStreamingProfile(reason: 'cleared');
   }
 
+  void failLastStreamingAssistant(Object error) {
+    if (state.isEmpty) return;
+    final lastMessage = state.last;
+    if (lastMessage.role != 'assistant' || !lastMessage.isStreaming) return;
+
+    final chatError = ChatMessageError(
+      content: chatErrorContentForException(error),
+    );
+    updateLastMessageWithFunction(
+      (message) => message.copyWith(error: chatError),
+    );
+    finishStreaming();
+  }
+
   void setMessages(List<ChatMessage> messages) {
     state = messages;
     _syncStreamingProfileWithState();
@@ -2172,8 +2186,8 @@ class ChatMessagesNotifier extends Notifier<List<ChatMessage>> {
       }
     }
 
-    // Skip server cache refresh for temporary chats
-    if (!isTemporaryChat(ref.read(activeConversationProvider)?.id)) {
+    // Skip server cache refresh for temporary or no-active-conversation chats.
+    if (activeConversation != null && !isTemporaryChat(activeConversation.id)) {
       try {
         refreshConversationsCache(ref);
       } catch (_) {}
@@ -4435,6 +4449,7 @@ Future<void> durableSend(
       text: message,
       files: durableFiles,
       modelId: selectedModel.id,
+      modelName: selectedModel.name,
       now: now,
     );
     final rows = ChatBlobMapper.blobToRows(
@@ -4501,15 +4516,13 @@ Future<void> durableSend(
       model: selectedModel.id,
       createdAt: now,
       orderIndex: 1,
-      payload: <String, dynamic>{
-        'id': assistantMessageId,
-        'parentId': userMessageId,
-        'childrenIds': <String>[],
-        'role': 'assistant',
-        'content': '',
-        'model': selectedModel.id,
-        'timestamp': now,
-      },
+      payload: _durableAssistantPayload(
+        id: assistantMessageId,
+        parentId: userMessageId,
+        modelId: selectedModel.id,
+        modelName: selectedModel.name,
+        timestamp: now,
+      ),
     );
 
     await chatLocks.runExclusive(chatId, () async {
@@ -4541,6 +4554,7 @@ Map<String, dynamic> _buildDurableNewChatBlob({
   required String text,
   required List<Map<String, dynamic>> files,
   required String modelId,
+  required String modelName,
   required int now,
 }) {
   return <String, dynamic>{
@@ -4559,18 +4573,53 @@ Map<String, dynamic> _buildDurableNewChatBlob({
           'models': <String>[modelId],
           'timestamp': now,
         },
-        asstId: <String, dynamic>{
-          'id': asstId,
-          'parentId': userMsgId,
-          'childrenIds': <String>[],
-          'role': 'assistant',
-          'content': '',
-          'model': modelId,
-          'timestamp': now,
-        },
+        asstId: _durableAssistantPayload(
+          id: asstId,
+          parentId: userMsgId,
+          modelId: modelId,
+          modelName: modelName,
+          timestamp: now,
+        ),
       },
     },
   };
+}
+
+Map<String, dynamic> _durableAssistantPayload({
+  required String id,
+  required String parentId,
+  required String modelId,
+  required String modelName,
+  required int timestamp,
+}) {
+  final trimmedModelName = modelName.trim();
+  return <String, dynamic>{
+    'id': id,
+    'parentId': parentId,
+    'childrenIds': <String>[],
+    'role': 'assistant',
+    'content': '',
+    'model': modelId,
+    if (trimmedModelName.isNotEmpty) 'modelName': trimmedModelName,
+    'timestamp': timestamp,
+  };
+}
+
+@visibleForTesting
+Map<String, dynamic> debugBuildDurableAssistantPayloadForTesting({
+  required String id,
+  required String parentId,
+  required String modelId,
+  required String modelName,
+  required int timestamp,
+}) {
+  return _durableAssistantPayload(
+    id: id,
+    parentId: parentId,
+    modelId: modelId,
+    modelName: modelName,
+    timestamp: timestamp,
+  );
 }
 
 typedef _AttachmentTypeMap = Map<String, String>;
@@ -5333,32 +5382,23 @@ Future<void> _sendMessageInternal(
     // message. This preserves the placeholder's ID and any files that
     // may have arrived before the error, matching OpenWebUI's same-slot
     // failure semantics.
-    final errorContent = _errorContentForException(e);
-
     // Explicit ChatMessage type on closures is required because `ref` is
     // `dynamic` — without it Dart infers (dynamic) => dynamic at runtime.
     final ChatMessagesNotifier notifier =
         ref.read(chatMessagesProvider.notifier) as ChatMessagesNotifier;
-    final chatError = ChatMessageError(content: errorContent);
     if (e.toString().contains('401') || e.toString().contains('403')) {
       // Authentication errors - clear auth state and redirect to login.
       // Still convert the placeholder so the UI is consistent.
-      notifier.updateLastMessageWithFunction(
-        (ChatMessage m) => m.copyWith(error: chatError),
-      );
-      notifier.finishStreaming();
+      notifier.failLastStreamingAssistant(e);
       ref.invalidate(authStateManagerProvider);
     } else {
-      notifier.updateLastMessageWithFunction(
-        (ChatMessage m) => m.copyWith(error: chatError),
-      );
-      notifier.finishStreaming();
+      notifier.failLastStreamingAssistant(e);
     }
   }
 }
 
 /// Returns a user-friendly error description based on the exception.
-String _errorContentForException(Object e) {
+String chatErrorContentForException(Object e) {
   final msg = e.toString();
   if (msg.contains('400')) {
     return 'There was an issue with the message format. This might be '

--- a/lib/features/chat/providers/chat_providers.dart
+++ b/lib/features/chat/providers/chat_providers.dart
@@ -947,6 +947,12 @@ class ChatMessagesNotifier extends Notifier<List<ChatMessage>> {
         // which must mirror the preserved typed `.followUps` field below.
         metadata['followUps'] = List<String>.from(localMessage.followUps);
       }
+      if (shouldPreserveModelName) {
+        // The raw server map may carry an empty/whitespace `modelName` that the
+        // union spread on top of the local one; restore the normalized local
+        // value so an empty server field can't blank the displayed model name.
+        metadata['modelName'] = _messageModelName(localMessage);
+      }
       merged.add(
         serverMessage.copyWith(
           content: preserveContent
@@ -2077,10 +2083,12 @@ class ChatMessagesNotifier extends Notifier<List<ChatMessage>> {
       content: chatErrorContentForException(error),
     );
     // Update by id so the error lands on the captured message even if it is no
-    // longer the list tail.
+    // longer the list tail, and clear its streaming flag directly: finishStreaming()
+    // only completes state.last, so a non-tail failed message would otherwise stay
+    // stuck in isStreaming: true.
     updateMessageById(
       target.id,
-      (message) => message.copyWith(error: chatError),
+      (message) => message.copyWith(error: chatError, isStreaming: false),
     );
     finishStreaming();
   }

--- a/lib/features/chat/providers/chat_providers.dart
+++ b/lib/features/chat/providers/chat_providers.dart
@@ -72,10 +72,6 @@ class _ChatMessageListStructure {
         ..write('\u0000')
         ..write(message.model ?? '')
         ..write('\u0000')
-        ..write(message.isStreaming ? 1 : 0)
-        ..write('\u0000')
-        ..write(message.isStreaming ? -1 : message.content.trim().length)
-        ..write('\u0000')
         ..write(message.attachmentIds?.length ?? 0)
         ..write('\u0000')
         ..write(message.files?.length ?? 0)
@@ -793,7 +789,7 @@ class ChatMessagesNotifier extends Notifier<List<ChatMessage>> {
     if (_hasTrackedStreamingTransport) {
       _dropStreamingTransportState(source: 'server adoption from $source');
     }
-    state = serverMessages;
+    state = _preserveFreshLocalAssistantState(serverMessages);
     _syncStreamingProfileWithState();
 
     if (needsCleanup) {
@@ -843,6 +839,112 @@ class ChatMessagesNotifier extends Notifier<List<ChatMessage>> {
         );
       },
     );
+  }
+
+  List<ChatMessage> _preserveFreshLocalAssistantState(
+    List<ChatMessage> serverMessages,
+  ) {
+    if (state.isEmpty || serverMessages.isEmpty) {
+      return serverMessages;
+    }
+
+    final localById = <String, ChatMessage>{
+      for (final message in state)
+        if (message.role == 'assistant' &&
+            (message.content.trim().isNotEmpty || message.followUps.isNotEmpty))
+          message.id: message,
+    };
+    if (localById.isEmpty) {
+      return serverMessages;
+    }
+
+    var changed = false;
+    final merged = <ChatMessage>[];
+    for (final serverMessage in serverMessages) {
+      final localMessage = localById[serverMessage.id];
+      final preserveContent =
+          localMessage != null &&
+          _shouldPreserveLocalAssistantContent(localMessage, serverMessage);
+      final sameResponseContent =
+          localMessage != null &&
+          _sameAssistantResponseText(
+            localMessage.content,
+            serverMessage.content,
+          );
+      final shouldPreserveFollowUps =
+          localMessage != null &&
+          serverMessage.role == 'assistant' &&
+          serverMessage.followUps.isEmpty &&
+          (sameResponseContent || preserveContent);
+      if (!preserveContent && !shouldPreserveFollowUps) {
+        merged.add(serverMessage);
+        continue;
+      }
+
+      changed = true;
+      final metadata = <String, dynamic>{...?serverMessage.metadata};
+      if (shouldPreserveFollowUps) {
+        metadata.putIfAbsent(
+          'followUps',
+          () => List<String>.from(localMessage.followUps),
+        );
+      }
+      merged.add(
+        serverMessage.copyWith(
+          content: preserveContent
+              ? localMessage.content
+              : serverMessage.content,
+          followUps: shouldPreserveFollowUps
+              ? List<String>.from(localMessage.followUps)
+              : serverMessage.followUps,
+          metadata: metadata.isEmpty ? null : metadata,
+        ),
+      );
+    }
+
+    return changed ? List<ChatMessage>.unmodifiable(merged) : serverMessages;
+  }
+
+  bool _shouldPreserveLocalAssistantContent(
+    ChatMessage localMessage,
+    ChatMessage serverMessage,
+  ) {
+    if (serverMessage.role != 'assistant') {
+      return false;
+    }
+    if (!_hasLocalStreamingProvenance(localMessage)) {
+      return false;
+    }
+    final localContent = localMessage.content;
+    final serverContent = serverMessage.content;
+    if (localContent.trim().isEmpty) {
+      return false;
+    }
+    if (serverContent.trim().isEmpty) {
+      return true;
+    }
+    if (localContent.length <= serverContent.length) {
+      return false;
+    }
+    return _sameAssistantResponsePrefix(localContent, serverContent);
+  }
+
+  bool _hasLocalStreamingProvenance(ChatMessage message) {
+    final metadata = message.metadata;
+    return message.isStreaming ||
+        metadata?['responseDone'] == true ||
+        metadata?['transport'] != null ||
+        metadata?['taskId'] != null ||
+        metadata?['hasActiveAbortHandle'] == true;
+  }
+
+  bool _sameAssistantResponseText(String left, String right) {
+    return left == right || left.trim() == right.trim();
+  }
+
+  bool _sameAssistantResponsePrefix(String longer, String shorter) {
+    return longer.startsWith(shorter) ||
+        longer.trimLeft().startsWith(shorter.trimLeft());
   }
 
   void _teardownPassiveConversationSync() {

--- a/lib/features/chat/providers/chat_providers.dart
+++ b/lib/features/chat/providers/chat_providers.dart
@@ -908,10 +908,10 @@ class ChatMessagesNotifier extends Notifier<List<ChatMessage>> {
         ...?serverMessage.metadata,
       };
       if (shouldPreserveFollowUps) {
-        metadata.putIfAbsent(
-          'followUps',
-          () => List<String>.from(localMessage.followUps),
-        );
+        // Overwrite (not putIfAbsent): the merged map may carry a stale
+        // `followUps` from the server snapshot (e.g. an explicit empty list),
+        // which must mirror the preserved typed `.followUps` field below.
+        metadata['followUps'] = List<String>.from(localMessage.followUps);
       }
       merged.add(
         serverMessage.copyWith(

--- a/lib/features/chat/providers/chat_providers.dart
+++ b/lib/features/chat/providers/chat_providers.dart
@@ -890,6 +890,7 @@ class ChatMessagesNotifier extends Notifier<List<ChatMessage>> {
           );
       final shouldPreserveFollowUps =
           localMessage != null &&
+          localMessage.followUps.isNotEmpty &&
           serverMessage.role == 'assistant' &&
           serverMessage.followUps.isEmpty &&
           (sameResponseContent || preserveContent);

--- a/lib/features/chat/providers/chat_providers.dart
+++ b/lib/features/chat/providers/chat_providers.dart
@@ -344,6 +344,10 @@ class ChatMessagesNotifier extends Notifier<List<ChatMessage>> {
   bool _queuedPassiveConversationRefresh = false;
   String? _passiveConversationId;
   String? _activeStreamingTransportMessageId;
+  // Foreign server-assigned message id bound to the streaming tail (socket
+  // resume). Lets the poll fallback resolve server messages by this id if the
+  // socket dies after binding but before delivering `done`.
+  String? _boundRemoteMessageId;
   String? _streamingProfileTaskKey;
   String? _streamingProfileMessageId;
   DateTime? _streamingProfileStartedAt;
@@ -1285,10 +1289,28 @@ class ChatMessagesNotifier extends Notifier<List<ChatMessage>> {
     _lastFlushedStreamingBufferVersion = -1;
   }
 
+  /// Records the foreign server message id the streaming helper bound to the
+  /// local assistant tail (socket resume), so [_syncRemoteTaskStatus] can match
+  /// the server's growing/final message even when its id differs from the local
+  /// placeholder id. Scoped to the current streaming tail.
+  void recordResumeBoundRemoteMessageId(
+    String localMessageId,
+    String remoteMessageId,
+  ) {
+    if (remoteMessageId.isEmpty || state.isEmpty) {
+      return;
+    }
+    if (state.last.id != localMessageId) {
+      return;
+    }
+    _boundRemoteMessageId = remoteMessageId;
+  }
+
   void _cancelMessageStream({bool clearStreamingContent = true}) {
     final controller = _messageStream;
     _messageStream = null;
     _activeStreamingTransportMessageId = null;
+    _boundRemoteMessageId = null;
     if (controller != null && controller.isActive) {
       unawaited(controller.cancel());
     }
@@ -1438,6 +1460,7 @@ class ChatMessagesNotifier extends Notifier<List<ChatMessage>> {
 
     _messageStream = null;
     _activeStreamingTransportMessageId = null;
+    _boundRemoteMessageId = null;
     cancelSocketSubscriptions();
     _clearStreamingBuffer();
     _streamingSyncTimer?.cancel();
@@ -1642,6 +1665,7 @@ class ChatMessagesNotifier extends Notifier<List<ChatMessage>> {
     _taskStatusCheckInFlight = false;
     _observedRemoteTask = false;
     _tasksDoneGracePolls = 0;
+    _boundRemoteMessageId = null;
   }
 
   Future<void> _syncRemoteTaskStatus() async {
@@ -1715,7 +1739,10 @@ class ChatMessagesNotifier extends Notifier<List<ChatMessage>> {
                 localLast.id,
               );
               final serverVersion = refreshed.messages
-                  .where((m) => m.id == localLast.id)
+                  .where(
+                    (m) =>
+                        m.id == localLast.id || m.id == _boundRemoteMessageId,
+                  )
                   .firstOrNull;
               final serverContent = serverVersion?.content ?? '';
               // Monotonic growth guard: only adopt when the server has strictly
@@ -1779,7 +1806,10 @@ class ChatMessagesNotifier extends Notifier<List<ChatMessage>> {
               final comparisonSnapshot =
                   _readStreamingMessageComparisonSnapshot(localLast.id);
               final serverVersion = serverMessages
-                  .where((m) => m.id == localLast.id)
+                  .where(
+                    (m) =>
+                        m.id == localLast.id || m.id == _boundRemoteMessageId,
+                  )
                   .firstOrNull;
 
               if (serverVersion != null) {

--- a/lib/features/chat/providers/chat_providers.dart
+++ b/lib/features/chat/providers/chat_providers.dart
@@ -381,7 +381,13 @@ class ChatMessagesNotifier extends Notifier<List<ChatMessage>> {
         _stopRemoteTaskMonitor();
 
         if (next != null) {
-          state = next.messages;
+          final nextMessages = next.messages;
+          final currentMessagesAlreadyVisible =
+              state.isNotEmpty &&
+              !_messagesDifferByStreamingSignatures(nextMessages, state);
+          if (!currentMessagesAlreadyVisible) {
+            state = nextMessages;
+          }
           _syncStreamingProfileWithState();
 
           // Update selected model if conversation has a different model

--- a/lib/features/chat/providers/chat_providers.dart
+++ b/lib/features/chat/providers/chat_providers.dart
@@ -335,6 +335,14 @@ class ChatMessagesNotifier extends Notifier<List<ChatMessage>> {
   Timer? _passiveConversationRefreshTimer;
   bool _taskStatusCheckInFlight = false;
   bool _observedRemoteTask = false;
+  // Feature C: number of consecutive polls that saw `tasksDone` while a socket
+  // resume stream still held protection. The poll's force-adoption is deferred
+  // for a short grace window so the socket's own `done` finalize wins and we
+  // never double-finalize. Reset whenever tasks are active again.
+  int _tasksDoneGracePolls = 0;
+  // Polls to wait after `tasksDone` before the poll force-adopts server state
+  // over a still-protected socket resume stream (~2s at the 1s cadence).
+  static const int _tasksDoneSocketGracePolls = 2;
   bool _passiveConversationRefreshInFlight = false;
   bool _queuedPassiveConversationRefresh = false;
   String? _passiveConversationId;
@@ -1356,6 +1364,39 @@ class ChatMessagesNotifier extends Notifier<List<ChatMessage>> {
         _taskStatusCheckInFlight;
   }
 
+  /// Test-only view of [_shouldProtectLocalStreamingState] so resume regression
+  /// tests can assert protection holds ONLY for the matching streaming message
+  /// id (Feature C de-risking) without coupling to private members.
+  @visibleForTesting
+  bool get debugShouldProtectLocalStreamingState =>
+      _shouldProtectLocalStreamingState;
+
+  /// Test-only view of the socket-resume grace-poll counter so the
+  /// double-finalize race guard (Feature C: "socket done wins / poll defers")
+  /// can be asserted across poll iterations without coupling to private state.
+  @visibleForTesting
+  int get debugTasksDoneGracePolls => _tasksDoneGracePolls;
+
+  /// Test-only entry point that drives a single remote-task poll iteration,
+  /// mirroring exactly one tick of the 1s monitor. Lets grace-window regression
+  /// tests exercise [_syncRemoteTaskStatus] deterministically.
+  @visibleForTesting
+  Future<void> debugSyncRemoteTaskStatus() => _syncRemoteTaskStatus();
+
+  /// Test-only hook that cancels just the periodic 1s poll timer without
+  /// clearing observed-task / grace state, so a test can drive poll iterations
+  /// manually via [debugSyncRemoteTaskStatus] without the timer racing them.
+  @visibleForTesting
+  void debugCancelRemoteTaskMonitorTimer() {
+    _taskStatusTimer?.cancel();
+    _taskStatusTimer = null;
+  }
+
+  /// Test-only view of the poll re-entry guard so a test can confirm no
+  /// background poll is mid-flight before driving deterministic manual polls.
+  @visibleForTesting
+  bool get debugTaskStatusCheckInFlight => _taskStatusCheckInFlight;
+
   /// True while streaming was re-engaged for a reopened, server-active chat
   /// (typing indicator + 1s poll) with no genuine local transport. The
   /// progressive poll owns content updates during this window; passive server
@@ -1460,7 +1501,91 @@ class ChatMessagesNotifier extends Notifier<List<ChatMessage>> {
     // Pre-seed so the monitor's tasksDone finalization resolves once the server
     // task disappears (otherwise tasksDone could never become true).
     _observedRemoteTask = true;
+    // Attach a socket resume stream so deltas render token-by-token (mirroring
+    // Open WebUI) instead of waiting on the 1s poll. The poll stays armed as a
+    // safety-net fallback below. When no connected socket is available the
+    // attach is a no-op and behaviour is identical to today's poll-only resume.
+    _attachResumeSocketStream(conversation, state.last);
     _ensureRemoteTaskMonitor();
+  }
+
+  /// Feature C: subscribe the reopened, server-active chat to the shared
+  /// Socket.IO `events` stream so token deltas render in real time, reusing the
+  /// full `dispatchChatTransport` callback wiring via `isResume: true`.
+  ///
+  /// This is best-effort: it only attaches when a connected socket is present.
+  /// Offline / disconnected opens fall through to the 1s task poll unchanged.
+  /// Registering the socket subscriptions makes [_shouldProtectLocalStreamingState]
+  /// true for the resumed message, which demotes the poll's content-adoption to
+  /// a pure fallback (the socket owns content).
+  void _attachResumeSocketStream(Conversation conversation, ChatMessage last) {
+    if (_disposed || isTemporaryChat(conversation.id)) {
+      return;
+    }
+    // A genuine local stream already owns this chat — never overwrite it.
+    if (_shouldProtectLocalStreamingState) {
+      return;
+    }
+    if (last.role != 'assistant') {
+      return;
+    }
+
+    final socketService = ref.read(socketServiceProvider);
+    if (socketService == null || !socketService.isConnected) {
+      // No live socket — rely on the poll fallback (today's behaviour).
+      return;
+    }
+
+    final api = ref.read(apiServiceProvider);
+    if (api == null) {
+      return;
+    }
+
+    // Resolve a model item for watchdog timing / logging only — resume content
+    // arrives over the socket, so the exact model item is non-critical.
+    final selectedModel = ref.read(selectedModelProvider);
+    final resolvedModelId = (last.model != null && last.model!.isNotEmpty)
+        ? last.model!
+        : (conversation.model ?? selectedModel?.id ?? '');
+    final modelItem =
+        (selectedModel != null && selectedModel.id == resolvedModelId)
+        ? _buildLocalModelItem(selectedModel)
+        : <String, dynamic>{
+            'id': resolvedModelId,
+            'name': resolvedModelId,
+          };
+
+    DebugLogger.log(
+      'Attaching socket resume stream for in-flight chat',
+      scope: 'chat/resume',
+      data: {'chatId': conversation.id, 'messageId': last.id},
+    );
+
+    final session = ChatCompletionSession.resumeSocket(
+      messageId: last.id,
+      conversationId: conversation.id,
+    );
+
+    unawaited(
+      dispatchChatTransport(
+        ref: ref,
+        session: session,
+        assistantMessageId: last.id,
+        modelId: resolvedModelId,
+        modelItem: modelItem,
+        activeConversationId: conversation.id,
+        api: api,
+        socketService: socketService,
+        workerManager: ref.read(workerManagerProvider),
+        webSearchEnabled: false,
+        imageGenerationEnabled: false,
+        isBackgroundFlow: false,
+        modelUsesReasoning: _modelUsesReasoning(resolvedModelId),
+        toolsEnabled: false,
+        isTemporary: false,
+        isResume: true,
+      ),
+    );
   }
 
   void _ensureRemoteTaskMonitor() {
@@ -1484,6 +1609,7 @@ class ChatMessagesNotifier extends Notifier<List<ChatMessage>> {
     _taskStatusTimer = null;
     _taskStatusCheckInFlight = false;
     _observedRemoteTask = false;
+    _tasksDoneGracePolls = 0;
   }
 
   Future<void> _syncRemoteTaskStatus() async {
@@ -1514,6 +1640,22 @@ class ChatMessagesNotifier extends Notifier<List<ChatMessage>> {
 
       // When no active tasks and we previously observed tasks, streaming should be done.
       final tasksDone = _observedRemoteTask && !hasActiveTasks;
+
+      // Feature C race guard: when a socket resume stream still owns this chat
+      // (protection holds), let its own `done` finalize win. Defer the poll's
+      // force-adoption for a short grace window so we never double-finalize the
+      // same message. The window starts the first poll that sees `tasksDone`
+      // while protected; once it elapses (or protection drops) the poll resumes
+      // as the authoritative recovery finalizer below.
+      if (tasksDone && _shouldProtectLocalStreamingState) {
+        _tasksDoneGracePolls++;
+      } else {
+        _tasksDoneGracePolls = 0;
+      }
+      final socketResumeGraceActive =
+          _shouldProtectLocalStreamingState &&
+          _tasksDoneGracePolls > 0 &&
+          _tasksDoneGracePolls <= _tasksDoneSocketGracePolls;
 
       // Resume case: while the server task is still running and no genuine local
       // stream owns this chat (i.e. we re-engaged streaming on reopen), adopt the
@@ -1571,7 +1713,13 @@ class ChatMessagesNotifier extends Notifier<List<ChatMessage>> {
       // like web search, which can take a long time to start on the server.
       // Note: If a socket connection silently fails before tasks complete, the
       // user can cancel via the stop button or navigate away to recover.
-      if (_hasStreamingAssistant && tasksDone) {
+      //
+      // Feature C: while the socket resume grace window is active, skip the
+      // force-adoption so the socket's own `done` finalize wins (avoids a
+      // double-finalize / content flicker race). After the window elapses (or
+      // if the socket silently died and dropped protection) the poll resumes as
+      // the authoritative recovery finalizer.
+      if (_hasStreamingAssistant && tasksDone && !socketResumeGraceActive) {
         try {
           final serverConversation = await api.getConversation(
             activeConversation.id,

--- a/lib/features/chat/providers/chat_providers.dart
+++ b/lib/features/chat/providers/chat_providers.dart
@@ -1672,6 +1672,18 @@ class ChatMessagesNotifier extends Notifier<List<ChatMessage>> {
     }
   }
 
+  void addMessages(List<ChatMessage> messages) {
+    if (messages.isEmpty) return;
+    state = [...state, ...messages];
+    for (final message in messages.reversed) {
+      if (message.role == 'assistant' && message.isStreaming) {
+        _beginStreamingProfile(message);
+        _touchStreamingActivity();
+        break;
+      }
+    }
+  }
+
   void removeLastMessage() {
     if (state.isNotEmpty) {
       state = state.sublist(0, state.length - 1);
@@ -2410,6 +2422,7 @@ ChatMessageVersion _buildAssistantVersionSnapshot(ChatMessage message) {
     content: message.content,
     timestamp: message.timestamp,
     model: message.model,
+    modelName: _messageModelName(message),
     files: message.files == null
         ? null
         : List<Map<String, dynamic>>.from(message.files!),
@@ -2429,6 +2442,12 @@ ChatMessageVersion _buildAssistantVersionSnapshot(ChatMessage message) {
   );
 }
 
+String? _messageModelName(ChatMessage message) {
+  final raw = message.metadata?['modelName'] ?? message.metadata?['model_name'];
+  final value = raw?.toString().trim();
+  return value == null || value.isEmpty ? null : value;
+}
+
 List<ChatMessageVersion> _buildReplayVersions(ChatMessage message) {
   return [...message.versions, _buildAssistantVersionSnapshot(message)];
 }
@@ -2441,6 +2460,7 @@ Future<String> _preseedAssistantAndPersist(
   dynamic ref, {
   String? existingAssistantId,
   required String modelId,
+  String? modelName,
 }) async {
   // Choose id: reuse existing if provided, else create new
   final String assistantMessageId =
@@ -2459,6 +2479,10 @@ Future<String> _preseedAssistantAndPersist(
       timestamp: DateTime.now(),
       model: modelId,
       isStreaming: true,
+      metadata: {
+        if (modelName != null && modelName.trim().isNotEmpty)
+          'modelName': modelName.trim(),
+      },
     );
     ref.read(chatMessagesProvider.notifier).addMessage(placeholder);
   } else {
@@ -2474,7 +2498,11 @@ Future<String> _preseedAssistantAndPersist(
         notifier.updateLastMessageWithFunction(
           (ChatMessage m) => m.copyWith(
             isStreaming: true,
-            metadata: notifier._metadataWithoutResponseDone(m.metadata),
+            metadata: {
+              ...?notifier._metadataWithoutResponseDone(m.metadata),
+              if (modelName != null && modelName.trim().isNotEmpty)
+                'modelName': modelName.trim(),
+            },
           ),
         );
       }
@@ -3475,6 +3503,7 @@ Future<void> regenerateMessage(
       timestamp: DateTime.now(),
       model: selectedModel.id,
       isStreaming: true,
+      metadata: {'modelName': selectedModel.name},
     );
     ref.read(chatMessagesProvider.notifier).addMessage(assistantMessage);
 
@@ -3603,6 +3632,7 @@ Future<void> regenerateMessage(
       ref,
       existingAssistantId: null,
       modelId: selectedModel.id,
+      modelName: selectedModel.name,
     );
 
     // Attach previous assistant as a version snapshot to the new assistant
@@ -3816,6 +3846,9 @@ Future<void> runQueuedCompletion(
   // Empty model => fall back to the selected default model (mirrors the
   // migrator's empty-model contract). A still-empty model is a hard error.
   final effectiveModelId = model.isNotEmpty ? model : (selectedModel?.id ?? '');
+  final effectiveModelName = selectedModel?.id == effectiveModelId
+      ? selectedModel?.name
+      : null;
   if (effectiveModelId.isEmpty) {
     throw StateError('runQueuedCompletion has no model to send');
   }
@@ -3857,6 +3890,7 @@ Future<void> runQueuedCompletion(
     ref,
     existingAssistantId: assistantMessageId,
     modelId: effectiveModelId,
+    modelName: effectiveModelName,
   );
 
   final Map<String, dynamic> modelItem =
@@ -4345,7 +4379,6 @@ Future<void> durableSend(
       'models': <String>[selectedModel.id],
     },
   );
-  ref.read(chatMessagesProvider.notifier).addMessage(userMessage);
   final assistantPlaceholder = ChatMessage(
     id: assistantMessageId,
     role: 'assistant',
@@ -4353,9 +4386,16 @@ Future<void> durableSend(
     timestamp: DateTime.now(),
     model: selectedModel.id,
     isStreaming: true,
-    metadata: {'parentId': userMessageId, 'childrenIds': const <String>[]},
+    metadata: {
+      'parentId': userMessageId,
+      'childrenIds': const <String>[],
+      'modelName': selectedModel.name,
+    },
   );
-  ref.read(chatMessagesProvider.notifier).addMessage(assistantPlaceholder);
+  ref.read(chatMessagesProvider.notifier).addMessages([
+    userMessage,
+    assistantPlaceholder,
+  ]);
 
   final chatLocks = ref.read(chatLocksProvider);
   final attachmentList = attachments ?? const <String>[];
@@ -4783,9 +4823,6 @@ Future<void> _sendMessageInternal(
     },
   );
 
-  // Add user message to UI immediately for instant feedback
-  ref.read(chatMessagesProvider.notifier).addMessage(userMessage);
-
   // Add assistant placeholder immediately to show typing indicator right away
   final assistantPlaceholder = ChatMessage(
     id: assistantMessageId,
@@ -4794,9 +4831,16 @@ Future<void> _sendMessageInternal(
     timestamp: DateTime.now(),
     model: selectedModel.id,
     isStreaming: true,
-    metadata: {'parentId': userMessageId, 'childrenIds': const <String>[]},
+    metadata: {
+      'parentId': userMessageId,
+      'childrenIds': const <String>[],
+      'modelName': selectedModel.name,
+    },
   );
-  ref.read(chatMessagesProvider.notifier).addMessage(assistantPlaceholder);
+  ref.read(chatMessagesProvider.notifier).addMessages([
+    userMessage,
+    assistantPlaceholder,
+  ]);
 
   // Now do async work in parallel: user settings + server file info
   String? userSystemPrompt;

--- a/lib/features/chat/providers/chat_providers.dart
+++ b/lib/features/chat/providers/chat_providers.dart
@@ -94,12 +94,9 @@ class _ChatMessageListStructure {
         ..write('\u0000')
         // Include the displayed model-name fallback so the structure signature
         // changes whenever the label changes, keeping the list-shell rebuild
-        // trigger in agreement with chat_page's layout signature.
-        ..write(
-          message.metadata?['modelName'] ??
-              message.metadata?['model_name'] ??
-              '',
-        )
+        // trigger in agreement with chat_page's layout signature. Use the
+        // normalized extractor so trim/empty handling matches the displayed name.
+        ..write(_messageModelName(message) ?? '')
         ..write('\u0000')
         ..write(message.versions.length);
       for (final version in message.versions) {

--- a/lib/features/chat/providers/chat_providers.dart
+++ b/lib/features/chat/providers/chat_providers.dart
@@ -868,8 +868,13 @@ class ChatMessagesNotifier extends Notifier<List<ChatMessage>> {
 
     final localById = <String, ChatMessage>{
       for (final message in state)
+        // Also index empty placeholders that still carry a local-only
+        // `modelName`, so a stale pre-first-token snapshot can't drop the model
+        // label before the metadata merge runs.
         if (message.role == 'assistant' &&
-            (message.content.trim().isNotEmpty || message.followUps.isNotEmpty))
+            (message.content.trim().isNotEmpty ||
+                message.followUps.isNotEmpty ||
+                _messageModelName(message) != null))
           message.id: message,
     };
     if (localById.isEmpty) {
@@ -885,10 +890,22 @@ class ChatMessagesNotifier extends Notifier<List<ChatMessage>> {
     var changed = false;
     final merged = <ChatMessage>[];
     for (final serverMessage in serverMessages) {
-      final localMessage = localById[serverMessage.id];
+      // A socket resume binds a foreign server message_id to the local tail; a
+      // lagging snapshot may carry that remote id instead of the local
+      // placeholder id, so resolve it back to the tail.
+      final boundToTail =
+          _boundRemoteMessageId != null &&
+          serverMessage.id == _boundRemoteMessageId &&
+          localTailId != null;
+      final localMessage =
+          localById[serverMessage.id] ??
+          (boundToTail ? localById[localTailId] : null);
+      final isStreamingTail =
+          localMessage != null &&
+          (serverMessage.id == localTailId || boundToTail);
       final preserveContent =
           localMessage != null &&
-          serverMessage.id == localTailId &&
+          isStreamingTail &&
           _shouldPreserveLocalAssistantContent(localMessage, serverMessage);
       final sameResponseContent =
           localMessage != null &&
@@ -902,7 +919,16 @@ class ChatMessagesNotifier extends Notifier<List<ChatMessage>> {
           serverMessage.role == 'assistant' &&
           serverMessage.followUps.isEmpty &&
           (sameResponseContent || preserveContent);
-      if (!preserveContent && !shouldPreserveFollowUps) {
+      // Preserve a local-only modelName the server snapshot hasn't caught up to
+      // (notably an empty placeholder whose first token hasn't landed).
+      final shouldPreserveModelName =
+          localMessage != null &&
+          serverMessage.role == 'assistant' &&
+          _messageModelName(localMessage) != null &&
+          _messageModelName(serverMessage) == null;
+      if (!preserveContent &&
+          !shouldPreserveFollowUps &&
+          !shouldPreserveModelName) {
         merged.add(serverMessage);
         continue;
       }
@@ -2023,7 +2049,7 @@ class ChatMessagesNotifier extends Notifier<List<ChatMessage>> {
     _finishStreamingProfile(reason: 'cleared');
   }
 
-  void failLastStreamingAssistant(Object error) {
+  void failLastStreamingAssistant(Object error, {String? assistantMessageId}) {
     if (state.isEmpty) {
       // No placeholder to mark failed, but still release any dangling
       // streaming/transport bookkeeping so a generic recovery catch cannot
@@ -2031,13 +2057,18 @@ class ChatMessagesNotifier extends Notifier<List<ChatMessage>> {
       finishStreaming();
       return;
     }
-    final lastMessage = state.last;
-    if (lastMessage.role != 'assistant' || !lastMessage.isStreaming) {
-      // The last message is no longer a streaming assistant (e.g. completed,
-      // or reshaped by a concurrent server adoption). There is no placeholder
-      // to attach the error to, but finishStreaming() is idempotent and
-      // releases transport/profile state, matching the prior unconditional
-      // cleanup this helper replaced.
+    // Resolve the target by the captured assistant id so a list reshape between
+    // placeholder insertion and this failure (e.g. a concurrent server
+    // adoption appending messages) can't attach the error to — or finalize —
+    // the wrong tail. Fall back to the last message when no id was captured.
+    final target = assistantMessageId != null
+        ? state.where((m) => m.id == assistantMessageId).firstOrNull
+        : state.last;
+    if (target == null || target.role != 'assistant' || !target.isStreaming) {
+      // The captured assistant is gone or no longer streaming (e.g. completed,
+      // or reshaped). There is no placeholder to attach the error to, but
+      // finishStreaming() is idempotent and releases transport/profile state,
+      // matching the prior unconditional cleanup this helper replaced.
       finishStreaming();
       return;
     }
@@ -2045,7 +2076,10 @@ class ChatMessagesNotifier extends Notifier<List<ChatMessage>> {
     final chatError = ChatMessageError(
       content: chatErrorContentForException(error),
     );
-    updateLastMessageWithFunction(
+    // Update by id so the error lands on the captured message even if it is no
+    // longer the list tail.
+    updateMessageById(
+      target.id,
       (message) => message.copyWith(error: chatError),
     );
     finishStreaming();
@@ -5731,7 +5765,7 @@ Future<void> _sendMessageInternal(
     // `dynamic` — without it Dart infers (dynamic) => dynamic at runtime.
     final ChatMessagesNotifier notifier =
         ref.read(chatMessagesProvider.notifier) as ChatMessagesNotifier;
-    notifier.failLastStreamingAssistant(e);
+    notifier.failLastStreamingAssistant(e, assistantMessageId: assistantMessageId);
     if (e.toString().contains('401') || e.toString().contains('403')) {
       // Authentication errors - clear auth state and redirect to login.
       ref.invalidate(authStateManagerProvider);

--- a/lib/features/chat/providers/chat_providers.dart
+++ b/lib/features/chat/providers/chat_providers.dart
@@ -92,6 +92,15 @@ class _ChatMessageListStructure {
         ..write('\u0000')
         ..write(message.metadata?['archivedVariant'] == true ? 1 : 0)
         ..write('\u0000')
+        // Include the displayed model-name fallback so the structure signature
+        // changes whenever the label changes, keeping the list-shell rebuild
+        // trigger in agreement with chat_page's layout signature.
+        ..write(
+          message.metadata?['modelName'] ??
+              message.metadata?['model_name'] ??
+              '',
+        )
+        ..write('\u0000')
         ..write(message.versions.length);
       for (final version in message.versions) {
         buffer
@@ -1805,9 +1814,23 @@ class ChatMessagesNotifier extends Notifier<List<ChatMessage>> {
   }
 
   void failLastStreamingAssistant(Object error) {
-    if (state.isEmpty) return;
+    if (state.isEmpty) {
+      // No placeholder to mark failed, but still release any dangling
+      // streaming/transport bookkeeping so a generic recovery catch cannot
+      // leave streaming state hung.
+      finishStreaming();
+      return;
+    }
     final lastMessage = state.last;
-    if (lastMessage.role != 'assistant' || !lastMessage.isStreaming) return;
+    if (lastMessage.role != 'assistant' || !lastMessage.isStreaming) {
+      // The last message is no longer a streaming assistant (e.g. completed,
+      // or reshaped by a concurrent server adoption). There is no placeholder
+      // to attach the error to, but finishStreaming() is idempotent and
+      // releases transport/profile state, matching the prior unconditional
+      // cleanup this helper replaced.
+      finishStreaming();
+      return;
+    }
 
     final chatError = ChatMessageError(
       content: chatErrorContentForException(error),
@@ -2590,6 +2613,12 @@ Future<String> _preseedAssistantAndPersist(
       ? existingAssistantId
       : const Uuid().v4();
 
+  final trimmedModelName = modelName?.trim();
+  final modelNameMetadata = <String, dynamic>{
+    if (trimmedModelName != null && trimmedModelName.isNotEmpty)
+      'modelName': trimmedModelName,
+  };
+
   // If the message with this id doesn't exist locally, add a placeholder
   final msgs = ref.read(chatMessagesProvider);
   final exists = msgs.any((m) => m.id == assistantMessageId);
@@ -2601,10 +2630,7 @@ Future<String> _preseedAssistantAndPersist(
       timestamp: DateTime.now(),
       model: modelId,
       isStreaming: true,
-      metadata: {
-        if (modelName != null && modelName.trim().isNotEmpty)
-          'modelName': modelName.trim(),
-      },
+      metadata: modelNameMetadata,
     );
     ref.read(chatMessagesProvider.notifier).addMessage(placeholder);
   } else {
@@ -2622,8 +2648,7 @@ Future<String> _preseedAssistantAndPersist(
             isStreaming: true,
             metadata: {
               ...?notifier._metadataWithoutResponseDone(m.metadata),
-              if (modelName != null && modelName.trim().isNotEmpty)
-                'modelName': modelName.trim(),
+              ...modelNameMetadata,
             },
           ),
         );
@@ -4511,7 +4536,8 @@ Future<void> durableSend(
     metadata: {
       'parentId': userMessageId,
       'childrenIds': const <String>[],
-      'modelName': selectedModel.name,
+      if (selectedModel.name.trim().isNotEmpty)
+        'modelName': selectedModel.name.trim(),
     },
   );
   ref.read(chatMessagesProvider.notifier).addMessages([
@@ -4991,7 +5017,8 @@ Future<void> _sendMessageInternal(
     metadata: {
       'parentId': userMessageId,
       'childrenIds': const <String>[],
-      'modelName': selectedModel.name,
+      if (selectedModel.name.trim().isNotEmpty)
+        'modelName': selectedModel.name.trim(),
     },
   );
   ref.read(chatMessagesProvider.notifier).addMessages([
@@ -5494,13 +5521,10 @@ Future<void> _sendMessageInternal(
     // `dynamic` — without it Dart infers (dynamic) => dynamic at runtime.
     final ChatMessagesNotifier notifier =
         ref.read(chatMessagesProvider.notifier) as ChatMessagesNotifier;
+    notifier.failLastStreamingAssistant(e);
     if (e.toString().contains('401') || e.toString().contains('403')) {
       // Authentication errors - clear auth state and redirect to login.
-      // Still convert the placeholder so the UI is consistent.
-      notifier.failLastStreamingAssistant(e);
       ref.invalidate(authStateManagerProvider);
-    } else {
-      notifier.failLastStreamingAssistant(e);
     }
   }
 }

--- a/lib/features/chat/providers/chat_providers.dart
+++ b/lib/features/chat/providers/chat_providers.dart
@@ -900,7 +900,13 @@ class ChatMessagesNotifier extends Notifier<List<ChatMessage>> {
       }
 
       changed = true;
-      final metadata = <String, dynamic>{...?serverMessage.metadata};
+      // Merge local + server metadata so local-only fields (e.g. `modelName`)
+      // survive a server snapshot captured before the durable payload was
+      // finalized. Server values take precedence; local fills only the gaps.
+      final metadata = <String, dynamic>{
+        ...?localMessage.metadata,
+        ...?serverMessage.metadata,
+      };
       if (shouldPreserveFollowUps) {
         metadata.putIfAbsent(
           'followUps',

--- a/lib/features/chat/providers/chat_providers.dart
+++ b/lib/features/chat/providers/chat_providers.dart
@@ -872,12 +872,19 @@ class ChatMessagesNotifier extends Notifier<List<ChatMessage>> {
       return serverMessages;
     }
 
+    // Content preservation only protects the streaming tail — the one message
+    // that may be mid-finalization when a lagging snapshot arrives. Older,
+    // already-completed assistant messages must defer to the server so an
+    // authoritative refresh can correct or truncate them.
+    final localTailId = state.last.role == 'assistant' ? state.last.id : null;
+
     var changed = false;
     final merged = <ChatMessage>[];
     for (final serverMessage in serverMessages) {
       final localMessage = localById[serverMessage.id];
       final preserveContent =
           localMessage != null &&
+          serverMessage.id == localTailId &&
           _shouldPreserveLocalAssistantContent(localMessage, serverMessage);
       final sameResponseContent =
           localMessage != null &&
@@ -1466,19 +1473,32 @@ class ChatMessagesNotifier extends Notifier<List<ChatMessage>> {
     }
 
     // Fast path: the active-chats set (populated by ActiveChatsSync) may already
-    // know. Otherwise ask the server's task registry directly.
+    // know. Otherwise ask the server's task registry directly. Either way we
+    // try to capture an active task id so the resumed message carries stoppable
+    // task metadata (stop/delete can then cancel the server task, not just the
+    // local subscription).
+    final api = ref.read(apiServiceProvider);
+    String? resumeTaskId;
     var isActive = ref.read(activeChatIdsProvider).contains(chatId);
     if (!isActive) {
-      final api = ref.read(apiServiceProvider);
       if (api == null) {
         return;
       }
       try {
         final taskIds = await api.getTaskIdsByChat(chatId);
         isActive = taskIds.isNotEmpty;
+        resumeTaskId = taskIds.isNotEmpty ? taskIds.first : null;
       } catch (_) {
         // Offline / unreachable: leave the response as-is (static).
         return;
+      }
+    } else if (api != null) {
+      // Already known-active; best-effort task-id fetch for stoppable metadata.
+      try {
+        final taskIds = await api.getTaskIdsByChat(chatId);
+        resumeTaskId = taskIds.isNotEmpty ? taskIds.first : null;
+      } catch (_) {
+        // Best-effort only; resume still proceeds without a task id.
       }
     }
     if (!isActive || _disposed) {
@@ -1509,7 +1529,7 @@ class ChatMessagesNotifier extends Notifier<List<ChatMessage>> {
     // Open WebUI) instead of waiting on the 1s poll. The poll stays armed as a
     // safety-net fallback below. When no connected socket is available the
     // attach is a no-op and behaviour is identical to today's poll-only resume.
-    _attachResumeSocketStream(conversation, state.last);
+    _attachResumeSocketStream(conversation, state.last, taskId: resumeTaskId);
     _ensureRemoteTaskMonitor();
   }
 
@@ -1522,7 +1542,11 @@ class ChatMessagesNotifier extends Notifier<List<ChatMessage>> {
   /// Registering the socket subscriptions makes [_shouldProtectLocalStreamingState]
   /// true for the resumed message, which demotes the poll's content-adoption to
   /// a pure fallback (the socket owns content).
-  void _attachResumeSocketStream(Conversation conversation, ChatMessage last) {
+  void _attachResumeSocketStream(
+    Conversation conversation,
+    ChatMessage last, {
+    String? taskId,
+  }) {
     if (_disposed || isTemporaryChat(conversation.id)) {
       return;
     }
@@ -1568,6 +1592,10 @@ class ChatMessagesNotifier extends Notifier<List<ChatMessage>> {
     final session = ChatCompletionSession.resumeSocket(
       messageId: last.id,
       conversationId: conversation.id,
+      // Carry the discovered task id so dispatchChatTransport writes stoppable
+      // task metadata onto the resumed message (stop/delete can cancel the
+      // server task, not just the local socket subscription).
+      taskId: taskId,
     );
 
     unawaited(

--- a/lib/features/chat/services/chat_transport_dispatch.dart
+++ b/lib/features/chat/services/chat_transport_dispatch.dart
@@ -351,6 +351,13 @@ Future<void> dispatchChatTransport({
         });
       }
     },
+    onRemoteMessageBound: (remoteMessageId) {
+      // Record the foreign server id bound to this assistant so the poll
+      // fallback can still resolve server content if the socket later dies.
+      ref
+          .read(chatMessagesProvider.notifier)
+          .recordResumeBoundRemoteMessageId(assistantMessageId, remoteMessageId);
+    },
     onChatActiveChanged: (chatId, active) {
       if (chatId == null || chatId.isEmpty) return;
       final notifier = ref.read(activeChatIdsProvider.notifier);

--- a/lib/features/chat/services/chat_transport_dispatch.dart
+++ b/lib/features/chat/services/chat_transport_dispatch.dart
@@ -79,11 +79,17 @@ Future<void> bindTaskSocketIfNeeded({
   required ChatCompletionSession session,
   required SocketService? socketService,
   Duration timeout = const Duration(seconds: 10),
+  bool isResume = false,
 }) async {
   if (session.transport != ChatCompletionTransport.taskSocket) return;
   if (socketService == null) return;
 
-  setAwaitingSocketBinding(ref: ref, value: true);
+  // Resume reuses the live socket subscription; there is no "awaiting binding"
+  // window to surface on the message (no fresh HTTP request was issued), so we
+  // skip that metadata churn but still ensure the socket is connected.
+  if (!isResume) {
+    setAwaitingSocketBinding(ref: ref, value: true);
+  }
 
   try {
     if (!socketService.isConnected) {
@@ -91,13 +97,15 @@ Future<void> bindTaskSocketIfNeeded({
       if (!connected) {
         DebugLogger.log(
           'Socket not available for taskSocket binding — will rely on poll recovery',
-          scope: 'transport/dispatch',
+          scope: isResume ? 'transport/resume' : 'transport/dispatch',
         );
         return;
       }
     }
   } finally {
-    setAwaitingSocketBinding(ref: ref, value: false);
+    if (!isResume) {
+      setAwaitingSocketBinding(ref: ref, value: false);
+    }
   }
 }
 
@@ -155,6 +163,25 @@ void stopActiveTransport(ChatMessage message, ApiService? api) {
 // Dispatch entry point
 // ---------------------------------------------------------------------------
 
+/// Whether the just-dispatched [session] should optimistically light the
+/// sidebar `generating` indicator for [conversationId].
+///
+/// A taskSocket session with a non-empty task ID is produced precisely when the
+/// completion POST returned a non-empty `task_ids`, which upstream OpenWebUI
+/// treats as the synchronous generation-START signal (alongside the async
+/// `chat:active{true}` push). Temporary chats are never tracked in the sidebar.
+bool shouldOptimisticallyMarkChatActive({
+  required ChatCompletionSession session,
+  required String? conversationId,
+}) {
+  return session.transport == ChatCompletionTransport.taskSocket &&
+      session.taskId != null &&
+      session.taskId!.isNotEmpty &&
+      conversationId != null &&
+      conversationId.isNotEmpty &&
+      !isTemporaryChat(conversationId);
+}
+
 /// Shared transport dispatch glue used by both `regenerateMessage()` and
 /// `_sendMessageInternal()`.
 ///
@@ -181,6 +208,15 @@ Future<void> dispatchChatTransport({
   required bool toolsEnabled,
   required bool isTemporary,
   List<String>? filterIds,
+
+  /// Whether this dispatch resumes an in-flight chat that is still generating
+  /// on the server (Feature C), rather than a fresh local send.
+  ///
+  /// When true the resume reuses the live socket subscription instead of an
+  /// HTTP request: the awaiting-binding metadata is skipped, no abort handle is
+  /// written, and the socket session ID is forced to `null` so the streaming
+  /// helper binds the server's (possibly foreign) `message_id` by `chat_id`.
+  bool isResume = false,
 }) async {
   // 1. Write transport + flow metadata onto assistant message
   writeTransportMetadata(ref: ref, session: session);
@@ -204,15 +240,41 @@ Future<void> dispatchChatTransport({
     ref: ref,
     session: session,
     socketService: socketService,
+    isResume: isResume,
   );
 
   // 3. Configure remote task monitoring
   configureRemoteTaskMonitoring(ref: ref, session: session);
 
+  // 3b. Optimistic generation-START for the sidebar indicator.
+  //
+  // Upstream OpenWebUI learns active state from two signals: the synchronous
+  // completion-POST response (`{status, task_ids, chat_id}`) AND the async
+  // `chat:active{active:true}` socket push. A taskSocket session is produced
+  // exactly when that POST returned a non-empty `task_ids`, so light the
+  // spinner immediately here instead of waiting for the socket event to land.
+  // The authoritative `chat:active{false}` (or the paired cancel/error/finalize
+  // `setInactive`) clears it, so no spinner is stranded.
+  if (shouldOptimisticallyMarkChatActive(
+    session: session,
+    conversationId: activeConversationId,
+  )) {
+    ref.read(activeChatIdsProvider.notifier).setActive(activeConversationId!);
+  }
+
   // 4. Build the effective session ID for socket event matching.
   // Prefer the live socket session ID over the one stored in the session
   // (the latter may be null when the socket was disconnected at send time).
-  final effectiveSessionId = socketService?.sessionId ?? session.sessionId;
+  //
+  // Resume forces a null session ID: upstream `chat:completion` envelopes for
+  // an in-flight chat carry no `session_id`, and the server's `message_id` may
+  // differ from the local placeholder id. A null session keeps
+  // `matchesCurrentStreamSession` permissive so the helper binds the foreign
+  // `message_id` by `chat_id` (`allowBindingForeignMessage`). Leaking the live
+  // socket session id here would reject those foreign-session events.
+  final effectiveSessionId = isResume
+      ? null
+      : (socketService?.sessionId ?? session.sessionId);
 
   // 5. Attach streaming
   final activeStream = attachUnifiedChunkedStreaming(

--- a/lib/features/chat/services/chat_transport_dispatch.dart
+++ b/lib/features/chat/services/chat_transport_dispatch.dart
@@ -368,15 +368,19 @@ Future<void> dispatchChatTransport({
         notifier.setInactive(chatId);
         return;
       }
+      // Capture the activation token now so a stream that starts for this chat
+      // during the async lookup is not clobbered by this stale clear.
+      final token = notifier.activationToken(chatId);
       unawaited(() async {
         try {
           final ids = await apiRef.getTaskIdsByChat(chatId);
           if (ids.isEmpty) {
-            notifier.setInactive(chatId);
+            notifier.setInactiveIfUnchanged(chatId, token);
           }
         } catch (_) {
-          // Unreachable registry: clear anyway so a spinner can't strand.
-          notifier.setInactive(chatId);
+          // Unreachable registry: clear anyway so a spinner can't strand,
+          // still guarded against a racing re-activation.
+          notifier.setInactiveIfUnchanged(chatId, token);
         }
       }());
     },

--- a/lib/features/chat/services/chat_transport_dispatch.dart
+++ b/lib/features/chat/services/chat_transport_dispatch.dart
@@ -353,11 +353,32 @@ Future<void> dispatchChatTransport({
     },
     onChatActiveChanged: (chatId, active) {
       if (chatId == null || chatId.isEmpty) return;
+      final notifier = ref.read(activeChatIdsProvider.notifier);
       if (active) {
-        ref.read(activeChatIdsProvider.notifier).setActive(chatId);
-      } else {
-        ref.read(activeChatIdsProvider.notifier).setInactive(chatId);
+        notifier.setActive(chatId);
+        return;
       }
+      // The backend `chat:active(false)` only fires when the LAST task for the
+      // chat finishes. This optimistic safety-net removal must be last-task
+      // aware too, or an overlapping multi-model / branched generation would
+      // drop the sidebar spinner while another stream is still running. Only
+      // clear once the task registry reports no remaining tasks for the chat.
+      final apiRef = ref.read(apiServiceProvider);
+      if (apiRef == null) {
+        notifier.setInactive(chatId);
+        return;
+      }
+      unawaited(() async {
+        try {
+          final ids = await apiRef.getTaskIdsByChat(chatId);
+          if (ids.isEmpty) {
+            notifier.setInactive(chatId);
+          }
+        } catch (_) {
+          // Unreachable registry: clear anyway so a spinner can't strand.
+          notifier.setInactive(chatId);
+        }
+      }());
     },
     completeStreamingUi: () =>
         ref.read(chatMessagesProvider.notifier).completeStreamingUi(),

--- a/lib/features/chat/views/chat_page.dart
+++ b/lib/features/chat/views/chat_page.dart
@@ -169,7 +169,6 @@ class _ChatPageState extends ConsumerState<ChatPage> {
   int _extentCacheInvalidationGeneration = 0;
   final Set<String> _pendingRowExtentInvalidationMessageIds = <String>{};
   bool _rowExtentInvalidationScheduled = false;
-  bool _pinToTopCompletionDismissScheduled = false;
 
   bool get _wantsPinToTop => _pinToTopState.isActive;
   String? get _pinnedUserMessageId => _pinToTopState.userMessageId;
@@ -267,7 +266,6 @@ class _ChatPageState extends ConsumerState<ChatPage> {
     _pinToTopState = const _PinToTopState.inactive();
     _invalidateChatListStableLayoutMetadata();
     _endPinToTopInFlight = false;
-    _pinToTopCompletionDismissScheduled = false;
     _isAnchoredToBottom = true;
 
     // Reset temporary chat state based on user preference
@@ -1341,7 +1339,6 @@ class _ChatPageState extends ConsumerState<ChatPage> {
       _pinToTopState = const _PinToTopState.inactive();
       _invalidateChatListStableLayoutMetadata();
       _endPinToTopInFlight = false;
-      _pinToTopCompletionDismissScheduled = false;
     }
     if (conversationId == null) {
       _pendingScrollAction = const _PendingChatScrollAction.none();
@@ -1621,23 +1618,6 @@ class _ChatPageState extends ConsumerState<ChatPage> {
 
   bool _endPinToTopInFlight = false;
 
-  void _scheduleEndPinToTopAfterStreamingCompletion() {
-    if (_pinToTopCompletionDismissScheduled) {
-      return;
-    }
-    _pinToTopCompletionDismissScheduled = true;
-    WidgetsBinding.instance.addPostFrameCallback((_) {
-      _pinToTopCompletionDismissScheduled = false;
-      if (!mounted || !_wantsPinToTop) {
-        return;
-      }
-      if (_hasActiveStreamingAssistant(ref.read(chatMessagesProvider))) {
-        return;
-      }
-      _endPinToTop(instant: true);
-    });
-  }
-
   void _dismissPinToTop({bool preserveStreamingId = false}) {
     if (!_wantsPinToTop || !mounted) {
       return;
@@ -1894,12 +1874,12 @@ class _ChatPageState extends ConsumerState<ChatPage> {
         _scrollToUserMessage();
       }
     }
-    if (!hasStreamingMessage) {
-      if (_wantsPinToTop) {
-        _scheduleEndPinToTopAfterStreamingCompletion();
-      } else if (_pinnedStreamingId != null) {
-        _pinToTopState = const _PinToTopState.inactive();
-      }
+    if (!hasStreamingMessage && !_wantsPinToTop && _pinnedStreamingId != null) {
+      // Streaming finished but pin-to-top is no longer active: clear the stale
+      // pinned streaming id. When pin-to-top IS still active we deliberately
+      // keep the phantom spacer so the prompt stays near the top until the user
+      // scrolls, sends, or switches chats — avoids a viewport jump mid-read.
+      _pinToTopState = const _PinToTopState.inactive();
     }
 
     final pinnedUserMessageIndex =

--- a/lib/features/chat/views/chat_page.dart
+++ b/lib/features/chat/views/chat_page.dart
@@ -118,12 +118,6 @@ class _PinToTopState {
       streamingMessageId: streamingMessageId,
     );
   }
-
-  _PinToTopState clearTracking() => _PinToTopState._(
-    isActive: isActive,
-    userMessageId: null,
-    streamingMessageId: null,
-  );
 }
 
 class ChatPage extends ConsumerStatefulWidget {
@@ -175,6 +169,7 @@ class _ChatPageState extends ConsumerState<ChatPage> {
   int _extentCacheInvalidationGeneration = 0;
   final Set<String> _pendingRowExtentInvalidationMessageIds = <String>{};
   bool _rowExtentInvalidationScheduled = false;
+  bool _pinToTopCompletionDismissScheduled = false;
 
   bool get _wantsPinToTop => _pinToTopState.isActive;
   String? get _pinnedUserMessageId => _pinToTopState.userMessageId;
@@ -272,6 +267,7 @@ class _ChatPageState extends ConsumerState<ChatPage> {
     _pinToTopState = const _PinToTopState.inactive();
     _invalidateChatListStableLayoutMetadata();
     _endPinToTopInFlight = false;
+    _pinToTopCompletionDismissScheduled = false;
     _isAnchoredToBottom = true;
 
     // Reset temporary chat state based on user preference
@@ -1345,6 +1341,7 @@ class _ChatPageState extends ConsumerState<ChatPage> {
       _pinToTopState = const _PinToTopState.inactive();
       _invalidateChatListStableLayoutMetadata();
       _endPinToTopInFlight = false;
+      _pinToTopCompletionDismissScheduled = false;
     }
     if (conversationId == null) {
       _pendingScrollAction = const _PendingChatScrollAction.none();
@@ -1624,6 +1621,23 @@ class _ChatPageState extends ConsumerState<ChatPage> {
 
   bool _endPinToTopInFlight = false;
 
+  void _scheduleEndPinToTopAfterStreamingCompletion() {
+    if (_pinToTopCompletionDismissScheduled) {
+      return;
+    }
+    _pinToTopCompletionDismissScheduled = true;
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      _pinToTopCompletionDismissScheduled = false;
+      if (!mounted || !_wantsPinToTop) {
+        return;
+      }
+      if (_hasActiveStreamingAssistant(ref.read(chatMessagesProvider))) {
+        return;
+      }
+      _endPinToTop(instant: true);
+    });
+  }
+
   void _dismissPinToTop({bool preserveStreamingId = false}) {
     if (!_wantsPinToTop || !mounted) {
       return;
@@ -1637,9 +1651,8 @@ class _ChatPageState extends ConsumerState<ChatPage> {
 
   /// Transitions out of pin-to-top mode.
   ///
-  /// When [instant] is true (e.g. during streaming), uses jumpTo to
-  /// avoid competing with per-chunk scroll updates. When false (e.g.
-  /// streaming just completed), animates smoothly.
+  /// When [instant] is true, uses jumpTo to avoid competing with streaming
+  /// row-size corrections.
   void _endPinToTop({bool instant = false, bool preserveStreamingId = false}) {
     if (!_wantsPinToTop || !mounted || _endPinToTopInFlight) return;
     if (_isUserInteractingWithScroll) {
@@ -1728,6 +1741,9 @@ class _ChatPageState extends ConsumerState<ChatPage> {
 
   Widget _buildMessagesList(ThemeData theme, WidgetRef watchRef) {
     watchRef.watch(chatMessageStructureSignatureProvider);
+    // Rebuild the list shell only when streaming starts or ends so pin-to-top
+    // cleanup runs on completion without rebuilding on every streamed chunk.
+    watchRef.watch(isChatStreamingProvider);
     final messages = watchRef.read(chatMessagesProvider);
     final isLoadingConversation = watchRef.watch(isLoadingConversationProvider);
     final showLoadingSkeleton = isLoadingConversation && messages.isEmpty;
@@ -1860,7 +1876,7 @@ class _ChatPageState extends ConsumerState<ChatPage> {
       _scheduleExtentCacheInvalidation();
     }
     _scheduleMarkdownPrewarm(messages, layoutMetadata: layoutMetadata);
-    final hasStreamingMessage = layoutMetadata.hasStreamingMessage;
+    final hasStreamingMessage = _hasActiveStreamingAssistant(messages);
 
     // Pin-to-top: detect new streaming response and scroll user message to top
     if (hasStreamingMessage && messages.length >= 2) {
@@ -1878,13 +1894,12 @@ class _ChatPageState extends ConsumerState<ChatPage> {
         _scrollToUserMessage();
       }
     }
-    // Don't end pin-to-top when streaming completes. Keep the phantom sliver so
-    // the user message remains near the top; it dismisses on user scroll, new
-    // message, manual scroll-to-bottom, or conversation switch.
-    //
-    // Clear the pinned ID so the next message can activate pin-to-top.
-    if (!hasStreamingMessage && _pinnedStreamingId != null) {
-      _pinToTopState = _pinToTopState.clearTracking();
+    if (!hasStreamingMessage) {
+      if (_wantsPinToTop) {
+        _scheduleEndPinToTopAfterStreamingCompletion();
+      } else if (_pinnedStreamingId != null) {
+        _pinToTopState = const _PinToTopState.inactive();
+      }
     }
 
     final pinnedUserMessageIndex =
@@ -3164,13 +3179,11 @@ class _ChatListStableLayoutMetadata {
     required this.rows,
     required this.indexByMessageId,
     required this.indexByMessageKey,
-    required this.hasStreamingMessage,
   });
 
   final List<_ChatRowLayoutMetadata> rows;
   final Map<String, int> indexByMessageId;
   final Map<String, int> indexByMessageKey;
-  final bool hasStreamingMessage;
 
   double estimatedOffsetBefore(int targetIndex) {
     if (targetIndex <= 0 || targetIndex >= rows.length) {
@@ -3193,10 +3206,6 @@ _ChatListStableLayoutSignature _buildChatListStableLayoutSignature(
       ..write(message.model ?? '')
       ..write('\u0000')
       ..write(_messageModelNameFallback(message) ?? '')
-      ..write('\u0000')
-      ..write(message.isStreaming ? 1 : 0)
-      ..write('\u0000')
-      ..write(message.isStreaming ? -1 : message.content.trim().length)
       ..write('\u0000')
       ..write(message.attachmentIds?.length ?? 0)
       ..write('\u0000')
@@ -3243,12 +3252,10 @@ _ChatListStableLayoutMetadata _buildChatListStableLayoutMetadata({
   final indexByMessageId = <String, int>{};
   final indexByMessageKey = <String, int>{};
   var leadingOffset = 0.0;
-  var hasStreamingMessage = false;
 
   for (var index = 0; index < messages.length; index++) {
     final message = messages[index];
     final isUser = message.role == 'user';
-    hasStreamingMessage = hasStreamingMessage || message.isStreaming;
     indexByMessageId[message.id] = index;
     indexByMessageKey['message-${message.id}'] = index;
 
@@ -3313,7 +3320,6 @@ _ChatListStableLayoutMetadata _buildChatListStableLayoutMetadata({
     rows: List<_ChatRowLayoutMetadata>.unmodifiable(rows),
     indexByMessageId: Map<String, int>.unmodifiable(indexByMessageId),
     indexByMessageKey: Map<String, int>.unmodifiable(indexByMessageKey),
-    hasStreamingMessage: hasStreamingMessage,
   );
 }
 
@@ -3523,25 +3529,6 @@ List<int> debugSelectMarkdownPrewarmCandidateIndicesForTesting(
   );
 }
 
-@visibleForTesting
-({bool isActive, String? userMessageId, String? streamingMessageId})
-debugClearPinToTopTrackingForTesting({
-  required bool isActive,
-  String? userMessageId,
-  String? streamingMessageId,
-}) {
-  final state = _PinToTopState._(
-    isActive: isActive,
-    userMessageId: userMessageId,
-    streamingMessageId: streamingMessageId,
-  ).clearTracking();
-  return (
-    isActive: state.isActive,
-    userMessageId: state.userMessageId,
-    streamingMessageId: state.streamingMessageId,
-  );
-}
-
 List<int> _selectMarkdownPrewarmCandidateIndices({
   required List<ChatMessage> messages,
   required _ChatListStableLayoutMetadata layoutMetadata,
@@ -3674,9 +3661,6 @@ double _estimateChatMessageExtent(
   var estimate = message.role == 'user' ? 84.0 : 132.0;
   estimate += estimatedLineCount * 22.0;
 
-  if (message.isStreaming) {
-    estimate += 56.0;
-  }
   if (message.error != null) {
     estimate += 64.0;
   }

--- a/lib/features/chat/views/chat_page.dart
+++ b/lib/features/chat/views/chat_page.dart
@@ -588,7 +588,7 @@ class _ChatPageState extends ConsumerState<ChatPage> {
         error: e,
         stackTrace: stackTrace,
       );
-      ref.read(chatMessagesProvider.notifier).finishStreaming();
+      ref.read(chatMessagesProvider.notifier).failLastStreamingAssistant(e);
     }
   }
 

--- a/lib/features/chat/views/chat_page.dart
+++ b/lib/features/chat/views/chat_page.dart
@@ -3057,11 +3057,16 @@ String _formatChatModelDisplayName(String name) {
 }) {
   final trimmedModel = rawModel?.trim();
   final trimmedFallback = fallbackModelName?.trim();
+  final fallback = trimmedFallback == null || trimmedFallback.isEmpty
+      ? null
+      : trimmedFallback;
   if (trimmedModel == null || trimmedModel.isEmpty) {
-    final fallback = trimmedFallback == null || trimmedFallback.isEmpty
-        ? null
-        : _formatChatModelDisplayName(trimmedFallback);
-    return (displayName: fallback, matchedModel: null);
+    return (
+      displayName: fallback == null
+          ? null
+          : _formatChatModelDisplayName(fallback),
+      matchedModel: null,
+    );
   }
 
   final matched = modelLookup?[trimmedModel];
@@ -3084,11 +3089,7 @@ String _formatChatModelDisplayName(String name) {
   }
 
   return (
-    displayName: _formatChatModelDisplayName(
-      trimmedFallback == null || trimmedFallback.isEmpty
-          ? trimmedModel
-          : trimmedFallback,
-    ),
+    displayName: _formatChatModelDisplayName(fallback ?? trimmedModel),
     matchedModel: null,
   );
 }

--- a/lib/features/chat/views/chat_page.dart
+++ b/lib/features/chat/views/chat_page.dart
@@ -842,10 +842,7 @@ class _ChatPageState extends ConsumerState<ChatPage> {
               }),
         );
       } catch (e) {
-        DebugLogger.log(
-          'Pasted upload prep failed: $e',
-          scope: 'chat/page',
-        );
+        DebugLogger.log('Pasted upload prep failed: $e', scope: 'chat/page');
       }
     }
 
@@ -3039,12 +3036,17 @@ String _formatChatModelDisplayName(String name) {
 
 ({String? displayName, Model? matchedModel}) _resolveChatModelPresentation({
   required String? rawModel,
+  String? fallbackModelName,
   required List<Model>? models,
   Map<String, Model>? modelLookup,
 }) {
   final trimmedModel = rawModel?.trim();
+  final trimmedFallback = fallbackModelName?.trim();
   if (trimmedModel == null || trimmedModel.isEmpty) {
-    return (displayName: null, matchedModel: null);
+    final fallback = trimmedFallback == null || trimmedFallback.isEmpty
+        ? null
+        : _formatChatModelDisplayName(trimmedFallback);
+    return (displayName: fallback, matchedModel: null);
   }
 
   final matched = modelLookup?[trimmedModel];
@@ -3067,9 +3069,19 @@ String _formatChatModelDisplayName(String name) {
   }
 
   return (
-    displayName: _formatChatModelDisplayName(trimmedModel),
+    displayName: _formatChatModelDisplayName(
+      trimmedFallback == null || trimmedFallback.isEmpty
+          ? trimmedModel
+          : trimmedFallback,
+    ),
     matchedModel: null,
   );
+}
+
+String? _messageModelNameFallback(ChatMessage message) {
+  final raw = message.metadata?['modelName'] ?? message.metadata?['model_name'];
+  final value = raw?.toString().trim();
+  return value == null || value.isEmpty ? null : value;
 }
 
 Map<String, Model>? _buildChatModelLookup(List<Model>? models) {
@@ -3180,6 +3192,8 @@ _ChatListStableLayoutSignature _buildChatListStableLayoutSignature(
       ..write('\u0000')
       ..write(message.model ?? '')
       ..write('\u0000')
+      ..write(_messageModelNameFallback(message) ?? '')
+      ..write('\u0000')
       ..write(message.isStreaming ? 1 : 0)
       ..write('\u0000')
       ..write(message.isStreaming ? -1 : message.content.trim().length)
@@ -3208,7 +3222,9 @@ _ChatListStableLayoutSignature _buildChatListStableLayoutSignature(
     for (final version in message.versions) {
       buffer
         ..write('\u0000')
-        ..write(version.model ?? '');
+        ..write(version.model ?? '')
+        ..write('\u0000')
+        ..write(version.modelName ?? '');
     }
     buffer.writeln();
   }
@@ -3238,6 +3254,7 @@ _ChatListStableLayoutMetadata _buildChatListStableLayoutMetadata({
 
     final modelPresentation = _resolveChatModelPresentation(
       rawModel: message.model,
+      fallbackModelName: _messageModelNameFallback(message),
       models: models,
       modelLookup: modelLookup,
     );
@@ -3246,6 +3263,7 @@ _ChatListStableLayoutMetadata _buildChatListStableLayoutMetadata({
     for (final version in message.versions) {
       final versionPresentation = _resolveChatModelPresentation(
         rawModel: version.model,
+        fallbackModelName: version.modelName,
         models: models,
         modelLookup: modelLookup,
       );
@@ -3386,6 +3404,7 @@ List<
     double estimatedExtent,
     bool isArchivedVariant,
     bool showFollowUps,
+    String? displayModelName,
   })
 >
 debugBuildChatListLayoutSummaryForTesting(
@@ -3405,6 +3424,7 @@ debugBuildChatListLayoutSummaryForTesting(
           estimatedExtent: row.estimatedExtent,
           isArchivedVariant: row.isArchivedVariant,
           showFollowUps: row.showFollowUps,
+          displayModelName: row.displayModelName,
         ),
       )
       .toList(growable: false);

--- a/lib/features/chat/widgets/assistant_message_widget.dart
+++ b/lib/features/chat/widgets/assistant_message_widget.dart
@@ -781,6 +781,14 @@ class _AssistantMessageWidgetState extends ConsumerState<AssistantMessageWidget>
 
     if (_activeVersionIndex >= 0 &&
         _activeVersionIndex < widget.message.versions.length) {
+      final rawVersionModelName = widget
+          .message
+          .versions[_activeVersionIndex]
+          .modelName
+          ?.trim();
+      if (rawVersionModelName != null && rawVersionModelName.isNotEmpty) {
+        return rawVersionModelName;
+      }
       final rawVersionModel = widget.message.versions[_activeVersionIndex].model
           ?.trim();
       if (rawVersionModel != null && rawVersionModel.isNotEmpty) {
@@ -966,7 +974,8 @@ class _AssistantMessageWidgetState extends ConsumerState<AssistantMessageWidget>
     }
     for (var index = 0; index < oldVersions.length; index += 1) {
       if (oldVersions[index].id != newVersions[index].id ||
-          oldVersions[index].model != newVersions[index].model) {
+          oldVersions[index].model != newVersions[index].model ||
+          oldVersions[index].modelName != newVersions[index].modelName) {
         return true;
       }
     }

--- a/lib/features/chat/widgets/assistant_message_widget.dart
+++ b/lib/features/chat/widgets/assistant_message_widget.dart
@@ -995,18 +995,11 @@ class _AssistantMessageWidgetState extends ConsumerState<AssistantMessageWidget>
     final hasStatusTimeline = displayStatusHistory.isNotEmpty;
     final activeCodeExecutions = _resolveActiveCodeExecutions();
     final hasCodeExecutions = activeCodeExecutions.isNotEmpty;
-    final activeFollowUps = _resolveActiveFollowUps();
-    final hasFollowUps =
-        widget.showFollowUps &&
-        activeFollowUps.isNotEmpty &&
-        _responseCompleted;
     final bool showingVersion = _activeVersionIndex >= 0;
     final activeFiles = showingVersion
         ? widget.message.versions[_activeVersionIndex].files
         : widget.message.files;
     final activeEmbeds = _resolveActiveEmbeds();
-    final activeSources = _resolveActiveSources();
-    final footer = _buildFooterBar(activeSources: activeSources);
     final queuedCompletionAsync = ref.watch(
       queuedCompletionInfoForMessageProvider(_messageId),
     );
@@ -1025,6 +1018,21 @@ class _AssistantMessageWidgetState extends ConsumerState<AssistantMessageWidget>
         queuedCompletion != null && _isAssistantResponseEmpty;
     final showQueuedRecoveryBanner =
         queuedCompletion != null && !showQueuedAsEmptyState;
+    final shouldBuildActionFooter = _showActionRowNow && !hasQueuedCompletion;
+    final activeFollowUps = shouldBuildActionFooter
+        ? _resolveActiveFollowUps()
+        : const <String>[];
+    final hasFollowUps =
+        shouldBuildActionFooter &&
+        widget.showFollowUps &&
+        activeFollowUps.isNotEmpty &&
+        _responseCompleted;
+    final activeSources = shouldBuildActionFooter
+        ? _resolveActiveSources()
+        : const <ChatSourceReference>[];
+    final footer = shouldBuildActionFooter
+        ? _buildFooterBar(activeSources: activeSources)
+        : null;
 
     final content = Container(
       width: double.infinity,

--- a/lib/features/chat/widgets/assistant_message_widget.dart
+++ b/lib/features/chat/widgets/assistant_message_widget.dart
@@ -608,14 +608,18 @@ class _AssistantMessageWidgetState extends ConsumerState<AssistantMessageWidget>
 
   Widget _buildStreamingContentBody() {
     final body = _buildMessageContent();
-    if (_disableAnimations ||
-        !_uiTreatsAsStreaming ||
-        _displayedContent.trim().isEmpty) {
-      return body;
-    }
+    // Always wrap in a FadeTransition with a stable key/type so the widget at
+    // this slot does not change runtimeType when streaming starts/completes.
+    // Toggling between FadeTransition and the bare body would defeat element
+    // reconciliation and tear down the markdown subtree at the streaming
+    // boundary. When not actively fading we feed a fully-opaque constant
+    // animation, which is visually identical to returning the bare body.
+    final fade = _canFadeStreamingContent(_displayedContent)
+        ? _streamingContentFade
+        : const AlwaysStoppedAnimation<double>(1.0);
     return FadeTransition(
       key: const ValueKey('assistant-streaming-content-fade'),
-      opacity: _streamingContentFade,
+      opacity: fade,
       child: body,
     );
   }

--- a/lib/features/chat/widgets/assistant_message_widget.dart
+++ b/lib/features/chat/widgets/assistant_message_widget.dart
@@ -30,7 +30,6 @@ import '../../../shared/utils/external_link_launcher.dart';
 import '../../../core/utils/debug_logger.dart';
 import '../../../core/services/platform_service.dart';
 import '../../../core/services/settings_service.dart';
-import '../../../core/utils/citation_parser.dart';
 import '../../../core/utils/embed_utils.dart';
 import 'sources/openwebui_sources.dart';
 import '../providers/assistant_response_builder_provider.dart';
@@ -51,53 +50,6 @@ final _ttsDetailsPattern = RegExp(
   r'<details[^>]*>[\s\S]*?<\/details>',
   caseSensitive: false,
 );
-const int _cheapStreamingTextThreshold = 900;
-const int _cheapStreamingTextLineThreshold = 12;
-final _markdownBlockSyntaxPattern = RegExp(
-  r'(^|\n)[ \t]{0,3}(?:#{1,6}\s|>\s|[-*+]\s|\d+[.)]\s|```|~~~)',
-  multiLine: true,
-);
-final _markdownLinkOrImagePattern = RegExp(
-  r'!\[[^\]]*]\([^)]+\)|\[[^\]]+]\([^)]+\)',
-);
-final _markdownReferenceLinkPattern = RegExp(
-  r'!\[[^\]]*]\[[^\]]*]|'
-  r'\[[^\]]+]\[[^\]]*]',
-);
-final _markdownInlineSyntaxPattern = RegExp(
-  r'`[^`\n]+`|\*\*[^*\n]+\*\*|__[^_\n]+__|~~[^~\n]+~~',
-);
-final _markdownSingleEmphasisPattern = RegExp(
-  r'(?:^|[\s(])\*[^*\s][^*\n]*?[^*\s]\*(?=$|[\s).,!?:;])|'
-  r'(?:^|[\s(])_[^_\s][^_\n]*?[^_\s]_(?=$|[\s).,!?:;])',
-);
-final _markdownTablePattern = RegExp(
-  r'^\s*\|?.+\|.+\s*$\n^\s*\|?(?:\s*:?-{3,}:?\s*\|)+\s*:?-{3,}:?\s*\|?\s*$',
-  multiLine: true,
-);
-final _markdownHorizontalRulePattern = RegExp(
-  r'(^|\n)[ \t]{0,3}(?:-{3,}|\*{3,}|_{3,})(?:\n|$)',
-  multiLine: true,
-);
-final _markdownHtmlPattern = RegExp(
-  r'<(?:a|img|br|details|summary|table|tr|td|th|blockquote|pre|code)\b',
-  caseSensitive: false,
-);
-final _markdownAutolinkPattern = RegExp(r'<[A-Za-z][A-Za-z0-9+.\-]*:[^<>\s]+>');
-final _markdownBareAutolinkPattern = RegExp(
-  r'(?:(?:https?|ftp):\/\/|www\.)[^\s<]+|'
-  r"(?:^|[\s(])[\w.!#$%&'*+/=?^`{|}~-]+@[\w-]+(?:\.[\w-]+)+(?=$|[\s).,!?:;])",
-  caseSensitive: false,
-);
-final _markdownIndentedCodeBlockPattern = RegExp(
-  r'(^|\n)(?: {4}|\t)\S',
-  multiLine: true,
-);
-final _markdownBlockLatexPattern = RegExp(
-  r'(^|\n)[ \t]{0,3}\$\$[\s\S]+?\$\$[ \t]*(?=\n|$)',
-  multiLine: true,
-);
-final _markdownInlineLatexPattern = RegExp(r'\$[^$\n]+\$');
 // Handle both URL formats: /api/v1/files/{id} and /api/v1/files/{id}/content
 final _fileIdPattern = RegExp(r'/api/v1/files/([^/]+)(?:/content)?$');
 
@@ -141,7 +93,8 @@ class AssistantMessageWidget extends ConsumerStatefulWidget {
 class _AssistantMessageWidgetState extends ConsumerState<AssistantMessageWidget>
     with TickerProviderStateMixin, WidgetsBindingObserver {
   late AnimationController _fadeController;
-  late AnimationController _slideController;
+  late AnimationController _streamingContentFadeController;
+  late CurvedAnimation _streamingContentFade;
   String _displayedContent = '';
   Widget? _cachedAvatar;
   String? _cachedAvatarModelName;
@@ -169,6 +122,8 @@ class _AssistantMessageWidgetState extends ConsumerState<AssistantMessageWidget>
   bool _hasAnimated = false;
   bool _isAppForeground = true;
   bool _isRouteVisible = true;
+  String? _visibleFollowUpScopeId;
+  List<String> _visibleFollowUps = const <String>[];
 
   /// Guards the triple-haptic so it fires only once per streaming session.
   bool _hasTriggeredContentHaptic = false;
@@ -226,13 +181,18 @@ class _AssistantMessageWidgetState extends ConsumerState<AssistantMessageWidget>
       vsync: this,
       value: shouldAnimateOnMount ? 0.0 : 1.0,
     );
-    _slideController = AnimationController(
-      duration: const Duration(milliseconds: 300),
+    _streamingContentFadeController = AnimationController(
+      duration: const Duration(milliseconds: 260),
       vsync: this,
-      value: shouldAnimateOnMount ? 0.0 : 1.0,
+      value: 1.0,
+    );
+    _streamingContentFade = CurvedAnimation(
+      parent: _streamingContentFadeController,
+      curve: Curves.easeOutCubic,
     );
     _hasAnimated = !shouldAnimateOnMount;
     _displayedContent = _resolvedMessageContent();
+    _primeInitialStreamingContentFade();
     _updateTypingIndicatorGate();
     _updateActionRowSettle();
     _syncStreamingContentSubscription();
@@ -246,8 +206,10 @@ class _AssistantMessageWidgetState extends ConsumerState<AssistantMessageWidget>
     _updateRouteVisibility();
     if (!_shouldAnimateOnMount && !_hasAnimated) {
       _fadeController.value = 1.0;
-      _slideController.value = 1.0;
       _hasAnimated = true;
+    }
+    if (_disableAnimations && !_streamingContentFadeController.isCompleted) {
+      _streamingContentFadeController.value = 1.0;
     }
     // Build cached avatar when theme context is available
     _buildCachedAvatar();
@@ -266,11 +228,16 @@ class _AssistantMessageWidgetState extends ConsumerState<AssistantMessageWidget>
       _cachedAvatar = null;
       _cachedAvatarModelName = null;
       _cachedAvatarIconUrl = null;
+      _clearVisibleFollowUps();
       _resetTtsPlainTextState();
       _hasAnimated = !_shouldAnimateOnMount;
       _hasTriggeredContentHaptic = false;
       _fadeController.value = _shouldAnimateOnMount ? 0.0 : 1.0;
-      _slideController.value = _shouldAnimateOnMount ? 0.0 : 1.0;
+      _streamingContentFadeController.value = 1.0;
+    }
+
+    if (!oldWidget.isStreaming && widget.isStreaming) {
+      _clearVisibleFollowUps();
     }
 
     // Re-sync subscription when streaming state changes
@@ -367,16 +334,23 @@ class _AssistantMessageWidgetState extends ConsumerState<AssistantMessageWidget>
   }
 
   void _applyDisplayedContent(String raw) {
+    final shouldFadeStreamingContent = _shouldFadeInStreamingContent(raw);
     final previousLength = _displayedContent.length;
     final contentChanged = raw != _displayedContent;
 
     if (contentChanged) {
+      if (shouldFadeStreamingContent) {
+        _streamingContentFadeController.value = 0.0;
+      }
       if (mounted) {
         setState(() {
           _displayedContent = raw;
         });
       } else {
         _displayedContent = raw;
+      }
+      if (shouldFadeStreamingContent) {
+        _streamingContentFadeController.forward();
       }
       if (widget.isStreaming) {
         _onStreamingChunk(previousLength, raw.length);
@@ -389,6 +363,31 @@ class _AssistantMessageWidgetState extends ConsumerState<AssistantMessageWidget>
       _resetTtsPlainTextState();
     }
     _updateTypingIndicatorGate();
+  }
+
+  void _primeInitialStreamingContentFade() {
+    if (!_canFadeStreamingContent(_displayedContent)) {
+      return;
+    }
+    _streamingContentFadeController.value = 0.0;
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted || _disableAnimations || !_uiTreatsAsStreaming) {
+        return;
+      }
+      _streamingContentFadeController.forward();
+    });
+  }
+
+  bool _shouldFadeInStreamingContent(String nextRaw) {
+    return _canFadeStreamingContent(nextRaw) &&
+        _displayedContent.trim().isEmpty;
+  }
+
+  bool _canFadeStreamingContent(String nextRaw) {
+    if (_disableAnimations || !_uiTreatsAsStreaming) {
+      return false;
+    }
+    return nextRaw.trim().isNotEmpty;
   }
 
   void _setActiveVersionIndex(int nextIndex) {
@@ -604,6 +603,20 @@ class _AssistantMessageWidgetState extends ConsumerState<AssistantMessageWidget>
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: children,
+    );
+  }
+
+  Widget _buildStreamingContentBody() {
+    final body = _buildMessageContent();
+    if (_disableAnimations ||
+        !_uiTreatsAsStreaming ||
+        _displayedContent.trim().isEmpty) {
+      return body;
+    }
+    return FadeTransition(
+      key: const ValueKey('assistant-streaming-content-fade'),
+      opacity: _streamingContentFade,
+      child: body,
     );
   }
 
@@ -893,7 +906,8 @@ class _AssistantMessageWidgetState extends ConsumerState<AssistantMessageWidget>
     _typingGateTimer?.cancel();
     _resetTtsPlainTextState();
     _fadeController.dispose();
-    _slideController.dispose();
+    _streamingContentFade.dispose();
+    _streamingContentFadeController.dispose();
     super.dispose();
   }
 
@@ -966,6 +980,11 @@ class _AssistantMessageWidgetState extends ConsumerState<AssistantMessageWidget>
 
   int _collectionLength(Iterable<dynamic>? values) => values?.length ?? 0;
 
+  void _clearVisibleFollowUps() {
+    _visibleFollowUpScopeId = null;
+    _visibleFollowUps = const <String>[];
+  }
+
   bool _didVersionMetadataChange(AssistantMessageWidget oldWidget) {
     final oldVersions = oldWidget.message.versions;
     final newVersions = widget.message.versions;
@@ -1007,9 +1026,10 @@ class _AssistantMessageWidgetState extends ConsumerState<AssistantMessageWidget>
         ? queuedCompletionAsync.value
         : null;
     final hasQueuedCompletion = queuedCompletion != null;
-    final footerSwitchDuration = widget.isStreaming
-        ? Duration.zero
-        : const Duration(milliseconds: 220);
+    final footerSwitchDuration =
+        (_showStreamingIndicatorNow || _showActionRowNow)
+        ? const Duration(milliseconds: 180)
+        : Duration.zero;
     final showQueuedAsEmptyState =
         queuedCompletion != null &&
         _isAssistantResponseEmpty &&
@@ -1020,7 +1040,7 @@ class _AssistantMessageWidgetState extends ConsumerState<AssistantMessageWidget>
         queuedCompletion != null && !showQueuedAsEmptyState;
     final shouldBuildActionFooter = _showActionRowNow && !hasQueuedCompletion;
     final activeFollowUps = shouldBuildActionFooter
-        ? _resolveActiveFollowUps()
+        ? _resolveVisibleFollowUps()
         : const <String>[];
     final hasFollowUps =
         shouldBuildActionFooter &&
@@ -1098,7 +1118,7 @@ class _AssistantMessageWidgetState extends ConsumerState<AssistantMessageWidget>
                     },
                     child: KeyedSubtree(
                       key: const ValueKey('content'),
-                      child: _buildMessageContent(),
+                      child: _buildStreamingContentBody(),
                     ),
                   ),
 
@@ -1134,7 +1154,7 @@ class _AssistantMessageWidgetState extends ConsumerState<AssistantMessageWidget>
               switchOutCurve: Curves.easeInCubic,
               layoutBuilder: (currentChild, previousChildren) {
                 final children = <Widget>[
-                  if (!widget.isStreaming) ...previousChildren,
+                  if (!_uiTreatsAsStreaming) ...previousChildren,
                   ?currentChild,
                 ];
                 if (children.isEmpty) {
@@ -1169,22 +1189,9 @@ class _AssistantMessageWidgetState extends ConsumerState<AssistantMessageWidget>
     if (!_hasAnimated) {
       _hasAnimated = true;
       _fadeController.forward();
-      _slideController.forward();
     }
 
-    return FadeTransition(
-      opacity: _fadeController,
-      child: SlideTransition(
-        position: Tween<Offset>(begin: const Offset(0, 0.1), end: Offset.zero)
-            .animate(
-              CurvedAnimation(
-                parent: _slideController,
-                curve: Curves.easeOutCubic,
-              ),
-            ),
-        child: content,
-      ),
-    );
+    return FadeTransition(opacity: _fadeController, child: content);
   }
 
   /// Builds the keyed child for the footer [AnimatedSwitcher]: the typing
@@ -1441,16 +1448,10 @@ class _AssistantMessageWidgetState extends ConsumerState<AssistantMessageWidget>
     final bodyTreatsAsStreaming = _uiTreatsAsStreaming;
 
     Widget buildDefault(BuildContext context) {
-      final cheapStreamingTextContent = _cheapStreamingTextContent(
-        processedContent,
-      );
-      if (_shouldUseCheapStreamingText(cheapStreamingTextContent)) {
-        return _buildCheapStreamingText(cheapStreamingTextContent);
-      }
-
       return StreamingMarkdownWidget(
         content: processedContent,
         isStreaming: bodyTreatsAsStreaming,
+        enableStreamingTextFade: bodyTreatsAsStreaming && !_disableAnimations,
         askConduitComposerTargetId: chatComposerTextInsertionTargetId,
         stateScopeId: _markdownStateScopeId(),
         onTapLink: (url, _) => launchExternalLink(url, scope: 'chat/assistant'),
@@ -1482,73 +1483,6 @@ class _AssistantMessageWidgetState extends ConsumerState<AssistantMessageWidget>
     }
 
     return buildDefault(context);
-  }
-
-  String _cheapStreamingTextContent(String content) {
-    if (!_uiTreatsAsStreaming || !content.contains(']:')) {
-      return content;
-    }
-    return ConduitMarkdownPreprocessor.stripLinkReferenceDefinitions(content);
-  }
-
-  bool _shouldUseCheapStreamingText(String content) {
-    if (!_uiTreatsAsStreaming) {
-      return false;
-    }
-
-    final trimmedContent = content.trim();
-    if (trimmedContent.isEmpty) {
-      return false;
-    }
-
-    final newlineCount = '\n'.allMatches(trimmedContent).length;
-    final isLongPlainCandidate =
-        trimmedContent.length >= _cheapStreamingTextThreshold ||
-        newlineCount >= _cheapStreamingTextLineThreshold;
-    if (!isLongPlainCandidate) {
-      return false;
-    }
-
-    return !_contentHasClearMarkdown(trimmedContent);
-  }
-
-  bool _contentHasClearMarkdown(String content) {
-    if (content.isEmpty) {
-      return false;
-    }
-
-    if (content.contains('```') ||
-        content.contains('~~~') ||
-        content.contains('data:image/') ||
-        content.contains(r'\(') ||
-        content.contains(r'\[')) {
-      return true;
-    }
-
-    return _markdownBlockSyntaxPattern.hasMatch(content) ||
-        _markdownLinkOrImagePattern.hasMatch(content) ||
-        _markdownReferenceLinkPattern.hasMatch(content) ||
-        _markdownAutolinkPattern.hasMatch(content) ||
-        _markdownBareAutolinkPattern.hasMatch(content) ||
-        _markdownIndentedCodeBlockPattern.hasMatch(content) ||
-        _markdownInlineSyntaxPattern.hasMatch(content) ||
-        _markdownSingleEmphasisPattern.hasMatch(content) ||
-        _markdownTablePattern.hasMatch(content) ||
-        _markdownHorizontalRulePattern.hasMatch(content) ||
-        _markdownHtmlPattern.hasMatch(content) ||
-        _markdownBlockLatexPattern.hasMatch(content) ||
-        _markdownInlineLatexPattern.hasMatch(content) ||
-        CitationParser.hasCitations(content);
-  }
-
-  Widget _buildCheapStreamingText(String content) {
-    final style = ConduitMarkdownStyle.fromTheme(context);
-    return Text(
-      content,
-      key: const ValueKey('assistant-streaming-plain-text'),
-      style: style.body,
-      softWrap: true,
-    );
   }
 
   String _markdownStateScopeId() {
@@ -1598,6 +1532,26 @@ class _AssistantMessageWidgetState extends ConsumerState<AssistantMessageWidget>
       return widget.message.versions[_activeVersionIndex].followUps;
     }
     return widget.message.followUps;
+  }
+
+  List<String> _resolveVisibleFollowUps() {
+    final rawFollowUps = _resolveActiveFollowUps();
+    if (!widget.showFollowUps || _uiTreatsAsStreaming || !_responseCompleted) {
+      return rawFollowUps;
+    }
+
+    final scopeId = _followUpStateScopeId();
+    if (rawFollowUps.isNotEmpty) {
+      _visibleFollowUpScopeId = scopeId;
+      _visibleFollowUps = List<String>.unmodifiable(rawFollowUps);
+      return rawFollowUps;
+    }
+
+    if (_visibleFollowUpScopeId == scopeId && _visibleFollowUps.isNotEmpty) {
+      return _visibleFollowUps;
+    }
+
+    return rawFollowUps;
   }
 
   List<ChatCodeExecution> _resolveActiveCodeExecutions() {

--- a/lib/shared/widgets/markdown/compiled_markdown_document.dart
+++ b/lib/shared/widgets/markdown/compiled_markdown_document.dart
@@ -578,10 +578,19 @@ class CompiledMarkdownLatexSegment extends CompiledMarkdownInlineSegment {
   const CompiledMarkdownLatexSegment({
     required this.tex,
     required this.isBlock,
+    this.placeholderLength = 0,
   });
 
   final String tex;
   final bool isBlock;
+
+  /// The length of the placeholder token this segment was recovered from in
+  /// the node's `textContent`.
+  ///
+  /// Streaming-fade offset accounting advances by this length so the visible
+  /// text offset stays aligned with the document-wide `textContent`
+  /// coordinate space (which still contains the placeholder tokens).
+  final int placeholderLength;
 
   @override
   int get weight => tex.length + (isBlock ? 1 : 0);
@@ -591,22 +600,25 @@ class CompiledMarkdownLatexSegment extends CompiledMarkdownInlineSegment {
     'kind': 'latex',
     'tex': tex,
     'isBlock': isBlock,
+    'placeholderLength': placeholderLength,
   };
 
   factory CompiledMarkdownLatexSegment.fromMap(Map<String, Object?> map) =>
       CompiledMarkdownLatexSegment(
         tex: (map['tex'] ?? '') as String,
         isBlock: (map['isBlock'] ?? false) as bool,
+        placeholderLength: (map['placeholderLength'] as num?)?.toInt() ?? 0,
       );
 
   @override
   bool operator ==(Object other) =>
       other is CompiledMarkdownLatexSegment &&
       other.tex == tex &&
-      other.isBlock == isBlock;
+      other.isBlock == isBlock &&
+      other.placeholderLength == placeholderLength;
 
   @override
-  int get hashCode => Object.hash(tex, isBlock);
+  int get hashCode => Object.hash(tex, isBlock, placeholderLength);
 }
 
 @immutable

--- a/lib/shared/widgets/markdown/markdown_compile_service.dart
+++ b/lib/shared/widgets/markdown/markdown_compile_service.dart
@@ -700,6 +700,7 @@ List<CompiledMarkdownInlineSegment> _compileInlineSegments(
         CompiledMarkdownLatexSegment(
           tex: latexSegment.content,
           isBlock: latexSegment.isBlock,
+          placeholderLength: latexSegment.placeholderLength,
         ),
       );
       continue;

--- a/lib/shared/widgets/markdown/renderer/block_renderer.dart
+++ b/lib/shared/widgets/markdown/renderer/block_renderer.dart
@@ -632,6 +632,11 @@ class BlockRenderer {
     final codeElement = _extractCodeChild(element);
     final language = element.language;
     final code = (codeElement ?? element).textContent;
+    // The code body is rendered outside the inline renderer, but it is still
+    // part of the document-wide textContent that the streaming-fade offset is
+    // measured against. Advance the offset so a streaming tail after this code
+    // block fades the correct character range.
+    inlineRenderer.advanceVisibleTextOffset(code.length);
     final blockKind = element.blockKind;
     final previewable = blockKind == CompiledMarkdownBlockKind.previewableCode;
     final inlinePreview = previewable && element.inlinePreview;

--- a/lib/shared/widgets/markdown/renderer/block_renderer.dart
+++ b/lib/shared/widgets/markdown/renderer/block_renderer.dart
@@ -55,6 +55,7 @@ class BlockRenderer {
     this.stateScopeId,
     this.nodePathPrefix,
     this.heavyBlockPolicy = MarkdownHeavyBlockPolicy.eager,
+    this.streamingFade,
   ]);
 
   /// The active build context.
@@ -83,6 +84,32 @@ class BlockRenderer {
 
   /// Controls how expensive block previews should behave.
   final MarkdownHeavyBlockPolicy heavyBlockPolicy;
+
+  /// Optional streaming suffix fade source. When non-null, paragraph/text/flow
+  /// inline runs that can fall in the streaming tail are rendered via
+  /// [FadableRichText] so the trailing block fades per frame without rebuilding
+  /// the span tree or its recognizers.
+  final MarkdownStreamingFade? streamingFade;
+
+  /// Builds a rich-text widget for an inline [nodes] run.
+  ///
+  /// When a [streamingFade] source is present the run is rendered through
+  /// [FadableRichText] (recording per-leaf ranges so the suffix can re-fade per
+  /// frame); otherwise it falls back to a plain [Text.rich] of the base tree.
+  Widget _buildInlineRichText(
+    List<CompiledMarkdownNode> nodes, {
+    TextStyle? parentStyle,
+  }) {
+    final fade = streamingFade;
+    if (fade == null) {
+      return Text.rich(inlineRenderer.render(nodes, parentStyle: parentStyle));
+    }
+    final rendered = inlineRenderer.renderWithRanges(
+      nodes,
+      parentStyle: parentStyle,
+    );
+    return FadableRichText(rendered: rendered, style: style, fade: fade);
+  }
 
   /// Renders a list of block [nodes] as a [Column].
   Widget renderBlocks(List<CompiledMarkdownNode> nodes) =>
@@ -224,7 +251,7 @@ class BlockRenderer {
   Widget? _renderTextNode(CompiledMarkdownText node) {
     final text = node.text.trim();
     if (text.isEmpty) return null;
-    return Text.rich(inlineRenderer.render([node]));
+    return _buildInlineRichText([node]);
   }
 
   Widget? _renderCompiledNodeBlock(CompiledMarkdownNodeBlock block) {
@@ -329,7 +356,7 @@ class BlockRenderer {
 
     return Padding(
       padding: EdgeInsets.only(bottom: style.paragraphSpacing),
-      child: Text.rich(inlineRenderer.render(children)),
+      child: _buildInlineRichText(children),
     );
   }
 
@@ -397,7 +424,7 @@ class BlockRenderer {
         return;
       }
 
-      flowWidgets.add(Text.rich(inlineRenderer.render(renderRun)));
+      flowWidgets.add(_buildInlineRichText(renderRun));
     }
 
     for (var index = 0; index < children.length; index += 1) {
@@ -766,6 +793,7 @@ class BlockRenderer {
       stateScopeId,
       nodePath,
       heavyBlockPolicy,
+      streamingFade,
     );
 
     return Padding(
@@ -868,7 +896,7 @@ class BlockRenderer {
 
     Widget content;
     if (inlineNodes.isNotEmpty && blockNodes.isEmpty) {
-      content = Text.rich(inlineRenderer.render(inlineNodes));
+      content = _buildInlineRichText(inlineNodes);
     } else if (blockNodes.isNotEmpty) {
       final inner = BlockRenderer(
         context,
@@ -880,6 +908,7 @@ class BlockRenderer {
         stateScopeId,
         nodePath,
         heavyBlockPolicy,
+        streamingFade,
       );
       final blockContent = inner.renderBlocks(blockNodes);
 
@@ -889,7 +918,7 @@ class BlockRenderer {
         content = Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
-            Text.rich(inlineRenderer.render(inlineNodes)),
+            _buildInlineRichText(inlineNodes),
             const SizedBox(height: Spacing.xs),
             blockContent,
           ],
@@ -1154,6 +1183,7 @@ class BlockRenderer {
       stateScopeId,
       nodePath,
       heavyBlockPolicy,
+      streamingFade,
     );
 
     return Padding(
@@ -1305,6 +1335,7 @@ class BlockRenderer {
       stateScopeId,
       nodePath,
       heavyBlockPolicy,
+      streamingFade,
     );
     return inner.renderBlocks(children);
   }

--- a/lib/shared/widgets/markdown/renderer/conduit_markdown_widget.dart
+++ b/lib/shared/widgets/markdown/renderer/conduit_markdown_widget.dart
@@ -9,6 +9,7 @@ import '../compiled_markdown_document.dart';
 import '../markdown_compile_service.dart';
 import '../markdown_document_controller.dart';
 import '../markdown_loading_skeleton.dart';
+import '../../../theme/theme_extensions.dart';
 import 'block_renderer.dart';
 import 'inline_renderer.dart';
 import 'latex_preprocessor.dart';
@@ -68,6 +69,7 @@ class ConduitMarkdownWidget extends ConsumerStatefulWidget {
     this.debugTreatAsWidgetTest,
     this.debugOnCompiledViewMounted,
     this.debugOnCompiledViewDisposed,
+    this.debugOnBaseRender,
     super.key,
   }) : assert(
          data != null || compiledDocument != null,
@@ -113,6 +115,9 @@ class ConduitMarkdownWidget extends ConsumerStatefulWidget {
 
   @visibleForTesting
   final VoidCallback? debugOnCompiledViewDisposed;
+
+  @visibleForTesting
+  final VoidCallback? debugOnBaseRender;
 
   @override
   ConsumerState<ConduitMarkdownWidget> createState() =>
@@ -173,6 +178,7 @@ class _ConduitMarkdownWidgetState extends ConsumerState<ConduitMarkdownWidget> {
       heavyBlockPolicy: widget.heavyBlockPolicy,
       debugOnMounted: widget.debugOnCompiledViewMounted,
       debugOnDisposed: widget.debugOnCompiledViewDisposed,
+      debugOnBaseRender: widget.debugOnBaseRender,
     );
   }
 
@@ -228,6 +234,7 @@ class _CompiledMarkdownView extends StatefulWidget {
     this.heavyBlockPolicy = MarkdownHeavyBlockPolicy.eager,
     this.debugOnMounted,
     this.debugOnDisposed,
+    this.debugOnBaseRender,
   });
 
   final CompiledMarkdownDocument document;
@@ -240,13 +247,15 @@ class _CompiledMarkdownView extends StatefulWidget {
   final MarkdownHeavyBlockPolicy heavyBlockPolicy;
   final VoidCallback? debugOnMounted;
   final VoidCallback? debugOnDisposed;
+  final VoidCallback? debugOnBaseRender;
 
   @override
   State<_CompiledMarkdownView> createState() => _CompiledMarkdownViewState();
 }
 
 class _CompiledMarkdownViewState extends State<_CompiledMarkdownView>
-    with SingleTickerProviderStateMixin {
+    with SingleTickerProviderStateMixin
+    implements MarkdownStreamingFade {
   InlineRenderer? _inlineRenderer;
   LatexPreprocessor _latexPreprocessor = LatexPreprocessor();
   late final AnimationController _streamingTextFadeController;
@@ -255,6 +264,35 @@ class _CompiledMarkdownViewState extends State<_CompiledMarkdownView>
   Timer? _latexStartupRetryTimer;
   int _latexStartupRetryCount = 0;
   int? _streamingTextFadeStartOffset;
+
+  /// Cached base render, rebuilt only when the document identity (or a render
+  /// input such as the resolved style / LaTeX startup future) changes — never
+  /// per fade frame. Recognizer churn happens here, not in [build].
+  CompiledMarkdownDocument? _renderedDocument;
+  // Identity-stable theme inputs the derived style depends on. The style object
+  // itself is freshly derived every build, so caching on it would never reuse;
+  // these inputs only change when the theme/scaling actually changes.
+  Object? _renderedThemeKey;
+  TextScaler? _renderedTextScaler;
+  Future<void>? _renderedLatexStartupFuture;
+  MarkdownRenderTier? _renderedTier;
+  // Widget-config inputs forwarded to the renderers. Any change must rebuild
+  // the base tree (e.g. heavy-block policy flips defer->eager when streaming
+  // ends and must re-hydrate previews).
+  MarkdownHeavyBlockPolicy? _renderedHeavyBlockPolicy;
+  bool? _renderedEnableStreamingTextFade;
+  LinkTapCallback? _renderedOnLinkTap;
+  List<ChatSourceReference>? _renderedSources;
+  void Function(int sourceIndex)? _renderedOnSourceTap;
+  ImageBuilder? _renderedImageBuilder;
+  String? _renderedStateScopeId;
+  Widget? _cachedView;
+
+  @override
+  Listenable get listenable => _streamingTextFade;
+
+  @override
+  InlineTextFadeSpec? get spec => _buildStreamingTextFadeSpec();
 
   @override
   void initState() {
@@ -315,37 +353,8 @@ class _CompiledMarkdownViewState extends State<_CompiledMarkdownView>
 
     try {
       final style = ConduitMarkdownStyle.fromTheme(context);
-      _inlineRenderer?.disposeRecognizers();
-      _inlineRenderer = InlineRenderer(
-        style,
-        _latexPreprocessor,
-        widget.onLinkTap,
-        widget.sources,
-        widget.onSourceTap,
-        _latexStartupFuture,
-        widget.heavyBlockPolicy == MarkdownHeavyBlockPolicy.eager,
-        _buildStreamingTextFadeSpec(),
-      );
-
-      final blockRenderer = BlockRenderer(
-        context,
-        style,
-        _inlineRenderer!,
-        _latexPreprocessor,
-        widget.onLinkTap,
-        widget.imageBuilder,
-        widget.stateScopeId,
-        null,
-        widget.heavyBlockPolicy,
-      );
-
-      return switch (widget.document.renderTier) {
-        MarkdownRenderTier.plainText => _buildPlainText(),
-        MarkdownRenderTier.richText => _buildRichText(style),
-        MarkdownRenderTier.blocks => blockRenderer.renderCompiledBlocks(
-          widget.document.blocks,
-        ),
-      };
+      _ensureBaseRender(style);
+      return _cachedView!;
     } finally {
       PerformanceProfiler.instance.finishTask(
         taskKey,
@@ -368,6 +377,103 @@ class _CompiledMarkdownViewState extends State<_CompiledMarkdownView>
       return null;
     }
     return InlineTextFadeSpec(startOffset: startOffset, opacity: opacity);
+  }
+
+  /// The streaming fade source for this view, or `null` when fading is disabled.
+  ///
+  /// When disabled the cached base render is shown directly with no animation
+  /// listener, preserving the plain non-streaming render.
+  MarkdownStreamingFade? _fadeSourceOrNull() {
+    return widget.enableStreamingTextFade ? this : null;
+  }
+
+  /// Builds (or reuses) the opacity-1 base render for the current document.
+  ///
+  /// The span tree and gesture recognizers are produced once per content change
+  /// (or when a render input such as the resolved [style] or LaTeX startup
+  /// future changes). Fade frames reuse this cache, so they never rebuild the
+  /// span tree or recreate [TapGestureRecognizer]s.
+  void _ensureBaseRender(ConduitMarkdownStyle style) {
+    final themeKey = context.conduitTheme;
+    final textScaler = MediaQuery.textScalerOf(context);
+    final reuse =
+        _cachedView != null &&
+        identical(_renderedDocument, widget.document) &&
+        identical(_renderedThemeKey, themeKey) &&
+        _renderedTextScaler == textScaler &&
+        identical(_renderedLatexStartupFuture, _latexStartupFuture) &&
+        _renderedTier == widget.document.renderTier &&
+        _renderedHeavyBlockPolicy == widget.heavyBlockPolicy &&
+        _renderedEnableStreamingTextFade == widget.enableStreamingTextFade &&
+        identical(_renderedOnLinkTap, widget.onLinkTap) &&
+        identical(_renderedSources, widget.sources) &&
+        identical(_renderedOnSourceTap, widget.onSourceTap) &&
+        identical(_renderedImageBuilder, widget.imageBuilder) &&
+        _renderedStateScopeId == widget.stateScopeId;
+    if (reuse) {
+      return;
+    }
+
+    widget.debugOnBaseRender?.call();
+
+    // Recognizer churn happens here — once per content change — not per frame.
+    _inlineRenderer?.disposeRecognizers();
+    final inlineRenderer = InlineRenderer(
+      style,
+      _latexPreprocessor,
+      widget.onLinkTap,
+      widget.sources,
+      widget.onSourceTap,
+      _latexStartupFuture,
+      widget.heavyBlockPolicy == MarkdownHeavyBlockPolicy.eager,
+    );
+    _inlineRenderer = inlineRenderer;
+
+    _cachedView = switch (widget.document.renderTier) {
+      MarkdownRenderTier.plainText => _buildPlainText(inlineRenderer, style),
+      MarkdownRenderTier.richText => _buildRichText(inlineRenderer, style),
+      MarkdownRenderTier.blocks => BlockRenderer(
+        context,
+        style,
+        inlineRenderer,
+        _latexPreprocessor,
+        widget.onLinkTap,
+        widget.imageBuilder,
+        widget.stateScopeId,
+        null,
+        widget.heavyBlockPolicy,
+        _fadeSourceOrNull(),
+      ).renderCompiledBlocks(widget.document.blocks),
+    };
+
+    _renderedDocument = widget.document;
+    _renderedThemeKey = themeKey;
+    _renderedTextScaler = textScaler;
+    _renderedLatexStartupFuture = _latexStartupFuture;
+    _renderedTier = widget.document.renderTier;
+    _renderedHeavyBlockPolicy = widget.heavyBlockPolicy;
+    _renderedEnableStreamingTextFade = widget.enableStreamingTextFade;
+    _renderedOnLinkTap = widget.onLinkTap;
+    _renderedSources = widget.sources;
+    _renderedOnSourceTap = widget.onSourceTap;
+    _renderedImageBuilder = widget.imageBuilder;
+    _renderedStateScopeId = widget.stateScopeId;
+  }
+
+  void _invalidateBaseRender() {
+    _renderedDocument = null;
+    _renderedThemeKey = null;
+    _renderedTextScaler = null;
+    _renderedLatexStartupFuture = null;
+    _renderedTier = null;
+    _renderedHeavyBlockPolicy = null;
+    _renderedEnableStreamingTextFade = null;
+    _renderedOnLinkTap = null;
+    _renderedSources = null;
+    _renderedOnSourceTap = null;
+    _renderedImageBuilder = null;
+    _renderedStateScopeId = null;
+    _cachedView = null;
   }
 
   void _primeStreamingTextFade(
@@ -413,17 +519,24 @@ class _CompiledMarkdownViewState extends State<_CompiledMarkdownView>
   }
 
   void _handleStreamingTextFadeTick() {
-    if (!mounted || _streamingTextFadeStartOffset == null) {
+    // Intermediate frames repaint via the [FadableRichText] AnimatedBuilders
+    // that listen to [_streamingTextFade] directly, so the document subtree is
+    // never rebuilt per frame. This listener only needs to settle the terminal
+    // state: once the suffix reaches full opacity, drop the start offset so the
+    // fade spec returns null and a later unrelated rebuild shows no stale fade.
+    if (_streamingTextFadeStartOffset == null) {
       return;
     }
-    setState(() {
-      if (_streamingTextFade.value >= 1) {
-        _streamingTextFadeStartOffset = null;
-      }
-    });
+    if (_streamingTextFade.value >= 1) {
+      _streamingTextFadeStartOffset = null;
+    }
   }
 
   void _hydrateDocument(CompiledMarkdownDocument document) {
+    // The document changed: the cached base span tree / block widgets and their
+    // recognizers no longer match. Invalidate so the next build rebuilds them
+    // once (recognizer churn happens here, not per fade frame).
+    _invalidateBaseRender();
     _cancelLatexStartupRetry();
     _latexStartupRetryCount = 0;
     _latexPreprocessor = document.buildLatexPreprocessor();
@@ -496,20 +609,38 @@ class _CompiledMarkdownViewState extends State<_CompiledMarkdownView>
     return Duration(milliseconds: 200 * (1 << clampedRetryCount));
   }
 
-  Widget _buildPlainText() {
+  Widget _buildPlainText(
+    InlineRenderer inlineRenderer,
+    ConduitMarkdownStyle style,
+  ) {
     final text = _plainTextContent(widget.document);
     if (text.trim().isEmpty) {
       return const SizedBox.shrink();
     }
-    return Text.rich(_inlineRenderer!.render([CompiledMarkdownText(text)]));
+    final rendered = inlineRenderer.renderWithRanges([
+      CompiledMarkdownText(text),
+    ]);
+    return FadableRichText(
+      rendered: rendered,
+      style: style,
+      fade: _fadeSourceOrNull(),
+    );
   }
 
-  Widget _buildRichText(ConduitMarkdownStyle style) {
+  Widget _buildRichText(
+    InlineRenderer inlineRenderer,
+    ConduitMarkdownStyle style,
+  ) {
     final inlineNodes = _richInlineNodes(widget.document);
     if (inlineNodes.isEmpty) {
-      return _buildPlainText();
+      return _buildPlainText(inlineRenderer, style);
     }
-    return Text.rich(_inlineRenderer!.render(inlineNodes));
+    final rendered = inlineRenderer.renderWithRanges(inlineNodes);
+    return FadableRichText(
+      rendered: rendered,
+      style: style,
+      fade: _fadeSourceOrNull(),
+    );
   }
 }
 

--- a/lib/shared/widgets/markdown/renderer/conduit_markdown_widget.dart
+++ b/lib/shared/widgets/markdown/renderer/conduit_markdown_widget.dart
@@ -63,6 +63,7 @@ class ConduitMarkdownWidget extends ConsumerStatefulWidget {
     this.sources,
     this.onSourceTap,
     this.stateScopeId,
+    this.enableStreamingTextFade = false,
     this.heavyBlockPolicy = MarkdownHeavyBlockPolicy.eager,
     this.debugTreatAsWidgetTest,
     this.debugOnCompiledViewMounted,
@@ -97,6 +98,9 @@ class ConduitMarkdownWidget extends ConsumerStatefulWidget {
 
   /// Optional scope used to preserve state for remounted markdown blocks.
   final String? stateScopeId;
+
+  /// Whether newly appended visible text should fade while streaming.
+  final bool enableStreamingTextFade;
 
   /// Controls how expensive preview-backed blocks should behave.
   final MarkdownHeavyBlockPolicy heavyBlockPolicy;
@@ -165,6 +169,7 @@ class _ConduitMarkdownWidgetState extends ConsumerState<ConduitMarkdownWidget> {
       sources: widget.sources,
       onSourceTap: widget.onSourceTap,
       stateScopeId: widget.stateScopeId,
+      enableStreamingTextFade: widget.enableStreamingTextFade,
       heavyBlockPolicy: widget.heavyBlockPolicy,
       debugOnMounted: widget.debugOnCompiledViewMounted,
       debugOnDisposed: widget.debugOnCompiledViewDisposed,
@@ -219,6 +224,7 @@ class _CompiledMarkdownView extends StatefulWidget {
     this.sources,
     this.onSourceTap,
     this.stateScopeId,
+    this.enableStreamingTextFade = false,
     this.heavyBlockPolicy = MarkdownHeavyBlockPolicy.eager,
     this.debugOnMounted,
     this.debugOnDisposed,
@@ -230,6 +236,7 @@ class _CompiledMarkdownView extends StatefulWidget {
   final List<ChatSourceReference>? sources;
   final void Function(int sourceIndex)? onSourceTap;
   final String? stateScopeId;
+  final bool enableStreamingTextFade;
   final MarkdownHeavyBlockPolicy heavyBlockPolicy;
   final VoidCallback? debugOnMounted;
   final VoidCallback? debugOnDisposed;
@@ -238,17 +245,30 @@ class _CompiledMarkdownView extends StatefulWidget {
   State<_CompiledMarkdownView> createState() => _CompiledMarkdownViewState();
 }
 
-class _CompiledMarkdownViewState extends State<_CompiledMarkdownView> {
+class _CompiledMarkdownViewState extends State<_CompiledMarkdownView>
+    with SingleTickerProviderStateMixin {
   InlineRenderer? _inlineRenderer;
   LatexPreprocessor _latexPreprocessor = LatexPreprocessor();
+  late final AnimationController _streamingTextFadeController;
+  late final CurvedAnimation _streamingTextFade;
   Future<void>? _latexStartupFuture;
   Timer? _latexStartupRetryTimer;
   int _latexStartupRetryCount = 0;
+  int? _streamingTextFadeStartOffset;
 
   @override
   void initState() {
     super.initState();
     widget.debugOnMounted?.call();
+    _streamingTextFadeController = AnimationController(
+      duration: const Duration(milliseconds: 320),
+      vsync: this,
+      value: 1,
+    )..addListener(_handleStreamingTextFadeTick);
+    _streamingTextFade = CurvedAnimation(
+      parent: _streamingTextFadeController,
+      curve: Curves.easeOutCubic,
+    );
     _hydrateDocument(widget.document);
   }
 
@@ -256,7 +276,11 @@ class _CompiledMarkdownViewState extends State<_CompiledMarkdownView> {
   void didUpdateWidget(covariant _CompiledMarkdownView oldWidget) {
     super.didUpdateWidget(oldWidget);
     if (oldWidget.document != widget.document) {
+      _primeStreamingTextFade(oldWidget.document, widget.document);
       _hydrateDocument(widget.document);
+    } else if (!widget.enableStreamingTextFade &&
+        oldWidget.enableStreamingTextFade) {
+      _clearStreamingTextFade();
     }
   }
 
@@ -265,6 +289,8 @@ class _CompiledMarkdownViewState extends State<_CompiledMarkdownView> {
     _cancelLatexStartupRetry();
     widget.debugOnDisposed?.call();
     _inlineRenderer?.disposeRecognizers();
+    _streamingTextFade.dispose();
+    _streamingTextFadeController.dispose();
     super.dispose();
   }
 
@@ -298,6 +324,7 @@ class _CompiledMarkdownViewState extends State<_CompiledMarkdownView> {
         widget.onSourceTap,
         _latexStartupFuture,
         widget.heavyBlockPolicy == MarkdownHeavyBlockPolicy.eager,
+        _buildStreamingTextFadeSpec(),
       );
 
       final blockRenderer = BlockRenderer(
@@ -313,7 +340,7 @@ class _CompiledMarkdownViewState extends State<_CompiledMarkdownView> {
       );
 
       return switch (widget.document.renderTier) {
-        MarkdownRenderTier.plainText => _buildPlainText(style),
+        MarkdownRenderTier.plainText => _buildPlainText(),
         MarkdownRenderTier.richText => _buildRichText(style),
         MarkdownRenderTier.blocks => blockRenderer.renderCompiledBlocks(
           widget.document.blocks,
@@ -329,6 +356,61 @@ class _CompiledMarkdownViewState extends State<_CompiledMarkdownView> {
         },
       );
     }
+  }
+
+  InlineTextFadeSpec? _buildStreamingTextFadeSpec() {
+    final startOffset = _streamingTextFadeStartOffset;
+    if (!widget.enableStreamingTextFade || startOffset == null) {
+      return null;
+    }
+    final opacity = _streamingTextFade.value;
+    if (opacity >= 1) {
+      return null;
+    }
+    return InlineTextFadeSpec(startOffset: startOffset, opacity: opacity);
+  }
+
+  void _primeStreamingTextFade(
+    CompiledMarkdownDocument previous,
+    CompiledMarkdownDocument next,
+  ) {
+    if (!widget.enableStreamingTextFade) {
+      _clearStreamingTextFade();
+      return;
+    }
+
+    final previousText = _visibleTextContent(previous);
+    final nextText = _visibleTextContent(next);
+    if (previousText.isEmpty || nextText.length <= previousText.length) {
+      _clearStreamingTextFade();
+      return;
+    }
+
+    final commonPrefixLength = _commonPrefixLength(previousText, nextText);
+    if (commonPrefixLength >= nextText.length) {
+      _clearStreamingTextFade();
+      return;
+    }
+
+    _streamingTextFadeStartOffset = commonPrefixLength;
+    _streamingTextFadeController.value = 0;
+    _streamingTextFadeController.forward();
+  }
+
+  void _clearStreamingTextFade() {
+    _streamingTextFadeStartOffset = null;
+    _streamingTextFadeController.value = 1;
+  }
+
+  void _handleStreamingTextFadeTick() {
+    if (!mounted || _streamingTextFadeStartOffset == null) {
+      return;
+    }
+    setState(() {
+      if (_streamingTextFade.value >= 1) {
+        _streamingTextFadeStartOffset = null;
+      }
+    });
   }
 
   void _hydrateDocument(CompiledMarkdownDocument document) {
@@ -404,18 +486,18 @@ class _CompiledMarkdownViewState extends State<_CompiledMarkdownView> {
     return Duration(milliseconds: 200 * (1 << clampedRetryCount));
   }
 
-  Widget _buildPlainText(ConduitMarkdownStyle style) {
+  Widget _buildPlainText() {
     final text = _plainTextContent(widget.document);
     if (text.trim().isEmpty) {
       return const SizedBox.shrink();
     }
-    return Text(text, style: style.body);
+    return Text.rich(_inlineRenderer!.render([CompiledMarkdownText(text)]));
   }
 
   Widget _buildRichText(ConduitMarkdownStyle style) {
     final inlineNodes = _richInlineNodes(widget.document);
     if (inlineNodes.isEmpty) {
-      return _buildPlainText(style);
+      return _buildPlainText();
     }
     return Text.rich(_inlineRenderer!.render(inlineNodes));
   }
@@ -449,4 +531,23 @@ List<CompiledMarkdownNode> _richInlineNodes(CompiledMarkdownDocument document) {
     return node.children;
   }
   return <CompiledMarkdownNode>[node];
+}
+
+String _visibleTextContent(CompiledMarkdownDocument document) {
+  if (document.nodes.isEmpty) {
+    return '';
+  }
+  return document.nodes.map((node) => node.textContent).join();
+}
+
+int _commonPrefixLength(String previous, String next) {
+  final maxLength = previous.length < next.length
+      ? previous.length
+      : next.length;
+  var index = 0;
+  while (index < maxLength &&
+      previous.codeUnitAt(index) == next.codeUnitAt(index)) {
+    index += 1;
+  }
+  return index;
 }

--- a/lib/shared/widgets/markdown/renderer/conduit_markdown_widget.dart
+++ b/lib/shared/widgets/markdown/renderer/conduit_markdown_widget.dart
@@ -392,6 +392,16 @@ class _CompiledMarkdownViewState extends State<_CompiledMarkdownView>
       return;
     }
 
+    // Only fade when `next` is a true append of `previous`. Streaming markdown
+    // is not strictly append-only: as content grows the compiler can
+    // re-segment earlier text (e.g. a lone `*` becoming part of `**bold**`).
+    // If the common prefix diverges before the end of `previousText`, fading
+    // from that point would re-fade already-visible, stable text and flicker.
+    if (commonPrefixLength < previousText.length) {
+      _clearStreamingTextFade();
+      return;
+    }
+
     _streamingTextFadeStartOffset = commonPrefixLength;
     _streamingTextFadeController.value = 0;
     _streamingTextFadeController.forward();
@@ -534,9 +544,6 @@ List<CompiledMarkdownNode> _richInlineNodes(CompiledMarkdownDocument document) {
 }
 
 String _visibleTextContent(CompiledMarkdownDocument document) {
-  if (document.nodes.isEmpty) {
-    return '';
-  }
   return document.nodes.map((node) => node.textContent).join();
 }
 
@@ -548,6 +555,20 @@ int _commonPrefixLength(String previous, String next) {
   while (index < maxLength &&
       previous.codeUnitAt(index) == next.codeUnitAt(index)) {
     index += 1;
+  }
+  // The split offset is later used to slice TextSpans. Snap it off any
+  // surrogate-pair boundary so the fade never splits a non-BMP character
+  // (e.g. emoji) into lone surrogate halves, which would render as tofu/
+  // replacement glyphs during the fade animation.
+  if (index > 0 && index < next.length) {
+    final highSurrogate = next.codeUnitAt(index - 1);
+    final lowSurrogate = next.codeUnitAt(index);
+    if (highSurrogate >= 0xD800 &&
+        highSurrogate <= 0xDBFF &&
+        lowSurrogate >= 0xDC00 &&
+        lowSurrogate <= 0xDFFF) {
+      index -= 1;
+    }
   }
   return index;
 }

--- a/lib/shared/widgets/markdown/renderer/inline_renderer.dart
+++ b/lib/shared/widgets/markdown/renderer/inline_renderer.dart
@@ -82,6 +82,21 @@ class InlineRenderer {
 
   int _visibleTextOffset = 0;
 
+  /// Advances the streaming-fade text offset by [length] without emitting any
+  /// fadable span.
+  ///
+  /// The streaming-fade [startOffset] is computed against the document-wide
+  /// `textContent` coordinate space. Block paths that emit text without routing
+  /// it through [_renderFadableText] (e.g. code-block bodies in the `blocks`
+  /// render tier) would otherwise leave [_visibleTextOffset] short of that
+  /// coordinate space, mis-sizing the faded tail for any streaming text that
+  /// follows. Callers advance the offset by the bypassed text length to keep
+  /// it aligned with `document.nodes` textContent.
+  void advanceVisibleTextOffset(int length) {
+    if (length <= 0) return;
+    _visibleTextOffset += length;
+  }
+
   /// Disposes all gesture recognizers created during
   /// rendering and clears the internal list.
   void disposeRecognizers() {
@@ -153,6 +168,11 @@ class InlineRenderer {
         }
         continue;
       }
+      // Keep the streaming-fade offset aligned with the document-wide
+      // textContent coordinate space, which still contains the placeholder
+      // token. The LaTeX WidgetSpan itself does not fade, so advance the
+      // offset by the consumed placeholder token length.
+      _visibleTextOffset += segment.placeholderLength;
       spans.add(
         WidgetSpan(
           alignment: PlaceholderAlignment.middle,
@@ -194,6 +214,9 @@ class InlineRenderer {
         continue;
       }
       if (segment is CompiledMarkdownLatexSegment) {
+        // Advance the streaming-fade offset by the placeholder token length so
+        // it stays aligned with the document-wide textContent coordinate space.
+        _visibleTextOffset += segment.placeholderLength;
         spans.add(
           WidgetSpan(
             alignment: PlaceholderAlignment.middle,

--- a/lib/shared/widgets/markdown/renderer/inline_renderer.dart
+++ b/lib/shared/widgets/markdown/renderer/inline_renderer.dart
@@ -15,6 +15,14 @@ import 'pdf_inline_view.dart';
 /// Callback invoked when a user taps a markdown link.
 typedef LinkTapCallback = void Function(String url, String title);
 
+@immutable
+class InlineTextFadeSpec {
+  const InlineTextFadeSpec({required this.startOffset, required this.opacity});
+
+  final int startOffset;
+  final double opacity;
+}
+
 /// Converts markdown AST inline nodes into a Flutter
 /// [InlineSpan] tree suitable for use with [Text.rich].
 ///
@@ -36,6 +44,7 @@ class InlineRenderer {
     this.onSourceTap,
     this.latexStartupFuture,
     this.renderPdfPreviews = true,
+    this.textFade,
   ]);
 
   /// The style configuration for rendering.
@@ -59,6 +68,9 @@ class InlineRenderer {
   /// Whether PDF links should hydrate preview cards instead of plain links.
   final bool renderPdfPreviews;
 
+  /// Optional visible text suffix fade for streaming updates.
+  final InlineTextFadeSpec? textFade;
+
   /// Gesture recognizers created during rendering.
   ///
   /// Callers should dispose these when the widget is
@@ -67,6 +79,8 @@ class InlineRenderer {
 
   /// All gesture recognizers created by this renderer.
   List<GestureRecognizer> get recognizers => List.unmodifiable(_recognizers);
+
+  int _visibleTextOffset = 0;
 
   /// Disposes all gesture recognizers created during
   /// rendering and clears the internal list.
@@ -105,7 +119,7 @@ class InlineRenderer {
     if (node is CompiledMarkdownElement) {
       return _renderElement(node, currentStyle);
     }
-    return [TextSpan(text: node.textContent)];
+    return _renderFadableText(node.textContent, currentStyle);
   }
 
   List<InlineSpan> _renderText(
@@ -162,19 +176,19 @@ class InlineRenderer {
     for (final segment in segments) {
       if (segment is CompiledMarkdownTextSegment) {
         if (segment.text.isNotEmpty) {
-          spans.add(TextSpan(text: segment.text, style: currentStyle));
+          spans.addAll(_renderFadableText(segment.text, currentStyle));
         }
         continue;
       }
       if (segment is CompiledMarkdownCitationSegment) {
         if (!_canRenderCitationBadge(segment.sourceIds)) {
-          spans.add(TextSpan(text: segment.rawText, style: currentStyle));
+          spans.addAll(_renderFadableText(segment.rawText, currentStyle));
           continue;
         }
         spans.add(
-          WidgetSpan(
-            alignment: PlaceholderAlignment.middle,
+          _buildFadableWidgetSpan(
             child: _buildCitationBadge(segment.sourceIds),
+            textLength: segment.rawText.length,
           ),
         );
         continue;
@@ -202,10 +216,10 @@ class InlineRenderer {
     required bool containsCitations,
   }) {
     if (sources == null || sources!.isEmpty || !containsCitations) {
-      return [TextSpan(text: text, style: currentStyle)];
+      return _renderFadableText(text, currentStyle);
     }
     return _renderCitations(text, currentStyle) ??
-        [TextSpan(text: text, style: currentStyle)];
+        _renderFadableText(text, currentStyle);
   }
 
   List<InlineSpan>? _renderCitations(String text, TextStyle currentStyle) {
@@ -217,17 +231,17 @@ class InlineRenderer {
     final spans = <InlineSpan>[];
     for (final segment in segments) {
       if (segment.isText && segment.text != null) {
-        spans.add(TextSpan(text: segment.text, style: currentStyle));
+        spans.addAll(_renderFadableText(segment.text!, currentStyle));
       } else if (segment.isCitation && segment.citation != null) {
         final citation = segment.citation!;
         if (!_canRenderCitationBadge(citation.sourceIds)) {
-          spans.add(TextSpan(text: citation.raw, style: currentStyle));
+          spans.addAll(_renderFadableText(citation.raw, currentStyle));
           continue;
         }
         spans.add(
-          WidgetSpan(
-            alignment: PlaceholderAlignment.middle,
+          _buildFadableWidgetSpan(
             child: _buildCitationBadge(citation.sourceIds),
+            textLength: citation.raw.length,
           ),
         );
       }
@@ -302,15 +316,13 @@ class InlineRenderer {
     CompiledMarkdownElement element,
     TextStyle currentStyle,
   ) {
-    return [
-      TextSpan(
-        text: element.textContent,
-        style: currentStyle.copyWith(
-          color: style.linkColor,
-          fontWeight: FontWeight.w600,
-        ),
+    return _renderFadableText(
+      element.textContent,
+      currentStyle.copyWith(
+        color: style.linkColor,
+        fontWeight: FontWeight.w600,
       ),
-    ];
+    );
   }
 
   List<InlineSpan> _renderStyled(
@@ -319,7 +331,7 @@ class InlineRenderer {
   ) {
     final children = element.children;
     if (children.isEmpty) {
-      return [TextSpan(text: element.textContent, style: styledText)];
+      return _renderFadableText(element.textContent, styledText);
     }
     final spans = <InlineSpan>[];
     for (final child in children) {
@@ -329,7 +341,8 @@ class InlineRenderer {
   }
 
   WidgetSpan _buildInlineCode(String code) {
-    return WidgetSpan(
+    return _buildFadableWidgetSpan(
+      textLength: code.length,
       alignment: PlaceholderAlignment.middle,
       child: _InlineCodeWidget(code: code, style: style),
     );
@@ -344,8 +357,8 @@ class InlineRenderer {
 
     if (renderPdfPreviews && PdfInlineView.isPdfLink(href)) {
       return [
-        WidgetSpan(
-          alignment: PlaceholderAlignment.middle,
+        _buildFadableWidgetSpan(
+          textLength: element.textContent.length,
           child: PdfInlineView(url: href, label: element.textContent),
         ),
       ];
@@ -366,13 +379,10 @@ class InlineRenderer {
 
     final children = element.children;
     if (children.isEmpty) {
-      return [
-        TextSpan(
-          text: element.textContent,
-          style: linkStyle,
-          recognizer: recognizer,
-        ),
-      ];
+      return _withRecognizer(
+        _renderFadableText(element.textContent, linkStyle),
+        recognizer,
+      );
     }
 
     final spans = <InlineSpan>[];
@@ -419,7 +429,7 @@ class InlineRenderer {
   ) {
     final alt = element.attributes['alt'] ?? '';
     if (alt.isEmpty) return [];
-    return [TextSpan(text: alt, style: currentStyle)];
+    return _renderFadableText(alt, currentStyle);
   }
 
   List<InlineSpan> _renderChildren(
@@ -448,6 +458,69 @@ class InlineRenderer {
       spans.addAll(_renderNode(child, currentStyle));
     }
     return spans;
+  }
+
+  List<InlineSpan> _renderFadableText(String text, TextStyle currentStyle) {
+    if (text.isEmpty) {
+      return const <InlineSpan>[];
+    }
+
+    final fade = textFade;
+    final startOffset = _visibleTextOffset;
+    final endOffset = startOffset + text.length;
+    _visibleTextOffset = endOffset;
+
+    if (fade == null || fade.opacity >= 1 || endOffset <= fade.startOffset) {
+      return [TextSpan(text: text, style: currentStyle)];
+    }
+
+    final fadeStyle = _styleWithFadeOpacity(currentStyle, fade.opacity);
+    if (startOffset >= fade.startOffset) {
+      return [TextSpan(text: text, style: fadeStyle)];
+    }
+
+    final splitIndex = fade.startOffset - startOffset;
+    return [
+      TextSpan(text: text.substring(0, splitIndex), style: currentStyle),
+      TextSpan(text: text.substring(splitIndex), style: fadeStyle),
+    ];
+  }
+
+  WidgetSpan _buildFadableWidgetSpan({
+    required Widget child,
+    required int textLength,
+    PlaceholderAlignment alignment = PlaceholderAlignment.middle,
+  }) {
+    final opacity = _opacityForFadableRange(textLength);
+    final effectiveChild = opacity >= 1
+        ? child
+        : Opacity(opacity: opacity, child: child);
+    return WidgetSpan(alignment: alignment, child: effectiveChild);
+  }
+
+  double _opacityForFadableRange(int textLength) {
+    if (textLength <= 0) {
+      return 1;
+    }
+    final fade = textFade;
+    final startOffset = _visibleTextOffset;
+    final endOffset = startOffset + textLength;
+    _visibleTextOffset = endOffset;
+    if (fade == null || fade.opacity >= 1 || endOffset <= fade.startOffset) {
+      return 1;
+    }
+    return fade.opacity.clamp(0.0, 1.0).toDouble();
+  }
+
+  TextStyle _styleWithFadeOpacity(TextStyle currentStyle, double opacity) {
+    final baseColor = currentStyle.color ?? style.body.color;
+    if (baseColor == null) {
+      return currentStyle;
+    }
+    final clampedOpacity = opacity.clamp(0.0, 1.0).toDouble();
+    return currentStyle.copyWith(
+      color: baseColor.withValues(alpha: baseColor.a * clampedOpacity),
+    );
   }
 }
 

--- a/lib/shared/widgets/markdown/renderer/inline_renderer.dart
+++ b/lib/shared/widgets/markdown/renderer/inline_renderer.dart
@@ -746,7 +746,11 @@ class InlineRenderer {
     FadableSpanRange? range,
     InlineTextFadeSpec fade,
   ) {
-    if (range == null || range.end <= fade.startOffset) {
+    // A widget span can't be split, so only fade it when it lies ENTIRELY in
+    // the new suffix. A widget that straddles the boundary (already partly
+    // visible) must stay opaque, or extending an adjacent span would flicker
+    // already-shown content (e.g. inline code `abc` -> `abcd`, citations/PDFs).
+    if (range == null || range.start < fade.startOffset) {
       return span;
     }
     final opacity = fade.opacity.clamp(0.0, 1.0).toDouble();

--- a/lib/shared/widgets/markdown/renderer/inline_renderer.dart
+++ b/lib/shared/widgets/markdown/renderer/inline_renderer.dart
@@ -23,6 +23,52 @@ class InlineTextFadeSpec {
   final double opacity;
 }
 
+/// Records the document-coordinate range covered by a single emitted leaf span.
+///
+/// Captured during the [InlineRenderer.renderWithRanges] walk so the streaming
+/// suffix fade can be reapplied later (via [InlineRenderer.applyFadeOpacity])
+/// without re-walking the document or recreating gesture recognizers.
+@immutable
+class FadableSpanRange {
+  const FadableSpanRange({
+    required this.start,
+    required this.end,
+    required this.isWidgetSpan,
+  });
+
+  /// Inclusive start offset in document-wide `textContent` coordinates.
+  final int start;
+
+  /// Exclusive end offset in document-wide `textContent` coordinates.
+  final int end;
+
+  /// Whether the emitted leaf is a [WidgetSpan] (faded via [Opacity]) rather
+  /// than a [TextSpan] (faded via color alpha).
+  final bool isWidgetSpan;
+}
+
+/// The result of a fade-agnostic inline render: the opacity-1 base span tree
+/// plus the per-leaf document-coordinate ranges recorded during the walk.
+///
+/// The base tree is built once per content change. [InlineRenderer.applyFadeOpacity]
+/// reapplies the streaming suffix alpha to only the in-range leaves of this
+/// cached tree, so fade frames never rebuild the span tree or its recognizers.
+///
+/// [ranges] is keyed by emitted leaf-span identity rather than position so that
+/// non-fadable leaves interleaved in the tree (e.g. hard line breaks, table or
+/// heading spans built outside the fadable path) are simply absent from the map
+/// and reused by reference during a fade.
+@immutable
+class RenderedInlineSpans {
+  const RenderedInlineSpans({required this.span, required this.ranges});
+
+  /// The opacity-1 base span tree (with link recognizers attached).
+  final InlineSpan span;
+
+  /// Recorded ranges keyed by the identity of the emitted leaf span.
+  final Map<InlineSpan, FadableSpanRange> ranges;
+}
+
 /// Converts markdown AST inline nodes into a Flutter
 /// [InlineSpan] tree suitable for use with [Text.rich].
 ///
@@ -44,7 +90,6 @@ class InlineRenderer {
     this.onSourceTap,
     this.latexStartupFuture,
     this.renderPdfPreviews = true,
-    this.textFade,
   ]);
 
   /// The style configuration for rendering.
@@ -68,8 +113,13 @@ class InlineRenderer {
   /// Whether PDF links should hydrate preview cards instead of plain links.
   final bool renderPdfPreviews;
 
-  /// Optional visible text suffix fade for streaming updates.
-  final InlineTextFadeSpec? textFade;
+  /// Per-leaf document-coordinate ranges recorded during the current walk,
+  /// keyed by emitted leaf-span identity.
+  ///
+  /// Populated only while [renderWithRanges] is running so the streaming suffix
+  /// fade can be reapplied to the cached base tree without re-walking. Reset at
+  /// the start of every render entry point.
+  Map<InlineSpan, FadableSpanRange>? _recordedRanges;
 
   /// Gesture recognizers created during rendering.
   ///
@@ -115,6 +165,10 @@ class InlineRenderer {
     List<CompiledMarkdownNode> nodes, {
     TextStyle? parentStyle,
   }) {
+    // Non-fadable call sites (tables, headings, cells) only need the base tree.
+    // Skip range recording entirely; the [_visibleTextOffset] cursor still
+    // advances as before so cross-block coordinates stay aligned.
+    _recordedRanges = null;
     final base = parentStyle ?? style.body;
     final spans = <InlineSpan>[];
     for (final node in nodes) {
@@ -122,6 +176,32 @@ class InlineRenderer {
     }
     if (spans.length == 1) return spans.first;
     return TextSpan(children: spans);
+  }
+
+  /// Renders [nodes] into the opacity-1 base span tree while recording, during
+  /// the same [_visibleTextOffset] walk, the document-coordinate range of every
+  /// emitted leaf span.
+  ///
+  /// The returned [RenderedInlineSpans] can be cached per content change and
+  /// re-faded via [applyFadeOpacity] without re-walking the document or
+  /// recreating gesture recognizers.
+  RenderedInlineSpans renderWithRanges(
+    List<CompiledMarkdownNode> nodes, {
+    TextStyle? parentStyle,
+  }) {
+    final ranges = <InlineSpan, FadableSpanRange>{};
+    _recordedRanges = ranges;
+    try {
+      final base = parentStyle ?? style.body;
+      final spans = <InlineSpan>[];
+      for (final node in nodes) {
+        spans.addAll(_renderNode(node, base));
+      }
+      final span = spans.length == 1 ? spans.first : TextSpan(children: spans);
+      return RenderedInlineSpans(span: span, ranges: ranges);
+    } finally {
+      _recordedRanges = null;
+    }
   }
 
   List<InlineSpan> _renderNode(
@@ -428,7 +508,7 @@ class InlineRenderer {
 
   InlineSpan _attachRecognizer(InlineSpan span, GestureRecognizer recognizer) {
     if (span is TextSpan) {
-      return TextSpan(
+      final copy = TextSpan(
         text: span.text,
         children: span.children
             ?.map((child) => _attachRecognizer(child, recognizer))
@@ -442,6 +522,16 @@ class InlineRenderer {
         locale: span.locale,
         spellOut: span.spellOut,
       );
+      // The fadable range was recorded against the pre-copy span identity; move
+      // it to the recognizer-bearing copy so the streaming fade still finds it.
+      final ranges = _recordedRanges;
+      if (ranges != null) {
+        final range = ranges.remove(span);
+        if (range != null) {
+          ranges[copy] = range;
+        }
+      }
+      return copy;
     }
     return span;
   }
@@ -488,25 +578,20 @@ class InlineRenderer {
       return const <InlineSpan>[];
     }
 
-    final fade = textFade;
+    // Always emit a single opacity-1 base span. The streaming fade is reapplied
+    // later by [applyFadeOpacity] using the recorded range, so the offset walk
+    // here stays decoupled from any opacity decision while remaining
+    // byte-identical in how it advances [_visibleTextOffset].
     final startOffset = _visibleTextOffset;
     final endOffset = startOffset + text.length;
     _visibleTextOffset = endOffset;
-
-    if (fade == null || fade.opacity >= 1 || endOffset <= fade.startOffset) {
-      return [TextSpan(text: text, style: currentStyle)];
-    }
-
-    final fadeStyle = _styleWithFadeOpacity(currentStyle, fade.opacity);
-    if (startOffset >= fade.startOffset) {
-      return [TextSpan(text: text, style: fadeStyle)];
-    }
-
-    final splitIndex = fade.startOffset - startOffset;
-    return [
-      TextSpan(text: text.substring(0, splitIndex), style: currentStyle),
-      TextSpan(text: text.substring(splitIndex), style: fadeStyle),
-    ];
+    final span = TextSpan(text: text, style: currentStyle);
+    _recordedRanges?[span] = FadableSpanRange(
+      start: startOffset,
+      end: endOffset,
+      isWidgetSpan: false,
+    );
+    return [span];
   }
 
   WidgetSpan _buildFadableWidgetSpan({
@@ -514,35 +599,233 @@ class InlineRenderer {
     required int textLength,
     PlaceholderAlignment alignment = PlaceholderAlignment.middle,
   }) {
-    final opacity = _opacityForFadableRange(textLength);
-    final effectiveChild = opacity >= 1
-        ? child
-        : Opacity(opacity: opacity, child: child);
-    return WidgetSpan(alignment: alignment, child: effectiveChild);
+    final span = WidgetSpan(alignment: alignment, child: child);
+    _recordFadableWidgetRange(span, textLength);
+    return span;
   }
 
-  double _opacityForFadableRange(int textLength) {
+  void _recordFadableWidgetRange(WidgetSpan span, int textLength) {
     if (textLength <= 0) {
-      return 1;
+      // Mirror the prior accounting: zero-length widget spans never advanced
+      // [_visibleTextOffset] and recorded no fadable range.
+      return;
     }
-    final fade = textFade;
     final startOffset = _visibleTextOffset;
     final endOffset = startOffset + textLength;
     _visibleTextOffset = endOffset;
-    if (fade == null || fade.opacity >= 1 || endOffset <= fade.startOffset) {
-      return 1;
-    }
-    return fade.opacity.clamp(0.0, 1.0).toDouble();
+    _recordedRanges?[span] = FadableSpanRange(
+      start: startOffset,
+      end: endOffset,
+      isWidgetSpan: true,
+    );
   }
 
-  TextStyle _styleWithFadeOpacity(TextStyle currentStyle, double opacity) {
-    final baseColor = currentStyle.color ?? style.body.color;
+  /// Reapplies the streaming suffix [fade] to only the in-range leaves of a
+  /// cached [base] render, returning a new span tree.
+  ///
+  /// This is a cheap, pure copy: leaves with no recorded range, or whose range
+  /// is entirely before [InlineTextFadeSpec.startOffset], are reused by
+  /// reference (recognizers included); leaves at/after the fade boundary have
+  /// their color alpha (text) or [Opacity] (widget) reapplied; the single leaf
+  /// straddling the boundary is split with the same `substring` logic as the
+  /// original walk. No document node walk, recognizer creation, or LaTeX
+  /// re-resolution occurs.
+  static InlineSpan applyFadeOpacity(
+    RenderedInlineSpans base,
+    InlineTextFadeSpec? fade, {
+    required ConduitMarkdownStyle style,
+  }) {
+    if (fade == null || fade.opacity >= 1) {
+      return base.span;
+    }
+    return _applyFadeToSpan(base.span, base.ranges, fade, style);
+  }
+
+  static InlineSpan _applyFadeToSpan(
+    InlineSpan span,
+    Map<InlineSpan, FadableSpanRange> ranges,
+    InlineTextFadeSpec fade,
+    ConduitMarkdownStyle style,
+  ) {
+    if (span is TextSpan) {
+      final children = span.children;
+      if (children != null && children.isNotEmpty) {
+        // Interior node: copy and recurse into children in order.
+        final newChildren = children
+            .map((child) => _applyFadeToSpan(child, ranges, fade, style))
+            .toList(growable: false);
+        return TextSpan(
+          text: span.text,
+          children: newChildren,
+          style: span.style,
+          recognizer: span.recognizer,
+          mouseCursor: span.mouseCursor,
+          onEnter: span.onEnter,
+          onExit: span.onExit,
+          semanticsLabel: span.semanticsLabel,
+          locale: span.locale,
+          spellOut: span.spellOut,
+        );
+      }
+      return _fadeTextLeaf(span, ranges[span], fade, style);
+    }
+    if (span is WidgetSpan) {
+      return _fadeWidgetLeaf(span, ranges[span], fade);
+    }
+    return span;
+  }
+
+  static InlineSpan _fadeTextLeaf(
+    TextSpan span,
+    FadableSpanRange? range,
+    InlineTextFadeSpec fade,
+    ConduitMarkdownStyle style,
+  ) {
+    final text = span.text;
+    if (range == null || text == null || range.end <= fade.startOffset) {
+      return span;
+    }
+
+    final fadeStyle = _styleWithFadeOpacityStatic(
+      span.style,
+      fade.opacity,
+      style,
+    );
+    if (range.start >= fade.startOffset) {
+      return TextSpan(
+        text: text,
+        style: fadeStyle,
+        recognizer: span.recognizer,
+        mouseCursor: span.mouseCursor,
+        onEnter: span.onEnter,
+        onExit: span.onExit,
+        semanticsLabel: span.semanticsLabel,
+        locale: span.locale,
+        spellOut: span.spellOut,
+      );
+    }
+
+    // Straddling leaf: split at the fade boundary using the same offset math as
+    // the original walk. [fade.startOffset] is already surrogate-snapped.
+    //
+    // Mirror the original walk, which emitted two sibling spans and attached the
+    // link recognizer to EACH of them: a TextSpan's recognizer only applies to
+    // its own `text`, so the recognizer is carried onto both child halves (and
+    // their per-span metadata) rather than a text-less parent wrapper.
+    final splitIndex = fade.startOffset - range.start;
+    return TextSpan(
+      children: [
+        TextSpan(
+          text: text.substring(0, splitIndex),
+          style: span.style,
+          recognizer: span.recognizer,
+          mouseCursor: span.mouseCursor,
+          onEnter: span.onEnter,
+          onExit: span.onExit,
+          semanticsLabel: span.semanticsLabel,
+          locale: span.locale,
+          spellOut: span.spellOut,
+        ),
+        TextSpan(
+          text: text.substring(splitIndex),
+          style: fadeStyle,
+          recognizer: span.recognizer,
+          mouseCursor: span.mouseCursor,
+          onEnter: span.onEnter,
+          onExit: span.onExit,
+          semanticsLabel: span.semanticsLabel,
+          locale: span.locale,
+          spellOut: span.spellOut,
+        ),
+      ],
+    );
+  }
+
+  static InlineSpan _fadeWidgetLeaf(
+    WidgetSpan span,
+    FadableSpanRange? range,
+    InlineTextFadeSpec fade,
+  ) {
+    if (range == null || range.end <= fade.startOffset) {
+      return span;
+    }
+    final opacity = fade.opacity.clamp(0.0, 1.0).toDouble();
+    return WidgetSpan(
+      alignment: span.alignment,
+      baseline: span.baseline,
+      style: span.style,
+      child: Opacity(opacity: opacity, child: span.child),
+    );
+  }
+
+  static TextStyle _styleWithFadeOpacityStatic(
+    TextStyle? currentStyle,
+    double opacity,
+    ConduitMarkdownStyle style,
+  ) {
+    final base = currentStyle ?? style.body;
+    final baseColor = base.color ?? style.body.color;
     if (baseColor == null) {
-      return currentStyle;
+      return base;
     }
     final clampedOpacity = opacity.clamp(0.0, 1.0).toDouble();
-    return currentStyle.copyWith(
+    return base.copyWith(
       color: baseColor.withValues(alpha: baseColor.a * clampedOpacity),
+    );
+  }
+}
+
+/// Read-only source of the current streaming suffix fade.
+///
+/// Exposes a [Listenable] (the fade animation) and the current
+/// [InlineTextFadeSpec] so [FadableRichText] widgets can repaint their own
+/// suffix opacity without forcing the whole markdown subtree to rebuild.
+abstract class MarkdownStreamingFade {
+  /// Drives per-frame repaints while the suffix fades.
+  Listenable get listenable;
+
+  /// The current fade spec, or `null` when nothing is fading.
+  InlineTextFadeSpec? get spec;
+}
+
+/// Renders a cached [RenderedInlineSpans] base tree, reapplying the streaming
+/// suffix fade per frame via [InlineRenderer.applyFadeOpacity] without
+/// rebuilding the span tree or its recognizers.
+///
+/// When [fade] is `null` the base tree is rendered directly with no listener.
+class FadableRichText extends StatelessWidget {
+  const FadableRichText({
+    required this.rendered,
+    required this.style,
+    this.fade,
+    super.key,
+  });
+
+  /// The cached opacity-1 base span tree plus recorded leaf ranges.
+  final RenderedInlineSpans rendered;
+
+  /// Style used to resolve fade base colors.
+  final ConduitMarkdownStyle style;
+
+  /// Optional streaming fade source. When `null`, no fade is applied.
+  final MarkdownStreamingFade? fade;
+
+  @override
+  Widget build(BuildContext context) {
+    final fadeSource = fade;
+    if (fadeSource == null) {
+      return Text.rich(rendered.span);
+    }
+    return AnimatedBuilder(
+      animation: fadeSource.listenable,
+      builder: (context, _) {
+        final span = InlineRenderer.applyFadeOpacity(
+          rendered,
+          fadeSource.spec,
+          style: style,
+        );
+        return Text.rich(span);
+      },
     );
   }
 }

--- a/lib/shared/widgets/markdown/renderer/latex_preprocessor.dart
+++ b/lib/shared/widgets/markdown/renderer/latex_preprocessor.dart
@@ -181,7 +181,13 @@ class LatexPreprocessor {
       }
       final key = match.group(0)!;
       final expr = allPlaceholders[key]!;
-      segments.add(LatexSegment.latex(expr.tex, isBlock: expr.isBlock));
+      segments.add(
+        LatexSegment.latex(
+          expr.tex,
+          isBlock: expr.isBlock,
+          placeholderLength: key.length,
+        ),
+      );
       lastEnd = match.end;
     }
 
@@ -292,10 +298,26 @@ class LatexSegment {
   /// Always `false` for plain text segments.
   final bool isBlock;
 
+  /// The length of the placeholder token consumed from the source text for
+  /// this segment.
+  ///
+  /// For plain-text segments this is the length of [content]. For LaTeX
+  /// segments [content] holds the recovered TeX, which is unrelated to the
+  /// placeholder token's length, so this records the token length instead.
+  /// Streaming-fade offset accounting must advance by the placeholder token
+  /// length to stay in the document-wide `textContent` coordinate space.
+  final int placeholderLength;
+
   /// Creates a plain-text segment.
-  const LatexSegment.text(this.content) : isLatex = false, isBlock = false;
+  const LatexSegment.text(this.content)
+    : isLatex = false,
+      isBlock = false,
+      placeholderLength = content.length;
 
   /// Creates a LaTeX expression segment.
-  const LatexSegment.latex(this.content, {required this.isBlock})
-    : isLatex = true;
+  const LatexSegment.latex(
+    this.content, {
+    required this.isBlock,
+    required this.placeholderLength,
+  }) : isLatex = true;
 }

--- a/lib/shared/widgets/markdown/streaming_markdown_widget.dart
+++ b/lib/shared/widgets/markdown/streaming_markdown_widget.dart
@@ -67,6 +67,7 @@ class StreamingMarkdownWidget extends ConsumerStatefulWidget {
     this.debugOnCompiledViewMounted,
     this.debugOnCompiledViewDisposed,
     this.debugOnStreamingRefreshFrame,
+    this.debugOnBaseRender,
   });
 
   final String content;
@@ -107,6 +108,11 @@ class StreamingMarkdownWidget extends ConsumerStatefulWidget {
 
   @visibleForTesting
   final VoidCallback? debugOnStreamingRefreshFrame;
+
+  /// Invoked each time the compiled view rebuilds its cached base span tree
+  /// (once per content change, never per fade frame).
+  @visibleForTesting
+  final VoidCallback? debugOnBaseRender;
 
   @override
   ConsumerState<StreamingMarkdownWidget> createState() =>
@@ -454,6 +460,7 @@ class _StreamingMarkdownWidgetState
           : MarkdownHeavyBlockPolicy.eager,
       debugOnCompiledViewMounted: widget.debugOnCompiledViewMounted,
       debugOnCompiledViewDisposed: widget.debugOnCompiledViewDisposed,
+      debugOnBaseRender: widget.debugOnBaseRender,
     );
   }
 

--- a/lib/shared/widgets/markdown/streaming_markdown_widget.dart
+++ b/lib/shared/widgets/markdown/streaming_markdown_widget.dart
@@ -61,6 +61,7 @@ class StreamingMarkdownWidget extends ConsumerStatefulWidget {
     this.onSourceTap,
     this.askConduitComposerTargetId,
     this.stateScopeId,
+    this.enableStreamingTextFade = true,
     this.debugTreatAsWidgetTest,
     this.debugRenderInterval,
     this.debugOnCompiledViewMounted,
@@ -88,6 +89,9 @@ class StreamingMarkdownWidget extends ConsumerStatefulWidget {
 
   /// Optional scope used to preserve state for remounted markdown blocks.
   final String? stateScopeId;
+
+  /// Fades newly appended visible text while streaming without moving layout.
+  final bool enableStreamingTextFade;
 
   @visibleForTesting
   final bool? debugTreatAsWidgetTest;
@@ -443,6 +447,8 @@ class _StreamingMarkdownWidgetState
       sources: widget.sources,
       onSourceTap: widget.onSourceTap,
       stateScopeId: widget.stateScopeId,
+      enableStreamingTextFade:
+          widget.isStreaming && widget.enableStreamingTextFade,
       heavyBlockPolicy: widget.isStreaming
           ? MarkdownHeavyBlockPolicy.defer
           : MarkdownHeavyBlockPolicy.eager,

--- a/test/core/providers/active_chats_sync_test.dart
+++ b/test/core/providers/active_chats_sync_test.dart
@@ -1,0 +1,365 @@
+import 'dart:async';
+
+import 'package:checks/checks.dart';
+import 'package:conduit/core/models/conversation.dart';
+import 'package:conduit/core/models/server_config.dart';
+import 'package:conduit/core/providers/app_providers.dart';
+import 'package:conduit/core/services/api_service.dart';
+import 'package:conduit/core/services/socket_service.dart';
+import 'package:conduit/core/services/worker_manager.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+// ---------------------------------------------------------------------------
+// Test doubles
+// ---------------------------------------------------------------------------
+
+/// A captured `addChatEventHandler` registration so tests can drive the
+/// global `chat:active` handler directly and assert the wildcard contract.
+class _CapturedRegistration {
+  _CapturedRegistration({
+    required this.conversationId,
+    required this.sessionId,
+    required this.messageId,
+    required this.requireFocus,
+    required this.handler,
+  });
+
+  final String? conversationId;
+  final String? sessionId;
+  final String? messageId;
+  final bool requireFocus;
+  final SocketChatEventHandler handler;
+}
+
+/// Minimal SocketService stand-in that records the handler `ActiveChatsSync`
+/// registers and lets the test deliver events to it. `onReconnect` is a
+/// broadcast controller the test can pump.
+class _MockSocketService implements SocketService {
+  final List<_CapturedRegistration> registrations = <_CapturedRegistration>[];
+  final _reconnectController = StreamController<void>.broadcast();
+
+  void emitReconnect() => _reconnectController.add(null);
+
+  @override
+  SocketEventSubscription addChatEventHandler({
+    String? conversationId,
+    String? sessionId,
+    String? messageId,
+    bool requireFocus = true,
+    required SocketChatEventHandler handler,
+  }) {
+    final reg = _CapturedRegistration(
+      conversationId: conversationId,
+      sessionId: sessionId,
+      messageId: messageId,
+      requireFocus: requireFocus,
+      handler: handler,
+    );
+    registrations.add(reg);
+    return SocketEventSubscription(
+      () => registrations.remove(reg),
+      handlerId: 'test-${registrations.length}',
+    );
+  }
+
+  @override
+  Stream<void> get onReconnect => _reconnectController.stream;
+
+  void disposeController() => _reconnectController.close();
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => null;
+}
+
+/// ApiService whose `checkActiveChats` returns a scripted set so the
+/// cold-open / reconnect reconciliation path can be tested deterministically.
+class _FakeApiService extends ApiService {
+  _FakeApiService()
+    : super(
+        serverConfig: const ServerConfig(
+          id: 'test',
+          name: 'Test',
+          url: 'http://localhost:0',
+        ),
+        workerManager: WorkerManager(),
+      );
+
+  Set<String> nextActive = const <String>{};
+  int checkActiveChatsCalls = 0;
+  List<String>? lastCheckedIds;
+
+  @override
+  Future<Set<String>> checkActiveChats(List<String> chatIds) async {
+    checkActiveChatsCalls += 1;
+    lastCheckedIds = chatIds;
+    return nextActive;
+  }
+}
+
+/// Conversations override returning a fixed list (avoids the DB-backed build).
+class _FakeConversations extends Conversations {
+  _FakeConversations(this._items);
+  final List<Conversation> _items;
+
+  @override
+  Future<List<Conversation>> build() async => _items;
+}
+
+Conversation _conv(String id) => Conversation(
+  id: id,
+  title: 'Conversation $id',
+  messages: const [],
+  createdAt: DateTime(2024),
+  updatedAt: DateTime(2024),
+);
+
+/// Builds the standard `chat:active` envelope:
+/// `{chat_id, message_id, data:{type:'chat:active', data:{active}}}`.
+Map<String, dynamic> _activeEnvelope({
+  required String chatId,
+  required bool active,
+  bool chatIdAtEnvelope = true,
+  bool chatIdNested = false,
+}) {
+  final inner = <String, dynamic>{
+    'active': active,
+    if (chatIdNested) 'chat_id': chatId,
+  };
+  return <String, dynamic>{
+    if (chatIdAtEnvelope) 'chat_id': chatId,
+    'message_id': 'm1',
+    'data': <String, dynamic>{
+      'type': 'chat:active',
+      'data': inner,
+      if (!chatIdAtEnvelope && !chatIdNested) 'chat_id': chatId,
+    },
+  };
+}
+
+ProviderContainer _makeContainer({
+  required _MockSocketService socket,
+  _FakeApiService? api,
+  List<Conversation> conversations = const <Conversation>[],
+}) {
+  final container = ProviderContainer(
+    overrides: [
+      socketServiceProvider.overrideWithValue(socket),
+      if (api != null) apiServiceProvider.overrideWithValue(api),
+      conversationsProvider.overrideWith(
+        () => _FakeConversations(conversations),
+      ),
+    ],
+  );
+  addTearDown(container.dispose);
+  return container;
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('ActiveChatsSync — chat:active envelope parsing', () {
+    test('active:true adds and active:false removes the chat id', () {
+      final socket = _MockSocketService();
+      addTearDown(socket.disposeController);
+      final container = _makeContainer(socket: socket);
+
+      // Materialize the keepAlive sync provider so it binds the socket.
+      container.read(activeChatsSyncProvider);
+      final reg = socket.registrations.single;
+
+      reg.handler(_activeEnvelope(chatId: 'c1', active: true), null);
+      check(container.read(activeChatIdsProvider)).contains('c1');
+
+      reg.handler(_activeEnvelope(chatId: 'c1', active: false), null);
+      check(container.read(activeChatIdsProvider)).not((s) => s.contains('c1'));
+    });
+
+    test('chat_id nested under data resolves (envelope-level absent)', () {
+      final socket = _MockSocketService();
+      addTearDown(socket.disposeController);
+      final container = _makeContainer(socket: socket);
+      container.read(activeChatsSyncProvider);
+      final reg = socket.registrations.single;
+
+      reg.handler(
+        _activeEnvelope(chatId: 'c2', active: true, chatIdAtEnvelope: false),
+        null,
+      );
+      check(container.read(activeChatIdsProvider)).contains('c2');
+    });
+
+    test('chat_id nested under data.data resolves', () {
+      final socket = _MockSocketService();
+      addTearDown(socket.disposeController);
+      final container = _makeContainer(socket: socket);
+      container.read(activeChatsSyncProvider);
+      final reg = socket.registrations.single;
+
+      reg.handler(
+        _activeEnvelope(
+          chatId: 'c3',
+          active: true,
+          chatIdAtEnvelope: false,
+          chatIdNested: true,
+        ),
+        null,
+      );
+      check(container.read(activeChatIdsProvider)).contains('c3');
+    });
+
+    test('non chat:active envelopes leave the set unchanged', () {
+      final socket = _MockSocketService();
+      addTearDown(socket.disposeController);
+      final container = _makeContainer(socket: socket);
+      container.read(activeChatsSyncProvider);
+      final reg = socket.registrations.single;
+
+      // Seed an active chat, then deliver unrelated types.
+      reg.handler(_activeEnvelope(chatId: 'c1', active: true), null);
+
+      reg.handler(<String, dynamic>{
+        'chat_id': 'c1',
+        'data': {
+          'type': 'chat:completion',
+          'data': {'content': 'hi'},
+        },
+      }, null);
+      reg.handler(<String, dynamic>{
+        'chat_id': 'cX',
+        'data': {'type': 'chat:list', 'data': <String, dynamic>{}},
+      }, null);
+
+      check(container.read(activeChatIdsProvider)).deepEquals({'c1'});
+    });
+
+    test('missing/non-bool active is ignored', () {
+      final socket = _MockSocketService();
+      addTearDown(socket.disposeController);
+      final container = _makeContainer(socket: socket);
+      container.read(activeChatsSyncProvider);
+      final reg = socket.registrations.single;
+
+      reg.handler(<String, dynamic>{
+        'chat_id': 'c1',
+        'data': {
+          'type': 'chat:active',
+          'data': {'active': 'yes'},
+        },
+      }, null);
+      check(container.read(activeChatIdsProvider)).isEmpty();
+    });
+  });
+
+  group('ActiveChatsSync — wildcard delivery contract', () {
+    test('registers an unscoped requireFocus:false handler', () {
+      final socket = _MockSocketService();
+      addTearDown(socket.disposeController);
+      final container = _makeContainer(socket: socket);
+      container.read(activeChatsSyncProvider);
+
+      final reg = socket.registrations.single;
+      // All-null selectors + requireFocus:false => SocketService._shouldDeliver
+      // short-circuits to deliver-always (cross-chat / other-device events).
+      check(reg.requireFocus).isFalse();
+      check(reg.conversationId).isNull();
+      check(reg.sessionId).isNull();
+      check(reg.messageId).isNull();
+    });
+
+    test(
+      'delivers a chat:active for a background chat while another is focused',
+      () {
+        final socket = _MockSocketService();
+        addTearDown(socket.disposeController);
+        final container = _makeContainer(socket: socket);
+        container.read(activeChatsSyncProvider);
+        final reg = socket.registrations.single;
+
+        // A different chat ("focused-chat") would be the foreground; the
+        // wildcard handler must still light up "background-chat".
+        reg.handler(
+          _activeEnvelope(chatId: 'background-chat', active: true),
+          null,
+        );
+        check(
+          container.read(activeChatIdsProvider),
+        ).contains('background-chat');
+      },
+    );
+  });
+
+  group('ActiveChatsSync — reconciliation fallback', () {
+    test('cold-open refresh replaces the set from checkActiveChats', () async {
+      final socket = _MockSocketService();
+      addTearDown(socket.disposeController);
+      final api = _FakeApiService()..nextActive = {'c2'};
+      final container = _makeContainer(
+        socket: socket,
+        api: api,
+        conversations: [_conv('c1'), _conv('c2')],
+      );
+
+      container.read(activeChatsSyncProvider);
+      // Resolve the conversations list so the cold-open listener fires.
+      await container.read(conversationsProvider.future);
+      await Future<void>.delayed(Duration.zero);
+
+      check(api.checkActiveChatsCalls).equals(1);
+      check(container.read(activeChatIdsProvider)).deepEquals({'c2'});
+    });
+
+    test('reconnect triggers a fresh checkActiveChats reconciliation', () async {
+      final socket = _MockSocketService();
+      addTearDown(socket.disposeController);
+      final api = _FakeApiService();
+      final container = _makeContainer(
+        socket: socket,
+        api: api,
+        conversations: [_conv('c1')],
+      );
+
+      container.read(activeChatsSyncProvider);
+      await container.read(conversationsProvider.future);
+      await Future<void>.delayed(Duration.zero);
+      final coldOpenCalls = api.checkActiveChatsCalls;
+
+      api.nextActive = {'c1'};
+      socket.emitReconnect();
+      await Future<void>.delayed(Duration.zero);
+
+      check(api.checkActiveChatsCalls).equals(coldOpenCalls + 1);
+      check(container.read(activeChatIdsProvider)).deepEquals({'c1'});
+    });
+  });
+
+  group('ActiveChatsSync — logout / socket teardown', () {
+    test('clears the set when the bound socket becomes null', () {
+      final socket = _MockSocketService();
+      addTearDown(socket.disposeController);
+
+      final container = ProviderContainer(
+        overrides: [
+          socketServiceProvider.overrideWithValue(socket),
+          conversationsProvider.overrideWith(() => _FakeConversations(const [])),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      container.read(activeChatsSyncProvider);
+      final reg = socket.registrations.single;
+      reg.handler(_activeEnvelope(chatId: 'c1', active: true), null);
+      check(container.read(activeChatIdsProvider)).contains('c1');
+
+      // Simulate logout: socketServiceProvider transitions to null. The
+      // `ref.listen<SocketService?>` inside ActiveChatsSync re-binds, and
+      // _bindSocket(null) clears the set so no stale spinner survives.
+      container.updateOverrides([
+        socketServiceProvider.overrideWithValue(null),
+        conversationsProvider.overrideWith(() => _FakeConversations(const [])),
+      ]);
+
+      check(container.read(activeChatIdsProvider)).isEmpty();
+    });
+  });
+}

--- a/test/core/providers/active_chats_sync_test.dart
+++ b/test/core/providers/active_chats_sync_test.dart
@@ -362,4 +362,41 @@ void main() {
       check(container.read(activeChatIdsProvider)).isEmpty();
     });
   });
+
+  group('ActiveChatIds — token-guarded conditional clear', () {
+    test('setInactiveIfUnchanged clears when not re-activated', () {
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+      final notifier = container.read(activeChatIdsProvider.notifier);
+
+      notifier.setActive('c1');
+      final token = notifier.activationToken('c1');
+      notifier.setInactiveIfUnchanged('c1', token);
+
+      check(container.read(activeChatIdsProvider)).not((s) => s.contains('c1'));
+    });
+
+    test(
+      'setInactiveIfUnchanged is a no-op after a racing re-activation',
+      () {
+        final container = ProviderContainer();
+        addTearDown(container.dispose);
+        final notifier = container.read(activeChatIdsProvider.notifier);
+
+        // Stream A activates the chat and finishes; its async clear captured
+        // the token now.
+        notifier.setActive('c1');
+        final tokenFromA = notifier.activationToken('c1');
+
+        // Stream B starts for the same chat before A's lookup resolves.
+        notifier.setActive('c1');
+
+        // A's stale clear resolves with an empty task list — must NOT clear,
+        // since B re-activated the chat (token changed).
+        notifier.setInactiveIfUnchanged('c1', tokenFromA);
+
+        check(container.read(activeChatIdsProvider)).contains('c1');
+      },
+    );
+  });
 }

--- a/test/core/services/chat_completion_transport_test.dart
+++ b/test/core/services/chat_completion_transport_test.dart
@@ -20,6 +20,23 @@ void main() {
       check(session.abort).isNotNull();
     });
 
+    test('resumeSocket session is socket-only with no stream or abort', () {
+      final session = ChatCompletionSession.resumeSocket(
+        messageId: 'assistant-1',
+        conversationId: 'chat-1',
+      );
+
+      // Feature C: resume maps to taskSocket transport but carries no HTTP body
+      // and no abort handle, and forces a null session id so the streaming
+      // helper binds the server's foreign message_id by chat_id.
+      check(session.transport).equals(ChatCompletionTransport.taskSocket);
+      check(session.messageId).equals('assistant-1');
+      check(session.conversationId).equals('chat-1');
+      check(session.byteStream).isNull();
+      check(session.abort).isNull();
+      check(session.sessionId).isNull();
+    });
+
     test('httpStream session stores byte stream and abort handle', () {
       final session = ChatCompletionSession.httpStream(
         messageId: 'assistant-2',

--- a/test/core/services/chat_completion_transport_test.dart
+++ b/test/core/services/chat_completion_transport_test.dart
@@ -37,6 +37,20 @@ void main() {
       check(session.sessionId).isNull();
     });
 
+    test('resumeSocket carries the discovered task id for stoppable metadata', () {
+      final session = ChatCompletionSession.resumeSocket(
+        messageId: 'assistant-1',
+        conversationId: 'chat-1',
+        taskId: 'task-42',
+      );
+
+      // The task id must survive so dispatchChatTransport writes stoppable
+      // metadata onto the resumed message (stop/delete can cancel the server
+      // task, not just the local socket subscription).
+      check(session.taskId).equals('task-42');
+      check(session.sessionId).isNull();
+    });
+
     test('httpStream session stores byte stream and abort handle', () {
       final session = ChatCompletionSession.httpStream(
         messageId: 'assistant-2',

--- a/test/core/services/conversation_parsing_test.dart
+++ b/test/core/services/conversation_parsing_test.dart
@@ -227,6 +227,29 @@ void main() {
         check(messages).length.equals(1);
         check(messages.first['content']).equals('Hi there');
       });
+
+      test('preserves Open WebUI modelName as display metadata', () {
+        final result = parseFullConversation({
+          'id': 'conv-1',
+          'messages': [
+            {
+              'id': 'msg-1',
+              'role': 'assistant',
+              'content': 'Hi there',
+              'timestamp': 1700000000,
+              'model': 'openai/gpt-4o',
+              'modelName': 'GPT-4o',
+              'modelIdx': 0,
+            },
+          ],
+        });
+
+        final messages = result['messages'] as List<Map<String, dynamic>>;
+        final metadata = messages.first['metadata'] as Map<String, dynamic>;
+        check(messages.first['model']).equals('openai/gpt-4o');
+        check(metadata['modelName']).equals('GPT-4o');
+        check(metadata['modelIdx']).equals(0);
+      });
     });
 
     group('extracts messages from history', () {

--- a/test/core/services/conversation_parsing_test.dart
+++ b/test/core/services/conversation_parsing_test.dart
@@ -248,6 +248,27 @@ void main() {
         check(messages.first['model']).equals('openai/gpt-4o');
         check(metadata['modelName']).equals('GPT-4o');
       });
+
+      test('empty modelName falls back to a populated model_name', () {
+        final result = parseFullConversation({
+          'id': 'conv-1',
+          'messages': [
+            {
+              'id': 'msg-1',
+              'role': 'assistant',
+              'content': 'Hi there',
+              'timestamp': 1700000000,
+              // Empty primary key must not shadow the populated fallback.
+              'modelName': '   ',
+              'model_name': 'GPT-4o',
+            },
+          ],
+        });
+
+        final messages = result['messages'] as List<Map<String, dynamic>>;
+        final metadata = messages.first['metadata'] as Map<String, dynamic>;
+        check(metadata['modelName']).equals('GPT-4o');
+      });
     });
 
     group('extracts messages from history', () {

--- a/test/core/services/conversation_parsing_test.dart
+++ b/test/core/services/conversation_parsing_test.dart
@@ -239,7 +239,6 @@ void main() {
               'timestamp': 1700000000,
               'model': 'openai/gpt-4o',
               'modelName': 'GPT-4o',
-              'modelIdx': 0,
             },
           ],
         });
@@ -248,7 +247,6 @@ void main() {
         final metadata = messages.first['metadata'] as Map<String, dynamic>;
         check(messages.first['model']).equals('openai/gpt-4o');
         check(metadata['modelName']).equals('GPT-4o');
-        check(metadata['modelIdx']).equals(0);
       });
     });
 

--- a/test/core/services/streaming_helper_transport_test.dart
+++ b/test/core/services/streaming_helper_transport_test.dart
@@ -904,9 +904,13 @@ void main() {
           activeConversationId: 'conv-1',
         );
 
-        await pumpMicrotasks();
-        await Future<void>.delayed(const Duration(milliseconds: 700));
-        for (var i = 0; i < 3; i++) {
+        // The post-completion snapshot refresh is an unawaited Future chain
+        // (ensureChatCompletedSynced -> refreshConversationSnapshot) with no
+        // production Timer of its own; against the fake API it settles on the
+        // event queue. Pump microtasks repeatedly to let it complete instead of
+        // waiting on a magic wall-clock delay that could silently fall out of
+        // sync with production timing.
+        for (var i = 0; i < 20; i++) {
           await pumpMicrotasks();
         }
 

--- a/test/core/services/streaming_helper_transport_test.dart
+++ b/test/core/services/streaming_helper_transport_test.dart
@@ -870,6 +870,51 @@ void main() {
       },
     );
 
+    test(
+      'httpStream snapshot refresh preserves already visible follow-ups',
+      () async {
+        final log = _CallbackLog(
+          initialMessages: [
+            ChatMessage(
+              id: 'msg-1',
+              role: 'assistant',
+              content: 'Answer',
+              timestamp: DateTime.now(),
+              isStreaming: true,
+              followUps: const ['Ask again'],
+            ),
+          ],
+        );
+        final api = _buildFakeApi(
+          pollResponse: _serverConversationResponse(
+            messages: [_serverAssistantMessage(content: 'Answer')],
+          ),
+        );
+
+        _attach(
+          session: ChatCompletionSession.httpStream(
+            messageId: 'msg-1',
+            sessionId: 'sess-1',
+            conversationId: 'conv-1',
+            byteStream: Stream<List<int>>.fromIterable([_sseDone()]),
+            abort: () async {},
+          ),
+          log: log,
+          api: api,
+          activeConversationId: 'conv-1',
+        );
+
+        await pumpMicrotasks();
+        await Future<void>.delayed(const Duration(milliseconds: 700));
+        for (var i = 0; i < 3; i++) {
+          await pumpMicrotasks();
+        }
+
+        check(log.finishCount).equals(1);
+        check(log.messages.last.followUps).deepEquals(['Ask again']);
+      },
+    );
+
     // -----------------------------------------------------------------------
     // 2. taskSocket sessions consume socket deltas and finish once on done
     // -----------------------------------------------------------------------

--- a/test/features/chat/providers/chat_messages_notifier_remote_sync_test.dart
+++ b/test/features/chat/providers/chat_messages_notifier_remote_sync_test.dart
@@ -541,6 +541,73 @@ void main() {
       check(last.isStreaming).isTrue();
     });
 
+    test(
+      'resume poll adopts server content matched by the bound foreign '
+      'message id (socket bound a server id then died)',
+      () async {
+        final timestamp = DateTime.now();
+        final opened = [
+          _userMessage('user-1', 'Hi', timestamp),
+          _assistantMessage('assistant-local', 'Partial', timestamp),
+        ];
+        // The server persists the message under its OWN (foreign) id, not the
+        // local placeholder id.
+        final grown = [
+          _userMessage('user-1', 'Hi', timestamp),
+          _assistantMessage('server-foreign', 'Partial answer that grew', timestamp),
+        ];
+        final api = _FakeApiService(_conversation('chat-1', grown, timestamp))
+          ..taskIds = ['task-1'];
+
+        final container = ProviderContainer(
+          overrides: [
+            activeConversationProvider.overrideWith(
+              () => _TestActiveConversationNotifier(),
+            ),
+            socketServiceProvider.overrideWithValue(null),
+            apiServiceProvider.overrideWithValue(api),
+          ],
+        );
+        addTearDown(container.dispose);
+
+        // Construct the notifier (so its conversation-change listener is live)
+        // before setting the conversation, so active-on-open fires.
+        check(container.read(chatMessagesProvider)).isEmpty();
+        final notifier = container.read(chatMessagesProvider.notifier);
+        container
+            .read(activeConversationProvider.notifier)
+            .set(_conversation('chat-1', opened, timestamp));
+
+        // Active-on-open re-engages streaming and arms the monitor. The first
+        // poll cannot match yet (server id differs, no bound id), so content
+        // stays 'Partial'.
+        await pumpMicrotasks();
+        await pumpMicrotasks();
+        check(container.read(chatMessagesProvider).last.isStreaming).isTrue();
+        check(container.read(chatMessagesProvider).last.content).equals('Partial');
+
+        notifier.debugCancelRemoteTaskMonitorTimer();
+        while (notifier.debugTaskStatusCheckInFlight) {
+          await pumpMicrotasks();
+        }
+
+        // The streaming helper binds the foreign server id to the local tail.
+        notifier.recordResumeBoundRemoteMessageId(
+          'assistant-local',
+          'server-foreign',
+        );
+
+        // Next poll resolves the server message by the bound foreign id and
+        // adopts its grown content (instead of leaving the chat stuck).
+        await notifier.debugSyncRemoteTaskStatus();
+        await pumpMicrotasks();
+
+        check(
+          container.read(chatMessagesProvider).last.content,
+        ).equals('Partial answer that grew');
+      },
+    );
+
     test('temporary chats are never probed for active tasks', () async {
       final timestamp = DateTime.now();
       final messages = [

--- a/test/features/chat/providers/chat_messages_notifier_remote_sync_test.dart
+++ b/test/features/chat/providers/chat_messages_notifier_remote_sync_test.dart
@@ -127,8 +127,13 @@ class _FakeApiService extends ApiService {
 
   List<String> taskIds = const <String>[];
 
+  int getConversationCalls = 0;
+
   @override
-  Future<Conversation> getConversation(String id) async => _conversation;
+  Future<Conversation> getConversation(String id) async {
+    getConversationCalls++;
+    return _conversation;
+  }
 
   @override
   Future<List<String>> getTaskIdsByChat(String chatId) async => taskIds;
@@ -568,6 +573,108 @@ void main() {
       // is skipped, so the message stays settled.
       check(container.read(chatMessagesProvider).last.isStreaming).isFalse();
     });
+
+    test(
+      'tasksDone poll defers force-adoption while a socket resume stream '
+      'still owns the chat, then finalizes once the grace window elapses',
+      () async {
+        // Feature C double-finalize race guard: when a socket resume stream
+        // protects this chat, the poll must let the socket's own `done` win for
+        // `_tasksDoneSocketGracePolls` iterations (no getConversation
+        // force-adopt). Once the window elapses, the poll resumes as the
+        // authoritative recovery finalizer and may force-adopt.
+        final timestamp = DateTime.now();
+        final messages = [
+          _userMessage('user-1', 'Hi', timestamp),
+          // Settled last message so the active-on-open probe runs (instead of
+          // immediately arming the monitor on an already-streaming message).
+          _assistantMessage('assistant-1', 'Partial', timestamp),
+        ];
+        // Server reports the finished answer (what the poll would force-adopt).
+        final finished = [
+          _userMessage('user-1', 'Hi', timestamp),
+          _assistantMessage('assistant-1', 'Final answer', timestamp),
+        ];
+        final api =
+            _FakeApiService(_conversation('chat-1', finished, timestamp))
+              // Start with an active task so the open probe observes it.
+              ..taskIds = ['task-1'];
+
+        final container = ProviderContainer(
+          overrides: [
+            activeConversationProvider.overrideWith(
+              () => _TestActiveConversationNotifier(),
+            ),
+            socketServiceProvider.overrideWithValue(null),
+            apiServiceProvider.overrideWithValue(api),
+          ],
+        );
+        addTearDown(container.dispose);
+
+        check(container.read(chatMessagesProvider)).isEmpty();
+        container
+            .read(activeConversationProvider.notifier)
+            .set(_conversation('chat-1', messages, timestamp));
+
+        final notifier = container.read(chatMessagesProvider.notifier);
+
+        // Let the active-on-open probe re-engage streaming + observe the task
+        // and arm the 1s monitor. getConversation is not used by that path.
+        await pumpMicrotasks();
+        await pumpMicrotasks();
+        check(container.read(chatMessagesProvider).last.isStreaming).isTrue();
+
+        // Cancel the periodic timer so only our manual poll iterations drive the
+        // grace logic (no background poll racing the deterministic assertions),
+        // then drain any in-flight background poll so the re-entry guard cannot
+        // short-circuit our first manual poll.
+        notifier.debugCancelRemoteTaskMonitorTimer();
+        while (notifier.debugTaskStatusCheckInFlight) {
+          await pumpMicrotasks();
+        }
+
+        // Establish a socket resume stream protecting the last message so
+        // _shouldProtectLocalStreamingState holds (Feature C resume state).
+        notifier.setSocketSubscriptions('assistant-1', [() {}]);
+        check(notifier.debugShouldProtectLocalStreamingState).isTrue();
+
+        // Reset the call counter so it cleanly measures only the force-adoption
+        // getConversation calls from the manual poll iterations below (the
+        // open-probe's progressive-resume fetch is unrelated to this guard).
+        api.getConversationCalls = 0;
+
+        // A baseline poll while the task is still active keeps protection +
+        // observed-task state intact without finalizing (tasksDone is false).
+        await notifier.debugSyncRemoteTaskStatus();
+        check(notifier.debugShouldProtectLocalStreamingState).isTrue();
+        check(notifier.debugTasksDoneGracePolls).equals(0);
+        check(api.getConversationCalls).equals(0);
+
+        // Task disappears: every subsequent poll now sees tasksDone. The grace
+        // window must suppress force-adoption for _tasksDoneSocketGracePolls (2).
+        api.taskIds = const <String>[];
+        check(notifier.debugShouldProtectLocalStreamingState).isTrue();
+
+        await notifier.debugSyncRemoteTaskStatus();
+        check(notifier.debugTasksDoneGracePolls).equals(1);
+        check(api.getConversationCalls).equals(0);
+
+        await notifier.debugSyncRemoteTaskStatus();
+        check(notifier.debugTasksDoneGracePolls).equals(2);
+        check(api.getConversationCalls).equals(0);
+
+        // Window elapsed (counter would advance past _tasksDoneSocketGracePolls):
+        // the poll resumes as the authoritative finalizer and force-adopts the
+        // server state. The finalize tears down the monitor, which resets the
+        // grace counter, so the observable post-finalize signal is the single
+        // getConversation force-adopt + the settled, adopted message.
+        await notifier.debugSyncRemoteTaskStatus();
+        check(api.getConversationCalls).equals(1);
+        check(container.read(chatMessagesProvider).last.content)
+            .equals('Final answer');
+        check(container.read(chatMessagesProvider).last.isStreaming).isFalse();
+      },
+    );
 
     test('finishStreaming releases stale socket subscriptions', () async {
       final timestamp = DateTime.now();

--- a/test/features/chat/providers/chat_messages_notifier_streaming_seams_test.dart
+++ b/test/features/chat/providers/chat_messages_notifier_streaming_seams_test.dart
@@ -482,6 +482,50 @@ void main() {
     );
 
     test(
+      'empty placeholder keeps its modelName when a pre-first-token server '
+      'snapshot lacks it',
+      () async {
+        final container = _buildContainer();
+        addTearDown(container.dispose);
+        container.read(chatMessagesProvider.notifier);
+
+        final userMessage = ChatMessage(
+          id: 'user-1',
+          role: 'user',
+          content: 'Hello',
+          timestamp: DateTime(2024, 1, 1),
+        );
+        // Fresh placeholder: no content yet, but already carries the modelName
+        // chip written at send time.
+        final placeholder = _assistantMessage(
+          id: 'assistant-1',
+          content: '',
+          metadata: const {'modelName': 'GPT-4o'},
+        );
+
+        container
+            .read(activeConversationProvider.notifier)
+            .set(_conversation('chat-1', [userMessage, placeholder]));
+        await Future<void>.delayed(Duration.zero);
+
+        // Stale snapshot adopted before the first token: server content arrives
+        // but without modelName.
+        final serverFirstTokens = _assistantMessage(
+          id: 'assistant-1',
+          content: 'Hel',
+        );
+        container
+            .read(activeConversationProvider.notifier)
+            .set(_conversation('chat-1', [userMessage, serverFirstTokens]));
+        await Future<void>.delayed(Duration.zero);
+
+        final adopted = container.read(chatMessagesProvider).last;
+        check(adopted.content).equals('Hel');
+        check(adopted.metadata?['modelName']).equals('GPT-4o');
+      },
+    );
+
+    test(
       'an older completed message defers to a corrected server snapshot; only '
       'the streaming tail is content-preserved',
       () async {

--- a/test/features/chat/providers/chat_messages_notifier_streaming_seams_test.dart
+++ b/test/features/chat/providers/chat_messages_notifier_streaming_seams_test.dart
@@ -387,4 +387,85 @@ void main() {
       },
     );
   });
+
+  group('Feature C — local streaming protection invariants', () {
+    // De-risk #1: a NORMAL send's protection behaviour must be byte-unchanged.
+    // Registering a stream/subscription for the *current* streaming message id
+    // makes protection hold; this is the exact seam dispatchChatTransport uses
+    // for both normal sends and resume, so it pins the shared behaviour.
+    test('registering subscriptions for the streaming tail enables '
+        'protection (normal-send behaviour, unchanged)', () {
+      final container = _buildContainer();
+      addTearDown(container.dispose);
+
+      final notifier = container.read(chatMessagesProvider.notifier);
+      notifier.setMessages([
+        _assistantMessage(id: 'assistant-1', content: '', isStreaming: true),
+      ]);
+
+      // No transport registered yet -> not protected.
+      check(notifier.debugShouldProtectLocalStreamingState).isFalse();
+
+      notifier.setSocketSubscriptions('assistant-1', [() {}]);
+
+      // Matching id + active subscription -> protected.
+      check(notifier.debugShouldProtectLocalStreamingState).isTrue();
+
+      // Release streaming bookkeeping before the container disposes.
+      notifier.cancelSocketSubscriptions();
+      notifier.clearMessages();
+    });
+
+    // De-risk #2: resume must set protection true ONLY for the matching message
+    // id. A subscription bound to a *different* message id than the streaming
+    // tail must NOT protect (otherwise a stale resume would suppress adoption of
+    // the genuine current message).
+    test('subscriptions bound to a non-matching message id do NOT '
+        'protect the streaming tail', () {
+      final container = _buildContainer();
+      addTearDown(container.dispose);
+
+      final notifier = container.read(chatMessagesProvider.notifier);
+      notifier.setMessages([
+        _assistantMessage(id: 'assistant-1', content: '', isStreaming: true),
+      ]);
+
+      // Register against a foreign id (simulating a stale/other-message resume).
+      notifier.setSocketSubscriptions('other-message', [() {}]);
+
+      check(notifier.debugShouldProtectLocalStreamingState).isFalse();
+
+      notifier.cancelSocketSubscriptions();
+      notifier.clearMessages();
+    });
+
+    // De-risk #5 (offline branch): with no socket, _detectActiveOnOpen's resume
+    // attach is a no-op, so opening a conversation registers no socket
+    // subscriptions and protection stays false (identical to today's poll-only
+    // behaviour). socketServiceProvider is overridden to null in _buildContainer.
+    test('opening a conversation with no socket registers no resume '
+        'subscriptions (offline poll-only fallback)', () async {
+      final container = _buildContainer();
+      addTearDown(container.dispose);
+
+      // Materialize the notifier so it listens to conversation changes.
+      container.read(chatMessagesProvider.notifier);
+
+      container
+          .read(activeConversationProvider.notifier)
+          .set(
+            _conversation('chat-1', [
+              _assistantMessage(id: 'assistant-1', content: 'Partial'),
+            ]),
+          );
+      await Future<void>.delayed(Duration.zero);
+
+      // No socket -> no resume subscriptions -> not protected. (The 1s poll
+      // fallback is gated on an API service, also null here, so it is inert.)
+      check(
+        container.read(chatMessagesProvider.notifier)
+            .debugShouldProtectLocalStreamingState,
+      ).isFalse();
+    });
+  });
 }

--- a/test/features/chat/providers/chat_messages_notifier_streaming_seams_test.dart
+++ b/test/features/chat/providers/chat_messages_notifier_streaming_seams_test.dart
@@ -386,6 +386,54 @@ void main() {
         ).deepEquals(['Ask again']);
       },
     );
+
+    test(
+      'content-preserving snapshot keeps local-only metadata (modelName) '
+      'when the server snapshot lacks it',
+      () async {
+        final container = _buildContainer();
+        addTearDown(container.dispose);
+        container.read(chatMessagesProvider.notifier);
+
+        final userMessage = ChatMessage(
+          id: 'user-1',
+          role: 'user',
+          content: 'Hello',
+          timestamp: DateTime(2024, 1, 1),
+        );
+        // Locally-streamed assistant carries the modelName chip this PR writes
+        // to every placeholder, and is fresher than the server snapshot.
+        final localAssistant = _assistantMessage(
+          id: 'assistant-1',
+          content: 'Answer that streamed completely',
+          // Locally streamed: carries provenance (transport) plus the modelName
+          // chip. The bug erased modelName when content was preserved.
+          metadata: const {'transport': 'httpStream', 'modelName': 'GPT-4o'},
+        );
+
+        container
+            .read(activeConversationProvider.notifier)
+            .set(_conversation('chat-1', [userMessage, localAssistant]));
+        await Future<void>.delayed(Duration.zero);
+
+        // Server snapshot captured before the durable payload was finalized:
+        // shorter content and no modelName.
+        final laggingServerAssistant = _assistantMessage(
+          id: 'assistant-1',
+          content: 'Answer that',
+        );
+        container
+            .read(activeConversationProvider.notifier)
+            .set(
+              _conversation('chat-1', [userMessage, laggingServerAssistant]),
+            );
+        await Future<void>.delayed(Duration.zero);
+
+        final adopted = container.read(chatMessagesProvider).last;
+        check(adopted.content).equals('Answer that streamed completely');
+        check(adopted.metadata?['modelName']).equals('GPT-4o');
+      },
+    );
   });
 
   group('Feature C — local streaming protection invariants', () {

--- a/test/features/chat/providers/chat_messages_notifier_streaming_seams_test.dart
+++ b/test/features/chat/providers/chat_messages_notifier_streaming_seams_test.dart
@@ -15,6 +15,8 @@ ChatMessage _assistantMessage({
   String id = 'assistant-1',
   String content = 'Visible response body',
   bool isStreaming = false,
+  List<String> followUps = const <String>[],
+  Map<String, dynamic>? metadata,
 }) {
   return ChatMessage(
     id: id,
@@ -22,6 +24,8 @@ ChatMessage _assistantMessage({
     content: content,
     timestamp: DateTime(2024, 1, 1),
     isStreaming: isStreaming,
+    followUps: followUps,
+    metadata: metadata,
   );
 }
 
@@ -258,6 +262,128 @@ void main() {
         check(notifications).equals(0);
 
         notifier.clearMessages();
+      },
+    );
+
+    test('streaming completion keeps the structure signature stable', () async {
+      final container = _buildContainer();
+      addTearDown(container.dispose);
+
+      final notifier = container.read(chatMessagesProvider.notifier);
+      notifier.setMessages([
+        _assistantMessage(content: 'Final response', isStreaming: true),
+      ]);
+      final initialSignature = container.read(
+        chatMessageStructureSignatureProvider,
+      );
+      var notifications = 0;
+      final subscription = container.listen<String>(
+        chatMessageStructureSignatureProvider,
+        (_, _) => notifications += 1,
+        fireImmediately: false,
+      );
+      addTearDown(subscription.close);
+
+      notifier.updateMessageById(
+        'assistant-1',
+        (current) => current.copyWith(isStreaming: false),
+      );
+      await Future<void>.delayed(Duration.zero);
+
+      check(
+        container.read(chatMessageStructureSignatureProvider),
+      ).equals(initialSignature);
+      check(notifications).equals(0);
+
+      notifier.clearMessages();
+    });
+
+    test(
+      'server snapshots do not clear already-visible follow-ups for same response',
+      () async {
+        final container = _buildContainer();
+        addTearDown(container.dispose);
+        container.read(chatMessagesProvider.notifier);
+
+        final userMessage = ChatMessage(
+          id: 'user-1',
+          role: 'user',
+          content: 'Hello',
+          timestamp: DateTime(2024, 1, 1),
+        );
+        final localAssistant = _assistantMessage(
+          id: 'assistant-1',
+          content: 'Answer',
+          followUps: const ['Ask again'],
+        );
+
+        container
+            .read(activeConversationProvider.notifier)
+            .set(_conversation('chat-1', [userMessage, localAssistant]));
+        await Future<void>.delayed(Duration.zero);
+
+        final serverAssistantWithoutFollowUps = _assistantMessage(
+          id: 'assistant-1',
+          content: 'Answer',
+        );
+        container
+            .read(activeConversationProvider.notifier)
+            .set(
+              _conversation('chat-1', [
+                userMessage,
+                serverAssistantWithoutFollowUps,
+              ]),
+            );
+        await Future<void>.delayed(Duration.zero);
+
+        check(
+          container.read(chatMessagesProvider).last.followUps,
+        ).deepEquals(['Ask again']);
+      },
+    );
+
+    test(
+      'server snapshots do not clear already-visible response content',
+      () async {
+        final container = _buildContainer();
+        addTearDown(container.dispose);
+        container.read(chatMessagesProvider.notifier);
+
+        final userMessage = ChatMessage(
+          id: 'user-1',
+          role: 'user',
+          content: 'Hello',
+          timestamp: DateTime(2024, 1, 1),
+        );
+        final localAssistant = _assistantMessage(
+          id: 'assistant-1',
+          content: 'Answer that streamed completely',
+          followUps: const ['Ask again'],
+          metadata: const {'transport': 'httpStream'},
+        );
+
+        container
+            .read(activeConversationProvider.notifier)
+            .set(_conversation('chat-1', [userMessage, localAssistant]));
+        await Future<void>.delayed(Duration.zero);
+
+        final laggingServerAssistant = _assistantMessage(
+          id: 'assistant-1',
+          content: '',
+        );
+        container
+            .read(activeConversationProvider.notifier)
+            .set(
+              _conversation('chat-1', [userMessage, laggingServerAssistant]),
+            );
+        await Future<void>.delayed(Duration.zero);
+
+        check(
+          container.read(chatMessagesProvider).last.content,
+        ).equals('Answer that streamed completely');
+        check(
+          container.read(chatMessagesProvider).last.followUps,
+        ).deepEquals(['Ask again']);
       },
     );
   });

--- a/test/features/chat/providers/chat_messages_notifier_streaming_seams_test.dart
+++ b/test/features/chat/providers/chat_messages_notifier_streaming_seams_test.dart
@@ -526,6 +526,47 @@ void main() {
     );
 
     test(
+      'an explicit empty server modelName does not blank the preserved local '
+      'model name',
+      () async {
+        final container = _buildContainer();
+        addTearDown(container.dispose);
+        container.read(chatMessagesProvider.notifier);
+
+        final userMessage = ChatMessage(
+          id: 'user-1',
+          role: 'user',
+          content: 'Hello',
+          timestamp: DateTime(2024, 1, 1),
+        );
+        final placeholder = _assistantMessage(
+          id: 'assistant-1',
+          content: '',
+          metadata: const {'modelName': 'GPT-4o'},
+        );
+
+        container
+            .read(activeConversationProvider.notifier)
+            .set(_conversation('chat-1', [userMessage, placeholder]));
+        await Future<void>.delayed(Duration.zero);
+
+        // Server snapshot carries an explicit empty modelName.
+        final serverWithBlankModel = _assistantMessage(
+          id: 'assistant-1',
+          content: 'Hel',
+          metadata: const {'modelName': '   '},
+        );
+        container
+            .read(activeConversationProvider.notifier)
+            .set(_conversation('chat-1', [userMessage, serverWithBlankModel]));
+        await Future<void>.delayed(Duration.zero);
+
+        final adopted = container.read(chatMessagesProvider).last;
+        check(adopted.metadata?['modelName']).equals('GPT-4o');
+      },
+    );
+
+    test(
       'an older completed message defers to a corrected server snapshot; only '
       'the streaming tail is content-preserved',
       () async {

--- a/test/features/chat/providers/chat_messages_notifier_streaming_seams_test.dart
+++ b/test/features/chat/providers/chat_messages_notifier_streaming_seams_test.dart
@@ -142,6 +142,49 @@ void main() {
       },
     );
 
+    test(
+      'first conversation activation preserves optimistic stream row',
+      () async {
+        final container = _buildContainer();
+        addTearDown(container.dispose);
+
+        final notifier = container.read(chatMessagesProvider.notifier);
+        final userMessage = ChatMessage(
+          id: 'user-1',
+          role: 'user',
+          content: 'Hello',
+          timestamp: DateTime(2024, 1, 1),
+        );
+        final assistantMessage = _assistantMessage(
+          id: 'assistant-1',
+          content: '',
+          isStreaming: true,
+        );
+        notifier.addMessages([userMessage, assistantMessage]);
+        final optimisticMessages = container.read(chatMessagesProvider);
+
+        var notifications = 0;
+        final subscription = container.listen<List<ChatMessage>>(
+          chatMessagesProvider,
+          (_, _) => notifications += 1,
+          fireImmediately: false,
+        );
+        addTearDown(subscription.close);
+
+        container
+            .read(activeConversationProvider.notifier)
+            .set(_conversation('local:first', [userMessage, assistantMessage]));
+        await Future<void>.delayed(Duration.zero);
+
+        check(notifications).equals(0);
+        check(
+          identical(container.read(chatMessagesProvider), optimisticMessages),
+        ).isTrue();
+
+        notifier.clearMessages();
+      },
+    );
+
     test('send failure converts active placeholder to an error row', () {
       final container = _buildContainer();
       addTearDown(container.dispose);

--- a/test/features/chat/providers/chat_messages_notifier_streaming_seams_test.dart
+++ b/test/features/chat/providers/chat_messages_notifier_streaming_seams_test.dart
@@ -480,6 +480,72 @@ void main() {
         check(adopted.metadata?['modelName']).equals('GPT-4o');
       },
     );
+
+    test(
+      'an older completed message defers to a corrected server snapshot; only '
+      'the streaming tail is content-preserved',
+      () async {
+        final container = _buildContainer();
+        addTearDown(container.dispose);
+        container.read(chatMessagesProvider.notifier);
+
+        final user1 = ChatMessage(
+          id: 'user-1',
+          role: 'user',
+          content: 'Q1',
+          timestamp: DateTime(2024, 1, 1),
+        );
+        final user2 = ChatMessage(
+          id: 'user-2',
+          role: 'user',
+          content: 'Q2',
+          timestamp: DateTime(2024, 1, 1),
+        );
+        // Older, already-completed assistant whose local body is longer than
+        // the server's with a matching prefix — must NOT block a correction.
+        final olderLocal = _assistantMessage(
+          id: 'assistant-1',
+          content: 'Answer one local-extra',
+          metadata: const {'responseDone': true},
+        );
+        // Streaming tail: its longer local body is still preserved.
+        final tailLocal = _assistantMessage(
+          id: 'assistant-2',
+          content: 'Answer two streamed completely',
+          metadata: const {'transport': 'httpStream'},
+        );
+
+        container
+            .read(activeConversationProvider.notifier)
+            .set(_conversation('chat-1', [user1, olderLocal, user2, tailLocal]));
+        await Future<void>.delayed(Duration.zero);
+
+        // Authoritative server snapshot: the older message is corrected
+        // (shorter, same prefix); the tail still lags.
+        final olderServer = _assistantMessage(
+          id: 'assistant-1',
+          content: 'Answer one',
+        );
+        final tailServer = _assistantMessage(
+          id: 'assistant-2',
+          content: 'Answer two',
+        );
+        container
+            .read(activeConversationProvider.notifier)
+            .set(
+              _conversation('chat-1', [user1, olderServer, user2, tailServer]),
+            );
+        await Future<void>.delayed(Duration.zero);
+
+        final messages = container.read(chatMessagesProvider);
+        final older = messages.firstWhere((m) => m.id == 'assistant-1');
+        final tail = messages.firstWhere((m) => m.id == 'assistant-2');
+        // Older completed message defers to the server correction.
+        check(older.content).equals('Answer one');
+        // Streaming tail keeps its longer local body.
+        check(tail.content).equals('Answer two streamed completely');
+      },
+    );
   });
 
   group('Feature C — local streaming protection invariants', () {

--- a/test/features/chat/providers/chat_messages_notifier_streaming_seams_test.dart
+++ b/test/features/chat/providers/chat_messages_notifier_streaming_seams_test.dart
@@ -142,6 +142,46 @@ void main() {
       },
     );
 
+    test('send failure converts active placeholder to an error row', () {
+      final container = _buildContainer();
+      addTearDown(container.dispose);
+
+      final notifier = container.read(chatMessagesProvider.notifier);
+      notifier.setMessages([
+        ChatMessage(
+          id: 'user-1',
+          role: 'user',
+          content: 'Hello',
+          timestamp: DateTime(2024, 1, 1),
+        ),
+        _assistantMessage(id: 'assistant-1', content: '', isStreaming: true),
+      ]);
+
+      notifier.failLastStreamingAssistant(Exception('500'));
+
+      final messages = container.read(chatMessagesProvider);
+      check(messages).length.equals(2);
+      check(messages.last.id).equals('assistant-1');
+      check(messages.last.isStreaming).isFalse();
+      check(messages.last.error).isNotNull();
+      check(
+        messages.last.error!.content ?? '',
+      ).contains('server returned an error');
+    });
+
+    test('durable assistant payload preserves display modelName', () {
+      final payload = debugBuildDurableAssistantPayloadForTesting(
+        id: 'assistant-1',
+        parentId: 'user-1',
+        modelId: 'openai/gpt-4o',
+        modelName: 'GPT-4o',
+        timestamp: 1700000000,
+      );
+
+      check(payload['model']).equals('openai/gpt-4o');
+      check(payload['modelName']).equals('GPT-4o');
+    });
+
     test(
       'streaming content-only changes keep the structure signature stable',
       () async {

--- a/test/features/chat/providers/chat_messages_notifier_streaming_seams_test.dart
+++ b/test/features/chat/providers/chat_messages_notifier_streaming_seams_test.dart
@@ -388,6 +388,52 @@ void main() {
     );
 
     test(
+      'preserved follow-ups also overwrite a stale empty followUps key in '
+      'server metadata',
+      () async {
+        final container = _buildContainer();
+        addTearDown(container.dispose);
+        container.read(chatMessagesProvider.notifier);
+
+        final userMessage = ChatMessage(
+          id: 'user-1',
+          role: 'user',
+          content: 'Hello',
+          timestamp: DateTime(2024, 1, 1),
+        );
+        final localAssistant = _assistantMessage(
+          id: 'assistant-1',
+          content: 'Answer',
+          followUps: const ['Ask again'],
+        );
+
+        container
+            .read(activeConversationProvider.notifier)
+            .set(_conversation('chat-1', [userMessage, localAssistant]));
+        await Future<void>.delayed(Duration.zero);
+
+        // Server snapshot drops the follow-ups AND carries an explicit empty
+        // followUps in its metadata map.
+        final serverAssistant = _assistantMessage(
+          id: 'assistant-1',
+          content: 'Answer',
+          metadata: const {'followUps': <String>[]},
+        );
+        container
+            .read(activeConversationProvider.notifier)
+            .set(_conversation('chat-1', [userMessage, serverAssistant]));
+        await Future<void>.delayed(Duration.zero);
+
+        final adopted = container.read(chatMessagesProvider).last;
+        check(adopted.followUps).deepEquals(['Ask again']);
+        // The metadata mirror must match the typed field, not stay stale [].
+        check(
+          (adopted.metadata?['followUps'] as List).cast<String>(),
+        ).deepEquals(['Ask again']);
+      },
+    );
+
+    test(
       'content-preserving snapshot keeps local-only metadata (modelName) '
       'when the server snapshot lacks it',
       () async {

--- a/test/features/chat/providers/chat_messages_notifier_streaming_seams_test.dart
+++ b/test/features/chat/providers/chat_messages_notifier_streaming_seams_test.dart
@@ -107,6 +107,42 @@ void main() {
     });
 
     test(
+      'batched optimistic turn exposes user and assistant together',
+      () async {
+        final container = _buildContainer();
+        addTearDown(container.dispose);
+
+        final notifier = container.read(chatMessagesProvider.notifier);
+        var notifications = 0;
+        final subscription = container.listen<List<ChatMessage>>(
+          chatMessagesProvider,
+          (_, _) => notifications += 1,
+          fireImmediately: false,
+        );
+        addTearDown(subscription.close);
+
+        notifier.addMessages([
+          ChatMessage(
+            id: 'user-1',
+            role: 'user',
+            content: 'Hello',
+            timestamp: DateTime(2024, 1, 1),
+          ),
+          _assistantMessage(id: 'assistant-1', content: '', isStreaming: true),
+        ]);
+        await Future<void>.delayed(Duration.zero);
+
+        final messages = container.read(chatMessagesProvider);
+        check(notifications).equals(1);
+        check(messages).length.equals(2);
+        check(messages.last.id).equals('assistant-1');
+        check(messages.last.isStreaming).isTrue();
+
+        notifier.clearMessages();
+      },
+    );
+
+    test(
       'streaming content-only changes keep the structure signature stable',
       () async {
         final container = _buildContainer();

--- a/test/features/chat/providers/chat_transport_parity_test.dart
+++ b/test/features/chat/providers/chat_transport_parity_test.dart
@@ -250,6 +250,7 @@ ActiveChatStream _attach({
   String sessionId = 'sess-1',
   String? activeConversationId = 'conv-1',
   SocketService? socketService,
+  void Function(String? chatId, bool active)? onChatActiveChanged,
 }) {
   return attachUnifiedChunkedStreaming(
     session: session,
@@ -261,6 +262,7 @@ ActiveChatStream _attach({
     activeConversationId: activeConversationId,
     api: api ?? _buildFakeApi(),
     socketService: socketService,
+    onChatActiveChanged: onChatActiveChanged,
     workerManager: workerManager ?? WorkerManager(maxConcurrentTasks: 1),
     appendToLastMessage: log.appendToLastMessage,
     bufferLastMessageContent: log.bufferLastMessageContent,
@@ -544,6 +546,362 @@ void main() {
       check(log.replacedContents.last).equals('Full JSON response');
       check(log.finishCount).equals(1);
     });
+  });
+
+  group('Feature C — socket resume session shape', () {
+    test('resumeSocket maps to a socket-only taskSocket session', () {
+      final session = ChatCompletionSession.resumeSocket(
+        messageId: 'local-msg-1',
+        conversationId: 'conv-1',
+      );
+
+      // Resume must be a socket-only taskSocket: no HTTP body to forward and no
+      // abort handle (cancellation flows through the task registry). sessionId
+      // is forced null so foreign-session chat:completion events still bind.
+      check(session.transport).equals(ChatCompletionTransport.taskSocket);
+      check(session.messageId).equals('local-msg-1');
+      check(session.conversationId).equals('conv-1');
+      check(session.byteStream).isNull();
+      check(session.abort).isNull();
+      check(session.sessionId).isNull();
+    });
+
+    test('resume binds a foreign server message_id by chat_id '
+        'when sessionId is null (REPLACE semantics)', () async {
+      // Local placeholder id differs from the server's message_id. With a null
+      // session id the helper must bind the foreign id via chat_id and apply
+      // cumulative `content` as REPLACE onto the local message.
+      final log = _CallbackLog(
+        initialMessages: _fakeStreamingMessages(id: 'local-msg-1'),
+      );
+      final registrar = FakeSocketInjector();
+      final socket = _MockSocketService(registrar);
+
+      _attach(
+        session: ChatCompletionSession.resumeSocket(
+          messageId: 'local-msg-1',
+          conversationId: 'conv-1',
+        ),
+        log: log,
+        assistantMessageId: 'local-msg-1',
+        // Force the helper into the resume registration mode (chat-id-only).
+        sessionId: '',
+        activeConversationId: 'conv-1',
+        socketService: socket,
+      );
+
+      await pumpMicrotasks();
+
+      // Cumulative REPLACE deltas carrying a *foreign* server message_id.
+      registrar.emitChatEvent(
+        'chat:completion',
+        {'content': 'Hel'},
+        conversationId: 'conv-1',
+        messageId: 'server-msg-1',
+      );
+      await pumpMicrotasks();
+      registrar.emitChatEvent(
+        'chat:completion',
+        {'content': 'Hello'},
+        conversationId: 'conv-1',
+        messageId: 'server-msg-1',
+      );
+      await pumpMicrotasks();
+
+      // The local message id is preserved; cumulative content is the latest.
+      check(log.messages.last.id).equals('local-msg-1');
+      check(log.messages.last.content).equals('Hello');
+      check(log.replacedContents.last).equals('Hello');
+
+      registrar.emitChatEvent(
+        'chat:completion',
+        {'done': true},
+        conversationId: 'conv-1',
+        messageId: 'server-msg-1',
+      );
+      await pumpMicrotasks();
+
+      check(log.finishCount).equals(1);
+      check(log.messages.last.isStreaming).isFalse();
+    });
+
+    test('resume socket done finalizes exactly once (helper-layer '
+        'idempotency)', () async {
+      // Helper-layer guard: a single socket `done` for the resumed message must
+      // produce exactly one finalize and leave the message settled. (The
+      // notifier-level poll/socket double-finalize grace window is covered in
+      // chat_messages_notifier_remote_sync_test.dart; this seam does not run
+      // that poll.)
+      final log = _CallbackLog(
+        initialMessages: _fakeStreamingMessages(id: 'local-msg-1'),
+      );
+      final registrar = FakeSocketInjector();
+      final socket = _MockSocketService(registrar);
+
+      _attach(
+        session: ChatCompletionSession.resumeSocket(
+          messageId: 'local-msg-1',
+          conversationId: 'conv-1',
+        ),
+        log: log,
+        assistantMessageId: 'local-msg-1',
+        sessionId: '',
+        activeConversationId: 'conv-1',
+        socketService: socket,
+      );
+
+      await pumpMicrotasks();
+
+      registrar.emitChatEvent(
+        'chat:completion',
+        {'content': 'Hello', 'done': true},
+        conversationId: 'conv-1',
+        messageId: 'server-msg-1',
+      );
+
+      // Pump generously so any redundant recovery path would have a chance to
+      // fire a second finalize.
+      for (var i = 0; i < 10; i++) {
+        await pumpMicrotasks();
+      }
+
+      check(log.finishCount).equals(1);
+      check(log.messages.last.isStreaming).isFalse();
+      check(log.messages.last.content).equals('Hello');
+    });
+
+    test('resume APPENDs choices[].delta.content increments', () async {
+      final log = _CallbackLog(
+        initialMessages: _fakeStreamingMessages(id: 'local-msg-1'),
+      );
+      final registrar = FakeSocketInjector();
+      final socket = _MockSocketService(registrar);
+
+      _attach(
+        session: ChatCompletionSession.resumeSocket(
+          messageId: 'local-msg-1',
+          conversationId: 'conv-1',
+        ),
+        log: log,
+        assistantMessageId: 'local-msg-1',
+        sessionId: '',
+        activeConversationId: 'conv-1',
+        socketService: socket,
+      );
+
+      await pumpMicrotasks();
+
+      registrar.emitChatEvent('chat:completion', {
+        'choices': [
+          {
+            'delta': {'content': 'He'},
+          },
+        ],
+      }, conversationId: 'conv-1', messageId: 'server-msg-1');
+      await pumpMicrotasks();
+      registrar.emitChatEvent('chat:completion', {
+        'choices': [
+          {
+            'delta': {'content': 'llo'},
+          },
+        ],
+      }, conversationId: 'conv-1', messageId: 'server-msg-1');
+      await pumpMicrotasks();
+
+      check(log.appendedChunks).deepEquals(['He', 'llo']);
+      check(log.messages.last.content).equals('Hello');
+    });
+  });
+
+  group('Sidebar indicator — optimistic START gating', () {
+    ChatCompletionSession taskSocket({String? taskId = 'task-1'}) =>
+        ChatCompletionSession.taskSocket(
+          messageId: 'msg-1',
+          sessionId: 'sess-1',
+          conversationId: 'conv-1',
+          taskId: taskId ?? '',
+        );
+
+    test('taskSocket with task id + persisted chat => true', () {
+      check(
+        shouldOptimisticallyMarkChatActive(
+          session: taskSocket(),
+          conversationId: 'conv-1',
+        ),
+      ).isTrue();
+    });
+
+    test('httpStream => false (no task_ids signal)', () {
+      check(
+        shouldOptimisticallyMarkChatActive(
+          session: ChatCompletionSession.httpStream(
+            messageId: 'msg-1',
+            byteStream: const Stream.empty(),
+            abort: () async {},
+          ),
+          conversationId: 'conv-1',
+        ),
+      ).isFalse();
+    });
+
+    test('jsonCompletion => false', () {
+      check(
+        shouldOptimisticallyMarkChatActive(
+          session: ChatCompletionSession.jsonCompletion(
+            messageId: 'msg-1',
+            jsonPayload: const <String, dynamic>{},
+          ),
+          conversationId: 'conv-1',
+        ),
+      ).isFalse();
+    });
+
+    test('taskSocket with empty task id => false', () {
+      check(
+        shouldOptimisticallyMarkChatActive(
+          session: taskSocket(taskId: ''),
+          conversationId: 'conv-1',
+        ),
+      ).isFalse();
+    });
+
+    test('null / empty conversation id => false', () {
+      check(
+        shouldOptimisticallyMarkChatActive(
+          session: taskSocket(),
+          conversationId: null,
+        ),
+      ).isFalse();
+      check(
+        shouldOptimisticallyMarkChatActive(
+          session: taskSocket(),
+          conversationId: '',
+        ),
+      ).isFalse();
+    });
+
+    test('temporary chat => false', () {
+      check(
+        shouldOptimisticallyMarkChatActive(
+          session: taskSocket(),
+          conversationId: 'local:abc',
+        ),
+      ).isFalse();
+    });
+  });
+
+  group('Sidebar indicator — paired setInactive on success/cancel/error', () {
+    test(
+      'chat:completion {done:true} fires onChatActiveChanged(chatId, false)',
+      () async {
+        final log = _CallbackLog();
+        final registrar = FakeSocketInjector();
+        final socket = _MockSocketService(registrar);
+        final activeEvents = <(String?, bool)>[];
+
+        _attach(
+          session: ChatCompletionSession.taskSocket(
+            messageId: 'msg-1',
+            sessionId: 'sess-1',
+            conversationId: 'conv-1',
+            taskId: 'task-1',
+          ),
+          log: log,
+          socketService: socket,
+          onChatActiveChanged: (chatId, active) =>
+              activeEvents.add((chatId, active)),
+        );
+
+        registrar.emitChatEvent(
+          'chat:completion',
+          {'content': 'Hello', 'done': true},
+          conversationId: 'conv-1',
+          sessionId: 'sess-1',
+          messageId: 'msg-1',
+        );
+
+        await pumpMicrotasks();
+
+        // The normal success finalize must clear the spinner directly, so a
+        // dropped/late backend chat:active{false} cannot strand it. Symmetric
+        // with the cancel + error branches.
+        check(activeEvents).contains(('conv-1', false));
+      },
+    );
+
+    test(
+      'chat:tasks:cancel fires onChatActiveChanged(chatId, false)',
+      () async {
+        final log = _CallbackLog();
+        final registrar = FakeSocketInjector();
+        final socket = _MockSocketService(registrar);
+        final activeEvents = <(String?, bool)>[];
+
+        _attach(
+          session: ChatCompletionSession.taskSocket(
+            messageId: 'msg-1',
+            sessionId: 'sess-1',
+            conversationId: 'conv-1',
+            taskId: 'task-1',
+          ),
+          log: log,
+          socketService: socket,
+          onChatActiveChanged: (chatId, active) =>
+              activeEvents.add((chatId, active)),
+        );
+
+        registrar.emitChatEvent(
+          'chat:tasks:cancel',
+          <String, dynamic>{},
+          conversationId: 'conv-1',
+          sessionId: 'sess-1',
+          messageId: 'msg-1',
+        );
+
+        await pumpMicrotasks();
+
+        // The spinner must be cleared even if the backend's chat:active{false}
+        // is never delivered (it only fires when the LAST task finishes).
+        check(activeEvents).contains(('conv-1', false));
+      },
+    );
+
+    test(
+      'chat:message:error fires onChatActiveChanged(chatId, false)',
+      () async {
+        final log = _CallbackLog();
+        final registrar = FakeSocketInjector();
+        final socket = _MockSocketService(registrar);
+        final activeEvents = <(String?, bool)>[];
+
+        _attach(
+          session: ChatCompletionSession.taskSocket(
+            messageId: 'msg-1',
+            sessionId: 'sess-1',
+            conversationId: 'conv-1',
+            taskId: 'task-1',
+          ),
+          log: log,
+          socketService: socket,
+          onChatActiveChanged: (chatId, active) =>
+              activeEvents.add((chatId, active)),
+        );
+
+        registrar.emitChatEvent(
+          'chat:message:error',
+          {
+            'error': {'content': 'boom'},
+          },
+          conversationId: 'conv-1',
+          sessionId: 'sess-1',
+          messageId: 'msg-1',
+        );
+
+        await pumpMicrotasks();
+
+        check(activeEvents).contains(('conv-1', false));
+      },
+    );
   });
 
   group('Transport-aware stop', () {

--- a/test/features/chat/providers/chat_transport_parity_test.dart
+++ b/test/features/chat/providers/chat_transport_parity_test.dart
@@ -711,6 +711,50 @@ void main() {
       check(log.appendedChunks).deepEquals(['He', 'llo']);
       check(log.messages.last.content).equals('Hello');
     });
+
+    test('resume APPEND deltas concatenate onto already-visible partial '
+        'content (seed, no prefix loss or duplication)', () async {
+      // The real resume scenario: the chat was opened already showing a partial
+      // assistant response, and the live socket continues it with incremental
+      // deltas. The rendered buffer must seed from the visible partial so the
+      // first delta appends onto it rather than replacing or duplicating it.
+      final log = _CallbackLog(
+        initialMessages: _fakeStreamingMessages(
+          id: 'local-msg-1',
+          content: 'Par',
+        ),
+      );
+      final registrar = FakeSocketInjector();
+      final socket = _MockSocketService(registrar);
+
+      _attach(
+        session: ChatCompletionSession.resumeSocket(
+          messageId: 'local-msg-1',
+          conversationId: 'conv-1',
+        ),
+        log: log,
+        assistantMessageId: 'local-msg-1',
+        sessionId: '',
+        activeConversationId: 'conv-1',
+        socketService: socket,
+      );
+
+      await pumpMicrotasks();
+
+      registrar.emitChatEvent('chat:completion', {
+        'choices': [
+          {
+            'delta': {'content': 'tial'},
+          },
+        ],
+      }, conversationId: 'conv-1', messageId: 'server-msg-1');
+      await pumpMicrotasks();
+
+      // Only the new delta is appended; the already-visible 'Par' prefix is
+      // preserved (not re-sent, not dropped).
+      check(log.appendedChunks).deepEquals(['tial']);
+      check(log.messages.last.content).equals('Partial');
+    });
   });
 
   group('Sidebar indicator — optimistic START gating', () {

--- a/test/features/chat/views/chat_page_layout_metadata_test.dart
+++ b/test/features/chat/views/chat_page_layout_metadata_test.dart
@@ -65,6 +65,26 @@ void main() {
     },
   );
 
+  test(
+    'layout metadata uses Open WebUI modelName before model lookup loads',
+    () {
+      final messages = <ChatMessage>[
+        ChatMessage(
+          id: 'assistant-1',
+          role: 'assistant',
+          content: 'Visible response',
+          timestamp: DateTime(2026),
+          model: 'openai/gpt-4o',
+          metadata: const {'modelName': 'GPT-4o'},
+        ),
+      ];
+
+      final summary = debugBuildChatListLayoutSummaryForTesting(messages);
+
+      expect(summary.single.displayModelName, 'GPT-4o');
+    },
+  );
+
   test('layout signature ignores streaming content-only changes', () {
     final streamingMessage = ChatMessage(
       id: 'assistant-streaming',

--- a/test/features/chat/views/chat_page_layout_metadata_test.dart
+++ b/test/features/chat/views/chat_page_layout_metadata_test.dart
@@ -111,6 +111,48 @@ void main() {
     expect(updatedSignature, initialSignature);
   });
 
+  test('layout signature ignores streaming completion-only changes', () {
+    final streamingMessage = ChatMessage(
+      id: 'assistant-streaming',
+      role: 'assistant',
+      content: 'Final response',
+      timestamp: DateTime(2026),
+      model: 'model-a',
+      isStreaming: true,
+      attachmentIds: const ['attachment-1'],
+      statusHistory: const [ChatStatusUpdate(description: 'Done')],
+    );
+    final completedMessage = streamingMessage.copyWith(isStreaming: false);
+
+    final streamingSignature =
+        debugBuildChatListStableLayoutSignatureForTesting([streamingMessage]);
+    final completedSignature =
+        debugBuildChatListStableLayoutSignatureForTesting([completedMessage]);
+
+    expect(completedSignature, streamingSignature);
+  });
+
+  test('layout estimates stay stable when streaming completes', () {
+    final streamingMessage = ChatMessage(
+      id: 'assistant-streaming',
+      role: 'assistant',
+      content: 'Final response with enough text to get a real height estimate.',
+      timestamp: DateTime(2026),
+      model: 'model-a',
+      isStreaming: true,
+    );
+    final completedMessage = streamingMessage.copyWith(isStreaming: false);
+
+    final streamingExtent = debugEstimateMessageListExtentForTesting([
+      streamingMessage,
+    ], index: 0);
+    final completedExtent = debugEstimateMessageListExtentForTesting([
+      completedMessage,
+    ], index: 0);
+
+    expect(completedExtent, streamingExtent);
+  });
+
   test('layout signature changes for structural layout inputs', () {
     final baseMessage = ChatMessage(
       id: 'assistant-1',
@@ -509,17 +551,5 @@ void main() {
 
     expect(whilePinnedToTop, isFalse);
     expect(whileUserScrolling, isFalse);
-  });
-
-  test('clearing pin-to-top tracking preserves the active phantom sliver', () {
-    final cleared = debugClearPinToTopTrackingForTesting(
-      isActive: true,
-      userMessageId: 'user-1',
-      streamingMessageId: 'assistant-1',
-    );
-
-    expect(cleared.isActive, isTrue);
-    expect(cleared.userMessageId, isNull);
-    expect(cleared.streamingMessageId, isNull);
   });
 }

--- a/test/features/chat/views/chat_page_layout_metadata_test.dart
+++ b/test/features/chat/views/chat_page_layout_metadata_test.dart
@@ -132,26 +132,51 @@ void main() {
     expect(completedSignature, streamingSignature);
   });
 
-  test('layout estimates stay stable when streaming completes', () {
-    final streamingMessage = ChatMessage(
-      id: 'assistant-streaming',
-      role: 'assistant',
-      content: 'Final response with enough text to get a real height estimate.',
-      timestamp: DateTime(2026),
-      model: 'model-a',
-      isStreaming: true,
-    );
-    final completedMessage = streamingMessage.copyWith(isStreaming: false);
+  test(
+    'layout estimate ignores the streaming flag but reacts to completion '
+    'content growth',
+    () {
+      final streamingMessage = ChatMessage(
+        id: 'assistant-streaming',
+        role: 'assistant',
+        content:
+            'Final response with enough text to get a real height estimate.',
+        timestamp: DateTime(2026),
+        model: 'model-a',
+        isStreaming: true,
+      );
+      // Flipping only the streaming flag must not change the estimate: the
+      // estimator intentionally does not read message.isStreaming.
+      final completedMessage = streamingMessage.copyWith(isStreaming: false);
 
-    final streamingExtent = debugEstimateMessageListExtentForTesting([
-      streamingMessage,
-    ], index: 0);
-    final completedExtent = debugEstimateMessageListExtentForTesting([
-      completedMessage,
-    ], index: 0);
+      final streamingExtent = debugEstimateMessageListExtentForTesting([
+        streamingMessage,
+      ], index: 0);
+      final completedExtent = debugEstimateMessageListExtentForTesting([
+        completedMessage,
+      ], index: 0);
 
-    expect(completedExtent, streamingExtent);
-  });
+      expect(completedExtent, streamingExtent);
+
+      // Positive control: the real completion-driven layout shift is content
+      // growing from a short stream to a full response. The estimator consumes
+      // content length, so a longer completed body must produce a larger
+      // extent. This proves the estimator is not inert and guards against the
+      // stability assertion above passing vacuously.
+      final grownMessage = completedMessage.copyWith(
+        content:
+            '${completedMessage.content}\n\n'
+            'A substantially longer follow-up paragraph that adds several more '
+            'lines of content so the estimated height must increase relative to '
+            'the shorter streaming body above.',
+      );
+      final grownExtent = debugEstimateMessageListExtentForTesting([
+        grownMessage,
+      ], index: 0);
+
+      expect(grownExtent, greaterThan(completedExtent));
+    },
+  );
 
   test('layout signature changes for structural layout inputs', () {
     final baseMessage = ChatMessage(

--- a/test/features/chat/widgets/assistant_message_widget_footer_test.dart
+++ b/test/features/chat/widgets/assistant_message_widget_footer_test.dart
@@ -1,4 +1,5 @@
 import 'package:conduit/core/models/chat_message.dart';
+import 'package:conduit/core/services/settings_service.dart';
 import 'package:conduit/features/chat/providers/assistant_response_builder_provider.dart';
 import 'package:conduit/features/chat/providers/chat_providers.dart';
 import 'package:conduit/features/chat/providers/queued_completion_provider.dart';
@@ -73,6 +74,7 @@ Widget _buildAssistantHarness(
       textToSpeechControllerProvider.overrideWith(
         _TestTextToSpeechController.new,
       ),
+      streamingHapticsEnabledProvider.overrideWithValue(false),
       if (isChatStreaming != null)
         isChatStreamingProvider.overrideWithValue(isChatStreaming),
     ],
@@ -94,6 +96,16 @@ Widget _buildAssistantHarness(
       ),
     ),
   );
+}
+
+bool _hasInProgressFadeAncestor(WidgetTester tester, Finder childFinder) {
+  final fadeFinder = find.ancestor(
+    of: childFinder,
+    matching: find.byType(FadeTransition),
+  );
+  return tester
+      .widgetList<FadeTransition>(fadeFinder)
+      .any((fade) => fade.opacity.value < 1);
 }
 
 Future<void> _tapVersionControl(
@@ -336,6 +348,49 @@ void main() {
     expect(find.text('Try another angle'), findsOneWidget);
   });
 
+  testWidgets('follow-ups stay visible through transient empty snapshots', (
+    tester,
+  ) async {
+    final baseline = ChatMessage(
+      id: 'assistant-follow-ups',
+      role: 'assistant',
+      content: 'Visible response body',
+      timestamp: DateTime(2024, 1, 1),
+    );
+
+    await tester.pumpWidget(
+      _buildAssistantHarness(
+        baseline.copyWith(followUps: const ['Ask again']),
+        showFollowUps: true,
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.byType(FollowUpSuggestionBar), findsOneWidget);
+    expect(find.text('Ask again'), findsOneWidget);
+
+    await tester.pumpWidget(
+      _buildAssistantHarness(baseline, showFollowUps: true),
+    );
+    await tester.pump();
+
+    expect(find.byType(FollowUpSuggestionBar), findsOneWidget);
+    expect(find.text('Ask again'), findsOneWidget);
+    expect(find.byType(SizeTransition), findsNothing);
+
+    await tester.pumpWidget(
+      _buildAssistantHarness(
+        baseline.copyWith(followUps: const ['Try another angle']),
+        showFollowUps: true,
+      ),
+    );
+    await tester.pump();
+
+    expect(find.byType(FollowUpSuggestionBar), findsOneWidget);
+    expect(find.text('Ask again'), findsNothing);
+    expect(find.text('Try another angle'), findsOneWidget);
+  });
+
   testWidgets(
     'response-done metadata shows enabled footer actions immediately',
     (tester) async {
@@ -454,6 +509,129 @@ void main() {
 
     expect(find.byKey(const ValueKey('typing')), findsOneWidget);
     expect(ttsBuilds, 0);
+  });
+
+  testWidgets('streaming footer fades typing in and crossfades to actions', (
+    tester,
+  ) async {
+    final streaming = ChatMessage(
+      id: 'assistant-streaming-footer-fade',
+      role: 'assistant',
+      content: '',
+      timestamp: DateTime(2024, 1, 1),
+      isStreaming: true,
+    );
+
+    await tester.pumpWidget(
+      _buildAssistantHarness(streaming, isStreaming: true),
+    );
+    await tester.pump();
+
+    final typingFinder = find.byKey(const ValueKey('typing'));
+    expect(typingFinder, findsNothing);
+
+    await tester.pump(const Duration(milliseconds: 150));
+
+    expect(typingFinder, findsOneWidget);
+    expect(_hasInProgressFadeAncestor(tester, typingFinder), isTrue);
+
+    await tester.pump(const Duration(milliseconds: 220));
+    expect(_hasInProgressFadeAncestor(tester, typingFinder), isFalse);
+
+    final done = streaming.copyWith(
+      content: 'Done',
+      metadata: const {'responseDone': true},
+    );
+    await tester.pumpWidget(_buildAssistantHarness(done, isStreaming: true));
+    await tester.pump();
+
+    final actionsFinder = find.byKey(const ValueKey('actions'));
+    expect(typingFinder, findsOneWidget);
+    expect(actionsFinder, findsOneWidget);
+    expect(_hasInProgressFadeAncestor(tester, actionsFinder), isTrue);
+
+    await tester.pump(const Duration(milliseconds: 220));
+
+    expect(typingFinder, findsNothing);
+    expect(actionsFinder, findsOneWidget);
+    expect(_hasInProgressFadeAncestor(tester, actionsFinder), isFalse);
+  });
+
+  testWidgets('streaming body fades in once when first content arrives', (
+    tester,
+  ) async {
+    ChatMessage streamingMessage(String content) => ChatMessage(
+      id: 'assistant-streaming-fade',
+      role: 'assistant',
+      content: content,
+      timestamp: DateTime(2024, 1, 1),
+      isStreaming: true,
+    );
+
+    await tester.pumpWidget(
+      _buildAssistantHarness(streamingMessage(''), isStreaming: true),
+    );
+    await tester.pump();
+
+    expect(
+      find.byKey(const ValueKey('assistant-streaming-content-fade')),
+      findsNothing,
+    );
+
+    await tester.pumpWidget(
+      _buildAssistantHarness(streamingMessage('Hello'), isStreaming: true),
+    );
+    await tester.pump();
+    await tester.pump();
+
+    final fadeFinder = find.byKey(
+      const ValueKey('assistant-streaming-content-fade'),
+    );
+    expect(fadeFinder, findsOneWidget);
+    expect(
+      tester.widget<FadeTransition>(fadeFinder).opacity.value,
+      lessThan(1),
+    );
+
+    await tester.pump(const Duration(milliseconds: 300));
+    expect(tester.widget<FadeTransition>(fadeFinder).opacity.value, 1);
+
+    await tester.pumpWidget(
+      _buildAssistantHarness(
+        streamingMessage('Hello again'),
+        isStreaming: true,
+      ),
+    );
+    await tester.pump();
+    await tester.pump();
+
+    expect(tester.widget<FadeTransition>(fadeFinder).opacity.value, 1);
+  });
+
+  testWidgets('streaming body fades when first content is present on mount', (
+    tester,
+  ) async {
+    final message = ChatMessage(
+      id: 'assistant-streaming-initial-fade',
+      role: 'assistant',
+      content: 'Already streaming',
+      timestamp: DateTime(2024, 1, 1),
+      isStreaming: true,
+    );
+
+    await tester.pumpWidget(_buildAssistantHarness(message, isStreaming: true));
+    await tester.pump();
+
+    final fadeFinder = find.byKey(
+      const ValueKey('assistant-streaming-content-fade'),
+    );
+    expect(fadeFinder, findsOneWidget);
+    expect(
+      tester.widget<FadeTransition>(fadeFinder).opacity.value,
+      lessThan(1),
+    );
+    await tester.pump(const Duration(milliseconds: 300));
+    expect(tester.widget<FadeTransition>(fadeFinder).opacity.value, 1);
   });
 
   testWidgets('response-done metadata enables copy immediately', (

--- a/test/features/chat/widgets/assistant_message_widget_footer_test.dart
+++ b/test/features/chat/widgets/assistant_message_widget_footer_test.dart
@@ -39,6 +39,18 @@ class _RecordingTextToSpeechController extends TextToSpeechController {
   }
 }
 
+class _CountingTextToSpeechController extends TextToSpeechController {
+  _CountingTextToSpeechController(this.onBuild);
+
+  final VoidCallback onBuild;
+
+  @override
+  TextToSpeechState build() {
+    onBuild();
+    return const TextToSpeechState();
+  }
+}
+
 Widget _buildHarness(Widget child) {
   return MaterialApp(
     theme: AppTheme.light(TweakcnThemes.t3Chat),
@@ -401,6 +413,47 @@ void main() {
 
     expect(find.byKey(const ValueKey('actions')), findsNothing);
     expect(find.byKey(const ValueKey('typing')), findsOneWidget);
+  });
+
+  testWidgets('streaming footer skips hidden action provider work', (
+    tester,
+  ) async {
+    var ttsBuilds = 0;
+    final message = ChatMessage(
+      id: 'assistant-streaming-footer',
+      role: 'assistant',
+      content: '',
+      timestamp: DateTime(2024, 1, 1),
+      isStreaming: true,
+    );
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          textToSpeechControllerProvider.overrideWith(
+            () => _CountingTextToSpeechController(() => ttsBuilds += 1),
+          ),
+          isChatStreamingProvider.overrideWithValue(true),
+        ],
+        child: _buildHarness(
+          AssistantMessageWidget(
+            message: message,
+            isStreaming: true,
+            animateOnMount: false,
+            modelName: message.model,
+            onCopy: () {},
+            onRegenerate: () {},
+            onDelete: () {},
+          ),
+        ),
+      ),
+    );
+
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 150));
+
+    expect(find.byKey(const ValueKey('typing')), findsOneWidget);
+    expect(ttsBuilds, 0);
   });
 
   testWidgets('response-done metadata enables copy immediately', (

--- a/test/features/chat/widgets/assistant_message_widget_footer_test.dart
+++ b/test/features/chat/widgets/assistant_message_widget_footer_test.dart
@@ -573,10 +573,14 @@ void main() {
     );
     await tester.pump();
 
-    expect(
-      find.byKey(const ValueKey('assistant-streaming-content-fade')),
-      findsNothing,
+    // The fade wrapper is always present (its type stays stable to avoid
+    // tearing down the markdown subtree at streaming boundaries), but it is
+    // fully opaque while there is no content to fade in.
+    final initialFadeFinder = find.byKey(
+      const ValueKey('assistant-streaming-content-fade'),
     );
+    expect(initialFadeFinder, findsOneWidget);
+    expect(tester.widget<FadeTransition>(initialFadeFinder).opacity.value, 1);
 
     await tester.pumpWidget(
       _buildAssistantHarness(streamingMessage('Hello'), isStreaming: true),
@@ -682,10 +686,6 @@ void main() {
       );
       await tester.pumpAndSettle();
 
-      expect(
-        find.byKey(const ValueKey('assistant-streaming-plain-text')),
-        findsNothing,
-      );
       expect(find.byType(SelectionArea), findsOneWidget);
     },
   );

--- a/test/shared/widgets/markdown/renderer/inline_fade_test.dart
+++ b/test/shared/widgets/markdown/renderer/inline_fade_test.dart
@@ -1,3 +1,4 @@
+import 'package:checks/checks.dart';
 import 'package:conduit/l10n/app_localizations.dart';
 import 'package:conduit/shared/theme/app_theme.dart';
 import 'package:conduit/shared/theme/tweakcn_themes.dart';
@@ -66,7 +67,7 @@ void main() {
       final baseLeaves = _leaves(base.span).toList();
       final docsLeaf = baseLeaves.singleWhere((leaf) => leaf.text == 'docs');
       final docsRecognizer = docsLeaf.recognizer;
-      expect(docsRecognizer, isA<TapGestureRecognizer>());
+      check(docsRecognizer).isA<TapGestureRecognizer>();
 
       // Fade the suffix beginning after 'See docs' (offset 8).
       const fade = InlineTextFadeSpec(startOffset: 8, opacity: 0.4);
@@ -74,25 +75,24 @@ void main() {
       final fadedLeaves = _leaves(faded).toList();
 
       // Same visible text, byte for byte.
-      expect(
+      check(
         fadedLeaves.map((leaf) => leaf.text ?? '').join(),
-        'See docs and more',
-      );
+      ).equals('See docs and more');
 
       // Prefix ('See ', 'docs') stays opaque; suffix fades.
       for (final leaf in fadedLeaves) {
         final text = leaf.text ?? '';
         final alpha = leaf.style?.color?.a ?? 1;
         if (text == 'See ' || text == 'docs') {
-          expect(alpha, 1, reason: 'prefix opaque: "$text"');
+          check(alpha, because: 'prefix opaque: "$text"').equals(1);
         } else if (text.trim().isNotEmpty) {
-          expect(alpha, lessThan(1), reason: 'suffix fades: "$text"');
+          check(alpha, because: 'suffix fades: "$text"').isLessThan(1);
         }
       }
 
       // The link recognizer is reused by reference (not recreated).
       final fadedDocs = fadedLeaves.singleWhere((leaf) => leaf.text == 'docs');
-      expect(identical(fadedDocs.recognizer, docsRecognizer), isTrue);
+      check(identical(fadedDocs.recognizer, docsRecognizer)).isTrue();
 
       // Sweeping opacity never changes the base tree, only the suffix alpha.
       double? suffixAlphaAt(double opacity) {
@@ -109,7 +109,7 @@ void main() {
 
       final lowAlpha = suffixAlphaAt(0.2)!;
       final highAlpha = suffixAlphaAt(0.8)!;
-      expect(lowAlpha, lessThan(highAlpha));
+      check(lowAlpha).isLessThan(highAlpha);
 
       // At opacity >= 1 the cached base tree is returned unchanged (identity).
       final settled = InlineRenderer.applyFadeOpacity(
@@ -117,7 +117,7 @@ void main() {
         const InlineTextFadeSpec(startOffset: 8, opacity: 1),
         style: style,
       );
-      expect(identical(settled, base.span), isTrue);
+      check(identical(settled, base.span)).isTrue();
 
       // A fade boundary that straddles the link text ('See do' | 'cs ...') must
       // keep the link recognizer attached to BOTH split halves so the link
@@ -131,9 +131,9 @@ void main() {
       final docHalves = straddleLeaves
           .where((leaf) => (leaf.text ?? '').isNotEmpty && 'docs'.contains(leaf.text!))
           .toList();
-      expect(docHalves.map((leaf) => leaf.text).join(), 'docs');
+      check(docHalves.map((leaf) => leaf.text).join()).equals('docs');
       for (final half in docHalves) {
-        expect(identical(half.recognizer, docsRecognizer), isTrue);
+        check(identical(half.recognizer, docsRecognizer)).isTrue();
       }
 
       renderer.disposeRecognizers();
@@ -164,7 +164,7 @@ void main() {
       // placeholder token. The renderer advances the offset by the placeholder
       // token length without emitting fadable text.
       final fullText = preprocessor.extract(r'a $x^2$ b tail');
-      expect(preprocessor.containsPlaceholder(fullText), isTrue);
+      check(preprocessor.containsPlaceholder(fullText)).isTrue();
       final renderer = InlineRenderer(style, preprocessor);
 
       final nodes = <CompiledMarkdownNode>[
@@ -189,13 +189,12 @@ void main() {
         final text = leaf.text ?? '';
         final alpha = leaf.style?.color?.a ?? 1;
         if (text == 'tail') {
-          expect(alpha, lessThan(1), reason: 'appended tail fades');
+          check(alpha, because: 'appended tail fades').isLessThan(1);
         } else if (text.trim().isNotEmpty) {
-          expect(
+          check(
             alpha,
-            1,
-            reason: 'text before the placeholder stays opaque: "$text"',
-          );
+            because: 'text before the placeholder stays opaque: "$text"',
+          ).equals(1);
         }
       }
 

--- a/test/shared/widgets/markdown/renderer/inline_fade_test.dart
+++ b/test/shared/widgets/markdown/renderer/inline_fade_test.dart
@@ -1,0 +1,205 @@
+import 'package:conduit/l10n/app_localizations.dart';
+import 'package:conduit/shared/theme/app_theme.dart';
+import 'package:conduit/shared/theme/tweakcn_themes.dart';
+import 'package:conduit/shared/widgets/markdown/compiled_markdown_document.dart';
+import 'package:conduit/shared/widgets/markdown/renderer/inline_renderer.dart';
+import 'package:conduit/shared/widgets/markdown/renderer/latex_preprocessor.dart';
+import 'package:conduit/shared/widgets/markdown/renderer/markdown_style.dart';
+import 'package:flutter/gestures.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+/// Depth-first flatten of every leaf [TextSpan] in [span].
+Iterable<TextSpan> _leaves(InlineSpan span) sync* {
+  if (span is! TextSpan) {
+    return;
+  }
+  final children = span.children;
+  if (children == null || children.isEmpty) {
+    yield span;
+    return;
+  }
+  for (final child in children) {
+    yield* _leaves(child);
+  }
+}
+
+void main() {
+  testWidgets(
+    'applyFadeOpacity reuses the base tree and recognizers, fading only the '
+    'suffix',
+    (tester) async {
+      late ConduitMarkdownStyle style;
+      await tester.pumpWidget(
+        MaterialApp(
+          theme: AppTheme.light(TweakcnThemes.t3Chat),
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: Builder(
+            builder: (context) {
+              style = ConduitMarkdownStyle.fromTheme(context);
+              return const SizedBox.shrink();
+            },
+          ),
+        ),
+      );
+
+      var tapCount = 0;
+      final renderer = InlineRenderer(
+        style,
+        LatexPreprocessor(),
+        (url, title) => tapCount += 1,
+      );
+
+      // 'See ' + link('docs') + ' and more' -> document text 'See docs and more'.
+      final nodes = <CompiledMarkdownNode>[
+        CompiledMarkdownText('See '),
+        CompiledMarkdownElement(
+          tag: 'a',
+          attributes: const {'href': 'https://a.test'},
+          children: [CompiledMarkdownText('docs')],
+        ),
+        CompiledMarkdownText(' and more'),
+      ];
+
+      final base = renderer.renderWithRanges(nodes);
+      final baseLeaves = _leaves(base.span).toList();
+      final docsLeaf = baseLeaves.singleWhere((leaf) => leaf.text == 'docs');
+      final docsRecognizer = docsLeaf.recognizer;
+      expect(docsRecognizer, isA<TapGestureRecognizer>());
+
+      // Fade the suffix beginning after 'See docs' (offset 8).
+      const fade = InlineTextFadeSpec(startOffset: 8, opacity: 0.4);
+      final faded = InlineRenderer.applyFadeOpacity(base, fade, style: style);
+      final fadedLeaves = _leaves(faded).toList();
+
+      // Same visible text, byte for byte.
+      expect(
+        fadedLeaves.map((leaf) => leaf.text ?? '').join(),
+        'See docs and more',
+      );
+
+      // Prefix ('See ', 'docs') stays opaque; suffix fades.
+      for (final leaf in fadedLeaves) {
+        final text = leaf.text ?? '';
+        final alpha = leaf.style?.color?.a ?? 1;
+        if (text == 'See ' || text == 'docs') {
+          expect(alpha, 1, reason: 'prefix opaque: "$text"');
+        } else if (text.trim().isNotEmpty) {
+          expect(alpha, lessThan(1), reason: 'suffix fades: "$text"');
+        }
+      }
+
+      // The link recognizer is reused by reference (not recreated).
+      final fadedDocs = fadedLeaves.singleWhere((leaf) => leaf.text == 'docs');
+      expect(identical(fadedDocs.recognizer, docsRecognizer), isTrue);
+
+      // Sweeping opacity never changes the base tree, only the suffix alpha.
+      double? suffixAlphaAt(double opacity) {
+        final span = InlineRenderer.applyFadeOpacity(
+          base,
+          InlineTextFadeSpec(startOffset: 8, opacity: opacity),
+          style: style,
+        );
+        final suffix = _leaves(
+          span,
+        ).firstWhere((leaf) => (leaf.text ?? '').contains('more'));
+        return suffix.style?.color?.a;
+      }
+
+      final lowAlpha = suffixAlphaAt(0.2)!;
+      final highAlpha = suffixAlphaAt(0.8)!;
+      expect(lowAlpha, lessThan(highAlpha));
+
+      // At opacity >= 1 the cached base tree is returned unchanged (identity).
+      final settled = InlineRenderer.applyFadeOpacity(
+        base,
+        const InlineTextFadeSpec(startOffset: 8, opacity: 1),
+        style: style,
+      );
+      expect(identical(settled, base.span), isTrue);
+
+      // A fade boundary that straddles the link text ('See do' | 'cs ...') must
+      // keep the link recognizer attached to BOTH split halves so the link
+      // stays tappable while fading.
+      final straddle = InlineRenderer.applyFadeOpacity(
+        base,
+        const InlineTextFadeSpec(startOffset: 6, opacity: 0.4),
+        style: style,
+      );
+      final straddleLeaves = _leaves(straddle).toList();
+      final docHalves = straddleLeaves
+          .where((leaf) => (leaf.text ?? '').isNotEmpty && 'docs'.contains(leaf.text!))
+          .toList();
+      expect(docHalves.map((leaf) => leaf.text).join(), 'docs');
+      for (final half in docHalves) {
+        expect(identical(half.recognizer, docsRecognizer), isTrue);
+      }
+
+      renderer.disposeRecognizers();
+    },
+  );
+
+  testWidgets(
+    'renderWithRanges keeps offsets aligned across a LaTeX placeholder so the '
+    'fade split lands after it',
+    (tester) async {
+      late ConduitMarkdownStyle style;
+      final preprocessor = LatexPreprocessor();
+      await tester.pumpWidget(
+        MaterialApp(
+          theme: AppTheme.light(TweakcnThemes.t3Chat),
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: Builder(
+            builder: (context) {
+              style = ConduitMarkdownStyle.fromTheme(context);
+              return const SizedBox.shrink();
+            },
+          ),
+        ),
+      );
+
+      // Extract an inline LaTeX expression so the document text carries a
+      // placeholder token. The renderer advances the offset by the placeholder
+      // token length without emitting fadable text.
+      final fullText = preprocessor.extract(r'a $x^2$ b tail');
+      expect(preprocessor.containsPlaceholder(fullText), isTrue);
+      final renderer = InlineRenderer(style, preprocessor);
+
+      final nodes = <CompiledMarkdownNode>[
+        CompiledMarkdownText(
+          fullText,
+          containsLatexPlaceholders: true,
+        ),
+      ];
+
+      final base = renderer.renderWithRanges(nodes);
+
+      // Document-coordinate offset where 'tail' begins.
+      final tailOffset = fullText.indexOf('tail');
+      final faded = InlineRenderer.applyFadeOpacity(
+        base,
+        InlineTextFadeSpec(startOffset: tailOffset, opacity: 0.3),
+        style: style,
+      );
+
+      final leaves = _leaves(faded).toList();
+      for (final leaf in leaves) {
+        final text = leaf.text ?? '';
+        final alpha = leaf.style?.color?.a ?? 1;
+        if (text == 'tail') {
+          expect(alpha, lessThan(1), reason: 'appended tail fades');
+        } else if (text.trim().isNotEmpty) {
+          expect(
+            alpha,
+            1,
+            reason: 'text before the placeholder stays opaque: "$text"',
+          );
+        }
+      }
+
+      renderer.disposeRecognizers();
+    },
+  );
+}

--- a/test/shared/widgets/markdown/renderer/streaming_markdown_widget_test.dart
+++ b/test/shared/widgets/markdown/renderer/streaming_markdown_widget_test.dart
@@ -1258,10 +1258,6 @@ Tail keeps growing
         );
         await tester.pump();
 
-        expect(
-          find.byKey(const ValueKey('assistant-streaming-plain-text')),
-          findsNothing,
-        );
         expect(find.byType(StreamingMarkdownWidget), findsOneWidget);
         expect(
           find.textContaining('Plain streaming sentence.'),
@@ -1307,10 +1303,6 @@ Tail keeps growing
         );
         await tester.pump();
 
-        expect(
-          find.byKey(const ValueKey('assistant-streaming-plain-text')),
-          findsNothing,
-        );
         expect(find.byType(StreamingMarkdownWidget), findsOneWidget);
         expect(
           find.textContaining('[docs]: https://example.com'),
@@ -1361,10 +1353,6 @@ Tail keeps growing
         );
         await tester.pump();
 
-        expect(
-          find.byKey(const ValueKey('assistant-streaming-plain-text')),
-          findsNothing,
-        );
         expect(find.byType(StreamingMarkdownWidget), findsOneWidget);
       } finally {
         container.dispose();
@@ -1406,10 +1394,6 @@ Tail keeps growing
         );
         await tester.pump();
 
-        expect(
-          find.byKey(const ValueKey('assistant-streaming-plain-text')),
-          findsNothing,
-        );
         expect(find.byType(StreamingMarkdownWidget), findsOneWidget);
       } finally {
         container.dispose();
@@ -1451,10 +1435,6 @@ Tail keeps growing
         );
         await tester.pump();
 
-        expect(
-          find.byKey(const ValueKey('assistant-streaming-plain-text')),
-          findsNothing,
-        );
         expect(find.byType(StreamingMarkdownWidget), findsOneWidget);
       } finally {
         container.dispose();
@@ -1496,10 +1476,6 @@ Tail keeps growing
         );
         await tester.pump();
 
-        expect(
-          find.byKey(const ValueKey('assistant-streaming-plain-text')),
-          findsNothing,
-        );
         expect(find.byType(StreamingMarkdownWidget), findsOneWidget);
       } finally {
         container.dispose();
@@ -1541,10 +1517,6 @@ Tail keeps growing
         );
         await tester.pump();
 
-        expect(
-          find.byKey(const ValueKey('assistant-streaming-plain-text')),
-          findsNothing,
-        );
         expect(find.byType(StreamingMarkdownWidget), findsOneWidget);
       } finally {
         container.dispose();
@@ -1586,10 +1558,6 @@ Tail keeps growing
         );
         await tester.pump();
 
-        expect(
-          find.byKey(const ValueKey('assistant-streaming-plain-text')),
-          findsNothing,
-        );
         expect(find.byType(StreamingMarkdownWidget), findsOneWidget);
       } finally {
         container.dispose();
@@ -1633,10 +1601,6 @@ Tail keeps growing
         );
         await tester.pump();
 
-        expect(
-          find.byKey(const ValueKey('assistant-streaming-plain-text')),
-          findsNothing,
-        );
         expect(find.byType(StreamingMarkdownWidget), findsOneWidget);
       } finally {
         container.dispose();
@@ -1679,10 +1643,6 @@ Tail keeps growing
         );
         await tester.pump();
 
-        expect(
-          find.byKey(const ValueKey('assistant-streaming-plain-text')),
-          findsNothing,
-        );
         expect(find.byType(StreamingMarkdownWidget), findsOneWidget);
       } finally {
         container.dispose();
@@ -1726,10 +1686,6 @@ Tail keeps growing
         );
         await tester.pump();
 
-        expect(
-          find.byKey(const ValueKey('assistant-streaming-plain-text')),
-          findsNothing,
-        );
         expect(find.byType(StreamingMarkdownWidget), findsOneWidget);
       } finally {
         container.dispose();
@@ -1771,10 +1727,6 @@ Tail keeps growing
         );
         await tester.pump();
 
-        expect(
-          find.byKey(const ValueKey('assistant-streaming-plain-text')),
-          findsNothing,
-        );
         expect(find.byType(StreamingMarkdownWidget), findsOneWidget);
       } finally {
         container.dispose();
@@ -1816,10 +1768,6 @@ Tail keeps growing
         );
         await tester.pump();
 
-        expect(
-          find.byKey(const ValueKey('assistant-streaming-plain-text')),
-          findsNothing,
-        );
         expect(find.byType(StreamingMarkdownWidget), findsOneWidget);
 
         await tester.pumpWidget(
@@ -1831,10 +1779,6 @@ Tail keeps growing
         );
         await tester.pump();
 
-        expect(
-          find.byKey(const ValueKey('assistant-streaming-plain-text')),
-          findsNothing,
-        );
         expect(find.byType(StreamingMarkdownWidget), findsOneWidget);
       } finally {
         container.dispose();

--- a/test/shared/widgets/markdown/renderer/streaming_markdown_widget_test.dart
+++ b/test/shared/widgets/markdown/renderer/streaming_markdown_widget_test.dart
@@ -37,6 +37,20 @@ Iterable<_RecordedPlatformCall> _mediumImpactCalls(
       call.arguments == 'HapticFeedbackType.mediumImpact',
 );
 
+Iterable<TextSpan> _textSpanLeaves(InlineSpan span) sync* {
+  if (span is! TextSpan) {
+    return;
+  }
+  final children = span.children;
+  if (children == null || children.isEmpty) {
+    yield span;
+    return;
+  }
+  for (final child in children) {
+    yield* _textSpanLeaves(child);
+  }
+}
+
 class _TestTextToSpeechController extends TextToSpeechController {
   @override
   TextToSpeechState build() => const TextToSpeechState();
@@ -498,6 +512,75 @@ graph TD
       greaterThan(0),
     );
     expect((paragraphPaddings.last.padding as EdgeInsets).bottom, 0);
+  });
+
+  testWidgets('streaming markdown fades newly appended rendered text', (
+    tester,
+  ) async {
+    await tester.pumpWidget(buildHarness('Hello', isStreaming: true));
+    await tester.pump();
+
+    await tester.pumpWidget(buildHarness('Hello **world**', isStreaming: true));
+    await tester.pump();
+
+    Text renderedText() {
+      return tester.widget<Text>(
+        find.byWidgetPredicate((widget) {
+          return widget is Text &&
+              widget.textSpan?.toPlainText() == 'Hello world';
+        }),
+      );
+    }
+
+    final fadingLeaves = _textSpanLeaves(renderedText().textSpan!).toList();
+    final fadingWorld = fadingLeaves.singleWhere(
+      (span) => span.text == 'world',
+    );
+    expect(fadingWorld.style?.fontWeight, FontWeight.bold);
+    expect(fadingWorld.style?.color?.a, lessThan(1));
+
+    await tester.pump(const Duration(milliseconds: 360));
+
+    final settledLeaves = _textSpanLeaves(renderedText().textSpan!).toList();
+    final settledWorld = settledLeaves.singleWhere(
+      (span) => span.text == 'world',
+    );
+    expect(settledWorld.style?.fontWeight, FontWeight.bold);
+    expect(settledWorld.style?.color?.a ?? 1, 1);
+  });
+
+  testWidgets('streaming markdown fades newly appended plain text', (
+    tester,
+  ) async {
+    await tester.pumpWidget(buildHarness('Hello', isStreaming: true));
+    await tester.pump();
+
+    await tester.pumpWidget(buildHarness('Hello world', isStreaming: true));
+    await tester.pump();
+
+    Text renderedText() {
+      return tester.widget<Text>(
+        find.byWidgetPredicate((widget) {
+          return widget is Text &&
+              widget.textSpan?.toPlainText() == 'Hello world';
+        }),
+      );
+    }
+
+    final fadingLeaves = _textSpanLeaves(renderedText().textSpan!).toList();
+    final fadingSuffix = fadingLeaves.singleWhere(
+      (span) => span.text == ' world',
+    );
+    expect(fadingSuffix.style?.color?.a, lessThan(1));
+
+    await tester.pump(const Duration(milliseconds: 360));
+
+    final settledLeaves = _textSpanLeaves(renderedText().textSpan!).toList();
+    expect(settledLeaves.map((span) => span.text).join(), 'Hello world');
+    expect(
+      settledLeaves.every((span) => (span.style?.color?.a ?? 1) == 1),
+      isTrue,
+    );
   });
 
   testWidgets('renders OpenWebUI mentions without placeholder leakage', (
@@ -1145,7 +1228,7 @@ Tail keeps growing
   );
 
   testWidgets(
-    'assistant streams long plain content through the cheap text path',
+    'assistant streams long plain content through markdown rendering',
     (tester) async {
       final container = ProviderContainer(
         overrides: [
@@ -1177,9 +1260,9 @@ Tail keeps growing
 
         expect(
           find.byKey(const ValueKey('assistant-streaming-plain-text')),
-          findsOneWidget,
+          findsNothing,
         );
-        expect(find.byType(StreamingMarkdownWidget), findsNothing);
+        expect(find.byType(StreamingMarkdownWidget), findsOneWidget);
         expect(
           find.textContaining('Plain streaming sentence.'),
           findsOneWidget,
@@ -1191,7 +1274,7 @@ Tail keeps growing
   );
 
   testWidgets(
-    'assistant cheap streaming text path strips markdown reference definitions',
+    'assistant streaming markdown renderer omits reference definitions',
     (tester) async {
       final container = ProviderContainer(
         overrides: [
@@ -1226,8 +1309,9 @@ Tail keeps growing
 
         expect(
           find.byKey(const ValueKey('assistant-streaming-plain-text')),
-          findsOneWidget,
+          findsNothing,
         );
+        expect(find.byType(StreamingMarkdownWidget), findsOneWidget);
         expect(
           find.textContaining('[docs]: https://example.com'),
           findsNothing,
@@ -1734,9 +1818,9 @@ Tail keeps growing
 
         expect(
           find.byKey(const ValueKey('assistant-streaming-plain-text')),
-          findsOneWidget,
+          findsNothing,
         );
-        expect(find.byType(StreamingMarkdownWidget), findsNothing);
+        expect(find.byType(StreamingMarkdownWidget), findsOneWidget);
 
         await tester.pumpWidget(
           buildAssistantHarness(

--- a/test/shared/widgets/markdown/renderer/streaming_markdown_widget_test.dart
+++ b/test/shared/widgets/markdown/renderer/streaming_markdown_widget_test.dart
@@ -14,6 +14,7 @@ import 'package:conduit/shared/widgets/markdown/compiled_markdown_document.dart'
 import 'package:conduit/shared/widgets/markdown/markdown_config.dart';
 import 'package:conduit/shared/widgets/markdown/markdown_compile_service.dart';
 import 'package:conduit/shared/widgets/markdown/markdown_loading_skeleton.dart';
+import 'package:conduit/shared/widgets/markdown/renderer/inline_renderer.dart';
 import 'package:conduit/shared/widgets/markdown/streaming_markdown_widget.dart';
 import 'package:conduit/shared/widgets/themed_sheets.dart';
 import 'package:flutter/foundation.dart';
@@ -36,6 +37,30 @@ Iterable<_RecordedPlatformCall> _mediumImpactCalls(
       call.method == 'HapticFeedback.vibrate' &&
       call.arguments == 'HapticFeedbackType.mediumImpact',
 );
+
+/// Returns `true` if [text] contains any unpaired UTF-16 surrogate, which would
+/// render as a tofu/replacement glyph (the regression the fade-split snap
+/// guards against).
+bool _hasLoneSurrogate(String text) {
+  for (var index = 0; index < text.length; index += 1) {
+    final unit = text.codeUnitAt(index);
+    final isHigh = unit >= 0xD800 && unit <= 0xDBFF;
+    final isLow = unit >= 0xDC00 && unit <= 0xDFFF;
+    if (isHigh) {
+      final hasLowFollower =
+          index + 1 < text.length &&
+          text.codeUnitAt(index + 1) >= 0xDC00 &&
+          text.codeUnitAt(index + 1) <= 0xDFFF;
+      if (!hasLowFollower) {
+        return true;
+      }
+      index += 1;
+    } else if (isLow) {
+      return true;
+    }
+  }
+  return false;
+}
 
 Iterable<TextSpan> _textSpanLeaves(InlineSpan span) sync* {
   if (span is! TextSpan) {
@@ -228,6 +253,8 @@ void main() {
     VoidCallback? onCompiledViewMounted,
     VoidCallback? onCompiledViewDisposed,
     VoidCallback? onStreamingRefreshFrame,
+    VoidCallback? onBaseRender,
+    MarkdownLinkTapCallback? onTapLink,
   }) {
     return ProviderScope(
       child: MaterialApp(
@@ -242,10 +269,12 @@ void main() {
               isStreaming: isStreaming,
               stateScopeId: stateScopeId,
               sources: sources,
+              onTapLink: onTapLink,
               debugRenderInterval: debugRenderInterval,
               debugOnCompiledViewMounted: onCompiledViewMounted,
               debugOnCompiledViewDisposed: onCompiledViewDisposed,
               debugOnStreamingRefreshFrame: onStreamingRefreshFrame,
+              debugOnBaseRender: onBaseRender,
             ),
           ),
         ),
@@ -444,11 +473,20 @@ graph TD
       await tester.pumpWidget(buildHarness(content, isStreaming: true));
       await tester.pumpAndSettle();
 
-      final row = tester.widget<Row>(
-        find.ancestor(of: find.text('•'), matching: find.byType(Row)),
+      // While streaming, the loose list-item inline run is rendered through a
+      // FadableRichText (so its suffix can fade), which builds a Text.rich
+      // internally. Locate that rendered Text regardless of the wrapper.
+      final textWidget = tester.widget<Text>(
+        find.descendant(
+          of: find.byType(FadableRichText),
+          matching: find.byWidgetPredicate(
+            (widget) =>
+                widget is Text &&
+                widget.textSpan?.toPlainText() ==
+                    '$firstParagraph $secondParagraph',
+          ),
+        ),
       );
-      final expanded = row.children.last as Expanded;
-      final textWidget = expanded.child as Text;
 
       expect(
         textWidget.textSpan?.toPlainText(),
@@ -579,6 +617,255 @@ graph TD
     expect(settledLeaves.map((span) => span.text).join(), 'Hello world');
     expect(
       settledLeaves.every((span) => (span.style?.color?.a ?? 1) == 1),
+      isTrue,
+    );
+  });
+
+  testWidgets(
+    'fade reuses the cached base span tree instead of rebuilding per frame',
+    (tester) async {
+      var baseRenders = 0;
+      Widget harness(String content) => buildHarness(
+        content,
+        isStreaming: true,
+        onBaseRender: () => baseRenders += 1,
+      );
+
+      await tester.pumpWidget(harness('Hello'));
+      await tester.pump();
+      expect(baseRenders, 1, reason: 'base render once for the first content');
+
+      await tester.pumpWidget(harness('Hello **world**'));
+      await tester.pump();
+      final beforeFade = baseRenders;
+      expect(
+        beforeFade,
+        greaterThanOrEqualTo(2),
+        reason: 'at least one additional base render for the new content',
+      );
+
+      // Sweep the 320ms fade across ~20 frames. The base span tree is produced
+      // once per content change and the fade reuses that cache, so a pure fade
+      // (unchanged document) must add at most ONE base render (the settle pass)
+      // and never one-per-frame. A small constant bound — independent of the
+      // frame count — catches partial (every-other-frame) regressions that the
+      // old `frames ~/ 2` bound tolerated.
+      var frames = 0;
+      for (var elapsed = 0; elapsed < 320; elapsed += 16) {
+        await tester.pump(const Duration(milliseconds: 16));
+        frames += 1;
+      }
+      expect(
+        baseRenders - beforeFade,
+        lessThanOrEqualTo(1),
+        reason:
+            'base render is not driven per fade frame ($frames frames swept)',
+      );
+
+      final afterFade = baseRenders;
+      await tester.pump(const Duration(milliseconds: 400));
+      expect(
+        baseRenders,
+        afterFade,
+        reason: 'settling adds no base render',
+      );
+    },
+  );
+
+  testWidgets('only the faded suffix changes alpha and recognizers are stable', (
+    tester,
+  ) async {
+    void onTap(String url, String title) {}
+    var baseRenders = 0;
+    await tester.pumpWidget(
+      buildHarness(
+        'See [docs](https://a.test)',
+        isStreaming: true,
+        onTapLink: onTap,
+        onBaseRender: () => baseRenders += 1,
+      ),
+    );
+    await tester.pump();
+
+    await tester.pumpWidget(
+      buildHarness(
+        'See [docs](https://a.test) and **more**',
+        isStreaming: true,
+        onTapLink: onTap,
+        onBaseRender: () => baseRenders += 1,
+      ),
+    );
+    await tester.pump();
+
+    Text renderedText() {
+      return tester.widget<Text>(
+        find.byWidgetPredicate((widget) {
+          return widget is Text &&
+              (widget.textSpan?.toPlainText() ?? '') == 'See docs and more';
+        }),
+      );
+    }
+
+    final fadingLeaves = _textSpanLeaves(renderedText().textSpan!).toList();
+    // The link prefix recognizer is captured to assert identity stability.
+    final docsLeaf = fadingLeaves.singleWhere((span) => span.text == 'docs');
+    final docsRecognizer = docsLeaf.recognizer;
+    expect(docsRecognizer, isNotNull);
+
+    // The stable prefix is the common 'See docs' text. Everything appended after
+    // it (' and ' + 'more') is the streaming suffix and fades together; the
+    // prefix stays fully opaque.
+    const suffixTexts = {' and ', 'more'};
+    var sawFadedSuffix = false;
+    for (final leaf in fadingLeaves) {
+      final alpha = leaf.style?.color?.a ?? 1;
+      if (suffixTexts.contains(leaf.text)) {
+        expect(alpha, lessThan(1), reason: 'suffix fades in: "${leaf.text}"');
+        sawFadedSuffix = true;
+      } else {
+        expect(alpha, 1, reason: 'prefix stays opaque: "${leaf.text}"');
+      }
+    }
+    expect(sawFadedSuffix, isTrue);
+
+    // Step the fade frame-by-frame and assert recognizer identity is stable
+    // across consecutive reuse frames (frames that do NOT re-resolve the base
+    // span tree). applyFadeOpacity must never recreate the recognizer, so a
+    // reuse frame's recognizer must be identical to the previous reuse frame's.
+    // We require at least one such cross-frame comparison so the assertion can
+    // never be silently skipped: a regression that rebuilds the span tree on
+    // every fade frame would leave `reuseFrameComparisons` zero and fail the
+    // test — the failure mode the old single-frame `if` guard let pass green.
+    Object? previousReuseRecognizer = docsRecognizer;
+    var reuseFrameComparisons = 0;
+    for (var i = 0; i < 12; i++) {
+      final rendersBeforeFrame = baseRenders;
+      await tester.pump(const Duration(milliseconds: 16));
+      final frameLeaves = _textSpanLeaves(renderedText().textSpan!).toList();
+      final frameDocs = frameLeaves.singleWhere((span) => span.text == 'docs');
+      if (baseRenders != rendersBeforeFrame) {
+        // This frame re-resolved the document, so a fresh recognizer is
+        // expected; reset the baseline and only compare across reuse frames.
+        previousReuseRecognizer = frameDocs.recognizer;
+        continue;
+      }
+      reuseFrameComparisons++;
+      expect(
+        identical(frameDocs.recognizer, previousReuseRecognizer),
+        isTrue,
+        reason: 'link recognizer identity is stable across fade frames',
+      );
+      previousReuseRecognizer = frameDocs.recognizer;
+    }
+    expect(
+      reuseFrameComparisons,
+      greaterThan(0),
+      reason:
+          'at least one fade frame must reuse the cached span tree (otherwise '
+          'the recognizer-stability assertion is silently skipped)',
+    );
+
+    await tester.pump(const Duration(milliseconds: 360));
+    final settledLeaves = _textSpanLeaves(renderedText().textSpan!).toList();
+    expect(
+      settledLeaves.every((span) => (span.style?.color?.a ?? 1) == 1),
+      isTrue,
+      reason: 'every span settles to full opacity',
+    );
+    final settledDocs = settledLeaves.singleWhere((span) => span.text == 'docs');
+    expect(
+      settledDocs.recognizer,
+      isNotNull,
+      reason: 'the link recognizer survives the fade',
+    );
+  });
+
+  testWidgets('faded suffix begins after a fenced code block prefix', (
+    tester,
+  ) async {
+    const prefix = 'Intro\n\n```\ncode body\n```\n\nTail';
+    await tester.pumpWidget(buildHarness(prefix, isStreaming: true));
+    await tester.pump();
+
+    await tester.pumpWidget(
+      buildHarness('$prefix appended', isStreaming: true),
+    );
+    await tester.pump();
+
+    Text tailText() {
+      return tester.widget<Text>(
+        find.byWidgetPredicate((widget) {
+          return widget is Text &&
+              (widget.textSpan?.toPlainText() ?? '') == 'Tail appended';
+        }),
+      );
+    }
+
+    final leaves = _textSpanLeaves(tailText().textSpan!).toList();
+    // The code body precedes the tail in document coordinates; the fade offset
+    // must still land exactly on the appended ' appended' suffix, so the stable
+    // 'Tail' text never re-fades.
+    final stable = leaves.where((span) => span.text == 'Tail');
+    final faded = leaves.where((span) => (span.style?.color?.a ?? 1) < 1);
+    expect(stable.every((span) => (span.style?.color?.a ?? 1) == 1), isTrue);
+    expect(faded.map((span) => span.text).join(), contains('appended'));
+
+    await tester.pump(const Duration(milliseconds: 360));
+    final settled = _textSpanLeaves(tailText().textSpan!).toList();
+    expect(
+      settled.every((span) => (span.style?.color?.a ?? 1) == 1),
+      isTrue,
+    );
+  });
+
+  testWidgets('surrogate-pair boundary never splits mid-emoji while fading', (
+    tester,
+  ) async {
+    // Append text right after a non-BMP emoji; the fade split must snap off the
+    // surrogate pair so no lone-surrogate/replacement glyph appears.
+    await tester.pumpWidget(buildHarness('Hi \u{1F600}', isStreaming: true));
+    await tester.pump();
+
+    await tester.pumpWidget(
+      buildHarness('Hi \u{1F600} there', isStreaming: true),
+    );
+    await tester.pump();
+
+    Text renderedText() {
+      return tester.widget<Text>(
+        find.byWidgetPredicate((widget) {
+          return widget is Text &&
+              (widget.textSpan?.toPlainText() ?? '') == 'Hi \u{1F600} there';
+        }),
+      );
+    }
+
+    for (var elapsed = 0; elapsed < 320; elapsed += 40) {
+      final leaves = _textSpanLeaves(renderedText().textSpan!).toList();
+      final joined = leaves.map((span) => span.text ?? '').join();
+      // The emoji round-trips intact (no replacement char, no lone surrogate).
+      expect(joined, 'Hi \u{1F600} there');
+      expect(joined.contains('�'), isFalse);
+      for (final leaf in leaves) {
+        final text = leaf.text;
+        if (text == null || text.isEmpty) continue;
+        expect(
+          _hasLoneSurrogate(text),
+          isFalse,
+          reason: 'leaf "$text" must not split the emoji surrogate pair',
+        );
+      }
+      await tester.pump(const Duration(milliseconds: 40));
+    }
+
+    await tester.pump(const Duration(milliseconds: 360));
+    final settled = _textSpanLeaves(renderedText().textSpan!).toList();
+    expect(
+      settled.map((span) => span.text ?? '').join(),
+      'Hi \u{1F600} there',
+    );
+    expect(
+      settled.every((span) => (span.style?.color?.a ?? 1) == 1),
       isTrue,
     );
   });


### PR DESCRIPTION
Brings the chat streaming experience closer to upstream Open WebUI: surfaces the model name, preserves optimistic streaming state across server snapshots, makes the streaming text-fade cheap, and resumes in-flight chats over the socket in real time.

## What's in here

**Model name (earlier commits)**
- Extract and display the Open WebUI `modelName` from `history.messages`/message data (camelCase + snake_case), thread it through the durable payload, and preserve it across streaming-error handling.

**Optimistic streaming state (earlier commits)**
- Preserve locally-streamed assistant content/follow-ups when adopting a server conversation snapshot, keyed by message id and guarded so a stale snapshot can't clobber fresher local content. Consolidated streaming-error teardown.

**A — Markdown fade-frame caching**
- `InlineRenderer.renderWithRanges()` builds the opacity-1 base span tree once per content change and records per-leaf `[start,end)` ranges; `applyFadeOpacity()` reapplies alpha to only the suffix spans via `FadableRichText`/`AnimatedBuilder`. `_handleStreamingTextFadeTick` no longer `setState()`s per frame (was ~19 full rebuilds per fade). Surrogate-pair snap and LaTeX/code offset alignment preserved.

**B — Sidebar "generating" indicator hardening**
- The indicator is socket-driven (`chat:active`). Added optimistic `setActive` on a non-empty `task_ids` response, paired `setInactive` on success/cancel/error (verified against `openwebui-src`), and clear-on-logout so spinners can't strand. REST `checkActiveChats` stays as cold-open/reconnect fallback.

**C — Socket-based resume of in-flight chats**
- Reopening a still-generating chat now streams token-by-token over the shared Socket.IO `events` envelope via `ChatCompletionSession.resumeSocket` through `dispatchChatTransport(isResume: true)` — REPLACE on `content`, APPEND on `choices[].delta.content`, finalize on `done`. The 1s task poll is demoted to a safety-net fallback. Guards: normal-send protection unchanged, resume protects only the matching message id, foreign `message_id` binding by `chat_id`, exactly-one-finalize race (socket vs poll grace window), offline poll-only fallback, and stop-mid-resume via the task registry.

**Fixes**
- `_preserveFreshLocalAssistantState` no longer writes `metadata: {followUps: []}` when there are no local follow-ups to preserve (gated on a non-empty local list) — fixes two pre-existing remote-sync test failures; non-empty preservation unchanged.

## Verification
- `dart run build_runner build` + `flutter analyze lib test`: **No issues found.**
- Affected suites green (markdown renderer, chat providers/widgets/views, streaming-helper transport, active-chats sync, transport parity), including new coverage: fade base-tree reuse / suffix-only opacity / surrogate alignment, active-chat START/STOP + logout-clear, resume foreign-id binding, exactly-one-finalize, and resume APPEND deltas concatenating onto an already-visible partial.

## Notes
- Resume content updates over the socket at real-time delta cadence; the 1s `/api/tasks` poll remains purely as a recovery fallback for silent socket death.
- Multi-model/branched chats resume the single streaming tail only (documented limitation).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added socket resume support to recover in-flight chat completions after reconnection.
  - Introduced streaming text fading for newly appended markdown content, with improved handling around LaTeX and code.

- **Bug Fixes**
  - Fixed stale “active/generating” indicators after logout and ensured paired active/inactive updates on completion, cancellation, and errors.
  - Preserved already-visible follow-up suggestions and response content across streaming and snapshot refreshes.

- **Improvements**
  - Improved model-name display and propagation (including fallbacks) across parsing, snapshots, and chat UI rebuilding.
  - Reduced chat state clobbering during conversation transitions and resume flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add streaming text fade, socket resume, and modelName display parity for Open WebUI
> - Adds a per-frame streaming text fade to the markdown renderer: newly appended text fades in without rebuilding the base span tree or recognizers each frame, using a cached opacity-1 span tree with selective alpha application to suffix leaves.
> - Replaces the cheap plain-text streaming fallback in `assistant_message_widget.dart` with a fade-in transition on first content arrival; removes the slide-in animation.
> - Adds socket resume support so in-flight chats reconnect via the live socket for real-time delta rendering instead of falling back immediately to polling; a ~2-poll grace window prevents double-finalization when both socket and poll compete.
> - Propagates `modelName` from Open WebUI message metadata through parsing, state, durable payloads, and the assistant message UI so the correct model label is displayed.
> - Follow-up suggestions are cached post-stream so they remain visible through transient empty server snapshots.
> - Risk: layout signatures, list-shell rebuild triggers, and streaming state reconciliation logic have changed; existing assumptions about when rebuilds occur or how server snapshots are adopted may not hold.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c2819ac.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR delivers four features: surface the Open WebUI `modelName` through parsing, state, durable payloads, and the assistant UI; preserve optimistic streaming state (content, follow-ups, `modelName`) across lagging server snapshots; add a per-frame streaming text fade that caches the opacity-1 span tree and reapplies alpha to suffix leaves only; and resume in-flight chats over the live Socket.IO `events` channel rather than immediately falling back to the 1 s poll.

- **Model name propagation**: `modelName` is now extracted from `history.messages` (camelCase and snake_case), injected into assistant placeholders and durable payloads via `_durableAssistantPayload`, and preserved across server snapshot merges in `_preserveFreshLocalAssistantState`.
- **Optimistic state preservation**: `_preserveFreshLocalAssistantState` merges local and server metadata (server wins; local fills gaps), guards follow-ups and streaming content from being clobbered by stale snapshots, and includes a `_boundRemoteMessageId` look-up so resume with a foreign server `message_id` survives lagging snapshots.
- **Fade-frame caching**: `InlineRenderer.renderWithRanges` builds the base span tree once per content change; `applyFadeOpacity` reapplies alpha to only in-range suffix leaves via `FadableRichText`/`AnimatedBuilder`, eliminating the previous per-frame full rebuild.
- **Socket resume**: `ChatCompletionSession.resumeSocket` → `dispatchChatTransport(isResume: true)` subscribes the shared socket with a null session ID so the helper binds the server's (possibly foreign) `message_id`; a 2-poll grace window prevents double-finalization; the 1 s poll remains as a safety-net fallback.

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The core streaming, fade-caching, and modelName propagation are well-constructed and test-covered; the main risk is in the socket-resume interaction with the existing server-adoption guard.

The `_isResumeStreamingActive` guard becomes `false` whenever the socket resume transport is active, allowing server snapshots to cancel the socket subscription via `_adoptServerMessages` and degrade the session silently to poll-based delivery. The additional API call issued for already-active chats before the socket subscription is registered also creates a window where socket `done` events can be missed. Both are degradation bugs rather than data-loss failures, and the poll fallback is always in place.

lib/features/chat/providers/chat_providers.dart — specifically `_isResumeStreamingActive`, `_adoptServerMessages`, and the task-id fetch ordering in `_detectActiveOnOpen`.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| lib/features/chat/providers/chat_providers.dart | Largest file; adds `_preserveFreshLocalAssistantState`, `failLastStreamingAssistant`, `_attachResumeSocketStream`, grace-poll counter, `_boundRemoteMessageId`, and `modelName` threading. Several previously-flagged residual risks remain (remote-id adoption, `_isResumeStreamingActive` guard, stale-content preservation). New code generally well-guarded. |
| lib/shared/widgets/markdown/renderer/inline_renderer.dart | Adds `renderWithRanges`, `applyFadeOpacity`, `FadableRichText`, and per-leaf `FadableSpanRange` tracking. Surrogate-pair snap, recognizer-range migration, and widget-span boundary handling are correct. Headings/tables still bypass the fade path (existing known limitation). |
| lib/features/chat/services/chat_transport_dispatch.dart | Adds `isResume` flag, optimistic `setActive`, and token-guarded async `setInactiveIfUnchanged`. Logic is mostly correct; a potential spinner stale-clear race under multi-task scenarios was noted in previous threads. |
| lib/core/services/streaming_helper.dart | Adds `extractNestedEventId`, chat-scope guard, `onRemoteMessageBound`, and paired `setInactive` calls for cancel/error/finalize. Several previously-flagged socket-resume edge cases (status-event early bind, nested message ids) are noted in previous threads. |
| lib/shared/widgets/markdown/renderer/conduit_markdown_widget.dart | Adds `_ensureBaseRender` base-render cache, `_primeStreamingTextFade`, `_streamingTextFadeStartOffset`, and `MarkdownStreamingFade` integration. Identity-based cache keys and lazy invalidation look correct. |
| lib/features/chat/widgets/assistant_message_widget.dart | Replaces slide animation with `_streamingContentFadeController`, adds `_resolveVisibleFollowUps` caching, and routes content through `_buildStreamingContentBody`. Fade animation is consistently applied with stable widget keys. |
| lib/core/providers/app_providers.dart | Adds activation-token tracking (`_seq`, `_activationToken`) to `ActiveChatIds` and logout-clear in `ActiveChatsSync`. Token guard correctly prevents stale async clears from racing new activations. |
| lib/core/services/conversation_parsing.dart | Adds `_extractOpenWebUiModelName` walking camelCase and snake_case keys, injects `modelName` into sibling version payloads and message metadata. Model field also picks up from `historyMsg` fallback. |

</details>


</details>


<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant U as User (reopens chat)
    participant CP as ChatMessagesNotifier
    participant API as ApiService
    participant SS as SocketService
    participant SH as StreamingHelper
    participant Poll as 1s Task Poll

    U->>CP: _detectActiveOnOpen(chatId)
    CP->>API: getTaskIdsByChat(chatId)
    API-->>CP: [taskId]
    CP->>CP: _attachResumeSocketStream(taskId)
    CP->>SH: dispatchChatTransport(isResume:true)
    SH->>SS: "subscribe events (sessionId=null)"
    SS-->>SH: chat:completion delta
    SH->>CP: updateMessage(content APPEND)
    CP->>Poll: _ensureRemoteTaskMonitor()
    Poll-->>CP: tasksDone? grace window
    SS-->>SH: chat:completion done
    SH->>CP: onRemoteMessageBound(remoteId)
    SH->>CP: finishStreaming()
    CP->>CP: _preserveFreshLocalAssistantState
    CP->>CP: _stopRemoteTaskMonitor()
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant U as User (reopens chat)
    participant CP as ChatMessagesNotifier
    participant API as ApiService
    participant SS as SocketService
    participant SH as StreamingHelper
    participant Poll as 1s Task Poll

    U->>CP: _detectActiveOnOpen(chatId)
    CP->>API: getTaskIdsByChat(chatId)
    API-->>CP: [taskId]
    CP->>CP: _attachResumeSocketStream(taskId)
    CP->>SH: dispatchChatTransport(isResume:true)
    SH->>SS: "subscribe events (sessionId=null)"
    SS-->>SH: chat:completion delta
    SH->>CP: updateMessage(content APPEND)
    CP->>Poll: _ensureRemoteTaskMonitor()
    Poll-->>CP: tasksDone? grace window
    SS-->>SH: chat:completion done
    SH->>CP: onRemoteMessageBound(remoteId)
    SH->>CP: finishStreaming()
    CP->>CP: _preserveFreshLocalAssistantState
    CP->>CP: _stopRemoteTaskMonitor()
```

</a>
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (10)</h3></summary>

1. `lib/shared/widgets/markdown/renderer/block_renderer.dart`, line 640-653 ([link](https://github.com/cogwheel0/conduit/blob/e247741bc87e204b97c4b5bf81edd455e31b217f/lib/shared/widgets/markdown/renderer/block_renderer.dart#L640-L653)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Headings skip fade path**

   Most inline block render paths now go through `_buildInlineRichText()`, which records ranges and applies `FadableRichText`, but headings still call `inlineRenderer.render()` and `Text.rich()` directly. When streaming content is inside a heading, appended heading text bypasses the new fade machinery and appears abruptly while other inline text fades. Route headings through the same fadable inline helper so the streaming behavior is consistent.

2. `lib/features/chat/providers/chat_providers.dart`, line 1781-1783 ([link](https://github.com/cogwheel0/conduit/blob/baf764bc844230528a6bf1f7f9ec26edb27c3046/lib/features/chat/providers/chat_providers.dart#L1781-L1783)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Resume fallback misses ids**

   The socket resume path allows the server's `message_id` to differ from the local placeholder id, but this poll fallback only looks for `localLast.id` in the final server snapshot. If the socket binds a foreign id and then dies before `done`, `/api/tasks` can report completion while `getConversation()` contains only the remote id. This branch then finds no `serverVersion`, never adopts the final content, and leaves the local assistant stuck in streaming state. Persist the bound remote id or use the same reverse-ordinal/neighbour matching used by the streaming recovery path before deciding there is nothing to finalize.

3. `lib/features/chat/services/chat_transport_dispatch.dart`, line 280-287 ([link](https://github.com/cogwheel0/conduit/blob/12589dcee97b2571a3064c02e167af17a8bc2d89/lib/features/chat/services/chat_transport_dispatch.dart#L280-L287)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Resume events are filtered**

   For resume streams this intentionally clears the session id so the streaming helper can bind a foreign server `message_id`, but the socket subscription still uses the local `assistantMessageId` as its message filter. When Open WebUI sends resume events with the server-assigned message id and no matching local id, `SocketService._shouldDeliver` drops the event before `allowBindingForeignMessage` can run. The reopened chat then misses the real-time socket stream and only recovers through slower polling/final fetch paths. Register the resume handler without the local message-id filter, or use a filter that matches the actual resume envelope.

4. `lib/core/services/streaming_helper.dart`, line 2481-2483 ([link](https://github.com/cogwheel0/conduit/blob/12589dcee97b2571a3064c02e167af17a8bc2d89/lib/core/services/streaming_helper.dart#L2481-L2483)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Nested message ids ignored**

   The socket service can deliver events whose `message_id` is nested under `data` or inner `data.data`, but this handler only reads the top-level `ev['message_id']`. For shared `events` envelopes with a nested server message id, the helper processes the event as if no id was present and never calls `onRemoteMessageBound`. If the socket later dies, `_syncRemoteTaskStatus` cannot match the server message by `_boundRemoteMessageId`, so the poll fallback can miss the correct growing or final assistant message.

5. `lib/features/chat/providers/chat_providers.dart`, line 1741-1755 ([link](https://github.com/cogwheel0/conduit/blob/12589dcee97b2571a3064c02e167af17a8bc2d89/lib/features/chat/providers/chat_providers.dart#L1741-L1755)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Remote id drops protection**

   This lookup can find `serverVersion` by `_boundRemoteMessageId`, but it then writes that server message directly into the local tail. In that case `state.last.id` changes from the local placeholder id to the remote id while `_activeStreamingTransportMessageId` still holds the local id. `_shouldProtectLocalStreamingState` becomes false, and the active socket helper can treat later deltas or `done` as superseded. When adopting a remote-id match into the streaming tail, preserve the local message id until final server adoption.

6. `lib/shared/widgets/markdown/renderer/block_renderer.dart`, line 640-653 ([link](https://github.com/cogwheel0/conduit/blob/12589dcee97b2571a3064c02e167af17a8bc2d89/lib/shared/widgets/markdown/renderer/block_renderer.dart#L640-L653)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Headings skip fade**

   Headings still render through `inlineRenderer.render()` and `Text.rich`, so they bypass the new `renderWithRanges()` and `FadableRichText` path. If a response streams a heading such as `# Title` token by token, the newly appended heading text appears fully opaque while paragraph text fades, because no fade listener or range map is attached to this visible text. Route heading inline content through the same fadable render path so heading text behaves consistently during streaming.

7. `lib/shared/widgets/markdown/renderer/block_renderer.dart`, line 1377-1385 ([link](https://github.com/cogwheel0/conduit/blob/12589dcee97b2571a3064c02e167af17a8bc2d89/lib/shared/widgets/markdown/renderer/block_renderer.dart#L1377-L1385)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Forward nested fade**

   This compiled details-body path creates a nested `ConduitMarkdownWidget` without forwarding the active streaming fade setting. The pending-body path above uses `StreamingMarkdownWidget(isStreaming: true)`, so details content can fade while pending but stop fading once the body is compiled through this branch. Pass the parent fade state into the nested widget so newly appended text inside details blocks keeps the same streaming behavior.

8. `lib/core/services/streaming_helper.dart`, line 2519-2524 ([link](https://github.com/cogwheel0/conduit/blob/bfc4598c58653e6d700c7177da10842ab897d6a4/lib/core/services/streaming_helper.dart#L2519-L2524)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Same-chat task can bind**

   Resume registers the socket handler for the whole conversation, and socket delivery accepts any event whose `chat_id` matches even when the `message_id` is for a different task. This branch then allows every `chat:completion` with a foreign message id to bind to the resumed assistant. In a chat with another in-flight branch or model response, whichever same-chat event arrives first can bind and stream the wrong content into the reopened tail. Restrict foreign-id binding to an event that is tied to the intended task/session, or ignore same-chat foreign ids until that link is proven.

9. `lib/shared/widgets/markdown/renderer/block_renderer.dart`, line 1075-1083 ([link](https://github.com/cogwheel0/conduit/blob/a124e3135800c53f6bf5b9d337694770d0c86750/lib/shared/widgets/markdown/renderer/block_renderer.dart#L1075-L1083)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Inline fade bypassed**

   Headings, table header cells, and table body cells still render inline content through plain `Text.rich(inlineRenderer.render(...))` instead of the new fade-aware path. When streamed markdown appends text in any of these sibling locations, such as `# Hel` to `# Hello` or a growing markdown table, the new suffix appears fully opaque while paragraphs and lists use `FadableRichText`. Route these call sites through the same cached fade-capable inline builder so suffix-only fade behavior is consistent across headings and tables.

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

10. `lib/core/services/streaming_helper.dart`, line 2705 ([link](https://github.com/cogwheel0/conduit/blob/a124e3135800c53f6bf5b9d337694770d0c86750/lib/core/services/streaming_helper.dart#L2705)) 

    <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Status events bind**

    During socket resume, the stream has no session id and this `status` path allows binding any foreign `message_id` from the same chat. If a status event for another in-flight same-chat message arrives before the intended `chat:completion`, it becomes the bound remote id for the reopened assistant. Later completion events for the real streaming tail can then be rejected as unexpected, leaving the resumed response stale or finalized from the wrong message. First-time foreign id binding should be limited to the content-bearing completion event, or otherwise require a stronger task/message correlation before status and cancel events can bind.
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (12): Last reviewed commit: ["fix(streaming): clear sidebar spinner on..."](https://github.com/cogwheel0/conduit/commit/c2819ac9da9a22e4a81378801b75496b2124122c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38836945)</sub>

<!-- /greptile_comment -->