### PR TITLE
feat(notifications): in-app notification parity layer from socket events

### DIFF
--- a/lib/core/models/server_user_settings.dart
+++ b/lib/core/models/server_user_settings.dart
@@ -8,12 +8,22 @@ class ServerUserSettings {
     this.memoryEnabled = false,
     this.defaultModelIds = const <String>[],
     this.pinnedModelIds = const <String>[],
+    this.notificationEnabled,
+    this.notificationSound,
+    this.notificationSoundAlways,
   });
 
   final String? systemPrompt;
   final bool memoryEnabled;
   final List<String> defaultModelIds;
   final List<String> pinnedModelIds;
+
+  /// Open WebUI notification preferences. Stored at the top level of the user
+  /// settings object (not nested under `ui`). Null means the server has no
+  /// stored value yet, so the client default applies.
+  final bool? notificationEnabled;
+  final bool? notificationSound;
+  final bool? notificationSoundAlways;
 
   /// The user's preferred default model, if one is configured.
   String? get defaultModelId =>
@@ -29,6 +39,9 @@ class ServerUserSettings {
       memoryEnabled: _coerceBool(ui?['memory']) ?? false,
       defaultModelIds: _coerceStringList(ui?['models']),
       pinnedModelIds: _coerceUniqueStringList(ui?['pinnedModels']),
+      notificationEnabled: _coerceBool(json['notificationEnabled']),
+      notificationSound: _coerceBool(json['notificationSound']),
+      notificationSoundAlways: _coerceBool(json['notificationSoundAlways']),
     );
   }
 
@@ -37,6 +50,9 @@ class ServerUserSettings {
     bool? memoryEnabled,
     List<String>? defaultModelIds,
     List<String>? pinnedModelIds,
+    bool? notificationEnabled,
+    bool? notificationSound,
+    bool? notificationSoundAlways,
   }) {
     return ServerUserSettings(
       systemPrompt: systemPrompt == _serverUserSettingsUnset
@@ -45,6 +61,10 @@ class ServerUserSettings {
       memoryEnabled: memoryEnabled ?? this.memoryEnabled,
       defaultModelIds: defaultModelIds ?? this.defaultModelIds,
       pinnedModelIds: pinnedModelIds ?? this.pinnedModelIds,
+      notificationEnabled: notificationEnabled ?? this.notificationEnabled,
+      notificationSound: notificationSound ?? this.notificationSound,
+      notificationSoundAlways:
+          notificationSoundAlways ?? this.notificationSoundAlways,
     );
   }
 }

