### PR TITLE
Fix debug log startup errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -117,6 +117,9 @@ lib/l10n/app_localizations_*.dart
 google-services.json
 GoogleService-Info.plist
 
+# Local workspace metadata
+.paseo/
+
 # Keystore files
 *.keystore
 *.jks

--- a/lib/core/database/database_manager.dart
+++ b/lib/core/database/database_manager.dart
@@ -31,9 +31,12 @@ class DatabaseManager {
   Future<void>? _pendingClose;
 
   /// Sync, lazy-open accessor for [server]'s database.
-  AppDatabase openFor(ServerConfig server) {
+  AppDatabase openFor(ServerConfig server) => openForServerId(server.id);
+
+  /// Sync, lazy-open accessor when only the stable server id is available.
+  AppDatabase openForServerId(String serverId) {
     final existing = _active;
-    if (existing != null && _activeServerId == server.id) {
+    if (existing != null && _activeServerId == serverId) {
       return existing;
     }
     if (existing != null) {
@@ -60,10 +63,10 @@ class DatabaseManager {
                 );
               });
     }
-    DebugLogger.log('open', scope: 'db/manager', data: {'serverId': server.id});
-    final db = _openDatabase(fileNameFor(server.id));
+    DebugLogger.log('open', scope: 'db/manager', data: {'serverId': serverId});
+    final db = _openDatabase(fileNameFor(serverId));
     _active = db;
-    _activeServerId = server.id;
+    _activeServerId = serverId;
     return db;
   }
 

--- a/lib/core/providers/app_providers.dart
+++ b/lib/core/providers/app_providers.dart
@@ -1825,6 +1825,7 @@ Future<Model?> defaultModel(Ref ref) async {
 
     // Get demo models and select the first one
     final models = await ref.read(modelsProvider.future);
+    if (!ref.mounted) return null;
     if (models.isNotEmpty) {
       final defaultModel = models.first;
       if (!ref.read(isManualModelSelectionProvider)) {
@@ -1863,9 +1864,11 @@ Future<Model?> defaultModel(Ref ref) async {
     final storedDefaultId =
         settingsDefaultId ??
         await SettingsService.getDefaultModel().catchError((_) => null);
+    if (!ref.mounted) return null;
 
     if (storedDefaultId != null && storedDefaultId.isNotEmpty) {
       final cachedMatch = await selectCachedModel(storage, storedDefaultId);
+      if (!ref.mounted) return null;
       if (cachedMatch != null && !ref.read(isManualModelSelectionProvider)) {
         ref.read(selectedModelProvider.notifier).set(cachedMatch);
         unawaited(
@@ -1883,8 +1886,10 @@ Future<Model?> defaultModel(Ref ref) async {
     // 2) Fallback: cached resolved default model (offline/fast startup).
     try {
       final cached = await storage.getLocalDefaultModel();
+      if (!ref.mounted) return null;
       if (cached != null && !ref.read(isManualModelSelectionProvider)) {
         final cachedMatch = await selectCachedModel(storage, cached.id);
+        if (!ref.mounted) return null;
         if (cachedMatch == null) {
           await storage.saveLocalDefaultModel(null);
         } else {
@@ -1903,8 +1908,10 @@ Future<Model?> defaultModel(Ref ref) async {
     // preference exists.
     try {
       final serverDefault = await api.getDefaultModel();
+      if (!ref.mounted) return null;
       if (serverDefault != null && serverDefault.isNotEmpty) {
         final models = await api.getModels();
+        if (!ref.mounted) return null;
         Model? resolved;
         try {
           resolved = models.firstWhere((m) => m.id == serverDefault);
@@ -1939,6 +1946,7 @@ Future<Model?> defaultModel(Ref ref) async {
     // 4) Fallback: fetch models and pick first available
     DebugLogger.log('fallback-path', scope: 'models/default');
     final models = await ref.read(modelsProvider.future);
+    if (!ref.mounted) return null;
     DebugLogger.log(
       'models-loaded',
       scope: 'models/default',

--- a/lib/core/providers/storage_providers.dart
+++ b/lib/core/providers/storage_providers.dart
@@ -3,6 +3,8 @@ import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 
 import '../database/database_provider.dart';
 import '../persistence/persistence_providers.dart';
+import '../persistence/persistence_keys.dart';
+import '../persistence/preferences_store.dart';
 import '../services/optimized_storage_service.dart';
 import '../services/worker_manager.dart';
 
@@ -30,12 +32,23 @@ final secureStorageProvider = Provider<FlutterSecureStorage>((ref) {
 final optimizedStorageServiceProvider = Provider<OptimizedStorageService>((
   ref,
 ) {
+  final databaseManager = ref.watch(databaseManagerProvider);
   return OptimizedStorageService(
     secureStorage: ref.watch(secureStorageProvider),
     boxes: ref.watch(hiveBoxesProvider),
     workerManager: ref.watch(workerManagerProvider),
-    // Lazy read (NOT watch) so structured caches resolve the active server's
-    // Drift DB at call time without creating a build-time dependency cycle.
-    database: () => ref.read(appDatabaseProvider),
+    // Resolve from the raw active-server preference instead of appDatabaseProvider.
+    // appDatabaseProvider depends on activeServerProvider, which itself reads this
+    // storage service; using it here re-enters Riverpod during active-server
+    // construction and trips CircularDependencyError on cold start.
+    database: () {
+      final serverId = PreferencesStore.getString(
+        PreferenceKeys.activeServerId,
+      );
+      if (serverId == null || serverId.isEmpty) {
+        return null;
+      }
+      return databaseManager.openForServerId(serverId);
+    },
   );
 });

--- a/lib/core/services/api_service.dart
+++ b/lib/core/services/api_service.dart
@@ -249,6 +249,7 @@ class ApiService {
   final Dio _dio;
   final ServerConfig serverConfig;
   final WorkerManager _workerManager;
+  final DateTime Function() _now;
   late final ApiAuthInterceptor _authInterceptor;
   _ChatRequestMetadataFormat? _chatRequestMetadataFormat;
   // Public getter for dio instance
@@ -267,6 +268,7 @@ class ApiService {
     required this.serverConfig,
     required WorkerManager workerManager,
     String? authToken,
+    DateTime Function()? now,
   }) : _dio = Dio(
          BaseOptions(
            baseUrl: serverConfig.url,
@@ -281,7 +283,8 @@ class ApiService {
                : null,
          ),
        ),
-       _workerManager = workerManager {
+       _workerManager = workerManager,
+       _now = now ?? DateTime.now {
     ServerTlsHttpClientFactory.configureDio(_dio, serverConfig);
 
     // Use API key from server config if provided and no explicit auth token
@@ -5592,18 +5595,25 @@ class ApiService {
     }
   }
 
-  /// Set once the bulk active-chats endpoint returns 404/405 (older servers), so we
+  /// Set once the bulk active-chats endpoint returns 404 (older servers), so we
   /// stop probing it for the rest of the session.
   bool _activeChatsEndpointUnsupported = false;
+  DateTime? _activeChatsMethodRejectedRetryAfter;
+  static const _activeChatsMethodRejectedRetryDelay = Duration(minutes: 1);
 
   /// POST `/api/v1/tasks/active/chats` `{chat_ids: [...]}` → `{active_chat_ids: [...]}`.
   ///
   /// Bulk query for which of [chatIds] currently have an active server task
   /// (mirrors OpenWebUI's `checkActiveChats`). Returns an empty set when
   /// [chatIds] is empty or the endpoint is missing on the server (cached after
-  /// the first 404/405 so we don't keep probing).
+  /// the first 404 so we don't keep probing). HTTP 405 is treated as a
+  /// retryable proxy/load-balancer rejection and only pauses probing briefly.
   Future<Set<String>> checkActiveChats(List<String> chatIds) async {
     if (chatIds.isEmpty || _activeChatsEndpointUnsupported) {
+      return <String>{};
+    }
+    final rejectedRetryAfter = _activeChatsMethodRejectedRetryAfter;
+    if (rejectedRetryAfter != null && _now().isBefore(rejectedRetryAfter)) {
       return <String>{};
     }
     try {
@@ -5611,6 +5621,7 @@ class ApiService {
         '/api/v1/tasks/active/chats',
         data: {'chat_ids': chatIds},
       );
+      _activeChatsMethodRejectedRetryAfter = null;
       final data = resp.data;
       if (data is Map && data['active_chat_ids'] is List) {
         return (data['active_chat_ids'] as List)
@@ -5620,12 +5631,26 @@ class ApiService {
       return <String>{};
     } on DioException catch (e) {
       final statusCode = e.response?.statusCode;
-      if (statusCode == 404 || statusCode == 405) {
+      if (statusCode == 404) {
         _activeChatsEndpointUnsupported = true;
         DebugLogger.log(
           'active-chats endpoint unsupported; disabling bulk probe',
           scope: 'api/tasks',
           data: {'status': statusCode},
+        );
+        return <String>{};
+      }
+      if (statusCode == 405) {
+        _activeChatsMethodRejectedRetryAfter = _now().add(
+          _activeChatsMethodRejectedRetryDelay,
+        );
+        DebugLogger.log(
+          'active-chats endpoint rejected; pausing bulk probe',
+          scope: 'api/tasks',
+          data: {
+            'status': statusCode,
+            'retryAfterMs': _activeChatsMethodRejectedRetryDelay.inMilliseconds,
+          },
         );
         return <String>{};
       }

--- a/lib/core/services/api_service.dart
+++ b/lib/core/services/api_service.dart
@@ -5592,23 +5592,23 @@ class ApiService {
     }
   }
 
-  /// Set once the bulk active-chats endpoint returns 404 (older servers), so we
+  /// Set once the bulk active-chats endpoint returns 404/405 (older servers), so we
   /// stop probing it for the rest of the session.
   bool _activeChatsEndpointUnsupported = false;
 
-  /// POST `/api/tasks/active/chats` `{chat_ids: [...]}` → `{active_chat_ids: [...]}`.
+  /// POST `/api/v1/tasks/active/chats` `{chat_ids: [...]}` → `{active_chat_ids: [...]}`.
   ///
   /// Bulk query for which of [chatIds] currently have an active server task
   /// (mirrors OpenWebUI's `checkActiveChats`). Returns an empty set when
   /// [chatIds] is empty or the endpoint is missing on the server (cached after
-  /// the first 404 so we don't keep probing).
+  /// the first 404/405 so we don't keep probing).
   Future<Set<String>> checkActiveChats(List<String> chatIds) async {
     if (chatIds.isEmpty || _activeChatsEndpointUnsupported) {
       return <String>{};
     }
     try {
       final resp = await _dio.post(
-        '/api/tasks/active/chats',
+        '/api/v1/tasks/active/chats',
         data: {'chat_ids': chatIds},
       );
       final data = resp.data;
@@ -5619,11 +5619,13 @@ class ApiService {
       }
       return <String>{};
     } on DioException catch (e) {
-      if (e.response?.statusCode == 404) {
+      final statusCode = e.response?.statusCode;
+      if (statusCode == 404 || statusCode == 405) {
         _activeChatsEndpointUnsupported = true;
         DebugLogger.log(
-          'active-chats endpoint unsupported (404); disabling bulk probe',
+          'active-chats endpoint unsupported; disabling bulk probe',
           scope: 'api/tasks',
+          data: {'status': statusCode},
         );
         return <String>{};
       }

--- a/lib/core/services/performance_profiler.dart
+++ b/lib/core/services/performance_profiler.dart
@@ -105,18 +105,20 @@ class PerformanceProfiler {
       final buildMs = timing.buildDuration.inMicroseconds / 1000.0;
       final rasterMs = timing.rasterDuration.inMicroseconds / 1000.0;
       final totalMs = timing.totalSpan.inMicroseconds / 1000.0;
+      final vsyncOverheadMs = timing.vsyncOverhead.inMicroseconds / 1000.0;
+      final workloadMs = totalMs - vsyncOverheadMs;
 
-      final isSlowFrame = totalMs > 16.7 || buildMs > 8.3 || rasterMs > 8.3;
+      final isSlowFrame = workloadMs > 16.7 || buildMs > 8.3 || rasterMs > 8.3;
       if (!isSlowFrame) {
         continue;
       }
 
       final data = <String, Object?>{
         'totalMs': totalMs.toStringAsFixed(2),
+        'workloadMs': workloadMs.toStringAsFixed(2),
         'buildMs': buildMs.toStringAsFixed(2),
         'rasterMs': rasterMs.toStringAsFixed(2),
-        'vsyncOverheadMs': (timing.vsyncOverhead.inMicroseconds / 1000.0)
-            .toStringAsFixed(2),
+        'vsyncOverheadMs': vsyncOverheadMs.toStringAsFixed(2),
       };
       developer.Timeline.instantSync(
         _eventName('frame', 'slow_frame'),

--- a/lib/features/chat/providers/chat_providers.dart
+++ b/lib/features/chat/providers/chat_providers.dart
@@ -3548,6 +3548,7 @@ Future<void> restoreDefaultModel(dynamic ref) async {
   final settingsDefault = ref.read(appSettingsProvider).defaultModel;
   if (settingsDefault == null || settingsDefault.isEmpty) {
     final storage = ref.read(optimizedStorageServiceProvider);
+    if (ref is Ref && !ref.mounted) return;
     await storage.saveLocalDefaultModel(null);
     if (ref is Ref && !ref.mounted) return;
     DebugLogger.log('cleared-cached-default', scope: 'chat/model');

--- a/lib/features/chat/providers/chat_providers.dart
+++ b/lib/features/chat/providers/chat_providers.dart
@@ -3549,6 +3549,7 @@ Future<void> restoreDefaultModel(dynamic ref) async {
   if (settingsDefault == null || settingsDefault.isEmpty) {
     final storage = ref.read(optimizedStorageServiceProvider);
     await storage.saveLocalDefaultModel(null);
+    if (ref is Ref && !ref.mounted) return;
     DebugLogger.log('cleared-cached-default', scope: 'chat/model');
   }
 

--- a/test/core/services/api_service_active_chats_test.dart
+++ b/test/core/services/api_service_active_chats_test.dart
@@ -51,17 +51,22 @@ void main() {
       check(adapter.requestCount).equals(1);
     });
 
-    test('405 degrades to empty and is cached (no re-probe)', () async {
+    test('405 degrades to empty and retries after a brief pause', () async {
+      var now = DateTime(2026);
       final adapter = _ActiveChatsAdapter(statusCode: 405, body: const {});
-      final api = _buildApiService(adapter);
+      final api = _buildApiService(adapter, now: () => now);
 
       final first = await api.checkActiveChats(['a']);
       final second = await api.checkActiveChats(['a', 'b']);
+      now = now.add(const Duration(minutes: 1, seconds: 1));
+      final third = await api.checkActiveChats(['a', 'b', 'c']);
 
       check(first).isEmpty();
       check(second).isEmpty();
-      // Only the first call hits the network; the 405 is cached.
-      check(adapter.requestCount).equals(1);
+      check(third).isEmpty();
+      // The immediate retry is paused, but 405 does not disable the probe for
+      // the whole session.
+      check(adapter.requestCount).equals(2);
     });
   });
 }
@@ -104,7 +109,10 @@ class _ActiveChatsAdapter implements HttpClientAdapter {
   void close({bool force = false}) {}
 }
 
-ApiService _buildApiService(HttpClientAdapter adapter) {
+ApiService _buildApiService(
+  HttpClientAdapter adapter, {
+  DateTime Function()? now,
+}) {
   final service = ApiService(
     serverConfig: const ServerConfig(
       id: 'test',
@@ -112,6 +120,7 @@ ApiService _buildApiService(HttpClientAdapter adapter) {
       url: 'http://localhost:0',
     ),
     workerManager: WorkerManager(),
+    now: now,
   );
   service.dio.httpClientAdapter = adapter;
   service.dio.interceptors.clear();

--- a/test/core/services/api_service_active_chats_test.dart
+++ b/test/core/services/api_service_active_chats_test.dart
@@ -22,8 +22,9 @@ void main() {
       final active = await api.checkActiveChats(['a', 'b', 'c']);
 
       check(active).deepEquals({'a', 'c'});
-      check(adapter.lastPath).equals('/api/tasks/active/chats');
-      final sentChatIds = (adapter.lastBody?['chat_ids'] as List).cast<String>();
+      check(adapter.lastPath).equals('/api/v1/tasks/active/chats');
+      final sentChatIds = (adapter.lastBody?['chat_ids'] as List)
+          .cast<String>();
       check(sentChatIds).deepEquals(['a', 'b', 'c']);
     });
 
@@ -47,6 +48,19 @@ void main() {
       check(first).isEmpty();
       check(second).isEmpty();
       // Only the first call hits the network; the 404 is cached.
+      check(adapter.requestCount).equals(1);
+    });
+
+    test('405 degrades to empty and is cached (no re-probe)', () async {
+      final adapter = _ActiveChatsAdapter(statusCode: 405, body: const {});
+      final api = _buildApiService(adapter);
+
+      final first = await api.checkActiveChats(['a']);
+      final second = await api.checkActiveChats(['a', 'b']);
+
+      check(first).isEmpty();
+      check(second).isEmpty();
+      // Only the first call hits the network; the 405 is cached.
       check(adapter.requestCount).equals(1);
     });
   });


### PR DESCRIPTION
## Summary
- break the optimized storage/database provider cycle by resolving the active server database from the raw active-server preference
- use the Open WebUI v1 active-chats endpoint and cache 404/405 unsupported responses
- guard async default-model restore paths against disposed Riverpod refs
- avoid logging idle vsync overhead as slow-frame app jank

## Verification
- dart run build_runner build --delete-conflicting-outputs
- flutter analyze
- flutter test
- flutter build ios --simulator --debug


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix debug log startup errors by adding disposal guards and 405 backoff to active chats polling
> - Adds `ref.mounted` guards throughout the `defaultModel` provider and `restoreDefaultModel` in [chat_providers.dart](https://github.com/cogwheel0/conduit/pull/527/files#diff-d40cac4b005693ed296f14004f1b80f218a826122c0e89df2756d9a98a43e28b) to prevent state writes after provider disposal.
> - Changes `checkActiveChats` in [api_service.dart](https://github.com/cogwheel0/conduit/pull/527/files#diff-2bd4fc55cec75446711de77327c23c8d5323d96d468b1b03070719b2db4482b5) to use the versioned path `/api/v1/tasks/active/chats` and treats HTTP 405 as a temporary rejection with a 1-minute backoff instead of permanently disabling polling.
> - Adds `openForServerId(String serverId)` to `DatabaseManager` and refactors `optimizedStorageServiceProvider` to resolve the database from the persisted active server ID, removing its dependency on `appDatabaseProvider`.
> - Behavioral Change: 405 responses no longer permanently disable active chat probing; probing resumes after ~1 minute.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f2b4dfb.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented model and database switching from continuing after disposal/unmount
  * Fixed database/storage initialization to consistently use the currently active server setting
  * Improved active-chat probing to better handle unsupported endpoints (reduces repeated failed requests and adds retry after temporary pauses)
* **Performance**
  * Improved slow-frame detection by profiling rendering workload time more accurately
* **Tests**
  * Updated active-chat API tests for the revised request path and new 405 retry timing behavior
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes several unrelated startup errors surfaced in debug logs: a circular dependency between `optimizedStorageServiceProvider` and `appDatabaseProvider` on cold start, disposed-Riverpod-ref writes in the `defaultModel` provider and `restoreDefaultModel`, a 405-treated-as-permanent issue on the active-chats probe, and idle vsync time being counted as slow-frame jank.

- Breaks the `optimizedStorageServiceProvider` → `appDatabaseProvider` → `activeServerProvider` → `optimizedStorageServiceProvider` cycle by reading the active server ID directly from the synchronous `PreferencesStore` (which is safe after bootstrap) and opening the database via a new `DatabaseManager.openForServerId` overload.
- Adds `ref.mounted` guards after every `await` in the `defaultModel` provider and `restoreDefaultModel`, and treats HTTP 405 on `/api/v1/tasks/active/chats` as a 1-minute retryable pause (backed by an injected clock and a new unit test) instead of a permanent session-level disable.
- Narrows the slow-frame threshold from `totalMs` to `workloadMs = totalMs − vsyncOverheadMs`, eliminating false positives caused by idle vsync wait time.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

All four fixes are self-contained, well-reasoned, and covered by updated tests; no regressions were found.

The circular-dependency fix reads from a synchronous, already-initialized preference store whose null return is handled gracefully. The disposal guards use the correct Riverpod 3 `Ref.mounted` API and are placed at every post-`await` boundary. The 405 backoff is tested with an injected clock. The slow-frame threshold change is directionally correct and removes false positives without masking real jank.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| lib/core/providers/storage_providers.dart | Breaks the circular dependency by reading the active server ID from `PreferencesStore` synchronously at closure call-time; `databaseManagerProvider` is correctly `watch`ed (keepAlive singleton) so the closure is stable. |
| lib/core/database/database_manager.dart | Adds `openForServerId(String serverId)` and makes `openFor` delegate to it; clean refactor with no behavioral change. |
| lib/core/providers/app_providers.dart | Adds `ref.mounted` guards after every `await` in `defaultModel`; guards are correctly positioned and use the Riverpod 3 `Ref.mounted` API. |
| lib/features/chat/providers/chat_providers.dart | Adds `ref is Ref && !ref.mounted` disposal guard in `restoreDefaultModel`; because `WidgetRef` extends `Ref` in Riverpod 3, the `is Ref` check covers both provider and widget ref callers. |
| lib/core/services/api_service.dart | Updates active-chats path to `/api/v1/tasks/active/chats`, adds 405 backoff with injected clock, resets backoff on success; 404 permanent-disable behaviour is unchanged. |
| lib/core/services/performance_profiler.dart | Uses `workloadMs = totalMs − vsyncOverheadMs` for the slow-frame gate, correctly excluding idle vsync wait from the 16.7 ms threshold. |
| test/core/services/api_service_active_chats_test.dart | Adds a 405 retry-after test using an injected `now` clock; test correctly validates 2 network hits (first 405, then retry after 61 s), not 3. |
| .gitignore | Adds `.paseo/` to the ignore list for local workspace metadata. |

</details>

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Caller
    participant ApiService
    participant Server

    Note over ApiService: _activeChatsMethodRejectedRetryAfter = null

    Caller->>ApiService: checkActiveChats(['a','b'])
    ApiService->>Server: POST /api/v1/tasks/active/chats
    Server-->>ApiService: 405 Method Not Allowed
    ApiService->>ApiService: "set retryAfter = now + 1 min"
    ApiService-->>Caller: "{} (empty)"

    Caller->>ApiService: checkActiveChats(['a','b']) within 1 min
    ApiService->>ApiService: "now < retryAfter → skip"
    ApiService-->>Caller: "{} (empty, no network call)"

    Note over ApiService: 1 minute passes

    Caller->>ApiService: checkActiveChats(['a','b'])
    ApiService->>Server: POST /api/v1/tasks/active/chats
    Server-->>ApiService: "200 OK {active_chat_ids: ['a']}"
    ApiService->>ApiService: "reset retryAfter = null"
    ApiService-->>Caller: "{'a'}"
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Caller
    participant ApiService
    participant Server

    Note over ApiService: _activeChatsMethodRejectedRetryAfter = null

    Caller->>ApiService: checkActiveChats(['a','b'])
    ApiService->>Server: POST /api/v1/tasks/active/chats
    Server-->>ApiService: 405 Method Not Allowed
    ApiService->>ApiService: "set retryAfter = now + 1 min"
    ApiService-->>Caller: "{} (empty)"

    Caller->>ApiService: checkActiveChats(['a','b']) within 1 min
    ApiService->>ApiService: "now < retryAfter → skip"
    ApiService-->>Caller: "{} (empty, no network call)"

    Note over ApiService: 1 minute passes

    Caller->>ApiService: checkActiveChats(['a','b'])
    ApiService->>Server: POST /api/v1/tasks/active/chats
    Server-->>ApiService: "200 OK {active_chat_ids: ['a']}"
    ApiService->>ApiService: "reset retryAfter = null"
    ApiService-->>Caller: "{'a'}"
```

</a>
</details>

<sub>Reviews (3): Last reviewed commit: ["Ignore Paseo workspace metadata"](https://github.com/cogwheel0/conduit/commit/f2b4dfb20e378f97faa7a9d0027eb41e0813fc21) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39079126)</sub>

<!-- /greptile_comment -->