--- a/lib/core/persistence/persistence_keys.dart
+++ b/lib/core/persistence/persistence_keys.dart
@@ -37,6 +37,17 @@ final class PreferenceKeys {
   static const String temporaryChatByDefault = 'temporary_chat_by_default';
   static const String pinnedModels = 'pinned_models';
 
+  // Notifications. The first three mirror Open WebUI's user-settings fields and
+  // are synced to the server; the rest are Conduit-only client preferences.
+  static const String notificationsEnabled = 'notifications_enabled';
+  static const String notificationSound = 'notification_sound';
+  static const String notificationSoundAlways = 'notification_sound_always';
+  static const String notificationInAppBanner = 'notification_in_app_banner';
+  static const String notificationSystem = 'notification_system';
+  static const String notificationChatEnabled = 'notification_chat_enabled';
+  static const String notificationChannelEnabled =
+      'notification_channel_enabled';
+
   // Drawer section collapsed states
   static const String drawerShowPinned = 'drawer_show_pinned';
   static const String drawerShowFolders = 'drawer_show_folders';

--- a/lib/core/providers/app_providers.dart
+++ b/lib/core/providers/app_providers.dart
@@ -2509,7 +2509,8 @@ class PersonalizationSettings extends _$PersonalizationSettings {
     // Only once per server so a fresh local toggle isn't overwritten by a
     // settings reload that raced the write-through.
     if (_notificationPrefsAppliedServerId != serverId) {
-      _notificationPrefsAppliedServerId = serverId;
+      // Lock the flag only after a successful mirror so a failed apply retries
+      // on a later reload instead of staying out of sync for the session.
       unawaited(
         ref
             .read(appSettingsProvider.notifier)
@@ -2517,6 +2518,17 @@ class PersonalizationSettings extends _$PersonalizationSettings {
               enabled: settings.notificationEnabled,
               sound: settings.notificationSound,
               soundAlways: settings.notificationSoundAlways,
+            )
+            .then(
+              (_) => _notificationPrefsAppliedServerId = serverId,
+              onError: (Object e, StackTrace st) {
+                DebugLogger.error(
+                  'failed to mirror server notification prefs',
+                  error: e,
+                  stackTrace: st,
+                  scope: 'notifications/settings',
+                );
+              },
             ),
       );
     }

--- a/lib/core/providers/app_providers.dart
+++ b/lib/core/providers/app_providers.dart
@@ -2500,6 +2500,17 @@ class PersonalizationSettings extends _$PersonalizationSettings {
     if (!_isCurrentServer(serverId)) {
       return _currentSettingsForActiveServerOrDefault();
     }
+    // Server is authoritative for the Open WebUI-aligned notification prefs;
+    // mirror them into local settings for cross-device parity (no-ops nulls).
+    unawaited(
+      ref
+          .read(appSettingsProvider.notifier)
+          .applyServerNotificationPrefs(
+            enabled: settings.notificationEnabled,
+            sound: settings.notificationSound,
+            soundAlways: settings.notificationSoundAlways,
+          ),
+    );
     if (readGeneration != _pinnedModelsWriteGeneration) {
       final merged = _settingsWithCurrentPinnedModels(settings, serverId);
       _settingsServerId = serverId;

--- a/lib/core/providers/app_providers.dart
+++ b/lib/core/providers/app_providers.dart
@@ -2345,6 +2345,10 @@ class PersonalizationSettings extends _$PersonalizationSettings {
   int _pinnedModelsWriteGeneration = 0;
   String? _settingsServerId;
   ServerUserSettings? _settingsSnapshot;
+  // Server is mirrored into local notification prefs once per server (on first
+  // load / server switch). Re-applying on every settings reload could clobber a
+  // just-made local toggle whose write-through hasn't reached the server yet.
+  String? _notificationPrefsAppliedServerId;
 
   @override
   Future<ServerUserSettings> build() async {
@@ -2502,15 +2506,20 @@ class PersonalizationSettings extends _$PersonalizationSettings {
     }
     // Server is authoritative for the Open WebUI-aligned notification prefs;
     // mirror them into local settings for cross-device parity (no-ops nulls).
-    unawaited(
-      ref
-          .read(appSettingsProvider.notifier)
-          .applyServerNotificationPrefs(
-            enabled: settings.notificationEnabled,
-            sound: settings.notificationSound,
-            soundAlways: settings.notificationSoundAlways,
-          ),
-    );
+    // Only once per server so a fresh local toggle isn't overwritten by a
+    // settings reload that raced the write-through.
+    if (_notificationPrefsAppliedServerId != serverId) {
+      _notificationPrefsAppliedServerId = serverId;
+      unawaited(
+        ref
+            .read(appSettingsProvider.notifier)
+            .applyServerNotificationPrefs(
+              enabled: settings.notificationEnabled,
+              sound: settings.notificationSound,
+              soundAlways: settings.notificationSoundAlways,
+            ),
+      );
+    }
     if (readGeneration != _pinnedModelsWriteGeneration) {
       final merged = _settingsWithCurrentPinnedModels(settings, serverId);
       _settingsServerId = serverId;

--- a/lib/core/providers/app_startup_providers.dart
+++ b/lib/core/providers/app_startup_providers.dart
@@ -26,6 +26,8 @@ import '../models/server_config.dart';
 import '../../features/tools/providers/tools_providers.dart';
 import '../../features/chat/providers/chat_providers.dart';
 import '../../features/chat/providers/remap_route_sync_provider.dart';
+import '../../features/notifications/providers/notification_socket_listener.dart';
+import '../../features/notifications/services/local_notification_service.dart';
 
 part 'app_startup_providers.g.dart';
 
@@ -100,6 +102,11 @@ Future<void> _cleanupUserScopedProvidersAfterSignOut(Ref ref) async {
     ref.invalidate(defaultModelProvider);
     ref.invalidate(backendConfigProvider);
     ref.invalidate(socketServiceManagerProvider);
+    // Clear posted notifications and drop the listener's dedup memory so a
+    // notification can't deep-link into the previous session/server.
+    unawaited(ref.read(localNotificationServiceProvider).cancelAll());
+    ref.invalidate(notificationRouterProvider);
+    ref.invalidate(notificationSocketListenerProvider);
   } catch (error, stackTrace) {
     DebugLogger.error(
       'user-scoped-provider-cleanup-failed',
@@ -953,6 +960,13 @@ class AppStartupFlow extends _$AppStartupFlow {
     // fetch) so the sidebar generating spinner is correct app-wide, including
     // for generations started by other sessions. keepAlive keeps it running.
     ref.read(activeChatsSyncProvider);
+    // Activate the notification listener (global chat/channel handlers feeding
+    // the NotificationRouter). The router gates on the master toggle, so this is
+    // safe to run unconditionally. Then drain any cold-launch notification tap.
+    ref.read(notificationSocketListenerProvider);
+    unawaited(
+      ref.read(notificationSocketListenerProvider.notifier).handleLaunchTap(),
+    );
     _scheduleDefaultModelPreload(
       keepDefaultModelAutoSelectionAlive: keepDefaultModelAutoSelectionAlive,
     );

--- a/lib/core/providers/app_startup_providers.dart
+++ b/lib/core/providers/app_startup_providers.dart
@@ -104,7 +104,19 @@ Future<void> _cleanupUserScopedProvidersAfterSignOut(Ref ref) async {
     ref.invalidate(socketServiceManagerProvider);
     // Clear posted notifications and drop the listener's dedup memory so a
     // notification can't deep-link into the previous session/server.
-    unawaited(ref.read(localNotificationServiceProvider).cancelAll());
+    unawaited(
+      ref.read(localNotificationServiceProvider).cancelAll().catchError((
+        Object e,
+        StackTrace st,
+      ) {
+        DebugLogger.error(
+          'failed to clear notifications on sign-out',
+          scope: 'notifications/system',
+          error: e,
+          stackTrace: st,
+        );
+      }),
+    );
     ref.invalidate(notificationRouterProvider);
     ref.invalidate(notificationSocketListenerProvider);
   } catch (error, stackTrace) {

--- a/lib/core/router/app_router.dart
+++ b/lib/core/router/app_router.dart
@@ -31,6 +31,7 @@ import '../../features/profile/views/app_customization_page.dart';
 import '../../features/profile/views/audio_settings_page.dart';
 import '../../features/profile/views/personalization_page.dart';
 import '../../features/profile/views/profile_page.dart';
+import '../../features/notifications/views/notification_settings_page.dart';
 import '../../l10n/app_localizations.dart';
 import '../models/server_config.dart';
 
@@ -352,6 +353,14 @@ final goRouterProvider = Provider<GoRouter>((ref) {
       name: RouteNames.appCustomization,
       pageBuilder: (context, state) =>
           _buildPlatformPage(state: state, child: const AppCustomizationPage()),
+    ),
+    GoRoute(
+      path: Routes.notificationSettings,
+      name: RouteNames.notificationSettings,
+      pageBuilder: (context, state) => _buildPlatformPage(
+        state: state,
+        child: const NotificationSettingsPage(),
+      ),
     ),
     GoRoute(
       path: Routes.about,

--- a/lib/core/services/api_service.dart
+++ b/lib/core/services/api_service.dart
@@ -2386,6 +2386,34 @@ class ApiService {
     return ServerUserSettings.fromJson(data);
   }
 
+  /// Persists the notification preferences that Open WebUI stores server-side.
+  /// These live at the top level of the user settings object (not under `ui`).
+  /// Only non-null values are written so callers can update a subset.
+  Future<ServerUserSettings> updateUserNotificationSettings({
+    bool? notificationEnabled,
+    bool? notificationSound,
+    bool? notificationSoundAlways,
+  }) async {
+    final settings = _deepCloneJsonMap(await getUserSettings());
+    if (notificationEnabled != null) {
+      settings['notificationEnabled'] = notificationEnabled;
+    }
+    if (notificationSound != null) {
+      settings['notificationSound'] = notificationSound;
+    }
+    if (notificationSoundAlways != null) {
+      settings['notificationSoundAlways'] = notificationSoundAlways;
+    }
+
+    _traceApi('Updating user notification settings');
+    final response = await _dio.post(
+      '/api/v1/users/user/settings/update',
+      data: settings,
+    );
+    final data = _coerceResponseMap(response.data) ?? settings;
+    return ServerUserSettings.fromJson(data);
+  }
+
   Future<ServerUserSettings> updateUserPinnedModels(
     List<String> modelIds,
   ) async {

--- a/lib/core/services/native_sheet_bridge.dart
+++ b/lib/core/services/native_sheet_bridge.dart
@@ -38,6 +38,7 @@ class NativeSheetRoutes {
   static const dataConnection = 'data-connection';
   static const helpAbout = 'help-about';
   static const about = 'about';
+  static const notificationSettings = 'notification-settings';
 }
 
 class NativeSheetBridge implements NativeSheetFlutterApi {

--- a/lib/core/services/native_sheet_hydration_service.dart
+++ b/lib/core/services/native_sheet_hydration_service.dart
@@ -472,86 +472,99 @@ class NativeSheetHydrationService {
   }
 
   Future<void> _hydrateNativeNotificationsDetail(AppLocalizations l10n) async {
-    final s = _ref.read(appSettingsProvider);
-    await _applyNativeDetail(
-      NativeSheetDetailConfig(
-        id: NativeSheetRoutes.notificationSettings,
-        title: l10n.notificationsTitle,
-        subtitle: l10n.notificationsSubtitle,
-        sections: [
-          NativeSheetSectionConfig(
-            items: [
-              NativeSheetItemConfig(
-                id: 'notifications-enabled',
-                title: l10n.notificationsEnabledTitle,
-                subtitle: l10n.notificationsEnabledDescription,
-                sfSymbol: 'bell.fill',
-                kind: NativeSheetItemKind.toggle,
-                value: s.notificationsEnabled,
-              ),
-            ],
-          ),
-          NativeSheetSectionConfig(
-            title: l10n.notificationSystemTitle,
-            items: [
-              NativeSheetItemConfig(
-                id: 'notification-in-app-banner',
-                title: l10n.notificationInAppBannerTitle,
-                subtitle: l10n.notificationInAppBannerDescription,
-                sfSymbol: 'rectangle.topthird.inset.filled',
-                kind: NativeSheetItemKind.toggle,
-                value: s.notificationInAppBanner,
-              ),
-              NativeSheetItemConfig(
-                id: 'notification-system',
-                title: l10n.notificationSystemTitle,
-                subtitle: l10n.notificationSystemDescription,
-                sfSymbol: 'bell.badge',
-                kind: NativeSheetItemKind.toggle,
-                value: s.notificationSystem,
-              ),
-              NativeSheetItemConfig(
-                id: 'notification-sound',
-                title: l10n.notificationSoundTitle,
-                subtitle: l10n.notificationSoundDescription,
-                sfSymbol: 'speaker.wave.2.fill',
-                kind: NativeSheetItemKind.toggle,
-                value: s.notificationSound,
-              ),
-              NativeSheetItemConfig(
-                id: 'notification-sound-always',
-                title: l10n.notificationSoundAlwaysTitle,
-                subtitle: l10n.notificationSoundAlwaysDescription,
-                sfSymbol: 'speaker.wave.3.fill',
-                kind: NativeSheetItemKind.toggle,
-                value: s.notificationSoundAlways,
-              ),
-            ],
-          ),
-          NativeSheetSectionConfig(
-            title: l10n.notificationsTitle,
-            items: [
-              NativeSheetItemConfig(
-                id: 'notification-chat',
-                title: l10n.notificationChatTitle,
-                subtitle: l10n.notificationChatDescription,
-                sfSymbol: 'bubble.left.and.bubble.right.fill',
-                kind: NativeSheetItemKind.toggle,
-                value: s.notificationChatEnabled,
-              ),
-              NativeSheetItemConfig(
-                id: 'notification-channel',
-                title: l10n.notificationChannelTitle,
-                subtitle: l10n.notificationChannelDescription,
-                sfSymbol: 'number',
-                kind: NativeSheetItemKind.toggle,
-                value: s.notificationChannelEnabled,
-              ),
-            ],
-          ),
-        ],
-      ),
-    );
+    try {
+      final s = _ref.read(appSettingsProvider);
+      await _applyNativeDetail(
+        NativeSheetDetailConfig(
+          id: NativeSheetRoutes.notificationSettings,
+          title: l10n.notificationsTitle,
+          subtitle: l10n.notificationsSubtitle,
+          sections: [
+            NativeSheetSectionConfig(
+              items: [
+                NativeSheetItemConfig(
+                  id: 'notifications-enabled',
+                  title: l10n.notificationsEnabledTitle,
+                  subtitle: l10n.notificationsEnabledDescription,
+                  sfSymbol: 'bell.fill',
+                  kind: NativeSheetItemKind.toggle,
+                  value: s.notificationsEnabled,
+                ),
+              ],
+            ),
+            NativeSheetSectionConfig(
+              title: l10n.notificationSystemTitle,
+              items: [
+                NativeSheetItemConfig(
+                  id: 'notification-in-app-banner',
+                  title: l10n.notificationInAppBannerTitle,
+                  subtitle: l10n.notificationInAppBannerDescription,
+                  sfSymbol: 'rectangle.topthird.inset.filled',
+                  kind: NativeSheetItemKind.toggle,
+                  value: s.notificationInAppBanner,
+                ),
+                NativeSheetItemConfig(
+                  id: 'notification-system',
+                  title: l10n.notificationSystemTitle,
+                  subtitle: l10n.notificationSystemDescription,
+                  sfSymbol: 'bell.badge',
+                  kind: NativeSheetItemKind.toggle,
+                  value: s.notificationSystem,
+                ),
+                NativeSheetItemConfig(
+                  id: 'notification-sound',
+                  title: l10n.notificationSoundTitle,
+                  subtitle: l10n.notificationSoundDescription,
+                  sfSymbol: 'speaker.wave.2.fill',
+                  kind: NativeSheetItemKind.toggle,
+                  value: s.notificationSound,
+                ),
+                NativeSheetItemConfig(
+                  id: 'notification-sound-always',
+                  title: l10n.notificationSoundAlwaysTitle,
+                  subtitle: l10n.notificationSoundAlwaysDescription,
+                  sfSymbol: 'speaker.wave.3.fill',
+                  kind: NativeSheetItemKind.toggle,
+                  value: s.notificationSoundAlways,
+                ),
+              ],
+            ),
+            NativeSheetSectionConfig(
+              title: l10n.notificationsTitle,
+              items: [
+                NativeSheetItemConfig(
+                  id: 'notification-chat',
+                  title: l10n.notificationChatTitle,
+                  subtitle: l10n.notificationChatDescription,
+                  sfSymbol: 'bubble.left.and.bubble.right.fill',
+                  kind: NativeSheetItemKind.toggle,
+                  value: s.notificationChatEnabled,
+                ),
+                NativeSheetItemConfig(
+                  id: 'notification-channel',
+                  title: l10n.notificationChannelTitle,
+                  subtitle: l10n.notificationChannelDescription,
+                  sfSymbol: 'number',
+                  kind: NativeSheetItemKind.toggle,
+                  value: s.notificationChannelEnabled,
+                ),
+              ],
+            ),
+          ],
+        ),
+      );
+    } catch (error, stackTrace) {
+      DebugLogger.error(
+        'native-notifications-hydration-failed',
+        scope: 'native-sheet',
+        error: error,
+        stackTrace: stackTrace,
+      );
+      await _patchNativeDetailError(
+        NativeSheetRoutes.notificationSettings,
+        l10n.unableToLoadOpenWebuiSettings,
+      );
+    }
   }
 
   Future<void> _hydrateNativeVoiceDetail(AppLocalizations l10n) async {

--- a/lib/core/services/native_sheet_hydration_service.dart
+++ b/lib/core/services/native_sheet_hydration_service.dart
@@ -144,6 +144,9 @@ class NativeSheetHydrationService {
       case NativeSheetRoutes.personalization:
         await _hydrateNativePersonalizationDetail(ctx, l10n);
         return;
+      case NativeSheetRoutes.notificationSettings:
+        await _hydrateNativeNotificationsDetail(l10n);
+        return;
       case 'advanced-prompt-overrides':
         await _hydrateNativeAdvancedPromptDetail(ctx, l10n);
         return;
@@ -466,6 +469,89 @@ class NativeSheetHydrationService {
         l10n.unableToLoadOpenWebuiSettings,
       );
     }
+  }
+
+  Future<void> _hydrateNativeNotificationsDetail(AppLocalizations l10n) async {
+    final s = _ref.read(appSettingsProvider);
+    await _applyNativeDetail(
+      NativeSheetDetailConfig(
+        id: NativeSheetRoutes.notificationSettings,
+        title: l10n.notificationsTitle,
+        subtitle: l10n.notificationsSubtitle,
+        sections: [
+          NativeSheetSectionConfig(
+            items: [
+              NativeSheetItemConfig(
+                id: 'notifications-enabled',
+                title: l10n.notificationsEnabledTitle,
+                subtitle: l10n.notificationsEnabledDescription,
+                sfSymbol: 'bell.fill',
+                kind: NativeSheetItemKind.toggle,
+                value: s.notificationsEnabled,
+              ),
+            ],
+          ),
+          NativeSheetSectionConfig(
+            title: l10n.notificationSystemTitle,
+            items: [
+              NativeSheetItemConfig(
+                id: 'notification-in-app-banner',
+                title: l10n.notificationInAppBannerTitle,
+                subtitle: l10n.notificationInAppBannerDescription,
+                sfSymbol: 'rectangle.topthird.inset.filled',
+                kind: NativeSheetItemKind.toggle,
+                value: s.notificationInAppBanner,
+              ),
+              NativeSheetItemConfig(
+                id: 'notification-system',
+                title: l10n.notificationSystemTitle,
+                subtitle: l10n.notificationSystemDescription,
+                sfSymbol: 'bell.badge',
+                kind: NativeSheetItemKind.toggle,
+                value: s.notificationSystem,
+              ),
+              NativeSheetItemConfig(
+                id: 'notification-sound',
+                title: l10n.notificationSoundTitle,
+                subtitle: l10n.notificationSoundDescription,
+                sfSymbol: 'speaker.wave.2.fill',
+                kind: NativeSheetItemKind.toggle,
+                value: s.notificationSound,
+              ),
+              NativeSheetItemConfig(
+                id: 'notification-sound-always',
+                title: l10n.notificationSoundAlwaysTitle,
+                subtitle: l10n.notificationSoundAlwaysDescription,
+                sfSymbol: 'speaker.wave.3.fill',
+                kind: NativeSheetItemKind.toggle,
+                value: s.notificationSoundAlways,
+              ),
+            ],
+          ),
+          NativeSheetSectionConfig(
+            title: l10n.notificationsTitle,
+            items: [
+              NativeSheetItemConfig(
+                id: 'notification-chat',
+                title: l10n.notificationChatTitle,
+                subtitle: l10n.notificationChatDescription,
+                sfSymbol: 'bubble.left.and.bubble.right.fill',
+                kind: NativeSheetItemKind.toggle,
+                value: s.notificationChatEnabled,
+              ),
+              NativeSheetItemConfig(
+                id: 'notification-channel',
+                title: l10n.notificationChannelTitle,
+                subtitle: l10n.notificationChannelDescription,
+                sfSymbol: 'number',
+                kind: NativeSheetItemKind.toggle,
+                value: s.notificationChannelEnabled,
+              ),
+            ],
+          ),
+        ],
+      ),
+    );
   }
 
   Future<void> _hydrateNativeVoiceDetail(AppLocalizations l10n) async {

--- a/lib/core/services/native_sheet_hydration_service.dart
+++ b/lib/core/services/native_sheet_hydration_service.dart
@@ -474,81 +474,69 @@ class NativeSheetHydrationService {
   Future<void> _hydrateNativeNotificationsDetail(AppLocalizations l10n) async {
     try {
       final s = _ref.read(appSettingsProvider);
+      // Dynamic detail patches only carry a flat `items` list (sections are
+      // dropped by applyDetailPatch), so build a single ordered list.
       await _applyNativeDetail(
         NativeSheetDetailConfig(
           id: NativeSheetRoutes.notificationSettings,
           title: l10n.notificationsTitle,
           subtitle: l10n.notificationsSubtitle,
-          sections: [
-            NativeSheetSectionConfig(
-              items: [
-                NativeSheetItemConfig(
-                  id: 'notifications-enabled',
-                  title: l10n.notificationsEnabledTitle,
-                  subtitle: l10n.notificationsEnabledDescription,
-                  sfSymbol: 'bell.fill',
-                  kind: NativeSheetItemKind.toggle,
-                  value: s.notificationsEnabled,
-                ),
-              ],
+          items: [
+            NativeSheetItemConfig(
+              id: 'notifications-enabled',
+              title: l10n.notificationsEnabledTitle,
+              subtitle: l10n.notificationsEnabledDescription,
+              sfSymbol: 'bell.fill',
+              kind: NativeSheetItemKind.toggle,
+              value: s.notificationsEnabled,
             ),
-            NativeSheetSectionConfig(
+            NativeSheetItemConfig(
+              id: 'notification-in-app-banner',
+              title: l10n.notificationInAppBannerTitle,
+              subtitle: l10n.notificationInAppBannerDescription,
+              sfSymbol: 'rectangle.topthird.inset.filled',
+              kind: NativeSheetItemKind.toggle,
+              value: s.notificationInAppBanner,
+            ),
+            NativeSheetItemConfig(
+              id: 'notification-system',
               title: l10n.notificationSystemTitle,
-              items: [
-                NativeSheetItemConfig(
-                  id: 'notification-in-app-banner',
-                  title: l10n.notificationInAppBannerTitle,
-                  subtitle: l10n.notificationInAppBannerDescription,
-                  sfSymbol: 'rectangle.topthird.inset.filled',
-                  kind: NativeSheetItemKind.toggle,
-                  value: s.notificationInAppBanner,
-                ),
-                NativeSheetItemConfig(
-                  id: 'notification-system',
-                  title: l10n.notificationSystemTitle,
-                  subtitle: l10n.notificationSystemDescription,
-                  sfSymbol: 'bell.badge',
-                  kind: NativeSheetItemKind.toggle,
-                  value: s.notificationSystem,
-                ),
-                NativeSheetItemConfig(
-                  id: 'notification-sound',
-                  title: l10n.notificationSoundTitle,
-                  subtitle: l10n.notificationSoundDescription,
-                  sfSymbol: 'speaker.wave.2.fill',
-                  kind: NativeSheetItemKind.toggle,
-                  value: s.notificationSound,
-                ),
-                NativeSheetItemConfig(
-                  id: 'notification-sound-always',
-                  title: l10n.notificationSoundAlwaysTitle,
-                  subtitle: l10n.notificationSoundAlwaysDescription,
-                  sfSymbol: 'speaker.wave.3.fill',
-                  kind: NativeSheetItemKind.toggle,
-                  value: s.notificationSoundAlways,
-                ),
-              ],
+              subtitle: l10n.notificationSystemDescription,
+              sfSymbol: 'bell.badge',
+              kind: NativeSheetItemKind.toggle,
+              value: s.notificationSystem,
             ),
-            NativeSheetSectionConfig(
-              title: l10n.notificationsTitle,
-              items: [
-                NativeSheetItemConfig(
-                  id: 'notification-chat',
-                  title: l10n.notificationChatTitle,
-                  subtitle: l10n.notificationChatDescription,
-                  sfSymbol: 'bubble.left.and.bubble.right.fill',
-                  kind: NativeSheetItemKind.toggle,
-                  value: s.notificationChatEnabled,
-                ),
-                NativeSheetItemConfig(
-                  id: 'notification-channel',
-                  title: l10n.notificationChannelTitle,
-                  subtitle: l10n.notificationChannelDescription,
-                  sfSymbol: 'number',
-                  kind: NativeSheetItemKind.toggle,
-                  value: s.notificationChannelEnabled,
-                ),
-              ],
+            NativeSheetItemConfig(
+              id: 'notification-sound',
+              title: l10n.notificationSoundTitle,
+              subtitle: l10n.notificationSoundDescription,
+              sfSymbol: 'speaker.wave.2.fill',
+              kind: NativeSheetItemKind.toggle,
+              value: s.notificationSound,
+            ),
+            NativeSheetItemConfig(
+              id: 'notification-sound-always',
+              title: l10n.notificationSoundAlwaysTitle,
+              subtitle: l10n.notificationSoundAlwaysDescription,
+              sfSymbol: 'speaker.wave.3.fill',
+              kind: NativeSheetItemKind.toggle,
+              value: s.notificationSoundAlways,
+            ),
+            NativeSheetItemConfig(
+              id: 'notification-chat',
+              title: l10n.notificationChatTitle,
+              subtitle: l10n.notificationChatDescription,
+              sfSymbol: 'bubble.left.and.bubble.right.fill',
+              kind: NativeSheetItemKind.toggle,
+              value: s.notificationChatEnabled,
+            ),
+            NativeSheetItemConfig(
+              id: 'notification-channel',
+              title: l10n.notificationChannelTitle,
+              subtitle: l10n.notificationChannelDescription,
+              sfSymbol: 'number',
+              kind: NativeSheetItemKind.toggle,
+              value: s.notificationChannelEnabled,
             ),
           ],
         ),

--- a/lib/core/services/navigation_service.dart
+++ b/lib/core/services/navigation_service.dart
@@ -130,6 +130,7 @@ class Routes {
   static const String personalization = '/profile/personalization';
   static const String audioSettings = '/profile/audio';
   static const String accountSettings = '/profile/account';
+  static const String notificationSettings = '/profile/notifications';
   static const String appCustomization = '/profile/customization';
   static const String about = '/profile/about';
   static const String notes = '/notes';
@@ -154,6 +155,7 @@ class RouteNames {
   static const String personalization = 'personalization';
   static const String audioSettings = 'audio-settings';
   static const String accountSettings = 'account-settings';
+  static const String notificationSettings = 'notification-settings';
   static const String appCustomization = 'app-customization';
   static const String about = 'about';
   static const String notes = 'notes';

--- a/lib/core/services/settings_service.dart
+++ b/lib/core/services/settings_service.dart
@@ -68,6 +68,19 @@ class SettingsService {
   static const String _androidAssistantTriggerKey =
       PreferenceKeys.androidAssistantTrigger;
   static const String _pinnedModelsKey = PreferenceKeys.pinnedModels;
+  // Notifications
+  static const String _notificationsEnabledKey =
+      PreferenceKeys.notificationsEnabled;
+  static const String _notificationSoundKey = PreferenceKeys.notificationSound;
+  static const String _notificationSoundAlwaysKey =
+      PreferenceKeys.notificationSoundAlways;
+  static const String _notificationInAppBannerKey =
+      PreferenceKeys.notificationInAppBanner;
+  static const String _notificationSystemKey = PreferenceKeys.notificationSystem;
+  static const String _notificationChatEnabledKey =
+      PreferenceKeys.notificationChatEnabled;
+  static const String _notificationChannelEnabledKey =
+      PreferenceKeys.notificationChannelEnabled;
 
   static T? _getPreference<T>(String key) => PreferencesStore.get<T>(key);
 
@@ -117,6 +130,76 @@ class SettingsService {
   /// Set streaming haptics suppression preference.
   static Future<void> setDisableHapticsWhileStreaming(bool value) {
     return _putPreference(_disableHapticsWhileStreamingKey, value);
+  }
+
+  // -- Notifications --------------------------------------------------------
+
+  /// Master notifications toggle. Defaults to `false`: notifications stay off
+  /// until the user opts in (which is also when permission is requested).
+  static Future<bool> getNotificationsEnabled() {
+    return Future.value(
+      _getPreference<bool>(_notificationsEnabledKey) ?? false,
+    );
+  }
+
+  static Future<void> setNotificationsEnabled(bool value) {
+    return _putPreference(_notificationsEnabledKey, value);
+  }
+
+  static Future<bool> getNotificationSound() {
+    return Future.value(_getPreference<bool>(_notificationSoundKey) ?? true);
+  }
+
+  static Future<void> setNotificationSound(bool value) {
+    return _putPreference(_notificationSoundKey, value);
+  }
+
+  static Future<bool> getNotificationSoundAlways() {
+    return Future.value(
+      _getPreference<bool>(_notificationSoundAlwaysKey) ?? false,
+    );
+  }
+
+  static Future<void> setNotificationSoundAlways(bool value) {
+    return _putPreference(_notificationSoundAlwaysKey, value);
+  }
+
+  static Future<bool> getNotificationInAppBanner() {
+    return Future.value(
+      _getPreference<bool>(_notificationInAppBannerKey) ?? true,
+    );
+  }
+
+  static Future<void> setNotificationInAppBanner(bool value) {
+    return _putPreference(_notificationInAppBannerKey, value);
+  }
+
+  static Future<bool> getNotificationSystem() {
+    return Future.value(_getPreference<bool>(_notificationSystemKey) ?? true);
+  }
+
+  static Future<void> setNotificationSystem(bool value) {
+    return _putPreference(_notificationSystemKey, value);
+  }
+
+  static Future<bool> getNotificationChatEnabled() {
+    return Future.value(
+      _getPreference<bool>(_notificationChatEnabledKey) ?? true,
+    );
+  }
+
+  static Future<void> setNotificationChatEnabled(bool value) {
+    return _putPreference(_notificationChatEnabledKey, value);
+  }
+
+  static Future<bool> getNotificationChannelEnabled() {
+    return Future.value(
+      _getPreference<bool>(_notificationChannelEnabledKey) ?? true,
+    );
+  }
+
+  static Future<void> setNotificationChannelEnabled(bool value) {
+    return _putPreference(_notificationChannelEnabledKey, value);
   }
 
   /// Get high contrast preference
@@ -189,6 +272,13 @@ class SettingsService {
           settings.androidAssistantTrigger.storageValue,
       PreferenceKeys.temporaryChatByDefault: settings.temporaryChatByDefault,
       _pinnedModelsKey: settings.pinnedModels.toList(),
+      _notificationsEnabledKey: settings.notificationsEnabled,
+      _notificationSoundKey: settings.notificationSound,
+      _notificationSoundAlwaysKey: settings.notificationSoundAlways,
+      _notificationInAppBannerKey: settings.notificationInAppBanner,
+      _notificationSystemKey: settings.notificationSystem,
+      _notificationChatEnabledKey: settings.notificationChatEnabled,
+      _notificationChannelEnabledKey: settings.notificationChannelEnabled,
     };
 
     await PreferencesStore.putAll(updates);
@@ -542,6 +632,20 @@ class SettingsService {
       pinnedModels: sanitizePinnedModels(
         PreferencesStore.getStringList(_pinnedModelsKey) ?? const <String>[],
       ),
+      notificationsEnabled:
+          PreferencesStore.get<bool>(_notificationsEnabledKey) ?? false,
+      notificationSound:
+          PreferencesStore.get<bool>(_notificationSoundKey) ?? true,
+      notificationSoundAlways:
+          PreferencesStore.get<bool>(_notificationSoundAlwaysKey) ?? false,
+      notificationInAppBanner:
+          PreferencesStore.get<bool>(_notificationInAppBannerKey) ?? true,
+      notificationSystem:
+          PreferencesStore.get<bool>(_notificationSystemKey) ?? true,
+      notificationChatEnabled:
+          PreferencesStore.get<bool>(_notificationChatEnabledKey) ?? true,
+      notificationChannelEnabled:
+          PreferencesStore.get<bool>(_notificationChannelEnabledKey) ?? true,
     );
   }
 }
@@ -581,6 +685,14 @@ class AppSettings {
   final int voiceSilenceDuration;
   final bool temporaryChatByDefault;
   final List<String> pinnedModels;
+  // Notifications (see PreferenceKeys for which are server-synced).
+  final bool notificationsEnabled;
+  final bool notificationSound;
+  final bool notificationSoundAlways;
+  final bool notificationInAppBanner;
+  final bool notificationSystem;
+  final bool notificationChatEnabled;
+  final bool notificationChannelEnabled;
   const AppSettings({
     this.reduceMotion = false,
     this.animationSpeed = 1.0,
@@ -610,6 +722,13 @@ class AppSettings {
     this.voiceSilenceDuration = SettingsService.defaultVoiceSilenceDurationMs,
     this.temporaryChatByDefault = false,
     this.pinnedModels = const [],
+    this.notificationsEnabled = false,
+    this.notificationSound = true,
+    this.notificationSoundAlways = false,
+    this.notificationInAppBanner = true,
+    this.notificationSystem = true,
+    this.notificationChatEnabled = true,
+    this.notificationChannelEnabled = true,
   });
 
   AppSettings copyWith({
@@ -641,6 +760,13 @@ class AppSettings {
     AndroidAssistantTrigger? androidAssistantTrigger,
     bool? temporaryChatByDefault,
     List<String>? pinnedModels,
+    bool? notificationsEnabled,
+    bool? notificationSound,
+    bool? notificationSoundAlways,
+    bool? notificationInAppBanner,
+    bool? notificationSystem,
+    bool? notificationChatEnabled,
+    bool? notificationChannelEnabled,
   }) {
     return AppSettings(
       reduceMotion: reduceMotion ?? this.reduceMotion,
@@ -685,6 +811,17 @@ class AppSettings {
       temporaryChatByDefault:
           temporaryChatByDefault ?? this.temporaryChatByDefault,
       pinnedModels: pinnedModels ?? this.pinnedModels,
+      notificationsEnabled: notificationsEnabled ?? this.notificationsEnabled,
+      notificationSound: notificationSound ?? this.notificationSound,
+      notificationSoundAlways:
+          notificationSoundAlways ?? this.notificationSoundAlways,
+      notificationInAppBanner:
+          notificationInAppBanner ?? this.notificationInAppBanner,
+      notificationSystem: notificationSystem ?? this.notificationSystem,
+      notificationChatEnabled:
+          notificationChatEnabled ?? this.notificationChatEnabled,
+      notificationChannelEnabled:
+          notificationChannelEnabled ?? this.notificationChannelEnabled,
     );
   }
 
@@ -717,6 +854,13 @@ class AppSettings {
         other.androidAssistantTrigger == androidAssistantTrigger &&
         other.voiceSilenceDuration == voiceSilenceDuration &&
         other.temporaryChatByDefault == temporaryChatByDefault &&
+        other.notificationsEnabled == notificationsEnabled &&
+        other.notificationSound == notificationSound &&
+        other.notificationSoundAlways == notificationSoundAlways &&
+        other.notificationInAppBanner == notificationInAppBanner &&
+        other.notificationSystem == notificationSystem &&
+        other.notificationChatEnabled == notificationChatEnabled &&
+        other.notificationChannelEnabled == notificationChannelEnabled &&
         _listEquals(other.pinnedModels, pinnedModels) &&
         _listEquals(other.quickPills, quickPills);
     // socketTransportMode intentionally not included in == to avoid frequent rebuilds
@@ -750,6 +894,13 @@ class AppSettings {
       androidAssistantTrigger,
       voiceSilenceDuration,
       temporaryChatByDefault,
+      notificationsEnabled,
+      notificationSound,
+      notificationSoundAlways,
+      notificationInAppBanner,
+      notificationSystem,
+      notificationChatEnabled,
+      notificationChannelEnabled,
       Object.hashAllUnordered(quickPills),
       Object.hashAll(pinnedModels),
     ]);
@@ -816,6 +967,64 @@ class AppSettingsNotifier extends _$AppSettingsNotifier {
   Future<void> setDisableHapticsWhileStreaming(bool value) async {
     state = state.copyWith(disableHapticsWhileStreaming: value);
     await SettingsService.setDisableHapticsWhileStreaming(value);
+  }
+
+  Future<void> setNotificationsEnabled(bool value) async {
+    state = state.copyWith(notificationsEnabled: value);
+    await SettingsService.setNotificationsEnabled(value);
+  }
+
+  Future<void> setNotificationSound(bool value) async {
+    state = state.copyWith(notificationSound: value);
+    await SettingsService.setNotificationSound(value);
+  }
+
+  Future<void> setNotificationSoundAlways(bool value) async {
+    state = state.copyWith(notificationSoundAlways: value);
+    await SettingsService.setNotificationSoundAlways(value);
+  }
+
+  Future<void> setNotificationInAppBanner(bool value) async {
+    state = state.copyWith(notificationInAppBanner: value);
+    await SettingsService.setNotificationInAppBanner(value);
+  }
+
+  Future<void> setNotificationSystem(bool value) async {
+    state = state.copyWith(notificationSystem: value);
+    await SettingsService.setNotificationSystem(value);
+  }
+
+  Future<void> setNotificationChatEnabled(bool value) async {
+    state = state.copyWith(notificationChatEnabled: value);
+    await SettingsService.setNotificationChatEnabled(value);
+  }
+
+  Future<void> setNotificationChannelEnabled(bool value) async {
+    state = state.copyWith(notificationChannelEnabled: value);
+    await SettingsService.setNotificationChannelEnabled(value);
+  }
+
+  /// Applies the three server-synced notification prefs fetched from Open WebUI
+  /// without echoing them back to the server. Used at bootstrap so the server
+  /// stays authoritative for cross-device parity. Only writes when a value
+  /// actually changed to avoid spurious rebuilds.
+  Future<void> applyServerNotificationPrefs({
+    bool? enabled,
+    bool? sound,
+    bool? soundAlways,
+  }) async {
+    final next = state.copyWith(
+      notificationsEnabled: enabled,
+      notificationSound: sound,
+      notificationSoundAlways: soundAlways,
+    );
+    if (next == state) return;
+    state = next;
+    if (enabled != null) await SettingsService.setNotificationsEnabled(enabled);
+    if (sound != null) await SettingsService.setNotificationSound(sound);
+    if (soundAlways != null) {
+      await SettingsService.setNotificationSoundAlways(soundAlways);
+    }
   }
 
   Future<void> setHighContrast(bool value) async {

--- a/lib/features/channels/providers/channel_providers.dart
+++ b/lib/features/channels/providers/channel_providers.dart
@@ -51,6 +51,24 @@ class ChannelsList extends _$ChannelsList {
       current.map((c) => c.id == updated.id ? updated : c).toList(),
     );
   }
+
+  /// Clears the unread badge for [channelId] when the user opens it
+  /// (reset-on-visit), pairing with the server-side `emitLastReadAt`. No-ops if
+  /// the channel is unknown or already read so it never triggers a rebuild
+  /// without a real change.
+  void markRead(String channelId) {
+    final current = state.value;
+    if (current == null) return;
+    var changed = false;
+    final updated = current.map((c) {
+      if (c.id == channelId && c.unreadCount != 0) {
+        changed = true;
+        return c.copyWith(unreadCount: 0);
+      }
+      return c;
+    }).toList();
+    if (changed) state = AsyncValue.data(updated);
+  }
 }
 
 /// Tracks the currently active/viewed channel.

--- a/lib/features/channels/views/channel_page.dart
+++ b/lib/features/channels/views/channel_page.dart
@@ -158,6 +158,9 @@ class _ChannelPageState extends ConsumerState<ChannelPage> {
       ref
           .read(channelSocketHandlerProvider.notifier)
           .emitLastReadAt(widget.channelId);
+      // Reset-on-visit: clear the local unread badge to match the server-side
+      // read we just emitted.
+      ref.read(channelsListProvider.notifier).markRead(widget.channelId);
     } catch (e, s) {
       developer.log(
         'Failed to load channel details',

--- a/lib/features/navigation/widgets/sidebar_user_pill.dart
+++ b/lib/features/navigation/widgets/sidebar_user_pill.dart
@@ -239,6 +239,11 @@ class SidebarProfileAppBarLeading extends ConsumerWidget {
               sfSymbol: 'wand.and.stars',
             ),
             NativeSheetItemConfig(
+              id: NativeSheetRoutes.notificationSettings,
+              title: l10n.notificationsTitle,
+              sfSymbol: 'bell',
+            ),
+            NativeSheetItemConfig(
               id: NativeSheetRoutes.dataConnection,
               title: dataConnectionTitle,
               sfSymbol: 'network',
@@ -366,6 +371,12 @@ class SidebarProfileAppBarLeading extends ConsumerWidget {
           l10n: l10n,
           id: NativeSheetRoutes.aiMemory,
           title: aiMemoryTitle,
+          subtitle: l10n.loadingShort,
+        ),
+        buildNativeLoadingDetail(
+          l10n: l10n,
+          id: NativeSheetRoutes.notificationSettings,
+          title: l10n.notificationsTitle,
           subtitle: l10n.loadingShort,
         ),
         buildNativeLoadingDetail(

--- a/lib/features/notifications/models/app_notification.dart
+++ b/lib/features/notifications/models/app_notification.dart
@@ -1,0 +1,66 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+// Freezed applies JsonKey to constructor parameters which triggers
+// invalid_annotation_target; suppress it for this data model file.
+// ignore_for_file: invalid_annotation_target
+
+part 'app_notification.freezed.dart';
+part 'app_notification.g.dart';
+
+/// The kind of a user-facing notification, mirroring the Open WebUI socket
+/// events that raise an alert in the upstream web client.
+///
+/// Open WebUI's `+layout.svelte` only surfaces a toast / browser Notification
+/// for three event types: `chat:completion` (terminal frame), `calendar:alert`,
+/// and channel `message`. Conduit has no calendar feature, so `calendar:alert`
+/// is intentionally not represented here. Every other socket event
+/// (`chat:title`, `chat:tags`, `chat:message:error`, channel reply / reaction /
+/// created, etc.) is a silent state refresh upstream and is likewise not a
+/// [NotificationKind].
+enum NotificationKind {
+  /// An assistant response finished in a chat the user is not currently
+  /// viewing — upstream `chat:completion` with `done == true`.
+  @JsonValue('chat_completion')
+  chatCompletion,
+
+  /// A new message arrived in a channel or DM authored by someone else —
+  /// upstream channel event with `type == 'message'`.
+  @JsonValue('channel_message')
+  channelMessage,
+}
+
+/// An immutable, transport-agnostic description of a notification to surface.
+///
+/// Produced by [NotificationEventClassifier] from a raw socket envelope and
+/// consumed by the notification router. It deliberately carries no routing or
+/// presentation concerns: navigation is derived later from [kind] + [sourceId],
+/// and received-time / read tracking belong to the (deferred) inbox layer.
+@freezed
+sealed class AppNotification with _$AppNotification {
+  const factory AppNotification({
+    /// What happened — selects the surface copy and the deep-link target.
+    required NotificationKind kind,
+
+    /// Headline text, already formatted from the payload (may be empty when
+    /// the source provides no title; the surface layer supplies a fallback).
+    required String title,
+
+    /// Body text — the message / completion content.
+    required String body,
+
+    /// The chat id or channel id this notification points at. Used both for
+    /// active-view suppression and to build the tap deep link.
+    required String sourceId,
+
+    /// Stable de-duplication key. Survives socket re-bind / buffered-event
+    /// replay so a replayed terminal frame never double-notifies. Shared with
+    /// any future push source so the two never duplicate each other.
+    required String dedupKey,
+
+    /// Whether the user has seen this notification (set by the inbox layer).
+    @Default(false) bool read,
+  }) = _AppNotification;
+
+  factory AppNotification.fromJson(Map<String, dynamic> json) =>
+      _$AppNotificationFromJson(json);
+}

--- a/lib/features/notifications/providers/notification_socket_listener.dart
+++ b/lib/features/notifications/providers/notification_socket_listener.dart
@@ -1,0 +1,207 @@
+import 'dart:async';
+
+import 'package:adaptive_platform_ui/adaptive_platform_ui.dart';
+import 'package:flutter/widgets.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+import '../../../core/providers/app_providers.dart';
+import '../../../core/database/local_conversation_loader.dart';
+import '../../../core/services/navigation_service.dart';
+import '../../../core/services/settings_service.dart';
+import '../../../core/services/socket_service.dart';
+import '../../../core/utils/current_localizations.dart';
+import '../../../core/utils/debug_logger.dart';
+import '../../channels/providers/channel_providers.dart';
+import '../models/app_notification.dart';
+import '../services/active_view_tracker.dart';
+import '../services/local_notification_service.dart';
+import '../services/notification_event_classifier.dart';
+import '../services/notification_router.dart';
+import '../services/notification_sound_service.dart';
+
+part 'notification_socket_listener.g.dart';
+
+const _classifier = NotificationEventClassifier();
+
+/// Builds the [NotificationRouter], wiring it to live app state. keepAlive so
+/// its dedup memory persists across socket re-binds.
+@Riverpod(keepAlive: true)
+NotificationRouter notificationRouter(Ref ref) {
+  return NotificationRouter(
+    readSettings: () => ref.read(appSettingsProvider),
+    readActiveView: () => ref.read(activeViewProvider),
+    isAppForeground: _isAppForeground,
+    localNotifications: ref.read(localNotificationServiceProvider),
+    sound: ref.read(notificationSoundServiceProvider),
+    showInAppBanner: (n) => _showInAppBanner(ref, n),
+    onChannelUnread: (n) => _bumpChannelUnread(ref, n),
+  );
+}
+
+bool _isAppForeground() {
+  final state = WidgetsBinding.instance.lifecycleState;
+  // Null very early in startup — treat as foreground so banners work.
+  return state == null || state == AppLifecycleState.resumed;
+}
+
+void _showInAppBanner(Ref ref, AppNotification notification) {
+  final context = NavigationService.navigatorKey.currentContext;
+  if (context == null) return;
+  final l10n = currentAppLocalizations();
+  final message = notification.title.isNotEmpty
+      ? '${notification.title}: ${notification.body}'
+      : notification.body;
+  AdaptiveSnackBar.show(
+    context,
+    message: message,
+    type: AdaptiveSnackBarType.info,
+    action: l10n.notificationViewAction,
+    onActionPressed: () => _handleTap(
+      ref,
+      NotificationTap(kind: notification.kind, sourceId: notification.sourceId),
+    ),
+  );
+}
+
+void _bumpChannelUnread(Ref ref, AppNotification notification) {
+  final list = ref.read(channelsListProvider).value;
+  if (list == null) return;
+  for (final channel in list) {
+    if (channel.id == notification.sourceId) {
+      ref
+          .read(channelsListProvider.notifier)
+          .updateChannel(
+            channel.copyWith(unreadCount: channel.unreadCount + 1),
+          );
+      return;
+    }
+  }
+}
+
+Future<void> _handleTap(Ref ref, NotificationTap tap) async {
+  switch (tap.kind) {
+    case NotificationKind.channelMessage:
+      NavigationService.navigateToChannel(tap.sourceId);
+    case NotificationKind.chatCompletion:
+      // DB-first open, mirroring the conversation-list selection flow.
+      await NavigationService.navigateToChat();
+      final local = await loadLocalConversation(ref, tap.sourceId);
+      if (local != null) {
+        ref.read(activeConversationProvider.notifier).set(local);
+      }
+      schedulePullChatNow(ref, tap.sourceId);
+  }
+}
+
+/// Single global subscriber that turns socket events into notifications.
+///
+/// Mirrors `ActiveChatsSync._bindSocket`: one chat handler + one channel
+/// handler, both `requireFocus:false`, re-bound on socket change and on
+/// reconnect. The [NotificationRouter] (not this class) owns all gating, so the
+/// listener can run unconditionally — when notifications are disabled the router
+/// simply drops everything.
+@Riverpod(keepAlive: true)
+class NotificationSocketListener extends _$NotificationSocketListener {
+  SocketEventSubscription? _chatSub;
+  SocketEventSubscription? _channelSub;
+  StreamSubscription<void>? _reconnectSub;
+  StreamSubscription<NotificationTap>? _tapSub;
+  SocketService? _boundSocket;
+
+  @override
+  void build() {
+    ref.onDispose(() {
+      _chatSub?.dispose();
+      _channelSub?.dispose();
+      _reconnectSub?.cancel();
+      _tapSub?.cancel();
+    });
+
+    final local = ref.read(localNotificationServiceProvider);
+    // Initialize the plugin (channel + tap handler) without requesting
+    // permission — permission is requested on master-toggle opt-in.
+    unawaited(local.initialize());
+
+    // System-notification taps (foreground) route to the target.
+    _tapSub = local.taps.listen((tap) {
+      unawaited(_handleTap(ref, tap));
+    });
+
+    _bindSocket(ref.read(socketServiceProvider));
+    ref.listen<SocketService?>(socketServiceProvider, (_, next) {
+      _bindSocket(next);
+    });
+  }
+
+  /// Handles a notification that cold-launched the app from a killed state.
+  /// Called once after the router is ready.
+  Future<void> handleLaunchTap() async {
+    final tap = await ref.read(localNotificationServiceProvider).launchTap();
+    if (tap != null) {
+      await _handleTap(ref, tap);
+    }
+  }
+
+  void _bindSocket(SocketService? socket) {
+    if (identical(socket, _boundSocket)) return;
+    _boundSocket = socket;
+    _chatSub?.dispose();
+    _chatSub = null;
+    _channelSub?.dispose();
+    _channelSub = null;
+    _reconnectSub?.cancel();
+    _reconnectSub = null;
+    if (socket == null) return;
+
+    // Wildcard handlers (all selectors null) so we see every chat/channel event.
+    _chatSub = socket.addChatEventHandler(
+      requireFocus: false,
+      handler: (event, _) => _onChatEvent(event),
+    );
+    _channelSub = socket.addChannelEventHandler(
+      requireFocus: false,
+      handler: (event, _) => _onChannelEvent(event),
+    );
+
+    // Unread counts can drift while disconnected; reconcile from the server.
+    _reconnectSub = socket.onReconnect.listen((_) {
+      unawaited(ref.read(channelsListProvider.notifier).refresh());
+    });
+  }
+
+  String get _currentUserId =>
+      ref.read(currentUserProvider).value?.id ?? '';
+
+  void _onChatEvent(Map<String, dynamic> event) {
+    final notification = _classifier.classifyChatEvent(
+      event,
+      currentUserId: _currentUserId,
+    );
+    if (notification != null) _route(notification);
+  }
+
+  void _onChannelEvent(Map<String, dynamic> event) {
+    final notification = _classifier.classifyChannelEvent(
+      event,
+      currentUserId: _currentUserId,
+    );
+    if (notification != null) _route(notification);
+  }
+
+  void _route(AppNotification notification) {
+    unawaited(
+      ref.read(notificationRouterProvider).route(notification).catchError((
+        Object e,
+        StackTrace st,
+      ) {
+        DebugLogger.error(
+          'notification routing failed',
+          error: e,
+          stackTrace: st,
+          scope: 'notifications/center',
+        );
+        return NotificationSurface.suppressed;
+      }),
+    );
+  }
+}

--- a/lib/features/notifications/providers/notification_socket_listener.dart
+++ b/lib/features/notifications/providers/notification_socket_listener.dart
@@ -198,9 +198,13 @@ class NotificationSocketListener extends _$NotificationSocketListener {
   }
 
   void _onChannelEvent(Map<String, dynamic> event) {
+    final userId = _currentUserId;
+    // Until the current user resolves we can't run the self-author filter, so
+    // skip rather than risk notifying the user for their own messages.
+    if (userId.isEmpty) return;
     final notification = _classifier.classifyChannelEvent(
       event,
-      currentUserId: _currentUserId,
+      currentUserId: userId,
     );
     if (notification != null) _route(notification);
   }

--- a/lib/features/notifications/providers/notification_socket_listener.dart
+++ b/lib/features/notifications/providers/notification_socket_listener.dart
@@ -79,17 +79,28 @@ void _bumpChannelUnread(Ref ref, AppNotification notification) {
 }
 
 Future<void> _handleTap(Ref ref, NotificationTap tap) async {
-  switch (tap.kind) {
-    case NotificationKind.channelMessage:
-      NavigationService.navigateToChannel(tap.sourceId);
-    case NotificationKind.chatCompletion:
-      // DB-first open, mirroring the conversation-list selection flow.
-      await NavigationService.navigateToChat();
-      final local = await loadLocalConversation(ref, tap.sourceId);
-      if (local != null) {
-        ref.read(activeConversationProvider.notifier).set(local);
-      }
-      schedulePullChatNow(ref, tap.sourceId);
+  // Fire-and-forget from tap streams / cold launch — never let a navigation
+  // failure surface as an uncaught async error.
+  try {
+    switch (tap.kind) {
+      case NotificationKind.channelMessage:
+        NavigationService.navigateToChannel(tap.sourceId);
+      case NotificationKind.chatCompletion:
+        // DB-first open, mirroring the conversation-list selection flow.
+        await NavigationService.navigateToChat();
+        final local = await loadLocalConversation(ref, tap.sourceId);
+        if (local != null) {
+          ref.read(activeConversationProvider.notifier).set(local);
+        }
+        schedulePullChatNow(ref, tap.sourceId);
+    }
+  } catch (e, st) {
+    DebugLogger.error(
+      'notification deep-link failed',
+      error: e,
+      stackTrace: st,
+      scope: 'notifications/center',
+    );
   }
 }
 

--- a/lib/features/notifications/providers/notification_socket_listener.dart
+++ b/lib/features/notifications/providers/notification_socket_listener.dart
@@ -147,7 +147,13 @@ class NotificationSocketListener extends _$NotificationSocketListener {
   /// Handles a notification that cold-launched the app from a killed state.
   /// Called once after the router is ready.
   Future<void> handleLaunchTap() async {
-    final tap = await ref.read(localNotificationServiceProvider).launchTap();
+    final local = ref.read(localNotificationServiceProvider);
+    // Ensure the plugin finished native init before querying the launch intent:
+    // on Android getNotificationAppLaunchDetails() returns null until then, so
+    // racing it would silently drop the deep link. initialize() is idempotent
+    // and shares the in-flight future started in build().
+    await local.initialize();
+    final tap = await local.launchTap();
     if (tap != null) {
       await _handleTap(ref, tap);
     }

--- a/lib/features/notifications/services/active_view_tracker.dart
+++ b/lib/features/notifications/services/active_view_tracker.dart
@@ -1,0 +1,31 @@
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+import '../../../core/providers/app_providers.dart';
+import '../../channels/providers/channel_providers.dart';
+
+part 'active_view_tracker.g.dart';
+
+/// The chat / channel the user is currently looking at.
+///
+/// Derived from the existing [activeConversationProvider] and
+/// [activeChannelProvider], which are set synchronously when their pages load.
+/// This is the source of truth for notification foreground-suppression — a
+/// `NavigatorObserver` cannot recover these ids (the chat route carries no path
+/// parameter), whereas these providers already track them reactively.
+class ActiveView {
+  const ActiveView({this.chatId, this.channelId});
+
+  final String? chatId;
+  final String? channelId;
+
+  bool isViewingChat(String id) => chatId != null && chatId == id;
+
+  bool isViewingChannel(String id) => channelId != null && channelId == id;
+}
+
+@Riverpod(keepAlive: true)
+ActiveView activeView(Ref ref) {
+  final conversation = ref.watch(activeConversationProvider);
+  final channel = ref.watch(activeChannelProvider);
+  return ActiveView(chatId: conversation?.id, channelId: channel?.id);
+}

--- a/lib/features/notifications/services/local_notification_service.dart
+++ b/lib/features/notifications/services/local_notification_service.dart
@@ -65,32 +65,46 @@ class LocalNotificationService {
   /// Emits when the user taps a message notification while the app is running.
   Stream<NotificationTap> get taps => _taps.stream;
 
-  Future<void> initialize() async {
-    if (_initialized) return;
-    if (!Platform.isAndroid && !Platform.isIOS) return;
+  Future<void>? _initializing;
 
-    const androidSettings = AndroidInitializationSettings('@mipmap/ic_launcher');
-    // No permission requests at init — see class doc.
-    const iosSettings = DarwinInitializationSettings(
-      requestAlertPermission: false,
-      requestBadgePermission: false,
-      requestSoundPermission: false,
-    );
-    const settings = InitializationSettings(
-      android: androidSettings,
-      iOS: iosSettings,
-    );
+  /// Initializes the plugin exactly once. Concurrent callers (e.g. several
+  /// `show()`s racing before setup completes) share the same in-flight future
+  /// instead of each running `_plugin.initialize()` in parallel.
+  Future<void> initialize() {
+    if (_initialized) return Future<void>.value();
+    if (!Platform.isAndroid && !Platform.isIOS) return Future<void>.value();
+    return _initializing ??= _doInitialize();
+  }
 
-    await _plugin.initialize(
-      settings: settings,
-      onDidReceiveNotificationResponse: _onResponse,
-    );
+  Future<void> _doInitialize() async {
+    try {
+      const androidSettings = AndroidInitializationSettings(
+        '@mipmap/ic_launcher',
+      );
+      // No permission requests at init — see class doc.
+      const iosSettings = DarwinInitializationSettings(
+        requestAlertPermission: false,
+        requestBadgePermission: false,
+        requestSoundPermission: false,
+      );
+      const settings = InitializationSettings(
+        android: androidSettings,
+        iOS: iosSettings,
+      );
 
-    if (Platform.isAndroid) {
-      await _createAndroidChannel();
+      await _plugin.initialize(
+        settings: settings,
+        onDidReceiveNotificationResponse: _onResponse,
+      );
+
+      if (Platform.isAndroid) {
+        await _createAndroidChannel();
+      }
+
+      _initialized = true;
+    } finally {
+      _initializing = null;
     }
-
-    _initialized = true;
   }
 
   Future<void> _createAndroidChannel() async {
@@ -109,6 +123,9 @@ class LocalNotificationService {
   }
 
   void _onResponse(NotificationResponse response) {
+    // The plugin singleton keeps this callback registered after dispose(), so a
+    // late tap could otherwise add to a closed controller and throw.
+    if (_taps.isClosed) return;
     final tap = NotificationTap.tryDecode(response.payload);
     if (tap != null) {
       _taps.add(tap);
@@ -145,17 +162,6 @@ class LocalNotificationService {
           false;
     }
     return false;
-  }
-
-  Future<bool> areEnabled() async {
-    if (Platform.isAndroid) {
-      final android = _plugin
-          .resolvePlatformSpecificImplementation<
-            AndroidFlutterLocalNotificationsPlugin
-          >();
-      return await android?.areNotificationsEnabled() ?? false;
-    }
-    return _initialized;
   }
 
   /// Posts an OS notification for [notification]. No-ops on unsupported

--- a/lib/features/notifications/services/local_notification_service.dart
+++ b/lib/features/notifications/services/local_notification_service.dart
@@ -1,0 +1,224 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter_local_notifications/flutter_local_notifications.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+import '../../../core/utils/current_localizations.dart';
+import '../../../core/utils/debug_logger.dart';
+import '../models/app_notification.dart';
+
+part 'local_notification_service.g.dart';
+
+/// A tap on a system notification, decoded back into the target it points at.
+class NotificationTap {
+  const NotificationTap({required this.kind, required this.sourceId});
+
+  final NotificationKind kind;
+  final String sourceId;
+
+  static NotificationTap? tryDecode(String? payload) {
+    if (payload == null || payload.isEmpty) return null;
+    try {
+      final map = jsonDecode(payload);
+      if (map is! Map) return null;
+      final kindName = map['kind'];
+      final sourceId = map['sourceId'];
+      if (kindName is! String || sourceId is! String || sourceId.isEmpty) {
+        return null;
+      }
+      final kind = NotificationKind.values
+          .where((k) => k.name == kindName)
+          .firstOrNull;
+      if (kind == null) return null;
+      return NotificationTap(kind: kind, sourceId: sourceId);
+    } catch (_) {
+      return null;
+    }
+  }
+
+  static String encode(AppNotification notification) => jsonEncode({
+    'kind': notification.kind.name,
+    'sourceId': notification.sourceId,
+  });
+}
+
+/// Wraps a single [FlutterLocalNotificationsPlugin] instance for OS-level
+/// message notifications. Deliberately separate from
+/// `VoiceCallNotificationService` for now (that refactor is a follow-up); this
+/// owns its own `conduit_messages` channel and never requests permission at
+/// init — permission is requested only when the user opts in.
+class LocalNotificationService {
+  LocalNotificationService();
+
+  final FlutterLocalNotificationsPlugin _plugin =
+      FlutterLocalNotificationsPlugin();
+
+  static const String _channelId = 'conduit_messages';
+
+  bool _initialized = false;
+
+  final StreamController<NotificationTap> _taps =
+      StreamController<NotificationTap>.broadcast();
+
+  /// Emits when the user taps a message notification while the app is running.
+  Stream<NotificationTap> get taps => _taps.stream;
+
+  Future<void> initialize() async {
+    if (_initialized) return;
+    if (!Platform.isAndroid && !Platform.isIOS) return;
+
+    const androidSettings = AndroidInitializationSettings('@mipmap/ic_launcher');
+    // No permission requests at init — see class doc.
+    const iosSettings = DarwinInitializationSettings(
+      requestAlertPermission: false,
+      requestBadgePermission: false,
+      requestSoundPermission: false,
+    );
+    const settings = InitializationSettings(
+      android: androidSettings,
+      iOS: iosSettings,
+    );
+
+    await _plugin.initialize(
+      settings: settings,
+      onDidReceiveNotificationResponse: _onResponse,
+    );
+
+    if (Platform.isAndroid) {
+      await _createAndroidChannel();
+    }
+
+    _initialized = true;
+  }
+
+  Future<void> _createAndroidChannel() async {
+    final l10n = currentAppLocalizations();
+    final channel = AndroidNotificationChannel(
+      _channelId,
+      l10n.notificationChannelMessagesName,
+      description: l10n.notificationChannelMessagesDescription,
+      importance: Importance.high,
+    );
+    await _plugin
+        .resolvePlatformSpecificImplementation<
+          AndroidFlutterLocalNotificationsPlugin
+        >()
+        ?.createNotificationChannel(channel);
+  }
+
+  void _onResponse(NotificationResponse response) {
+    final tap = NotificationTap.tryDecode(response.payload);
+    if (tap != null) {
+      _taps.add(tap);
+    }
+  }
+
+  /// The notification that cold-launched the app, if any (e.g. tapped from a
+  /// killed state). Returns null when the launch was not from a notification.
+  Future<NotificationTap?> launchTap() async {
+    if (!Platform.isAndroid && !Platform.isIOS) return null;
+    final details = await _plugin.getNotificationAppLaunchDetails();
+    if (details?.didNotificationLaunchApp != true) return null;
+    return NotificationTap.tryDecode(details?.notificationResponse?.payload);
+  }
+
+  Future<bool> requestPermissions() async {
+    if (Platform.isAndroid) {
+      final android = _plugin
+          .resolvePlatformSpecificImplementation<
+            AndroidFlutterLocalNotificationsPlugin
+          >();
+      return await android?.requestNotificationsPermission() ?? false;
+    }
+    if (Platform.isIOS) {
+      final ios = _plugin
+          .resolvePlatformSpecificImplementation<
+            IOSFlutterLocalNotificationsPlugin
+          >();
+      return await ios?.requestPermissions(
+            alert: true,
+            badge: true,
+            sound: true,
+          ) ??
+          false;
+    }
+    return false;
+  }
+
+  Future<bool> areEnabled() async {
+    if (Platform.isAndroid) {
+      final android = _plugin
+          .resolvePlatformSpecificImplementation<
+            AndroidFlutterLocalNotificationsPlugin
+          >();
+      return await android?.areNotificationsEnabled() ?? false;
+    }
+    return _initialized;
+  }
+
+  /// Posts an OS notification for [notification]. No-ops on unsupported
+  /// platforms. Safe to call before [initialize] (it self-initializes).
+  Future<void> show(AppNotification notification) async {
+    if (!Platform.isAndroid && !Platform.isIOS) return;
+    if (!_initialized) await initialize();
+
+    final l10n = currentAppLocalizations();
+    final title = notification.title.isNotEmpty
+        ? notification.title
+        : l10n.notificationDefaultTitle;
+
+    final androidDetails = AndroidNotificationDetails(
+      _channelId,
+      l10n.notificationChannelMessagesName,
+      channelDescription: l10n.notificationChannelMessagesDescription,
+      importance: Importance.high,
+      priority: Priority.high,
+      icon: '@mipmap/ic_launcher',
+    );
+    const iosDetails = DarwinNotificationDetails(
+      presentAlert: true,
+      presentBadge: true,
+      presentSound: true,
+    );
+
+    try {
+      await _plugin.show(
+        id: notification.dedupKey.hashCode & 0x7fffffff,
+        title: title,
+        body: notification.body,
+        notificationDetails: NotificationDetails(
+          android: androidDetails,
+          iOS: iosDetails,
+        ),
+        payload: NotificationTap.encode(notification),
+      );
+    } catch (e, st) {
+      DebugLogger.error(
+        'failed to show system notification',
+        error: e,
+        stackTrace: st,
+        scope: 'notifications/system',
+      );
+    }
+  }
+
+  /// Clears all posted message notifications — used on logout / server switch
+  /// to avoid cross-server deep links.
+  Future<void> cancelAll() async {
+    if (!Platform.isAndroid && !Platform.isIOS) return;
+    await _plugin.cancelAll();
+  }
+
+  void dispose() {
+    _taps.close();
+  }
+}
+
+@Riverpod(keepAlive: true)
+LocalNotificationService localNotificationService(Ref ref) {
+  final service = LocalNotificationService();
+  ref.onDispose(service.dispose);
+  return service;
+}

--- a/lib/features/notifications/services/local_notification_service.dart
+++ b/lib/features/notifications/services/local_notification_service.dart
@@ -59,6 +59,13 @@ class LocalNotificationService {
 
   bool _initialized = false;
 
+  /// Monotonic OS-notification id. Using a counter (rather than a hash of the
+  /// dedup key) avoids 31-bit hash collisions silently replacing a notification
+  /// in the drawer. De-duplication is handled upstream by the router.
+  int _idCounter = 0;
+
+  int _nextNotificationId() => _idCounter = (_idCounter + 1) & 0x7fffffff;
+
   final StreamController<NotificationTap> _taps =
       StreamController<NotificationTap>.broadcast();
 
@@ -102,6 +109,15 @@ class LocalNotificationService {
       }
 
       _initialized = true;
+    } catch (e, st) {
+      // Contain init failures here so they can't bubble into notification
+      // routing. _initialized stays false so a later call can retry.
+      DebugLogger.error(
+        'failed to initialize local notifications',
+        error: e,
+        stackTrace: st,
+        scope: 'notifications/system',
+      );
     } finally {
       _initializing = null;
     }
@@ -166,7 +182,14 @@ class LocalNotificationService {
 
   /// Posts an OS notification for [notification]. No-ops on unsupported
   /// platforms. Safe to call before [initialize] (it self-initializes).
-  Future<void> show(AppNotification notification) async {
+  ///
+  /// [playSound] honors the user's notification-sound preference. Note Android
+  /// 8+ governs sound at the channel level, so the per-notification flag is
+  /// best-effort there; it is authoritative on iOS.
+  Future<void> show(
+    AppNotification notification, {
+    required bool playSound,
+  }) async {
     if (!Platform.isAndroid && !Platform.isIOS) return;
     if (!_initialized) await initialize();
 
@@ -182,16 +205,17 @@ class LocalNotificationService {
       importance: Importance.high,
       priority: Priority.high,
       icon: '@mipmap/ic_launcher',
+      playSound: playSound,
     );
-    const iosDetails = DarwinNotificationDetails(
+    final iosDetails = DarwinNotificationDetails(
       presentAlert: true,
       presentBadge: true,
-      presentSound: true,
+      presentSound: playSound,
     );
 
     try {
       await _plugin.show(
-        id: notification.dedupKey.hashCode & 0x7fffffff,
+        id: _nextNotificationId(),
         title: title,
         body: notification.body,
         notificationDetails: NotificationDetails(

--- a/lib/features/notifications/services/notification_event_classifier.dart
+++ b/lib/features/notifications/services/notification_event_classifier.dart
@@ -72,10 +72,12 @@ class NotificationEventClassifier {
     final data = _asMap(envelope['data']);
     if (data == null) return null;
 
-    // Never notify for the user's own messages (upstream filters by author id).
+    // Require a valid author. Missing author metadata is malformed (and also
+    // covers system/non-user messages we don't notify for). Never notify for
+    // the user's own messages (upstream filters by author id).
     final author = _asMap(data['user']);
     final authorId = _asString(author?['id']);
-    if (authorId.isNotEmpty && authorId == currentUserId) return null;
+    if (authorId.isEmpty || authorId == currentUserId) return null;
 
     final channelId = _asNonEmptyString(event['channel_id']);
     if (channelId == null) return null;

--- a/lib/features/notifications/services/notification_event_classifier.dart
+++ b/lib/features/notifications/services/notification_event_classifier.dart
@@ -1,0 +1,119 @@
+import '../models/app_notification.dart';
+
+/// Pure translator from raw Open WebUI socket envelopes to [AppNotification]s.
+///
+/// This is the single owner of upstream event-envelope semantics: the nested
+/// `data.type` / `data.data` unfolding, which event types are notifiable, the
+/// terminal-frame rule for completions, and self-authored filtering. Keeping it
+/// pure (no Riverpod, no IO, no clock) makes it exhaustively unit-testable
+/// against captured payloads and isolates the brittle coupling to upstream's
+/// schema in one place.
+///
+/// Every method returns `null` for anything non-notifiable — unknown types,
+/// non-terminal frames, self-authored messages, malformed envelopes — and never
+/// throws on unexpected shapes, so schema drift degrades to "no notification"
+/// rather than a crash.
+class NotificationEventClassifier {
+  const NotificationEventClassifier();
+
+  /// Classifies an event from the personal `events` socket stream.
+  ///
+  /// Notifiable: `chat:completion` with `done == true`. Mirrors upstream
+  /// `+layout.svelte`, which alerts only on the terminal completion frame.
+  AppNotification? classifyChatEvent(
+    Map<String, dynamic> event, {
+    required String currentUserId,
+  }) {
+    final envelope = _asMap(event['data']);
+    if (envelope == null) return null;
+
+    final type = envelope['type'];
+    if (type != 'chat:completion') return null;
+
+    final data = _asMap(envelope['data']);
+    if (data == null) return null;
+
+    // Only the terminal frame is user-facing; the middleware emits many
+    // intermediate frames for the same response.
+    if (data['done'] != true) return null;
+
+    final chatId = _asNonEmptyString(event['chat_id']);
+    if (chatId == null) return null;
+
+    final content = _asString(data['content']);
+    final title = _asString(data['title']);
+
+    return AppNotification(
+      kind: NotificationKind.chatCompletion,
+      title: title,
+      body: content,
+      sourceId: chatId,
+      // Completion frames carry no stable message id, so key on the chat plus
+      // the content: a replayed identical terminal frame dedupes, while a later
+      // distinct response in the same chat still notifies.
+      dedupKey: 'chat:$chatId:${content.hashCode}',
+    );
+  }
+
+  /// Classifies an event from the `events:channel` socket stream.
+  ///
+  /// Notifiable: `type == 'message'` authored by someone other than the current
+  /// user. Replies, reactions, updates, deletes and channel lifecycle events are
+  /// silent state refreshes upstream and yield `null` here.
+  AppNotification? classifyChannelEvent(
+    Map<String, dynamic> event, {
+    required String currentUserId,
+  }) {
+    final envelope = _asMap(event['data']);
+    if (envelope == null) return null;
+
+    if (envelope['type'] != 'message') return null;
+
+    final data = _asMap(envelope['data']);
+    if (data == null) return null;
+
+    // Never notify for the user's own messages (upstream filters by author id).
+    final author = _asMap(data['user']);
+    final authorId = _asString(author?['id']);
+    if (authorId.isNotEmpty && authorId == currentUserId) return null;
+
+    final channelId = _asNonEmptyString(event['channel_id']);
+    if (channelId == null) return null;
+
+    final messageId = _asNonEmptyString(data['id']);
+    final content = _asString(data['content']);
+
+    return AppNotification(
+      kind: NotificationKind.channelMessage,
+      title: _channelTitle(event, author),
+      body: content,
+      sourceId: channelId,
+      // Channel messages carry a stable id; fall back to content keying only if
+      // the server omits it.
+      dedupKey: messageId != null
+          ? 'channel:$channelId:$messageId'
+          : 'channel:$channelId:${content.hashCode}',
+    );
+  }
+
+  /// Builds the headline: author name, suffixed with `(#channel)` for non-DM
+  /// channels, matching upstream's `+layout.svelte` formatting.
+  String _channelTitle(Map<String, dynamic> event, Map<String, dynamic>? author) {
+    final authorName = _asString(author?['name']);
+    final channel = _asMap(event['channel']);
+    final channelType = _asString(channel?['type']);
+    final channelName = _asString(channel?['name']);
+    if (channelType != 'dm' && channelName.isNotEmpty) {
+      return '$authorName (#$channelName)';
+    }
+    return authorName;
+  }
+
+  static Map<String, dynamic>? _asMap(Object? value) =>
+      value is Map<String, dynamic> ? value : null;
+
+  static String _asString(Object? value) => value is String ? value : '';
+
+  static String? _asNonEmptyString(Object? value) =>
+      value is String && value.isNotEmpty ? value : null;
+}

--- a/lib/features/notifications/services/notification_router.dart
+++ b/lib/features/notifications/services/notification_router.dart
@@ -75,8 +75,15 @@ class NotificationRouter {
       return NotificationSurface.suppressed;
     }
 
-    // 4. Don't alert for content the user is already looking at.
-    if (_isViewingTarget(notification)) return NotificationSurface.suppressed;
+    final foreground = _isAppForeground();
+
+    // 4. Don't alert for content the user is actively looking at — but only in
+    // the foreground. Backgrounded, the user can't see any view, so a
+    // completion in the chat they just left (the "active" chat) must still
+    // notify. Mirrors Open WebUI's `(notViewingChat) || isInBackground` gate.
+    if (foreground && _isViewingTarget(notification)) {
+      return NotificationSurface.suppressed;
+    }
 
     // 5. Side effects for everything that passed gating.
     if (settings.notificationSound && settings.notificationSoundAlways) {
@@ -90,7 +97,7 @@ class NotificationRouter {
     // web client (which can show an in-app toast AND a browser Notification at
     // once), a foregrounded mobile app only needs the in-app banner; the OS
     // notification is the background affordance.
-    if (_isAppForeground()) {
+    if (foreground) {
       if (settings.notificationInAppBanner) {
         _showInAppBanner(notification);
         return NotificationSurface.banner;

--- a/lib/features/notifications/services/notification_router.dart
+++ b/lib/features/notifications/services/notification_router.dart
@@ -1,0 +1,137 @@
+import 'dart:collection';
+
+import '../../../core/services/settings_service.dart';
+import '../models/app_notification.dart';
+import 'active_view_tracker.dart';
+import 'local_notification_service.dart';
+import 'notification_sound_service.dart';
+
+/// The visible surface a notification was routed to (or why it was dropped).
+enum NotificationSurface {
+  /// In-app banner (app foreground).
+  banner,
+
+  /// OS system notification (app background).
+  system,
+
+  /// Passed gating but no visible surface (the relevant surface pref is off).
+  silent,
+
+  /// Suppressed by gating (pref off, duplicate, or currently viewing target).
+  suppressed,
+}
+
+/// The single decision point for whether and how to surface a classified
+/// [AppNotification]. UI-free and dependency-injected so every gating branch is
+/// unit-testable. The widget/provider layer supplies the collaborators.
+class NotificationRouter {
+  NotificationRouter({
+    required AppSettings Function() readSettings,
+    required ActiveView Function() readActiveView,
+    required bool Function() isAppForeground,
+    required LocalNotificationService localNotifications,
+    required NotificationSoundService sound,
+    required void Function(AppNotification) showInAppBanner,
+    required void Function(AppNotification) onChannelUnread,
+    int dedupCapacity = 200,
+  }) : _readSettings = readSettings,
+       _readActiveView = readActiveView,
+       _isAppForeground = isAppForeground,
+       _localNotifications = localNotifications,
+       _sound = sound,
+       _showInAppBanner = showInAppBanner,
+       _onChannelUnread = onChannelUnread,
+       _dedupCapacity = dedupCapacity;
+
+  final AppSettings Function() _readSettings;
+  final ActiveView Function() _readActiveView;
+  final bool Function() _isAppForeground;
+  final LocalNotificationService _localNotifications;
+  final NotificationSoundService _sound;
+  final void Function(AppNotification) _showInAppBanner;
+  final void Function(AppNotification) _onChannelUnread;
+  final int _dedupCapacity;
+
+  /// Bounded LRU of recently surfaced dedup keys. Lives for the router's
+  /// lifetime (a keepAlive provider), so it survives socket re-bind and the
+  /// buffered-event replay that re-delivers a terminal frame on re-registration.
+  final LinkedHashSet<String> _seen = LinkedHashSet<String>();
+
+  /// Routes [notification] through the gating chain and dispatches it. Returns
+  /// the surface taken, primarily for tests and diagnostics.
+  Future<NotificationSurface> route(AppNotification notification) async {
+    final settings = _readSettings();
+
+    // 1. Master toggle.
+    if (!settings.notificationsEnabled) return NotificationSurface.suppressed;
+
+    // 2. Per-kind toggle.
+    if (!_kindEnabled(notification.kind, settings)) {
+      return NotificationSurface.suppressed;
+    }
+
+    // 3. De-duplication (also guards replayed terminal frames after re-bind).
+    if (!_markFresh(notification.dedupKey)) {
+      return NotificationSurface.suppressed;
+    }
+
+    // 4. Don't alert for content the user is already looking at.
+    if (_isViewingTarget(notification)) return NotificationSurface.suppressed;
+
+    // 5. Side effects for everything that passed gating.
+    if (settings.notificationSound && settings.notificationSoundAlways) {
+      await _sound.play();
+    }
+    if (notification.kind == NotificationKind.channelMessage) {
+      _onChannelUnread(notification);
+    }
+
+    // 6. Exactly one primary surface, chosen by lifecycle. Unlike Open WebUI's
+    // web client (which can show an in-app toast AND a browser Notification at
+    // once), a foregrounded mobile app only needs the in-app banner; the OS
+    // notification is the background affordance.
+    if (_isAppForeground()) {
+      if (settings.notificationInAppBanner) {
+        _showInAppBanner(notification);
+        return NotificationSurface.banner;
+      }
+      return NotificationSurface.silent;
+    } else {
+      if (settings.notificationSystem) {
+        await _localNotifications.show(notification);
+        return NotificationSurface.system;
+      }
+      return NotificationSurface.silent;
+    }
+  }
+
+  bool _kindEnabled(NotificationKind kind, AppSettings settings) {
+    switch (kind) {
+      case NotificationKind.chatCompletion:
+        return settings.notificationChatEnabled;
+      case NotificationKind.channelMessage:
+        return settings.notificationChannelEnabled;
+    }
+  }
+
+  bool _isViewingTarget(AppNotification notification) {
+    final view = _readActiveView();
+    switch (notification.kind) {
+      case NotificationKind.chatCompletion:
+        return view.isViewingChat(notification.sourceId);
+      case NotificationKind.channelMessage:
+        return view.isViewingChannel(notification.sourceId);
+    }
+  }
+
+  /// Returns true if [key] was not seen before (and records it). Evicts the
+  /// oldest key once capacity is exceeded.
+  bool _markFresh(String key) {
+    if (_seen.contains(key)) return false;
+    _seen.add(key);
+    if (_seen.length > _dedupCapacity) {
+      _seen.remove(_seen.first);
+    }
+    return true;
+  }
+}

--- a/lib/features/notifications/services/notification_router.dart
+++ b/lib/features/notifications/services/notification_router.dart
@@ -98,7 +98,10 @@ class NotificationRouter {
       return NotificationSurface.silent;
     } else {
       if (settings.notificationSystem) {
-        await _localNotifications.show(notification);
+        await _localNotifications.show(
+          notification,
+          playSound: settings.notificationSound,
+        );
         return NotificationSurface.system;
       }
       return NotificationSurface.silent;

--- a/lib/features/notifications/services/notification_sound_service.dart
+++ b/lib/features/notifications/services/notification_sound_service.dart
@@ -1,0 +1,23 @@
+import 'package:flutter/services.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'notification_sound_service.g.dart';
+
+/// Foreground notification cue.
+///
+/// Open WebUI plays a bundled `notification.mp3`; Conduit ships no such asset
+/// yet, so v1 uses a haptic cue (system-notification sound is handled by the
+/// Android channel / iOS `presentSound` on the background path). Swapping in a
+/// designer-provided sound via `just_audio` (already a dependency) is a
+/// follow-up — keep this the single place that owns the foreground cue.
+class NotificationSoundService {
+  const NotificationSoundService();
+
+  Future<void> play() async {
+    await HapticFeedback.mediumImpact();
+  }
+}
+
+@Riverpod(keepAlive: true)
+NotificationSoundService notificationSoundService(Ref ref) =>
+    const NotificationSoundService();

--- a/lib/features/notifications/views/notification_settings_page.dart
+++ b/lib/features/notifications/views/notification_settings_page.dart
@@ -1,0 +1,187 @@
+import 'dart:async';
+
+import 'package:adaptive_platform_ui/adaptive_platform_ui.dart';
+import 'package:flutter/cupertino.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../core/providers/app_providers.dart';
+import '../../../core/services/settings_service.dart';
+import '../../../core/utils/debug_logger.dart';
+import '../../../l10n/app_localizations.dart';
+import '../../../shared/theme/theme_extensions.dart';
+import '../../profile/widgets/customization_tile.dart';
+import '../../profile/widgets/settings_page_scaffold.dart';
+import '../services/local_notification_service.dart';
+
+/// Notification preferences. The master toggle requests OS permission on
+/// opt-in. The three Open WebUI-aligned prefs (master / sound / sound-always)
+/// are mirrored to the server for cross-device parity; the rest are local-only.
+class NotificationSettingsPage extends ConsumerWidget {
+  const NotificationSettingsPage({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final l10n = AppLocalizations.of(context)!;
+    final theme = context.conduitTheme;
+    final settings = ref.watch(appSettingsProvider);
+    final notifier = ref.read(appSettingsProvider.notifier);
+    final enabled = settings.notificationsEnabled;
+
+    Widget tile({
+      required IconData icon,
+      required String title,
+      required String subtitle,
+      required bool value,
+      required ValueChanged<bool> onChanged,
+      bool dependantOnMaster = true,
+    }) {
+      final interactive = !dependantOnMaster || enabled;
+      return Opacity(
+        opacity: interactive ? 1 : 0.5,
+        child: CustomizationTile(
+          leading: SettingsIconBadge(icon: icon, color: theme.buttonPrimary),
+          title: title,
+          subtitle: subtitle,
+          showChevron: false,
+          trailing: AdaptiveSwitch(
+            value: value,
+            onChanged: interactive ? onChanged : null,
+          ),
+          onTap: interactive ? () => onChanged(!value) : null,
+        ),
+      );
+    }
+
+    return SettingsPageScaffold(
+      title: l10n.notificationsTitle,
+      children: [
+        tile(
+          icon: CupertinoIcons.bell_fill,
+          title: l10n.notificationsEnabledTitle,
+          subtitle: l10n.notificationsEnabledDescription,
+          value: enabled,
+          dependantOnMaster: false,
+          onChanged: (value) => _setMaster(context, ref, value),
+        ),
+        const SizedBox(height: Spacing.sm),
+        SettingsSectionHeader(title: l10n.notificationSystemTitle),
+        const SizedBox(height: Spacing.sm),
+        tile(
+          icon: CupertinoIcons.app_badge,
+          title: l10n.notificationInAppBannerTitle,
+          subtitle: l10n.notificationInAppBannerDescription,
+          value: settings.notificationInAppBanner,
+          onChanged: notifier.setNotificationInAppBanner,
+        ),
+        const SizedBox(height: Spacing.sm),
+        tile(
+          icon: CupertinoIcons.bell,
+          title: l10n.notificationSystemTitle,
+          subtitle: l10n.notificationSystemDescription,
+          value: settings.notificationSystem,
+          onChanged: notifier.setNotificationSystem,
+        ),
+        const SizedBox(height: Spacing.sm),
+        tile(
+          icon: CupertinoIcons.speaker_2_fill,
+          title: l10n.notificationSoundTitle,
+          subtitle: l10n.notificationSoundDescription,
+          value: settings.notificationSound,
+          onChanged: (value) => _setSound(ref, value),
+        ),
+        const SizedBox(height: Spacing.sm),
+        tile(
+          icon: CupertinoIcons.speaker_3_fill,
+          title: l10n.notificationSoundAlwaysTitle,
+          subtitle: l10n.notificationSoundAlwaysDescription,
+          value: settings.notificationSoundAlways,
+          onChanged: (value) => _setSoundAlways(ref, value),
+        ),
+        const SizedBox(height: Spacing.lg),
+        SettingsSectionHeader(title: l10n.notificationsTitle),
+        const SizedBox(height: Spacing.sm),
+        tile(
+          icon: CupertinoIcons.chat_bubble_2_fill,
+          title: l10n.notificationChatTitle,
+          subtitle: l10n.notificationChatDescription,
+          value: settings.notificationChatEnabled,
+          onChanged: notifier.setNotificationChatEnabled,
+        ),
+        const SizedBox(height: Spacing.sm),
+        tile(
+          icon: CupertinoIcons.number,
+          title: l10n.notificationChannelTitle,
+          subtitle: l10n.notificationChannelDescription,
+          value: settings.notificationChannelEnabled,
+          onChanged: notifier.setNotificationChannelEnabled,
+        ),
+      ],
+    );
+  }
+
+  Future<void> _setMaster(
+    BuildContext context,
+    WidgetRef ref,
+    bool value,
+  ) async {
+    await ref.read(appSettingsProvider.notifier).setNotificationsEnabled(value);
+    _syncToServer(ref, enabled: value);
+
+    if (value) {
+      final granted = await ref
+          .read(localNotificationServiceProvider)
+          .requestPermissions();
+      if (!granted && context.mounted) {
+        AdaptiveSnackBar.show(
+          context,
+          message: AppLocalizations.of(context)!.notificationsPermissionDenied,
+          type: AdaptiveSnackBarType.warning,
+        );
+      }
+    }
+  }
+
+  Future<void> _setSound(WidgetRef ref, bool value) async {
+    await ref.read(appSettingsProvider.notifier).setNotificationSound(value);
+    _syncToServer(ref, sound: value);
+  }
+
+  Future<void> _setSoundAlways(WidgetRef ref, bool value) async {
+    await ref
+        .read(appSettingsProvider.notifier)
+        .setNotificationSoundAlways(value);
+    _syncToServer(ref, soundAlways: value);
+  }
+
+  /// Mirrors the three Open WebUI-aligned prefs to the server. Fire-and-forget:
+  /// local persistence already succeeded, so a failed sync only loses
+  /// cross-device parity, not the setting itself.
+  void _syncToServer(
+    WidgetRef ref, {
+    bool? enabled,
+    bool? sound,
+    bool? soundAlways,
+  }) {
+    final api = ref.read(apiServiceProvider);
+    if (api == null) return;
+    unawaited(
+      api
+          .updateUserNotificationSettings(
+            notificationEnabled: enabled,
+            notificationSound: sound,
+            notificationSoundAlways: soundAlways,
+          )
+          .then(
+            (_) {},
+            onError: (Object e, StackTrace st) {
+              DebugLogger.error(
+                'failed to sync notification prefs to server',
+                error: e,
+                stackTrace: st,
+                scope: 'notifications/settings',
+              );
+            },
+          ),
+    );
+  }
+}

--- a/lib/features/profile/views/profile_page.dart
+++ b/lib/features/profile/views/profile_page.dart
@@ -363,6 +363,18 @@ class ProfilePage extends ConsumerWidget {
           context.pushNamed(RouteNames.appCustomization);
         },
       ),
+      _buildAccountOption(
+        context,
+        icon: UiUtils.platformIcon(
+          ios: CupertinoIcons.bell,
+          android: Icons.notifications_outlined,
+        ),
+        title: AppLocalizations.of(context)!.notificationsTitle,
+        subtitle: AppLocalizations.of(context)!.notificationsSubtitle,
+        onTap: () {
+          context.pushNamed(RouteNames.notificationSettings);
+        },
+      ),
       _buildAboutTile(context),
       _buildAccountOption(
         context,

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -3501,5 +3501,89 @@
   "securityCertificateError": "Security certificate error. Unable to verify the server identity.",
   "@securityCertificateError": {
     "description": "Error shown when the server TLS certificate cannot be trusted or verified."
+  },
+  "notificationsTitle": "Notifications",
+  "@notificationsTitle": {
+    "description": "Title of the notification settings page and the profile row that opens it."
+  },
+  "notificationsSubtitle": "Alerts for replies, messages, and finished responses",
+  "@notificationsSubtitle": {
+    "description": "Subtitle for the Notifications row in the profile/settings list."
+  },
+  "notificationsEnabledTitle": "Enable notifications",
+  "@notificationsEnabledTitle": {
+    "description": "Master toggle title for all notifications."
+  },
+  "notificationsEnabledDescription": "Receive alerts when the app is in the background and inside the app.",
+  "@notificationsEnabledDescription": {
+    "description": "Master toggle description."
+  },
+  "notificationSoundTitle": "Sound",
+  "@notificationSoundTitle": {
+    "description": "Toggle title for the notification sound/haptic cue."
+  },
+  "notificationSoundDescription": "Play a cue when a notification arrives.",
+  "@notificationSoundDescription": {
+    "description": "Toggle description for the notification sound."
+  },
+  "notificationSoundAlwaysTitle": "Always play sound",
+  "@notificationSoundAlwaysTitle": {
+    "description": "Toggle title mirroring Open WebUI's notificationSoundAlways setting."
+  },
+  "notificationSoundAlwaysDescription": "Play the cue even when the app is open and focused.",
+  "@notificationSoundAlwaysDescription": {
+    "description": "Toggle description for always playing the notification cue."
+  },
+  "notificationInAppBannerTitle": "In-app banners",
+  "@notificationInAppBannerTitle": {
+    "description": "Toggle title for in-app banner notifications shown while the app is open."
+  },
+  "notificationInAppBannerDescription": "Show a banner inside the app while it is open.",
+  "@notificationInAppBannerDescription": {
+    "description": "Toggle description for in-app banners."
+  },
+  "notificationSystemTitle": "System notifications",
+  "@notificationSystemTitle": {
+    "description": "Toggle title for OS-level notifications shown when the app is backgrounded."
+  },
+  "notificationSystemDescription": "Show notifications outside the app when it is in the background.",
+  "@notificationSystemDescription": {
+    "description": "Toggle description for system notifications."
+  },
+  "notificationChatTitle": "Chat responses",
+  "@notificationChatTitle": {
+    "description": "Toggle title for notifications when an assistant response finishes."
+  },
+  "notificationChatDescription": "Notify when a response finishes in a chat you are not viewing.",
+  "@notificationChatDescription": {
+    "description": "Toggle description for chat-response notifications."
+  },
+  "notificationChannelTitle": "Channel messages",
+  "@notificationChannelTitle": {
+    "description": "Toggle title for notifications when a new channel or DM message arrives."
+  },
+  "notificationChannelDescription": "Notify when someone sends a message in a channel or DM.",
+  "@notificationChannelDescription": {
+    "description": "Toggle description for channel-message notifications."
+  },
+  "notificationChannelMessagesName": "Messages",
+  "@notificationChannelMessagesName": {
+    "description": "Android notification channel name for chat and channel messages."
+  },
+  "notificationChannelMessagesDescription": "Replies, channel messages, and finished responses",
+  "@notificationChannelMessagesDescription": {
+    "description": "Android notification channel description for messages."
+  },
+  "notificationDefaultTitle": "New message",
+  "@notificationDefaultTitle": {
+    "description": "Fallback notification title when the source provides none."
+  },
+  "notificationViewAction": "View",
+  "@notificationViewAction": {
+    "description": "Action label on an in-app notification banner that opens the target."
+  },
+  "notificationsPermissionDenied": "Notifications are turned off in system settings.",
+  "@notificationsPermissionDenied": {
+    "description": "Shown when the user enables notifications but the OS permission was denied."
   }
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -34,6 +34,7 @@ import 'core/models/tool.dart';
 import 'package:conduit/l10n/app_localizations.dart';
 import 'core/services/quick_actions_service.dart';
 import 'core/providers/app_startup_providers.dart';
+import 'features/notifications/services/local_notification_service.dart';
 
 const bool _enableFlutterDriverExtension = bool.fromEnvironment(
   'ENABLE_FLUTTER_DRIVER_EXTENSION',
@@ -294,6 +295,37 @@ class _ConduitAppState extends ConsumerState<ConduitApp> {
     }
   }
 
+  /// Mirrors the three Open WebUI-aligned notification prefs to the server when
+  /// toggled from the iOS native sheet. Fire-and-forget: local persistence has
+  /// already succeeded, so a failed sync only loses cross-device parity.
+  void _syncNotificationPrefsToServer({
+    bool? enabled,
+    bool? sound,
+    bool? soundAlways,
+  }) {
+    final api = ref.read(apiServiceProvider);
+    if (api == null) return;
+    unawaited(
+      api
+          .updateUserNotificationSettings(
+            notificationEnabled: enabled,
+            notificationSound: sound,
+            notificationSoundAlways: soundAlways,
+          )
+          .then(
+            (_) {},
+            onError: (Object e, StackTrace st) {
+              DebugLogger.error(
+                'failed to sync notification prefs to server',
+                error: e,
+                stackTrace: st,
+                scope: 'notifications/settings',
+              );
+            },
+          ),
+    );
+  }
+
   Future<void> _handleNativeSheetControlChanged(
     NativeSheetControlChanged event,
   ) async {
@@ -501,6 +533,57 @@ class _ConduitAppState extends ConsumerState<ConduitApp> {
             await ref
                 .read(appSettingsProvider.notifier)
                 .setDisableHapticsWhileStreaming(value);
+          }
+        case 'notifications-enabled':
+          if (value is bool) {
+            await ref
+                .read(appSettingsProvider.notifier)
+                .setNotificationsEnabled(value);
+            _syncNotificationPrefsToServer(enabled: value);
+            if (value) {
+              // Best-effort OS permission on opt-in; OS governs delivery.
+              await ref
+                  .read(localNotificationServiceProvider)
+                  .requestPermissions();
+            }
+          }
+        case 'notification-in-app-banner':
+          if (value is bool) {
+            await ref
+                .read(appSettingsProvider.notifier)
+                .setNotificationInAppBanner(value);
+          }
+        case 'notification-system':
+          if (value is bool) {
+            await ref
+                .read(appSettingsProvider.notifier)
+                .setNotificationSystem(value);
+          }
+        case 'notification-sound':
+          if (value is bool) {
+            await ref
+                .read(appSettingsProvider.notifier)
+                .setNotificationSound(value);
+            _syncNotificationPrefsToServer(sound: value);
+          }
+        case 'notification-sound-always':
+          if (value is bool) {
+            await ref
+                .read(appSettingsProvider.notifier)
+                .setNotificationSoundAlways(value);
+            _syncNotificationPrefsToServer(soundAlways: value);
+          }
+        case 'notification-chat':
+          if (value is bool) {
+            await ref
+                .read(appSettingsProvider.notifier)
+                .setNotificationChatEnabled(value);
+          }
+        case 'notification-channel':
+          if (value is bool) {
+            await ref
+                .read(appSettingsProvider.notifier)
+                .setNotificationChannelEnabled(value);
           }
         case 'transport-auto':
           await ref

--- a/test/core/models/server_backed_settings_models_test.dart
+++ b/test/core/models/server_backed_settings_models_test.dart
@@ -52,6 +52,26 @@ void main() {
       check(updated.defaultModelIds).deepEquals(['gpt-4.1']);
       check(updated.pinnedModelIds).deepEquals(['new-model']);
     });
+
+    test('parses top-level notification preferences', () {
+      final settings = ServerUserSettings.fromJson({
+        'notificationEnabled': true,
+        'notificationSound': false,
+        'notificationSoundAlways': true,
+      });
+
+      check(settings.notificationEnabled).equals(true);
+      check(settings.notificationSound).equals(false);
+      check(settings.notificationSoundAlways).equals(true);
+    });
+
+    test('leaves notification preferences null when the server omits them', () {
+      final settings = ServerUserSettings.fromJson({'ui': {}});
+
+      check(settings.notificationEnabled).isNull();
+      check(settings.notificationSound).isNull();
+      check(settings.notificationSoundAlways).isNull();
+    });
   });
 
   group('AccountMetadata.fromJson', () {

--- a/test/features/channels/providers/channel_providers_test.dart
+++ b/test/features/channels/providers/channel_providers_test.dart
@@ -70,6 +70,50 @@ void main() {
       },
     );
   });
+
+  group('ChannelsList.markRead (reset-on-visit)', () {
+    Future<ProviderContainer> loadWith(
+      List<Map<String, dynamic>> rawChannels,
+    ) async {
+      final api = _FakeChannelApiService(rawChannels: rawChannels);
+      final container = ProviderContainer(
+        overrides: [
+          apiServiceProvider.overrideWithValue(api),
+          authTokenProvider3.overrideWith((ref) => 'token'),
+        ],
+      );
+      addTearDown(container.dispose);
+      await container.read(channelsListProvider.future);
+      return container;
+    }
+
+    test('clears the unread badge for the opened channel', () async {
+      final container = await loadWith([
+        {'id': 'c1', 'name': 'One', 'unread_count': 3, 'updated_at': 2},
+        {'id': 'c2', 'name': 'Two', 'unread_count': 5, 'updated_at': 1},
+      ]);
+
+      container.read(channelsListProvider.notifier).markRead('c1');
+
+      final channels = container.read(channelsListProvider).value!;
+      expect(channels.firstWhere((c) => c.id == 'c1').unreadCount, 0);
+      // Other channels are untouched.
+      expect(channels.firstWhere((c) => c.id == 'c2').unreadCount, 5);
+    });
+
+    test('is a no-op for an unknown or already-read channel', () async {
+      final container = await loadWith([
+        {'id': 'c1', 'name': 'One', 'unread_count': 0, 'updated_at': 1},
+      ]);
+      final before = container.read(channelsListProvider).value;
+
+      container.read(channelsListProvider.notifier).markRead('c1');
+      container.read(channelsListProvider.notifier).markRead('missing');
+
+      // No rebuild: same list instance is retained when nothing changed.
+      expect(identical(container.read(channelsListProvider).value, before), isTrue);
+    });
+  });
 }
 
 class _FakeChannelApiService extends ApiService {

--- a/test/features/notifications/notification_event_classifier_test.dart
+++ b/test/features/notifications/notification_event_classifier_test.dart
@@ -1,0 +1,241 @@
+import 'package:checks/checks.dart';
+import 'package:conduit/features/notifications/models/app_notification.dart';
+import 'package:conduit/features/notifications/services/notification_event_classifier.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  const classifier = NotificationEventClassifier();
+  const currentUserId = 'me-123';
+
+  // Mirrors the personal `events` stream envelope:
+  // { chat_id, session_id, data: { type, data: { done, content, title } } }
+  Map<String, dynamic> chatEvent({
+    String? chatId = 'chat-1',
+    String type = 'chat:completion',
+    Object? inner = const {
+      'done': true,
+      'content': 'Hello there',
+      'title': 'Greeting',
+    },
+  }) => {
+    'chat_id': ?chatId,
+    'session_id': 'sess-1',
+    'data': {'type': type, 'data': inner},
+  };
+
+  // Mirrors the `events:channel` stream envelope:
+  // { channel_id, channel: {type,name}, data: { type, data: {...message} } }
+  Map<String, dynamic> channelEvent({
+    String? channelId = 'chan-1',
+    String type = 'message',
+    String channelType = 'group',
+    String channelName = 'general',
+    Object? inner = const {
+      'id': 'msg-1',
+      'content': 'Anyone around?',
+      'user': {'id': 'other-456', 'name': 'Ada'},
+    },
+  }) => {
+    'channel_id': ?channelId,
+    'channel': {'type': channelType, 'name': channelName},
+    'data': {'type': type, 'data': inner},
+  };
+
+  group('classifyChatEvent', () {
+    test('terminal completion in another chat yields a notification', () {
+      final result = classifier.classifyChatEvent(
+        chatEvent(),
+        currentUserId: currentUserId,
+      );
+
+      check(result).isNotNull();
+      check(result!.kind).equals(NotificationKind.chatCompletion);
+      check(result.title).equals('Greeting');
+      check(result.body).equals('Hello there');
+      check(result.sourceId).equals('chat-1');
+      check(result.read).isFalse();
+    });
+
+    test('non-terminal completion (done != true) is ignored', () {
+      final result = classifier.classifyChatEvent(
+        chatEvent(inner: const {'done': false, 'content': 'partial'}),
+        currentUserId: currentUserId,
+      );
+      check(result).isNull();
+    });
+
+    test('completion with no done flag is ignored', () {
+      final result = classifier.classifyChatEvent(
+        chatEvent(inner: const {'content': 'partial'}),
+        currentUserId: currentUserId,
+      );
+      check(result).isNull();
+    });
+
+    test('empty title is preserved for the surface layer to fall back', () {
+      final result = classifier.classifyChatEvent(
+        chatEvent(inner: const {'done': true, 'content': 'hi', 'title': ''}),
+        currentUserId: currentUserId,
+      );
+      check(result).isNotNull();
+      check(result!.title).equals('');
+    });
+
+    test('missing chat_id is ignored', () {
+      final result = classifier.classifyChatEvent(
+        chatEvent(chatId: null),
+        currentUserId: currentUserId,
+      );
+      check(result).isNull();
+    });
+
+    test('non-notifiable chat types are ignored', () {
+      for (final type in const [
+        'chat:title',
+        'chat:tags',
+        'chat:message:error',
+        'chat:message:delta',
+        'request:chat:completion',
+      ]) {
+        final result = classifier.classifyChatEvent(
+          chatEvent(type: type),
+          currentUserId: currentUserId,
+        );
+        check(because: 'type "$type" must not notify', result).isNull();
+      }
+    });
+
+    test('malformed envelopes return null without throwing', () {
+      check(
+        classifier.classifyChatEvent({}, currentUserId: currentUserId),
+      ).isNull();
+      check(
+        classifier.classifyChatEvent({
+          'data': 'not-a-map',
+        }, currentUserId: currentUserId),
+      ).isNull();
+      check(
+        classifier.classifyChatEvent({
+          'chat_id': 'c',
+          'data': {'type': 'chat:completion', 'data': 'not-a-map'},
+        }, currentUserId: currentUserId),
+      ).isNull();
+    });
+
+    test('dedupKey is stable for identical terminal frames', () {
+      final a = classifier.classifyChatEvent(
+        chatEvent(),
+        currentUserId: currentUserId,
+      );
+      final b = classifier.classifyChatEvent(
+        chatEvent(),
+        currentUserId: currentUserId,
+      );
+      check(a!.dedupKey).equals(b!.dedupKey);
+    });
+
+    test('dedupKey differs for distinct responses in the same chat', () {
+      final a = classifier.classifyChatEvent(
+        chatEvent(inner: const {'done': true, 'content': 'first'}),
+        currentUserId: currentUserId,
+      );
+      final b = classifier.classifyChatEvent(
+        chatEvent(inner: const {'done': true, 'content': 'second'}),
+        currentUserId: currentUserId,
+      );
+      check(a!.dedupKey).not((it) => it.equals(b!.dedupKey));
+    });
+  });
+
+  group('classifyChannelEvent', () {
+    test('message from another user in a group channel notifies', () {
+      final result = classifier.classifyChannelEvent(
+        channelEvent(),
+        currentUserId: currentUserId,
+      );
+
+      check(result).isNotNull();
+      check(result!.kind).equals(NotificationKind.channelMessage);
+      check(result.title).equals('Ada (#general)');
+      check(result.body).equals('Anyone around?');
+      check(result.sourceId).equals('chan-1');
+      check(result.dedupKey).equals('channel:chan-1:msg-1');
+    });
+
+    test('DM channel title omits the channel-name suffix', () {
+      final result = classifier.classifyChannelEvent(
+        channelEvent(channelType: 'dm'),
+        currentUserId: currentUserId,
+      );
+      check(result).isNotNull();
+      check(result!.title).equals('Ada');
+    });
+
+    test('self-authored message is ignored', () {
+      final result = classifier.classifyChannelEvent(
+        channelEvent(
+          inner: const {
+            'id': 'msg-2',
+            'content': 'my own message',
+            'user': {'id': currentUserId, 'name': 'Me'},
+          },
+        ),
+        currentUserId: currentUserId,
+      );
+      check(result).isNull();
+    });
+
+    test('non-message channel types are ignored', () {
+      for (final type in const [
+        'message:reply',
+        'message:reaction:add',
+        'message:reaction:remove',
+        'message:update',
+        'message:delete',
+        'channel:created',
+        'channel:delete',
+        'typing',
+      ]) {
+        final result = classifier.classifyChannelEvent(
+          channelEvent(type: type),
+          currentUserId: currentUserId,
+        );
+        check(because: 'type "$type" must not notify', result).isNull();
+      }
+    });
+
+    test('missing channel_id is ignored', () {
+      final result = classifier.classifyChannelEvent(
+        channelEvent(channelId: null),
+        currentUserId: currentUserId,
+      );
+      check(result).isNull();
+    });
+
+    test('dedupKey falls back to content hash when message id is absent', () {
+      final result = classifier.classifyChannelEvent(
+        channelEvent(
+          inner: const {
+            'content': 'no id here',
+            'user': {'id': 'other-456', 'name': 'Ada'},
+          },
+        ),
+        currentUserId: currentUserId,
+      );
+      check(result).isNotNull();
+      check(result!.dedupKey).equals('channel:chan-1:${'no id here'.hashCode}');
+    });
+
+    test('malformed envelopes return null without throwing', () {
+      check(
+        classifier.classifyChannelEvent({}, currentUserId: currentUserId),
+      ).isNull();
+      check(
+        classifier.classifyChannelEvent({
+          'channel_id': 'c',
+          'data': {'type': 'message', 'data': 'not-a-map'},
+        }, currentUserId: currentUserId),
+      ).isNull();
+    });
+  });
+}

--- a/test/features/notifications/notification_event_classifier_test.dart
+++ b/test/features/notifications/notification_event_classifier_test.dart
@@ -185,6 +185,16 @@ void main() {
       check(result).isNull();
     });
 
+    test('message with missing/empty author is ignored as malformed', () {
+      final result = classifier.classifyChannelEvent(
+        channelEvent(
+          inner: const {'id': 'msg-3', 'content': 'no author'},
+        ),
+        currentUserId: currentUserId,
+      );
+      check(result).isNull();
+    });
+
     test('non-message channel types are ignored', () {
       for (final type in const [
         'message:reply',

--- a/test/features/notifications/notification_router_test.dart
+++ b/test/features/notifications/notification_router_test.dart
@@ -1,0 +1,196 @@
+import 'package:checks/checks.dart';
+import 'package:conduit/core/services/settings_service.dart';
+import 'package:conduit/features/notifications/models/app_notification.dart';
+import 'package:conduit/features/notifications/services/active_view_tracker.dart';
+import 'package:conduit/features/notifications/services/local_notification_service.dart';
+import 'package:conduit/features/notifications/services/notification_router.dart';
+import 'package:conduit/features/notifications/services/notification_sound_service.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+
+class _MockLocalNotifications extends Mock implements LocalNotificationService {}
+
+class _MockSound extends Mock implements NotificationSoundService {}
+
+AppNotification _chat({String id = 'chat-1', String key = 'k-chat'}) =>
+    AppNotification(
+      kind: NotificationKind.chatCompletion,
+      title: 'Title',
+      body: 'Body',
+      sourceId: id,
+      dedupKey: key,
+    );
+
+AppNotification _channel({String id = 'chan-1', String key = 'k-chan'}) =>
+    AppNotification(
+      kind: NotificationKind.channelMessage,
+      title: 'Ada',
+      body: 'hi',
+      sourceId: id,
+      dedupKey: key,
+    );
+
+void main() {
+  // Master + both kinds + both sound flags on; surfaces on. Tests override.
+  const allOn = AppSettings(
+    notificationsEnabled: true,
+    notificationSound: true,
+    notificationSoundAlways: true,
+    notificationInAppBanner: true,
+    notificationSystem: true,
+    notificationChatEnabled: true,
+    notificationChannelEnabled: true,
+  );
+
+  setUpAll(() {
+    registerFallbackValue(_chat());
+  });
+
+  late _MockLocalNotifications local;
+  late _MockSound sound;
+  late List<AppNotification> banners;
+  late List<AppNotification> unreads;
+
+  setUp(() {
+    local = _MockLocalNotifications();
+    sound = _MockSound();
+    banners = [];
+    unreads = [];
+    when(() => local.show(any())).thenAnswer((_) async {});
+    when(() => sound.play()).thenAnswer((_) async {});
+  });
+
+  NotificationRouter build({
+    AppSettings settings = allOn,
+    ActiveView view = const ActiveView(),
+    bool foreground = true,
+  }) => NotificationRouter(
+    readSettings: () => settings,
+    readActiveView: () => view,
+    isAppForeground: () => foreground,
+    localNotifications: local,
+    sound: sound,
+    showInAppBanner: banners.add,
+    onChannelUnread: unreads.add,
+  );
+
+  group('gating', () {
+    test('master toggle off suppresses everything', () async {
+      final router = build(
+        settings: allOn.copyWith(notificationsEnabled: false),
+      );
+      final surface = await router.route(_chat());
+      check(surface).equals(NotificationSurface.suppressed);
+      check(banners).isEmpty();
+      verifyNever(() => local.show(any()));
+      verifyNever(() => sound.play());
+    });
+
+    test('per-kind chat toggle off suppresses chat completions', () async {
+      final router = build(
+        settings: allOn.copyWith(notificationChatEnabled: false),
+      );
+      check(await router.route(_chat())).equals(NotificationSurface.suppressed);
+    });
+
+    test('per-kind channel toggle off suppresses channel messages', () async {
+      final router = build(
+        settings: allOn.copyWith(notificationChannelEnabled: false),
+      );
+      check(
+        await router.route(_channel()),
+      ).equals(NotificationSurface.suppressed);
+    });
+
+    test('duplicate dedupKey is suppressed on the second delivery', () async {
+      final router = build();
+      check(await router.route(_chat(key: 'dup'))).equals(
+        NotificationSurface.banner,
+      );
+      check(
+        await router.route(_chat(key: 'dup')),
+      ).equals(NotificationSurface.suppressed);
+    });
+
+    test('currently viewing the chat suppresses its completion', () async {
+      final router = build(view: const ActiveView(chatId: 'chat-1'));
+      check(
+        await router.route(_chat(id: 'chat-1')),
+      ).equals(NotificationSurface.suppressed);
+    });
+
+    test('currently viewing the channel suppresses its message', () async {
+      final router = build(view: const ActiveView(channelId: 'chan-1'));
+      check(
+        await router.route(_channel(id: 'chan-1')),
+      ).equals(NotificationSurface.suppressed);
+    });
+  });
+
+  group('surface selection', () {
+    test('foreground shows an in-app banner only', () async {
+      final router = build(foreground: true);
+      check(await router.route(_chat())).equals(NotificationSurface.banner);
+      check(banners).length.equals(1);
+      verifyNever(() => local.show(any()));
+    });
+
+    test('foreground with banners off is silent', () async {
+      final router = build(
+        foreground: true,
+        settings: allOn.copyWith(notificationInAppBanner: false),
+      );
+      check(await router.route(_chat())).equals(NotificationSurface.silent);
+      check(banners).isEmpty();
+    });
+
+    test('background posts a system notification only', () async {
+      final router = build(foreground: false);
+      check(await router.route(_chat())).equals(NotificationSurface.system);
+      check(banners).isEmpty();
+      verify(() => local.show(any())).called(1);
+    });
+
+    test('background with system off is silent', () async {
+      final router = build(
+        foreground: false,
+        settings: allOn.copyWith(notificationSystem: false),
+      );
+      check(await router.route(_chat())).equals(NotificationSurface.silent);
+      verifyNever(() => local.show(any()));
+    });
+  });
+
+  group('side effects', () {
+    test('sound plays only when sound AND soundAlways are on', () async {
+      final router = build();
+      await router.route(_chat());
+      verify(() => sound.play()).called(1);
+    });
+
+    test('sound does not play when soundAlways is off', () async {
+      final router = build(
+        settings: allOn.copyWith(notificationSoundAlways: false),
+      );
+      await router.route(_chat());
+      verifyNever(() => sound.play());
+    });
+
+    test('channel messages bump unread; chat completions do not', () async {
+      final router = build();
+      await router.route(_channel());
+      await router.route(_chat());
+      check(unreads).length.equals(1);
+      check(unreads.single.kind).equals(NotificationKind.channelMessage);
+    });
+
+    test('suppressed notifications have no side effects', () async {
+      final router = build(
+        settings: allOn.copyWith(notificationsEnabled: false),
+      );
+      await router.route(_channel());
+      check(unreads).isEmpty();
+      verifyNever(() => sound.play());
+    });
+  });
+}

--- a/test/features/notifications/notification_router_test.dart
+++ b/test/features/notifications/notification_router_test.dart
@@ -125,6 +125,18 @@ void main() {
         await router.route(_channel(id: 'chan-1')),
       ).equals(NotificationSurface.suppressed);
     });
+
+    test('backgrounded, the active chat still notifies (not suppressed)', () async {
+      // Start a chat (it is the active view), then background the app: the
+      // completion must still fire an OS notification.
+      final router = build(
+        foreground: false,
+        view: const ActiveView(chatId: 'chat-1'),
+      );
+      check(
+        await router.route(_chat(id: 'chat-1')),
+      ).equals(NotificationSurface.system);
+    });
   });
 
   group('surface selection', () {

--- a/test/features/notifications/notification_router_test.dart
+++ b/test/features/notifications/notification_router_test.dart
@@ -56,7 +56,7 @@ void main() {
     sound = _MockSound();
     banners = [];
     unreads = [];
-    when(() => local.show(any())).thenAnswer((_) async {});
+    when(() => local.show(any(), playSound: any(named: 'playSound'))).thenAnswer((_) async {});
     when(() => sound.play()).thenAnswer((_) async {});
   });
 
@@ -82,7 +82,7 @@ void main() {
       final surface = await router.route(_chat());
       check(surface).equals(NotificationSurface.suppressed);
       check(banners).isEmpty();
-      verifyNever(() => local.show(any()));
+      verifyNever(() => local.show(any(), playSound: any(named: 'playSound')));
       verifyNever(() => sound.play());
     });
 
@@ -132,7 +132,7 @@ void main() {
       final router = build(foreground: true);
       check(await router.route(_chat())).equals(NotificationSurface.banner);
       check(banners).length.equals(1);
-      verifyNever(() => local.show(any()));
+      verifyNever(() => local.show(any(), playSound: any(named: 'playSound')));
     });
 
     test('foreground with banners off is silent', () async {
@@ -148,7 +148,21 @@ void main() {
       final router = build(foreground: false);
       check(await router.route(_chat())).equals(NotificationSurface.system);
       check(banners).isEmpty();
-      verify(() => local.show(any())).called(1);
+      verify(() => local.show(any(), playSound: any(named: 'playSound'))).called(1);
+    });
+
+    test('system notification sound follows the notificationSound pref', () async {
+      final router = build(
+        foreground: false,
+        settings: allOn.copyWith(notificationSound: false),
+      );
+      await router.route(_chat());
+      final played =
+          verify(
+                () => local.show(any(), playSound: captureAny(named: 'playSound')),
+              ).captured.single
+              as bool;
+      check(played).isFalse();
     });
 
     test('background with system off is silent', () async {
@@ -157,7 +171,7 @@ void main() {
         settings: allOn.copyWith(notificationSystem: false),
       );
       check(await router.route(_chat())).equals(NotificationSurface.silent);
-      verifyNever(() => local.show(any()));
+      verifyNever(() => local.show(any(), playSound: any(named: 'playSound')));
     });
   });
 

--- a/test/features/notifications/notification_socket_listener_test.dart
+++ b/test/features/notifications/notification_socket_listener_test.dart
@@ -1,0 +1,253 @@
+import 'dart:async';
+
+import 'package:checks/checks.dart';
+import 'package:conduit/core/models/channel.dart';
+import 'package:conduit/core/providers/app_providers.dart';
+import 'package:conduit/core/services/settings_service.dart';
+import 'package:conduit/core/services/socket_service.dart';
+import 'package:conduit/features/channels/providers/channel_providers.dart';
+import 'package:conduit/features/notifications/models/app_notification.dart';
+import 'package:conduit/features/notifications/providers/notification_socket_listener.dart';
+import 'package:conduit/features/notifications/services/active_view_tracker.dart';
+import 'package:conduit/features/notifications/services/local_notification_service.dart';
+import 'package:conduit/features/notifications/services/notification_router.dart';
+import 'package:conduit/features/notifications/services/notification_sound_service.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+class _CapturedChat {
+  _CapturedChat({required this.requireFocus, required this.handler});
+  final bool requireFocus;
+  final SocketChatEventHandler handler;
+}
+
+class _CapturedChannel {
+  _CapturedChannel({required this.requireFocus, required this.handler});
+  final bool requireFocus;
+  final SocketChannelEventHandler handler;
+}
+
+/// SocketService stand-in that records the wildcard chat/channel handlers the
+/// listener registers and lets the test drive them + pump reconnect.
+class _MockSocketService implements SocketService {
+  final List<_CapturedChat> chat = <_CapturedChat>[];
+  final List<_CapturedChannel> channel = <_CapturedChannel>[];
+  final _reconnect = StreamController<void>.broadcast();
+
+  void emitReconnect() => _reconnect.add(null);
+  void disposeController() => _reconnect.close();
+
+  @override
+  SocketEventSubscription addChatEventHandler({
+    String? conversationId,
+    String? sessionId,
+    String? messageId,
+    bool requireFocus = true,
+    required SocketChatEventHandler handler,
+  }) {
+    final reg = _CapturedChat(requireFocus: requireFocus, handler: handler);
+    chat.add(reg);
+    return SocketEventSubscription(() => chat.remove(reg));
+  }
+
+  @override
+  SocketEventSubscription addChannelEventHandler({
+    String? conversationId,
+    String? sessionId,
+    bool requireFocus = true,
+    required SocketChannelEventHandler handler,
+  }) {
+    final reg = _CapturedChannel(requireFocus: requireFocus, handler: handler);
+    channel.add(reg);
+    return SocketEventSubscription(() => channel.remove(reg));
+  }
+
+  @override
+  Stream<void> get onReconnect => _reconnect.stream;
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => null;
+}
+
+/// Channels list whose `refresh` is counted (reconnect reconciliation).
+class _FakeChannelsList extends ChannelsList {
+  int refreshCalls = 0;
+
+  @override
+  Future<List<Channel>> build() async => const <Channel>[];
+
+  @override
+  Future<void> refresh() async {
+    refreshCalls += 1;
+  }
+}
+
+Map<String, dynamic> _chatCompletion({
+  String chatId = 'chat-1',
+  bool done = true,
+  String type = 'chat:completion',
+}) => {
+  'chat_id': chatId,
+  'data': {
+    'type': type,
+    'data': {'done': done, 'content': 'hello', 'title': 'Greeting'},
+  },
+};
+
+Map<String, dynamic> _channelMessage({
+  String channelId = 'chan-1',
+  String type = 'message',
+}) => {
+  'channel_id': channelId,
+  'channel': {'type': 'group', 'name': 'general'},
+  'data': {
+    'type': type,
+    'data': {
+      'id': 'm1',
+      'content': 'hi',
+      'user': {'id': 'other', 'name': 'Ada'},
+    },
+  },
+};
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  const settings = AppSettings(
+    notificationsEnabled: true,
+    notificationSound: false,
+    notificationSoundAlways: false,
+    notificationInAppBanner: true,
+    notificationSystem: true,
+    notificationChatEnabled: true,
+    notificationChannelEnabled: true,
+  );
+
+  late List<AppNotification> routed;
+
+  ProviderContainer makeContainer(_MockSocketService socket) {
+    routed = <AppNotification>[];
+    final captureRouter = NotificationRouter(
+      readSettings: () => settings,
+      readActiveView: () => const ActiveView(),
+      isAppForeground: () => true,
+      localNotifications: LocalNotificationService(),
+      sound: const NotificationSoundService(),
+      showInAppBanner: routed.add,
+      onChannelUnread: (_) {},
+    );
+    final container = ProviderContainer(
+      overrides: [
+        socketServiceProvider.overrideWithValue(socket),
+        notificationRouterProvider.overrideWithValue(captureRouter),
+        channelsListProvider.overrideWith(_FakeChannelsList.new),
+      ],
+    );
+    addTearDown(container.dispose);
+    return container;
+  }
+
+  test('registers one wildcard chat + channel handler, requireFocus:false', () {
+    final socket = _MockSocketService();
+    addTearDown(socket.disposeController);
+    final container = makeContainer(socket);
+
+    container.read(notificationSocketListenerProvider);
+
+    check(socket.chat).length.equals(1);
+    check(socket.channel).length.equals(1);
+    check(socket.chat.single.requireFocus).isFalse();
+    check(socket.channel.single.requireFocus).isFalse();
+  });
+
+  test('routes a notifiable chat completion', () async {
+    final socket = _MockSocketService();
+    addTearDown(socket.disposeController);
+    final container = makeContainer(socket);
+    container.read(notificationSocketListenerProvider);
+
+    socket.chat.single.handler(_chatCompletion(), null);
+    await Future<void>.delayed(Duration.zero);
+
+    check(routed).length.equals(1);
+    check(routed.single.kind).equals(NotificationKind.chatCompletion);
+  });
+
+  test('ignores a non-terminal completion frame', () async {
+    final socket = _MockSocketService();
+    addTearDown(socket.disposeController);
+    final container = makeContainer(socket);
+    container.read(notificationSocketListenerProvider);
+
+    socket.chat.single.handler(_chatCompletion(done: false), null);
+    await Future<void>.delayed(Duration.zero);
+
+    check(routed).isEmpty();
+  });
+
+  test('ignores a non-notifiable chat type', () async {
+    final socket = _MockSocketService();
+    addTearDown(socket.disposeController);
+    final container = makeContainer(socket);
+    container.read(notificationSocketListenerProvider);
+
+    socket.chat.single.handler(_chatCompletion(type: 'chat:title'), null);
+    await Future<void>.delayed(Duration.zero);
+
+    check(routed).isEmpty();
+  });
+
+  test('routes a notifiable channel message', () async {
+    final socket = _MockSocketService();
+    addTearDown(socket.disposeController);
+    final container = makeContainer(socket);
+    container.read(notificationSocketListenerProvider);
+
+    socket.channel.single.handler(_channelMessage(), null);
+    await Future<void>.delayed(Duration.zero);
+
+    check(routed).length.equals(1);
+    check(routed.single.kind).equals(NotificationKind.channelMessage);
+  });
+
+  test('reconnect reconciles channel unread via refresh', () async {
+    final socket = _MockSocketService();
+    addTearDown(socket.disposeController);
+    final container = makeContainer(socket);
+    container.read(notificationSocketListenerProvider);
+
+    final channels = container.read(channelsListProvider.notifier)
+        as _FakeChannelsList;
+    final before = channels.refreshCalls;
+
+    socket.emitReconnect();
+    await Future<void>.delayed(Duration.zero);
+
+    check(channels.refreshCalls).equals(before + 1);
+  });
+
+  test('re-binds handlers when the socket instance changes', () {
+    final socket1 = _MockSocketService();
+    final socket2 = _MockSocketService();
+    addTearDown(socket1.disposeController);
+    addTearDown(socket2.disposeController);
+    final container = makeContainer(socket1);
+
+    container.read(notificationSocketListenerProvider);
+    check(socket1.chat).length.equals(1);
+
+    container.updateOverrides([
+      socketServiceProvider.overrideWithValue(socket2),
+      notificationRouterProvider.overrideWithValue(
+        container.read(notificationRouterProvider),
+      ),
+      channelsListProvider.overrideWith(_FakeChannelsList.new),
+    ]);
+
+    // Old subscriptions disposed, fresh ones registered on the new socket.
+    check(socket1.chat).isEmpty();
+    check(socket1.channel).isEmpty();
+    check(socket2.chat).length.equals(1);
+    check(socket2.channel).length.equals(1);
+  });
+}

--- a/test/features/notifications/notification_socket_listener_test.dart
+++ b/test/features/notifications/notification_socket_listener_test.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 
 import 'package:checks/checks.dart';
 import 'package:conduit/core/models/channel.dart';
+import 'package:conduit/core/models/user.dart';
 import 'package:conduit/core/providers/app_providers.dart';
 import 'package:conduit/core/services/settings_service.dart';
 import 'package:conduit/core/services/socket_service.dart';
@@ -141,6 +142,14 @@ void main() {
         socketServiceProvider.overrideWithValue(socket),
         notificationRouterProvider.overrideWithValue(captureRouter),
         channelsListProvider.overrideWith(_FakeChannelsList.new),
+        currentUserProvider.overrideWith(
+          (ref) async => const User(
+            id: 'me',
+            username: 'me',
+            email: 'me@example.com',
+            role: 'user',
+          ),
+        ),
       ],
     );
     addTearDown(container.dispose);
@@ -202,12 +211,27 @@ void main() {
     addTearDown(socket.disposeController);
     final container = makeContainer(socket);
     container.read(notificationSocketListenerProvider);
+    await container.read(currentUserProvider.future); // resolve self id
 
     socket.channel.single.handler(_channelMessage(), null);
     await Future<void>.delayed(Duration.zero);
 
     check(routed).length.equals(1);
     check(routed.single.kind).equals(NotificationKind.channelMessage);
+  });
+
+  test('skips channel classification until the current user resolves', () async {
+    final socket = _MockSocketService();
+    addTearDown(socket.disposeController);
+    final container = makeContainer(socket);
+    container.read(notificationSocketListenerProvider);
+
+    // Do NOT await currentUserProvider: id is still unresolved, so a channel
+    // message must be skipped rather than risk self-notifying.
+    socket.channel.single.handler(_channelMessage(), null);
+    await Future<void>.delayed(Duration.zero);
+
+    check(routed).isEmpty();
   });
 
   test('reconnect reconciles channel unread via refresh', () async {
@@ -242,6 +266,14 @@ void main() {
         container.read(notificationRouterProvider),
       ),
       channelsListProvider.overrideWith(_FakeChannelsList.new),
+      currentUserProvider.overrideWith(
+        (ref) async => const User(
+          id: 'me',
+          username: 'me',
+          email: 'me@example.com',
+          role: 'user',
+        ),
+      ),
     ]);
 
     // Old subscriptions disposed, fresh ones registered on the new socket.


### PR DESCRIPTION
## Summary

Adds an in-app **notification system** modeled on Open WebUI, derived **client-side** from the existing Socket.IO streams (`events`, `events:channel`) — no FCM/APNs, no server changes, no new endpoints. Notifications surface as an in-app banner (foreground) or an OS notification (background), with a cue, channel unread badges, and tap-to-deeplink.

Master toggle **defaults off**, so the feature is dormant until a user opts in.

## How Open WebUI does it (what we mirror)

Open WebUI "notifications" are client-side reactions to two socket channels, raised only for three event types in `openwebui-src/src/routes/+layout.svelte`: `chat:completion` (terminal `done` frame), `calendar:alert`, and channel `message`. Everything else (`chat:title`, `chat:tags`, `chat:message:error`, channel reply/reaction/created) is a silent state refresh.

**Strict parity for Conduit → two notifiable kinds:** `chatCompletion` (done frame) and `channelMessage`. `calendar:alert` is dropped (Conduit has no calendar feature); `chat:message:error` is dropped (upstream doesn't notify on it).

## Architecture

New `lib/features/notifications/`:

- **`models/app_notification.dart`** — Freezed `AppNotification` + `NotificationKind`.
- **`services/notification_event_classifier.dart`** — pure translator owning all envelope semantics (nested `data.type`, terminal-frame rule, self-author/malformed filtering); returns `null` for anything non-notifiable, never throws.
- **`services/active_view_tracker.dart`** — reads existing `activeConversationProvider` / `activeChannelProvider` for foreground-suppression (a `NavigatorObserver` can't recover the ids — the chat route has no path param).
- **`services/notification_router.dart`** — the single decision point: gating predicate + bounded LRU dedup (survives socket re-bind / buffered-event replay). UI-free and dependency-injected.
- **`services/local_notification_service.dart`** — standalone `flutter_local_notifications` wrapper (`conduit_messages` channel), platform-guarded, with a tap stream + cold-launch tap.
- **`services/notification_sound_service.dart`** — foreground cue.
- **`providers/notification_socket_listener.dart`** — single global chat+channel wildcard listener reusing the proven `ActiveChatsSync._bindSocket` pattern (`requireFocus:false`, re-bind on socket change + `onReconnect`); deep-link tap handling; reconnect → channel unread reconcile.
- **`views/notification_settings_page.dart`** — preferences UI.

**Settings & persistence:** 7 prefs added to `AppSettings`/`SettingsService` mirroring the `hapticFeedback` triad. The three Open WebUI-aligned prefs (`notificationEnabled` / `notificationSound` / `notificationSoundAlways`) are **synced to the server** (top-level user-settings fields, applied once per server for cross-device parity); the rest are local-only. Route `/profile/notifications` + profile row. Bootstrapped post-auth; cleared/invalidated on sign-out.

## Data flow

`socket event → classifier (unfold + filter) → AppNotification? → router (master/per-kind/dedup/active-view gate) → banner (foreground) OR system notification (background) + cue + channel unread bump`. Tap → deep link (channel page, or DB-first chat open).

## Intentional deviations (documented in code)

- **Surface is exclusive by lifecycle** (foreground=banner, background=system), not additive like the web client — correct mobile UX.
- **Cue is a haptic, not a bundled mp3** — couldn't author a binary asset; `just_audio` (already a dep) swap with a designer sound is a follow-up. System-notification sound uses the OS channel.
- **`VoiceCallNotificationService` refactor deferred** — `LocalNotificationService` ships new/standalone to keep a shipping feature out of this PR's blast radius.
- **Plugin init happens at listener bootstrap** (post-auth), not `main.dart`.

## Deferred to follow-ups

Drift-backed notification inbox · OS app-icon badge count · FCM/APNs remote push · per-channel mute · quiet hours/DND.

## Platform notes

`POST_NOTIFICATIONS` already in the manifest; permission requested on master-toggle opt-in (iOS alert/badge/sound, Android 13+). iOS background delivery is best-effort (socket suspends, no APNs).

## Testing

`flutter analyze` clean; **full suite 2261 passing** (47 new):
- Classifier: 17 tests (per-kind, terminal-frame, self/malformed-author, dedup, malformed envelopes)
- Router: 14 tests (every gating branch, surface selection, side effects)
- Listener: 7 tests (wildcard registration, classify→route, reconnect reconcile, re-bind on socket change)
- Reset-on-visit: `ChannelsList.markRead` clears local unread on channel open (2 tests)
- Server-settings parsing (2 tests)

## CodeRabbit

Reviewed; 3 valid findings fixed (server-pref clobber race, malformed-author suppression, fire-and-forget error handling), 1 false positive documented (Dart 3 switch has no fall-through).


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add in-app notification system with socket event routing and settings UI
> - Adds a `NotificationSocketListener` that subscribes to chat and channel socket events, classifies them into `AppNotification` instances via `NotificationEventClassifier`, and routes them through `NotificationRouter` to in-app banners or system notifications based on user preferences.
> - Adds a `NotificationSettingsPage` (accessible from the profile page and profile sheet) with toggles for master enable, in-app banners, system notifications, sound, chat, and channel notifications; the three server-aligned prefs (`notificationEnabled`, `notificationSound`, `notificationSoundAlways`) are mirrored to the server via `ApiService.updateUserNotificationSettings`.
> - On authenticated startup, the listener is attached and any cold-launch notification tap is handled to deep-link into the target chat or channel.
> - Signing out clears all posted local notifications and resets the router and listener state.
> - Visiting a channel now immediately clears its local unread badge via `ChannelsList.markRead`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 29f78bc.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

**New Features**
- Added a Notifications settings page in your profile (profile → notifications) with master enablement plus granular controls for sound, in-app banners, system notifications, chat responses, and channel messages.
- Introduced live notification handling for socket events and OS notification taps, including deep-link routing, de-duplication, and sound/haptic cues, with unread updates.
- Added server-to-device mirroring for notification enablement and sound options.

**Bug Fixes**
- Visiting a channel now resets the local unread badge to match the server state.

**Tests**
- Expanded automated coverage for notification settings, routing, and socket/tap behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds a client-side in-app notification layer that translates Socket.IO events into in-app banners (foreground) or OS notifications (background), driven by a `NotificationEventClassifier` → `NotificationRouter` pipeline. The feature defaults off and requests OS permission only on master-toggle opt-in. Seven new preferences are persisted locally; three of them (`notificationEnabled`, `notificationSound`, `notificationSoundAlways`) are synced to the server to match Open WebUI's cross-device parity model.

- Introduces `lib/features/notifications/` with classifier, router, active-view tracker, local-notification wrapper, and settings page; all wired to existing `SocketService` streams via a `keepAlive` `NotificationSocketListener` that mirrors the `ActiveChatsSync` pattern.
- Extends `AppSettings`, `SettingsService`, `PersistenceKeys`, and `AppStartupFlow` with seven notification prefs; clears posted notifications and invalidates state on sign-out.
- Adds `ChannelsList.markRead` reset-on-visit to synchronize local unread badges when a channel is opened.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge. The feature defaults off, the routing pipeline is fully gated by the master toggle, all three previously-flagged bugs (sound preference not honored, hash-collision IDs, cold-launch race) are correctly addressed, and the 47-test suite covers every gating branch.

The classifier is pure and exhaustively tested; the router is dependency-injected and tested in isolation; the listener re-binds correctly on socket change and cleans up on sign-out. No crash paths or data-loss risks were identified in the changed code.

No files require special attention. The two small findings (identical section-header/tile label and haptic cue firing in the background path) are cosmetic.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| lib/features/notifications/services/notification_router.dart | Core routing logic: LRU dedup, per-kind toggles, active-view suppression, foreground/background surface selection. Well-structured and fully unit-tested. |
| lib/features/notifications/providers/notification_socket_listener.dart | Single global subscriber that re-binds on socket change/reconnect, delegates to classifier and router, handles cold-launch tap with proper await-before-query fix applied. |
| lib/features/notifications/services/local_notification_service.dart | flutter_local_notifications wrapper with idempotent init, counter-based notification IDs (no hash collision), playSound flag wired from settings. Sound-preference and ID-collision fixes from earlier review rounds are correctly applied. |
| lib/features/notifications/services/notification_event_classifier.dart | Pure, dependency-free classifier that translates raw socket envelopes into AppNotification; never throws on malformed input and returns null for non-notifiable events. |
| lib/features/notifications/views/notification_settings_page.dart | Settings UI with permission request on master-toggle opt-in and server sync for OW-aligned prefs; minor section header/tile title collision (see comment). |
| lib/core/providers/app_providers.dart | Adds _notificationPrefsAppliedServerId guard to PersonalizationSettings to prevent server values from clobbering a recently written local toggle. |
| lib/core/providers/app_startup_providers.dart | Bootstraps notification listener post-auth and handles cold-launch tap; clears posted notifications and invalidates router/listener state on sign-out. |
| lib/core/services/settings_service.dart | Adds seven notification preference keys with correct defaults (master off, sound on, banners on, system on, per-kind on) following existing hapticFeedback triad pattern. |
| lib/core/services/api_service.dart | Adds updateUserNotificationSettings using read-modify-write pattern consistent with other settings update methods in this file. |
| lib/features/channels/providers/channel_providers.dart | Adds markRead(channelId) to ChannelsList notifier; correctly no-ops when unreadCount is already 0 to avoid spurious rebuilds. |

</details>


</details>


<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Socket as SocketService
    participant Listener as NotificationSocketListener
    participant Classifier as NotificationEventClassifier
    participant Router as NotificationRouter
    participant ActiveView as ActiveViewTracker
    participant Local as LocalNotificationService
    participant Sound as NotificationSoundService
    participant UI as Banner/DeepLink

    Socket->>Listener: chat event / channel event
    Listener->>Classifier: classifyChatEvent / classifyChannelEvent
    Classifier-->>Listener: "AppNotification? (null = drop)"
    Listener->>Router: route(notification)
    Router->>Router: master toggle check
    Router->>Router: per-kind toggle check
    Router->>Router: LRU dedup check
    Router->>ActiveView: isViewingTarget?
    alt foreground + viewing target
        Router-->>Listener: suppressed
    else foreground
        Router->>Sound: play() (if soundAlways)
        Router->>UI: showInAppBanner()
        Router-->>Listener: banner
    else background
        Router->>Sound: play() (if soundAlways - no-op)
        Router->>Local: show(notification, playSound)
        Router-->>Listener: system
    end
    UI->>Listener: tap → _handleTap → NavigationService
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Socket as SocketService
    participant Listener as NotificationSocketListener
    participant Classifier as NotificationEventClassifier
    participant Router as NotificationRouter
    participant ActiveView as ActiveViewTracker
    participant Local as LocalNotificationService
    participant Sound as NotificationSoundService
    participant UI as Banner/DeepLink

    Socket->>Listener: chat event / channel event
    Listener->>Classifier: classifyChatEvent / classifyChannelEvent
    Classifier-->>Listener: "AppNotification? (null = drop)"
    Listener->>Router: route(notification)
    Router->>Router: master toggle check
    Router->>Router: per-kind toggle check
    Router->>Router: LRU dedup check
    Router->>ActiveView: isViewingTarget?
    alt foreground + viewing target
        Router-->>Listener: suppressed
    else foreground
        Router->>Sound: play() (if soundAlways)
        Router->>UI: showInAppBanner()
        Router-->>Listener: banner
    else background
        Router->>Sound: play() (if soundAlways - no-op)
        Router->>Local: show(notification, playSound)
        Router-->>Listener: system
    end
    UI->>Listener: tap → _handleTap → NavigationService
```

</a>
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `lib/features/notifications/providers/notification_socket_listener.dart`, line 813 ([link](https://github.com/cogwheel0/conduit/blob/3c03bf0489594f58010294e0a2d8d11d549d7f7e/lib/features/notifications/providers/notification_socket_listener.dart#L813)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Cold-launch tap can be missed due to uninitialized plugin**

   `build()` fires `unawaited(local.initialize())` and immediately starts the tap subscription. In `app_startup_providers.dart`, `handleLaunchTap()` is also called with `unawaited` right after reading the provider, meaning `_plugin.getNotificationAppLaunchDetails()` may be invoked before `_plugin.initialize()` has completed. On Android the plugin records the launch intent during `initialize()`; calling `getNotificationAppLaunchDetails()` before that returns `null`, silently dropping the cold-launch deep link. `handleLaunchTap()` should `await local.initialize()` before querying launch details.
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (7): Last reviewed commit: ["fix(notifications): notify for the activ..."](https://github.com/cogwheel0/conduit/commit/29f78bcd78402659ce4240dde4441c08f38fcf33) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38890188)</sub>

<!-- /greptile_comment -->