### PR TITLE
Fix initial login sync refresh

### DIFF
--- a/lib/core/providers/app_providers.dart
+++ b/lib/core/providers/app_providers.dart
@@ -45,6 +45,7 @@ import '../database/database_provider.dart';
 import '../database/local_conversation_loader.dart';
 import '../database/mappers/conversation_assembler.dart';
 import '../sync/chat_locks.dart';
+import '../sync/pull_sync.dart';
 import '../sync/sync_engine.dart';
 
 export 'storage_providers.dart';
@@ -1430,13 +1431,23 @@ class Conversations extends _$Conversations {
       scope: 'conversations',
       data: {'action': action},
     );
+    Future<PullResult?> pull;
+    try {
+      pull = ref
+          .read(syncEngineProvider.notifier)
+          .requestPull(reason: 'conversations-reconcile');
+    } catch (error, stackTrace) {
+      DebugLogger.error(
+        'reconcile-pull-failed',
+        scope: 'conversations',
+        error: error,
+        stackTrace: stackTrace,
+        data: {'action': action},
+      );
+      return;
+    }
     unawaited(
-      Future<void>.microtask(() async {
-        if (!ref.mounted) return;
-        await ref
-            .read(syncEngineProvider.notifier)
-            .requestPull(reason: 'conversations-reconcile');
-      }).catchError((Object error, StackTrace stackTrace) {
+      pull.catchError((Object error, StackTrace stackTrace) {
         DebugLogger.error(
           'reconcile-pull-failed',
           scope: 'conversations',
@@ -3436,13 +3447,23 @@ class Folders extends _$Folders {
       scope: 'folders',
       data: {'action': action},
     );
+    Future<PullResult?> pull;
+    try {
+      pull = ref
+          .read(syncEngineProvider.notifier)
+          .requestPull(reason: 'folders-reconcile');
+    } catch (error, stackTrace) {
+      DebugLogger.error(
+        'reconcile-pull-failed',
+        scope: 'folders',
+        error: error,
+        stackTrace: stackTrace,
+        data: {'action': action},
+      );
+      return;
+    }
     unawaited(
-      Future<void>.microtask(() async {
-        if (!ref.mounted) return;
-        await ref
-            .read(syncEngineProvider.notifier)
-            .requestPull(reason: 'folders-reconcile');
-      }).catchError((Object error, StackTrace stackTrace) {
+      pull.catchError((Object error, StackTrace stackTrace) {
         DebugLogger.error(
           'reconcile-pull-failed',
           scope: 'folders',

--- a/lib/core/providers/app_providers.dart
+++ b/lib/core/providers/app_providers.dart
@@ -501,7 +501,8 @@ final socketServiceProvider = Provider<SocketService?>((ref) {
   // there is no active server / reviewer mode / it was disposed.
   return asyncService.maybeWhen(
     data: (service) => service,
-    orElse: () => ref.read(socketServiceManagerProvider.notifier).currentService,
+    orElse: () =>
+        ref.read(socketServiceManagerProvider.notifier).currentService,
   );
 });
 
@@ -1430,19 +1431,21 @@ class Conversations extends _$Conversations {
       data: {'action': action},
     );
     unawaited(
-      ref
-          .read(syncEngineProvider.notifier)
-          .requestPull(reason: 'conversations-reconcile')
-          .catchError((Object error, StackTrace stackTrace) {
-            DebugLogger.error(
-              'reconcile-pull-failed',
-              scope: 'conversations',
-              error: error,
-              stackTrace: stackTrace,
-              data: {'action': action},
-            );
-            return null;
-          }),
+      Future<void>.microtask(() async {
+        if (!ref.mounted) return;
+        await ref
+            .read(syncEngineProvider.notifier)
+            .requestPull(reason: 'conversations-reconcile');
+      }).catchError((Object error, StackTrace stackTrace) {
+        DebugLogger.error(
+          'reconcile-pull-failed',
+          scope: 'conversations',
+          error: error,
+          stackTrace: stackTrace,
+          data: {'action': action},
+        );
+        return null;
+      }),
     );
   }
 
@@ -3434,19 +3437,21 @@ class Folders extends _$Folders {
       data: {'action': action},
     );
     unawaited(
-      ref
-          .read(syncEngineProvider.notifier)
-          .requestPull(reason: 'folders-reconcile')
-          .catchError((Object error, StackTrace stackTrace) {
-            DebugLogger.error(
-              'reconcile-pull-failed',
-              scope: 'folders',
-              error: error,
-              stackTrace: stackTrace,
-              data: {'action': action},
-            );
-            return null;
-          }),
+      Future<void>.microtask(() async {
+        if (!ref.mounted) return;
+        await ref
+            .read(syncEngineProvider.notifier)
+            .requestPull(reason: 'folders-reconcile');
+      }).catchError((Object error, StackTrace stackTrace) {
+        DebugLogger.error(
+          'reconcile-pull-failed',
+          scope: 'folders',
+          error: error,
+          stackTrace: stackTrace,
+          data: {'action': action},
+        );
+        return null;
+      }),
     );
   }
 

--- a/lib/core/providers/app_providers.dart
+++ b/lib/core/providers/app_providers.dart
@@ -1244,6 +1244,44 @@ _RemovedItems<T> _removeItemById<T>(
 int _epochSecondsOf(DateTime dateTime) =>
     dateTime.millisecondsSinceEpoch ~/ 1000;
 
+void _submitReconcilePull(
+  Ref ref, {
+  required String reason,
+  required String scope,
+  required String action,
+}) {
+  DebugLogger.log(
+    'reconcile-after-remote-mutation',
+    scope: scope,
+    data: {'action': action},
+  );
+  Future<PullResult?> pull;
+  try {
+    pull = ref.read(syncEngineProvider.notifier).requestPull(reason: reason);
+  } catch (error, stackTrace) {
+    DebugLogger.error(
+      'reconcile-pull-failed',
+      scope: scope,
+      error: error,
+      stackTrace: stackTrace,
+      data: {'action': action},
+    );
+    return;
+  }
+  unawaited(
+    pull.catchError((Object error, StackTrace stackTrace) {
+      DebugLogger.error(
+        'reconcile-pull-failed',
+        scope: scope,
+        error: error,
+        stackTrace: stackTrace,
+        data: {'action': action},
+      );
+      return null;
+    }),
+  );
+}
+
 // Conversation list provider — Drift-backed read path (CDT-RFC-001 Phase 1).
 //
 // The list renders from `ChatsDao.watchChatList()` (a narrow projection that
@@ -1426,37 +1464,11 @@ class Conversations extends _$Conversations {
   }
 
   void _requestConversationReconcilePull({required String action}) {
-    DebugLogger.log(
-      'reconcile-after-remote-mutation',
+    _submitReconcilePull(
+      ref,
+      reason: 'conversations-reconcile',
       scope: 'conversations',
-      data: {'action': action},
-    );
-    Future<PullResult?> pull;
-    try {
-      pull = ref
-          .read(syncEngineProvider.notifier)
-          .requestPull(reason: 'conversations-reconcile');
-    } catch (error, stackTrace) {
-      DebugLogger.error(
-        'reconcile-pull-failed',
-        scope: 'conversations',
-        error: error,
-        stackTrace: stackTrace,
-        data: {'action': action},
-      );
-      return;
-    }
-    unawaited(
-      pull.catchError((Object error, StackTrace stackTrace) {
-        DebugLogger.error(
-          'reconcile-pull-failed',
-          scope: 'conversations',
-          error: error,
-          stackTrace: stackTrace,
-          data: {'action': action},
-        );
-        return null;
-      }),
+      action: action,
     );
   }
 
@@ -3442,37 +3454,11 @@ class Folders extends _$Folders {
   }
 
   void _requestReconcilePull({required String action}) {
-    DebugLogger.log(
-      'reconcile-after-remote-mutation',
+    _submitReconcilePull(
+      ref,
+      reason: 'folders-reconcile',
       scope: 'folders',
-      data: {'action': action},
-    );
-    Future<PullResult?> pull;
-    try {
-      pull = ref
-          .read(syncEngineProvider.notifier)
-          .requestPull(reason: 'folders-reconcile');
-    } catch (error, stackTrace) {
-      DebugLogger.error(
-        'reconcile-pull-failed',
-        scope: 'folders',
-        error: error,
-        stackTrace: stackTrace,
-        data: {'action': action},
-      );
-      return;
-    }
-    unawaited(
-      pull.catchError((Object error, StackTrace stackTrace) {
-        DebugLogger.error(
-          'reconcile-pull-failed',
-          scope: 'folders',
-          error: error,
-          stackTrace: stackTrace,
-          data: {'action': action},
-        );
-        return null;
-      }),
+      action: action,
     );
   }
 

--- a/lib/core/sync/chat_locks.dart
+++ b/lib/core/sync/chat_locks.dart
@@ -124,11 +124,23 @@ class ChatLocks {
   bool get isIdle => _tails.isEmpty;
 }
 
+/// Lock domain for chat/conversation rows.
+///
+/// Kept as a distinct type from [FolderLocks] and [NoteLocks] so constructor
+/// injection catches accidental cross-domain wiring at compile time.
+class ConversationLocks extends ChatLocks {}
+
+/// Lock domain for folder rows.
+class FolderLocks extends ChatLocks {}
+
+/// Lock domain for note rows.
+class NoteLocks extends ChatLocks {}
+
 /// Fresh instance per database identity so locks never leak across servers.
 @Riverpod(keepAlive: true)
-ChatLocks chatLocks(Ref ref) {
+ConversationLocks chatLocks(Ref ref) {
   ref.watch(appDatabaseProvider);
-  return ChatLocks();
+  return ConversationLocks();
 }
 
 /// Folder ops own a SEPARATE lock domain from chats (`OutboxDao.isFolderKind`):
@@ -136,9 +148,9 @@ ChatLocks chatLocks(Ref ref) {
 /// instance from [chatLocksProvider] so a folder op never contends a chat op
 /// (and vice versa). Also recreated per database identity.
 @Riverpod(keepAlive: true)
-ChatLocks folderLocks(Ref ref) {
+FolderLocks folderLocks(Ref ref) {
   ref.watch(appDatabaseProvider);
-  return ChatLocks();
+  return FolderLocks();
 }
 
 /// Note ops own a SEPARATE lock domain from chats and folders
@@ -147,7 +159,7 @@ ChatLocks folderLocks(Ref ref) {
 /// contends a chat/folder op (and vice versa). Recreated per database identity
 /// so locks never leak across servers. The per-key id is the NOTE id.
 @Riverpod(keepAlive: true)
-ChatLocks noteLocks(Ref ref) {
+NoteLocks noteLocks(Ref ref) {
   ref.watch(appDatabaseProvider);
-  return ChatLocks();
+  return NoteLocks();
 }

--- a/lib/core/sync/deletion_reconcile.dart
+++ b/lib/core/sync/deletion_reconcile.dart
@@ -80,7 +80,7 @@ class DeletionReconcile {
   DeletionReconcile({
     required SyncApiClient client,
     required AppDatabase db,
-    required ChatLocks locks,
+    required ConversationLocks locks,
     required SyncClock clock,
   }) : _client = client,
        _db = db,
@@ -89,7 +89,7 @@ class DeletionReconcile {
 
   final SyncApiClient _client;
   final AppDatabase _db;
-  final ChatLocks _locks;
+  final ConversationLocks _locks;
   final SyncClock _clock;
 
   /// Runs the reconcile subject to the throttle. On a completed run (not

--- a/lib/core/sync/note_deletion_reconcile.dart
+++ b/lib/core/sync/note_deletion_reconcile.dart
@@ -25,7 +25,7 @@ class NoteDeletionReconcile {
   NoteDeletionReconcile({
     required SyncApiClient client,
     required AppDatabase db,
-    required ChatLocks locks,
+    required NoteLocks locks,
     required SyncClock clock,
   }) : _client = client,
        _db = db,
@@ -34,7 +34,7 @@ class NoteDeletionReconcile {
 
   final SyncApiClient _client;
   final AppDatabase _db;
-  final ChatLocks _locks;
+  final NoteLocks _locks;
   final SyncClock _clock;
 
   Future<ReconcileResult> run(ReconcileReason reason) async {

--- a/lib/core/sync/note_sync.dart
+++ b/lib/core/sync/note_sync.dart
@@ -35,7 +35,7 @@ class NotePullSync {
   NotePullSync({
     required SyncApiClient client,
     required AppDatabase db,
-    required ChatLocks locks,
+    required NoteLocks locks,
     IdRemapper? remapper,
     void Function(bool enabled)? onFeatureEnabled,
   }) : _client = client,
@@ -47,7 +47,7 @@ class NotePullSync {
 
   final SyncApiClient _client;
   final AppDatabase _db;
-  final ChatLocks _locks;
+  final NoteLocks _locks;
 
   /// Used by pull-side note create crash-heal when a process crashed after the
   /// server minted a note but before the local `noteCreate` remap committed.
@@ -189,7 +189,7 @@ class NotePushSync {
   NotePushSync({
     required SyncApiClient client,
     required AppDatabase db,
-    required ChatLocks noteLocks,
+    required NoteLocks noteLocks,
     required IdRemapper remapper,
   }) : _client = client,
        _db = db,
@@ -198,7 +198,7 @@ class NotePushSync {
 
   final SyncApiClient _client;
   final AppDatabase _db;
-  final ChatLocks _noteLocks;
+  final NoteLocks _noteLocks;
   final IdRemapper _remapper;
 
   // ---- noteCreate (§7.3 analog) ----

--- a/lib/core/sync/outbox_drainer.dart
+++ b/lib/core/sync/outbox_drainer.dart
@@ -87,6 +87,8 @@ class OutboxDrainer {
   bool _draining = false;
   bool _rerun = false;
 
+  bool get isDraining => _draining;
+
   /// Stranded-`inFlight` recovery runs exactly once per process, before the
   /// first claim of the first drain (§7.2/§11 crash recovery). Guarded so a
   /// rerun mid-session never re-reclaims an op a live worker just flipped to

--- a/lib/core/sync/outbox_task_queue_migrator.dart
+++ b/lib/core/sync/outbox_task_queue_migrator.dart
@@ -33,7 +33,7 @@ class OutboxTaskQueueMigrator {
   OutboxTaskQueueMigrator({
     required AppDatabase db,
     required HiveBoxes hiveBoxes,
-    required ChatLocks chatLocks,
+    required ConversationLocks chatLocks,
     required SyncClock clock,
     String Function() resolveDefaultModel = _emptyModel,
     Uuid uuid = const Uuid(),
@@ -57,7 +57,7 @@ class OutboxTaskQueueMigrator {
 
   final AppDatabase _db;
   final HiveBoxes _boxes;
-  final ChatLocks _chatLocks;
+  final ConversationLocks _chatLocks;
   final SyncClock _clock;
   final String Function() _resolveDefaultModel;
   final Uuid _uuid;

--- a/lib/core/sync/pull_sync.dart
+++ b/lib/core/sync/pull_sync.dart
@@ -78,7 +78,7 @@ class PullSync {
   PullSync({
     required SyncApiClient client,
     required AppDatabase db,
-    required ChatLocks locks,
+    required ConversationLocks locks,
     IdRemapper? remapper,
   }) : _client = client,
        _db = db,
@@ -87,7 +87,7 @@ class PullSync {
 
   final SyncApiClient _client;
   final AppDatabase _db;
-  final ChatLocks _locks;
+  final ConversationLocks _locks;
   final IdRemapper? _remapper;
 
   /// Runs one pull cycle. The watermark advances only when every list page

--- a/lib/core/sync/push_sync.dart
+++ b/lib/core/sync/push_sync.dart
@@ -28,8 +28,8 @@ class PushSync {
   PushSync({
     required SyncApiClient client,
     required AppDatabase db,
-    required ChatLocks chatLocks,
-    required ChatLocks folderLocks,
+    required ConversationLocks chatLocks,
+    required FolderLocks folderLocks,
     required SyncClock clock,
     required IdRemapper remapper,
   }) : _client = client,
@@ -41,8 +41,8 @@ class PushSync {
 
   final SyncApiClient _client;
   final AppDatabase _db;
-  final ChatLocks _chatLocks;
-  final ChatLocks _folderLocks;
+  final ConversationLocks _chatLocks;
+  final FolderLocks _folderLocks;
 
   /// Held for signature parity + future use. The dirty/serverUpdatedAt rule
   /// uses the server response `updated_at`, never a device clock (§7.2

--- a/lib/core/sync/sync_engine.dart
+++ b/lib/core/sync/sync_engine.dart
@@ -772,7 +772,7 @@ class SyncEngine extends _$SyncEngine {
       if (inFlight != null) {
         final inFlightDb = _migrationDb;
         await inFlight;
-        if (identical(inFlightDb, db) && identical(_boundDb, db)) {
+        if (_migrated && identical(inFlightDb, db) && identical(_boundDb, db)) {
           return;
         }
         continue;

--- a/lib/core/sync/sync_engine.dart
+++ b/lib/core/sync/sync_engine.dart
@@ -801,8 +801,11 @@ class SyncEngine extends _$SyncEngine {
   }) async {
     try {
       final taskQueueMigrator = _buildMigrator();
-      final cacheMigrator = _buildCacheMigrator();
       await taskQueueMigrator?.migrateIfNeeded();
+      if (!identical(_boundDb, migrationDb)) {
+        return;
+      }
+      final cacheMigrator = _buildCacheMigrator();
       await cacheMigrator?.migrateIfNeeded();
       if (identical(_boundDb, migrationDb)) {
         _migrated = true;

--- a/lib/core/sync/sync_engine.dart
+++ b/lib/core/sync/sync_engine.dart
@@ -240,8 +240,7 @@ class SyncEngine extends _$SyncEngine {
     final activeDrainer = _drainer?.isDraining ?? false;
     final preserveActiveDrainer =
         sameServerBinding && authenticatedSameSession && activeDrainer;
-    final retireActiveDrainerRemapper =
-        authChanged && sameServerBinding && activeDrainer;
+    final retireActiveDrainerRemapper = activeDrainer && !preserveActiveDrainer;
     final preserveJoinable =
         _joinable != null &&
         !_joinable!.isCompleted &&
@@ -614,6 +613,7 @@ class SyncEngine extends _$SyncEngine {
       }
     }
     final db = _boundDb;
+    final client = _boundClient;
     final clock = _boundClock;
     final backoff = _boundBackoff;
     final completion = _boundCompletionRunner;
@@ -622,6 +622,7 @@ class SyncEngine extends _$SyncEngine {
     // so a separate _buildPushSync() here would be a discarded duplicate.
     final adapters = _buildAdapters();
     if (db == null ||
+        client == null ||
         clock == null ||
         backoff == null ||
         completion == null ||
@@ -629,12 +630,16 @@ class SyncEngine extends _$SyncEngine {
       return null;
     }
     final drainerAuthEpoch = _authEpoch;
+    final drainerDb = db;
+    final drainerClient = client;
     return _drainer = OutboxDrainer(
       db: db,
       clock: clock,
       backoff: backoff,
       isOnline: () =>
           ref.mounted &&
+          identical(_boundDb, drainerDb) &&
+          identical(_boundClient, drainerClient) &&
           _boundAuthenticated == true &&
           _authEpoch == drainerAuthEpoch &&
           ref.read(isOnlineProvider),

--- a/lib/core/sync/sync_engine.dart
+++ b/lib/core/sync/sync_engine.dart
@@ -284,6 +284,9 @@ class SyncEngine extends _$SyncEngine {
     _debounce?.cancel();
     _debounce = null;
     if (preserveDrainer) {
+      if (retireActiveDrainerRemapper) {
+        _retireActiveDrainerRemapperForCleanup();
+      }
       _drainerStaleAfterDrain = true;
     } else {
       if (retireActiveDrainerRemapper) {
@@ -299,8 +302,9 @@ class SyncEngine extends _$SyncEngine {
     }
     if (!preserveMigration) {
       _migrated = false;
-      _migrationInFlight = null;
-      _migrationDb = null;
+      if (_migrationInFlight == null) {
+        _migrationDb = null;
+      }
     }
     _ftsBuildInFlight = false;
     if (completeJoinable) {
@@ -352,8 +356,14 @@ class SyncEngine extends _$SyncEngine {
   }
 
   void _disposeSessionBoundState() {
-    _resetSessionBoundState();
-    _disposeRetiredDrainerRemappers();
+    final activeDrainer = _drainer?.isDraining ?? false;
+    _resetSessionBoundState(
+      preserveDrainer: activeDrainer,
+      retireActiveDrainerRemapper: activeDrainer,
+    );
+    if (!activeDrainer) {
+      _disposeRetiredDrainerRemappers();
+    }
     _boundDb = null;
     _boundClient = null;
     _boundChatLocks = null;
@@ -632,6 +642,13 @@ class SyncEngine extends _$SyncEngine {
     final drainerAuthEpoch = _authEpoch;
     final drainerDb = db;
     final drainerClient = client;
+    final drainerChatLocks = _boundChatLocks;
+    final drainerFolderLocks = _boundFolderLocks;
+    final drainerNoteLocks = _boundNoteLocks;
+    final drainerClock = clock;
+    final drainerBackoff = backoff;
+    final drainerCompletion = completion;
+    final drainerRemapper = _remapper;
     return _drainer = OutboxDrainer(
       db: db,
       clock: clock,
@@ -640,6 +657,13 @@ class SyncEngine extends _$SyncEngine {
           ref.mounted &&
           identical(_boundDb, drainerDb) &&
           identical(_boundClient, drainerClient) &&
+          identical(_boundChatLocks, drainerChatLocks) &&
+          identical(_boundFolderLocks, drainerFolderLocks) &&
+          identical(_boundNoteLocks, drainerNoteLocks) &&
+          identical(_boundClock, drainerClock) &&
+          identical(_boundBackoff, drainerBackoff) &&
+          identical(_boundCompletionRunner, drainerCompletion) &&
+          identical(_remapper, drainerRemapper) &&
           _boundAuthenticated == true &&
           _authEpoch == drainerAuthEpoch &&
           ref.read(isOnlineProvider),
@@ -659,7 +683,6 @@ class SyncEngine extends _$SyncEngine {
       _retiredDrainerRemapForwards.remove(drainer);
       unawaited(retiredForward?.cancel());
       unawaited(retiredRemapper?.dispose());
-      return;
     }
     if (!identical(_drainer, drainer) ||
         !_drainerStaleAfterDrain ||
@@ -740,23 +763,37 @@ class SyncEngine extends _$SyncEngine {
 
   /// §9 step 2 / §11: convert the legacy Hive task queue into rows+ops EXACTLY
   /// ONCE per process, BEFORE any drain entry point can consume the outbox.
-  Future<void> _migrateLegacyTaskQueueIfNeeded() {
-    if (_migrated) return Future<void>.value();
-    final db = _boundDb;
-    if (db == null) return Future<void>.value();
-    final inFlight = _migrationInFlight;
-    if (inFlight != null && identical(_migrationDb, db)) return inFlight;
-
-    late final Future<void> migration;
-    migration = _runLegacyTaskQueueMigration(migrationDb: db).whenComplete(() {
-      if (identical(_migrationInFlight, migration)) {
-        _migrationInFlight = null;
-        _migrationDb = null;
+  Future<void> _migrateLegacyTaskQueueIfNeeded() async {
+    while (true) {
+      if (_migrated) return;
+      final db = _boundDb;
+      if (db == null) return;
+      final inFlight = _migrationInFlight;
+      if (inFlight != null) {
+        final inFlightDb = _migrationDb;
+        await inFlight;
+        if (identical(inFlightDb, db) && identical(_boundDb, db)) {
+          return;
+        }
+        continue;
       }
-    });
-    _migrationInFlight = migration;
-    _migrationDb = db;
-    return migration;
+
+      late final Future<void> migration;
+      migration = _runLegacyTaskQueueMigration(migrationDb: db).whenComplete(
+        () {
+          if (identical(_migrationInFlight, migration)) {
+            _migrationInFlight = null;
+            _migrationDb = null;
+          }
+        },
+      );
+      _migrationInFlight = migration;
+      _migrationDb = db;
+      await migration;
+      if (identical(_boundDb, db)) {
+        return;
+      }
+    }
   }
 
   Future<void> _runLegacyTaskQueueMigration({

--- a/lib/core/sync/sync_engine.dart
+++ b/lib/core/sync/sync_engine.dart
@@ -141,11 +141,11 @@ class SyncEngine extends _$SyncEngine {
   int _authEpoch = 0;
   bool _disposeHookRegistered = false;
   bool _drainerStaleAfterDrain = false;
-  final Map<OutboxDrainer, IdRemapper> _retiredDrainerRemappers =
-      <OutboxDrainer, IdRemapper>{};
-  final Map<OutboxDrainer, StreamSubscription<RemapEvent>>
+  final Map<OutboxDrainer, List<IdRemapper>> _retiredDrainerRemappers =
+      <OutboxDrainer, List<IdRemapper>>{};
+  final Map<OutboxDrainer, List<StreamSubscription<RemapEvent>>>
   _retiredDrainerRemapForwards =
-      <OutboxDrainer, StreamSubscription<RemapEvent>>{};
+      <OutboxDrainer, List<StreamSubscription<RemapEvent>>>{};
 
   @override
   SyncStatus build() {
@@ -673,16 +673,15 @@ class SyncEngine extends _$SyncEngine {
   }
 
   void _clearStaleDrainerIfIdle(OutboxDrainer drainer) {
-    final retiredRemapper = _retiredDrainerRemappers[drainer];
-    final retiredForward = _retiredDrainerRemapForwards[drainer];
-    if (retiredRemapper != null || retiredForward != null) {
+    final hasRetiredRemappers =
+        _retiredDrainerRemappers[drainer]?.isNotEmpty ?? false;
+    final hasRetiredForwards =
+        _retiredDrainerRemapForwards[drainer]?.isNotEmpty ?? false;
+    if (hasRetiredRemappers || hasRetiredForwards) {
       if (drainer.isDraining) {
         return;
       }
-      _retiredDrainerRemappers.remove(drainer);
-      _retiredDrainerRemapForwards.remove(drainer);
-      unawaited(retiredForward?.cancel());
-      unawaited(retiredRemapper?.dispose());
+      _disposeRetiredDrainerRemappersFor(drainer);
     }
     if (!identical(_drainer, drainer) ||
         !_drainerStaleAfterDrain ||
@@ -698,9 +697,11 @@ class SyncEngine extends _$SyncEngine {
     final remapper = _remapper;
     final forward = _remapForward;
     if (drainer != null && remapper != null) {
-      _retiredDrainerRemappers[drainer] = remapper;
+      (_retiredDrainerRemappers[drainer] ??= <IdRemapper>[]).add(remapper);
       if (forward != null) {
-        _retiredDrainerRemapForwards[drainer] = forward;
+        (_retiredDrainerRemapForwards[drainer] ??=
+                <StreamSubscription<RemapEvent>>[])
+            .add(forward);
       }
     } else {
       unawaited(forward?.cancel());
@@ -715,12 +716,23 @@ class SyncEngine extends _$SyncEngine {
         _retiredDrainerRemapForwards.isEmpty) {
       return;
     }
-    final remappers = _retiredDrainerRemappers.values.toList(growable: false);
-    final forwards = _retiredDrainerRemapForwards.values.toList(
-      growable: false,
-    );
-    _retiredDrainerRemappers.clear();
-    _retiredDrainerRemapForwards.clear();
+    final drainers = <OutboxDrainer>{
+      ..._retiredDrainerRemappers.keys,
+      ..._retiredDrainerRemapForwards.keys,
+    };
+    for (final drainer in drainers) {
+      if (!drainer.isDraining) {
+        _disposeRetiredDrainerRemappersFor(drainer);
+      }
+    }
+  }
+
+  void _disposeRetiredDrainerRemappersFor(OutboxDrainer drainer) {
+    final remappers =
+        _retiredDrainerRemappers.remove(drainer) ?? const <IdRemapper>[];
+    final forwards =
+        _retiredDrainerRemapForwards.remove(drainer) ??
+        const <StreamSubscription<RemapEvent>>[];
     for (final forward in forwards) {
       unawaited(forward.cancel());
     }

--- a/lib/core/sync/sync_engine.dart
+++ b/lib/core/sync/sync_engine.dart
@@ -108,9 +108,9 @@ class SyncEngine extends _$SyncEngine {
 
   AppDatabase? _boundDb;
   SyncApiClient? _boundClient;
-  ChatLocks? _boundChatLocks;
-  ChatLocks? _boundFolderLocks;
-  ChatLocks? _boundNoteLocks;
+  ConversationLocks? _boundChatLocks;
+  FolderLocks? _boundFolderLocks;
+  NoteLocks? _boundNoteLocks;
   SyncClock? _boundClock;
   Backoff? _boundBackoff;
   RequestCompletionRunner? _boundCompletionRunner;
@@ -133,19 +133,72 @@ class SyncEngine extends _$SyncEngine {
   /// lock/clock/backoff/completion bindings change so in-flight cycles can
   /// abort before crossing work into a different server/session.
   int _sessionEpoch = 0;
+  void Function()? _removeDisposeHook;
+  bool _drainerStaleAfterDrain = false;
 
   @override
   SyncStatus build() {
-    final db = ref.watch(appDatabaseProvider);
-    final client = ref.watch(syncApiClientProvider);
-    final authenticated = ref.watch(isAuthenticatedProvider2);
-    final chatLocks = ref.watch(chatLocksProvider);
-    final folderLocks = ref.watch(folderLocksProvider);
-    final noteLocks = ref.watch(noteLocksProvider);
-    final clock = ref.watch(syncClockProvider);
-    final backoff = ref.watch(backoffProvider);
-    final completionRunner = ref.watch(requestCompletionRunnerProvider);
+    _registerDisposeForBuild();
+    _bindDependencies(
+      db: ref.watch(appDatabaseProvider),
+      client: ref.watch(syncApiClientProvider),
+      authenticated: ref.watch(isAuthenticatedProvider2),
+      chatLocks: ref.watch(chatLocksProvider),
+      folderLocks: ref.watch(folderLocksProvider),
+      noteLocks: ref.watch(noteLocksProvider),
+      clock: ref.watch(syncClockProvider),
+      backoff: ref.watch(backoffProvider),
+      completionRunner: ref.watch(requestCompletionRunnerProvider),
+    );
+    return const SyncStatus();
+  }
 
+  void _registerDisposeForBuild() {
+    _removeDisposeHook?.call();
+    _removeDisposeHook = ref.onDispose(() {
+      _removeDisposeHook = null;
+      _resetSessionBoundState(
+        completeJoinable: false,
+        preserveDrainer: _drainer?.isDraining ?? false,
+      );
+      scheduleMicrotask(() {
+        if (ref.mounted) {
+          return;
+        }
+        _disposeSessionBoundState();
+      });
+    });
+  }
+
+  bool _refreshBoundDependencies() {
+    if (!ref.mounted) {
+      return false;
+    }
+    _bindDependencies(
+      db: ref.read(appDatabaseProvider),
+      client: ref.read(syncApiClientProvider),
+      authenticated: ref.read(isAuthenticatedProvider2),
+      chatLocks: ref.read(chatLocksProvider),
+      folderLocks: ref.read(folderLocksProvider),
+      noteLocks: ref.read(noteLocksProvider),
+      clock: ref.read(syncClockProvider),
+      backoff: ref.read(backoffProvider),
+      completionRunner: ref.read(requestCompletionRunnerProvider),
+    );
+    return true;
+  }
+
+  void _bindDependencies({
+    required AppDatabase? db,
+    required SyncApiClient? client,
+    required bool authenticated,
+    required ConversationLocks chatLocks,
+    required FolderLocks folderLocks,
+    required NoteLocks noteLocks,
+    required SyncClock clock,
+    required Backoff backoff,
+    required RequestCompletionRunner completionRunner,
+  }) {
     final dependenciesChanged =
         !identical(_boundDb, db) ||
         !identical(_boundClient, client) ||
@@ -156,42 +209,110 @@ class SyncEngine extends _$SyncEngine {
         !identical(_boundBackoff, backoff) ||
         !identical(_boundCompletionRunner, completionRunner) ||
         _boundAuthenticated != authenticated;
-    if (dependenciesChanged) {
-      _sessionEpoch++;
-      _resetSessionBoundState();
-      _boundDb = db;
-      _boundClient = client;
-      _boundChatLocks = chatLocks;
-      _boundFolderLocks = folderLocks;
-      _boundNoteLocks = noteLocks;
-      _boundClock = clock;
-      _boundBackoff = backoff;
-      _boundCompletionRunner = completionRunner;
-      _boundAuthenticated = authenticated;
+    if (!dependenciesChanged) {
+      // A reactive rebuild can follow an eager _refreshBoundDependencies() call
+      // that already updated the snapshot. onDispose cancels the debounce but
+      // keeps the joinable, so a no-op build must repair the armed waiter.
+      _reschedulePreservedJoinableIfNeeded();
+      return;
     }
-    ref.onDispose(_disposeSessionBoundState);
-    return const SyncStatus();
+
+    final sameServerBinding =
+        identical(_boundDb, db) && identical(_boundClient, client);
+    final preserveActiveDrainer =
+        sameServerBinding && (_drainer?.isDraining ?? false);
+    final preserveJoinable =
+        _joinable != null &&
+        !_joinable!.isCompleted &&
+        sameServerBinding &&
+        db != null &&
+        client != null &&
+        authenticated;
+
+    _sessionEpoch++;
+    _resetSessionBoundState(
+      completeJoinable: !preserveJoinable,
+      preserveDrainer: preserveActiveDrainer,
+    );
+    _boundDb = db;
+    _boundClient = client;
+    _boundChatLocks = chatLocks;
+    _boundFolderLocks = folderLocks;
+    _boundNoteLocks = noteLocks;
+    _boundClock = clock;
+    _boundBackoff = backoff;
+    _boundCompletionRunner = completionRunner;
+    _boundAuthenticated = authenticated;
+    if (preserveJoinable) {
+      _schedulePreservedJoinable();
+    }
   }
 
-  void _resetSessionBoundState() {
+  void _resetSessionBoundState({
+    bool completeJoinable = true,
+    bool preserveDrainer = false,
+  }) {
     _debounce?.cancel();
     _debounce = null;
-    unawaited(_remapForward?.cancel());
-    _remapForward = null;
-    unawaited(_remapper?.dispose());
-    _remapper = null;
-    _drainer = null;
+    if (preserveDrainer) {
+      _drainerStaleAfterDrain = true;
+    } else {
+      unawaited(_remapForward?.cancel());
+      _remapForward = null;
+      unawaited(_remapper?.dispose());
+      _remapper = null;
+      _drainer = null;
+      _drainerStaleAfterDrain = false;
+    }
     _migrated = false;
     _migrationInFlight = null;
     _ftsBuildInFlight = false;
-    final joinable = _joinable;
-    _joinable = null;
-    if (joinable != null && !joinable.isCompleted) {
-      joinable.complete(null);
+    if (completeJoinable) {
+      final joinable = _joinable;
+      _joinable = null;
+      if (joinable != null && !joinable.isCompleted) {
+        joinable.complete(null);
+      }
     }
     if (!_running) {
       _rerunRequested = false;
     }
+  }
+
+  void _schedulePreservedJoinable() {
+    if (_joinable == null) {
+      return;
+    }
+    if (_running) {
+      assert(
+        _joinable != null && !_joinable!.isCompleted,
+        'A queued rerun requires a live joinable.',
+      );
+      // The current cycle already captured its own completer in _startCycle.
+      // If the epoch change aborts that cycle, those callers receive null.
+      // This preserved _joinable belongs to callers that queued a rerun while
+      // the cycle was active; the finally block below will start their cycle.
+      // Until that finally block runs, future reset paths must not clear
+      // _joinable without also completing it or clearing _rerunRequested.
+      _rerunRequested = true;
+      return;
+    }
+    assert(_debounce == null);
+    if (_debounce != null) {
+      return;
+    }
+    _debounce = Timer(kSyncPullDebounce, _startCycle);
+  }
+
+  void _reschedulePreservedJoinableIfNeeded() {
+    final joinable = _joinable;
+    if (joinable == null ||
+        joinable.isCompleted ||
+        _debounce != null ||
+        _inert) {
+      return;
+    }
+    _schedulePreservedJoinable();
   }
 
   void _disposeSessionBoundState() {
@@ -249,9 +370,16 @@ class SyncEngine extends _$SyncEngine {
   /// Connectivity-regained drain (Wiring, §A6/A7): resets backoff on pending
   /// ops then drains. Called from `sync_triggers` on the false->true edge.
   Future<void> drainNow() async {
+    if (!_refreshBoundDependencies()) return;
     if (_inert) return;
     await _migrateLegacyTaskQueueIfNeeded();
-    await _ensureDrainer()?.onConnectivityRegained();
+    final drainer = _ensureDrainer();
+    if (drainer == null) return;
+    try {
+      await drainer.onConnectivityRegained();
+    } finally {
+      _clearStaleDrainerIfIdle(drainer);
+    }
   }
 
   /// Plain outbox drain (no backoff reset). Used by the active-conversation
@@ -259,9 +387,16 @@ class SyncEngine extends _$SyncEngine {
   /// (request_completion_runner Option B) runs promptly once the user opens its
   /// chat. Single-flight via the shared drainer's `_draining` guard.
   Future<void> drainOutbox() async {
+    if (!_refreshBoundDependencies()) return;
     if (_inert) return;
     await _migrateLegacyTaskQueueIfNeeded();
-    await _ensureDrainer()?.drain();
+    final drainer = _ensureDrainer();
+    if (drainer == null) return;
+    try {
+      await drainer.drain();
+    } finally {
+      _clearStaleDrainerIfIdle(drainer);
+    }
   }
 
   /// Single debounced entry point (RFC §7.6). 300 ms debounce; single-flight:
@@ -269,6 +404,9 @@ class SyncEngine extends _$SyncEngine {
   /// queued cycle). The returned future completes when the cycle the caller
   /// joined finishes — pull-to-refresh spinners await it.
   Future<PullResult?> requestPull({required String reason}) {
+    if (!_refreshBoundDependencies()) {
+      return Future.value(null);
+    }
     if (_inert) {
       DebugLogger.log('inert', scope: 'sync/engine', data: {'reason': reason});
       return Future.value(null);
@@ -288,6 +426,7 @@ class SyncEngine extends _$SyncEngine {
 
   /// Immediate, not debounced; serialization comes from [ChatLocks].
   Future<Conversation?> pullChatNow(String chatId) async {
+    if (!_refreshBoundDependencies()) return null;
     if (_inert) {
       DebugLogger.log(
         'inert',
@@ -422,7 +561,14 @@ class SyncEngine extends _$SyncEngine {
   /// Returns null (and does NOT cache) until db/client are ready.
   OutboxDrainer? _ensureDrainer() {
     final existing = _drainer;
-    if (existing != null) return existing;
+    if (existing != null) {
+      if (_drainerStaleAfterDrain && !existing.isDraining) {
+        _drainer = null;
+        _drainerStaleAfterDrain = false;
+      } else {
+        return existing;
+      }
+    }
     final db = _boundDb;
     final clock = _boundClock;
     final backoff = _boundBackoff;
@@ -446,6 +592,16 @@ class SyncEngine extends _$SyncEngine {
       completion: completion,
       adapters: adapters,
     );
+  }
+
+  void _clearStaleDrainerIfIdle(OutboxDrainer drainer) {
+    if (!identical(_drainer, drainer) ||
+        !_drainerStaleAfterDrain ||
+        drainer.isDraining) {
+      return;
+    }
+    _drainer = null;
+    _drainerStaleAfterDrain = false;
   }
 
   /// Engine-internal: the one-time legacy Hive task-queue migrator. Built
@@ -559,6 +715,7 @@ class SyncEngine extends _$SyncEngine {
   /// Manual pull-to-refresh deletion reconcile (bypasses the 24h throttle) for
   /// both chats and notes. Safe to call ad hoc; no-op until db/client are ready.
   Future<void> reconcileNow() async {
+    if (!_refreshBoundDependencies()) return;
     if (_inert) return;
     // Independent try/catch per entity: an unexpected error from the chat
     // reconcile must NOT skip the note reconcile (and vice versa).

--- a/lib/core/sync/sync_engine.dart
+++ b/lib/core/sync/sync_engine.dart
@@ -120,6 +120,7 @@ class SyncEngine extends _$SyncEngine {
   /// idempotent + flag-gated per server, so a re-attempt is a cheap no-op).
   bool _migrated = false;
   Future<void>? _migrationInFlight;
+  AppDatabase? _migrationDb;
 
   /// Prevents overlapping fire-and-forget FTS backfills while the durable
   /// `fts_built` flag is still unset.
@@ -140,6 +141,8 @@ class SyncEngine extends _$SyncEngine {
   int _authEpoch = 0;
   void Function()? _removeDisposeHook;
   bool _drainerStaleAfterDrain = false;
+  final Map<OutboxDrainer, IdRemapper> _retiredDrainerRemappers =
+      <OutboxDrainer, IdRemapper>{};
 
   @override
   SyncStatus build() {
@@ -165,6 +168,7 @@ class SyncEngine extends _$SyncEngine {
       _resetSessionBoundState(
         completeJoinable: false,
         preserveDrainer: _drainer?.isDraining ?? false,
+        preserveMigration: _boundDb != null,
       );
       scheduleMicrotask(() {
         if (ref.mounted) {
@@ -223,19 +227,15 @@ class SyncEngine extends _$SyncEngine {
       return;
     }
 
-    final sameServerBinding =
-        identical(_boundDb, db) && identical(_boundClient, client);
+    final sameDbBinding = identical(_boundDb, db);
+    final sameServerBinding = sameDbBinding && identical(_boundClient, client);
     final authenticatedSameSession =
         _boundAuthenticated == true && authenticated;
     final activeDrainer = _drainer?.isDraining ?? false;
     final preserveActiveDrainer =
         sameServerBinding && authenticatedSameSession && activeDrainer;
-    // An auth-boundary rebind must drop the cached drainer, but an op that
-    // already started before the boundary can still return. Keep the DB-bound
-    // remapper alive so that result can settle without losing its local->server
-    // mapping; the drainer's captured auth epoch prevents it from claiming any
-    // further network work after logout/token invalidation.
-    final preserveRemapperForActiveDrainer = sameServerBinding && activeDrainer;
+    final retireActiveDrainerRemapper =
+        authChanged && sameServerBinding && activeDrainer;
     final preserveJoinable =
         _joinable != null &&
         !_joinable!.isCompleted &&
@@ -251,8 +251,9 @@ class SyncEngine extends _$SyncEngine {
     _resetSessionBoundState(
       completeJoinable: !preserveJoinable,
       preserveDrainer: preserveActiveDrainer,
-      preserveRemapper:
-          preserveActiveDrainer || preserveRemapperForActiveDrainer,
+      preserveRemapper: preserveActiveDrainer,
+      retireActiveDrainerRemapper: retireActiveDrainerRemapper,
+      preserveMigration: sameDbBinding && db != null,
     );
     _boundDb = db;
     _boundClient = client;
@@ -272,13 +273,24 @@ class SyncEngine extends _$SyncEngine {
     bool completeJoinable = true,
     bool preserveDrainer = false,
     bool preserveRemapper = false,
+    bool retireActiveDrainerRemapper = false,
+    bool preserveMigration = false,
   }) {
     _debounce?.cancel();
     _debounce = null;
     if (preserveDrainer) {
       _drainerStaleAfterDrain = true;
     } else {
-      if (!preserveRemapper) {
+      if (retireActiveDrainerRemapper) {
+        final drainer = _drainer;
+        final remapper = _remapper;
+        if (drainer != null && remapper != null) {
+          _retiredDrainerRemappers[drainer] = remapper;
+        }
+        unawaited(_remapForward?.cancel());
+        _remapForward = null;
+        _remapper = null;
+      } else if (!preserveRemapper) {
         unawaited(_remapForward?.cancel());
         _remapForward = null;
         unawaited(_remapper?.dispose());
@@ -287,8 +299,11 @@ class SyncEngine extends _$SyncEngine {
       _drainer = null;
       _drainerStaleAfterDrain = false;
     }
-    _migrated = false;
-    _migrationInFlight = null;
+    if (!preserveMigration) {
+      _migrated = false;
+      _migrationInFlight = null;
+      _migrationDb = null;
+    }
     _ftsBuildInFlight = false;
     if (completeJoinable) {
       final joinable = _joinable;
@@ -340,6 +355,7 @@ class SyncEngine extends _$SyncEngine {
 
   void _disposeSessionBoundState() {
     _resetSessionBoundState();
+    _disposeRetiredDrainerRemappers();
     _boundDb = null;
     _boundClient = null;
     _boundChatLocks = null;
@@ -392,6 +408,9 @@ class SyncEngine extends _$SyncEngine {
 
   @visibleForTesting
   bool get hasCachedDrainerForTesting => _drainer != null;
+
+  @visibleForTesting
+  bool get hasCachedRemapperForTesting => _remapper != null;
 
   /// Connectivity-regained drain (Wiring, §A6/A7): resets backoff on pending
   /// ops then drains. Called from `sync_triggers` on the false->true edge.
@@ -626,6 +645,15 @@ class SyncEngine extends _$SyncEngine {
   }
 
   void _clearStaleDrainerIfIdle(OutboxDrainer drainer) {
+    final retiredRemapper = _retiredDrainerRemappers[drainer];
+    if (retiredRemapper != null) {
+      if (drainer.isDraining) {
+        return;
+      }
+      _retiredDrainerRemappers.remove(drainer);
+      unawaited(retiredRemapper.dispose());
+      return;
+    }
     if (!identical(_drainer, drainer) ||
         !_drainerStaleAfterDrain ||
         drainer.isDraining) {
@@ -633,6 +661,17 @@ class SyncEngine extends _$SyncEngine {
     }
     _drainer = null;
     _drainerStaleAfterDrain = false;
+  }
+
+  void _disposeRetiredDrainerRemappers() {
+    if (_retiredDrainerRemappers.isEmpty) {
+      return;
+    }
+    final remappers = _retiredDrainerRemappers.values.toList(growable: false);
+    _retiredDrainerRemappers.clear();
+    for (final remapper in remappers) {
+      unawaited(remapper.dispose());
+    }
   }
 
   /// Engine-internal: the one-time legacy Hive task-queue migrator. Built
@@ -671,26 +710,32 @@ class SyncEngine extends _$SyncEngine {
   /// ONCE per process, BEFORE any drain entry point can consume the outbox.
   Future<void> _migrateLegacyTaskQueueIfNeeded() {
     if (_migrated) return Future<void>.value();
+    final db = _boundDb;
+    if (db == null) return Future<void>.value();
     final inFlight = _migrationInFlight;
-    if (inFlight != null) return inFlight;
+    if (inFlight != null && identical(_migrationDb, db)) return inFlight;
 
-    final migrationEpoch = _sessionEpoch;
     late final Future<void> migration;
-    migration = _runLegacyTaskQueueMigration(migrationEpoch).whenComplete(() {
-      if (migrationEpoch == _sessionEpoch &&
-          identical(_migrationInFlight, migration)) {
+    migration = _runLegacyTaskQueueMigration(migrationDb: db).whenComplete(() {
+      if (identical(_migrationInFlight, migration)) {
         _migrationInFlight = null;
+        _migrationDb = null;
       }
     });
     _migrationInFlight = migration;
+    _migrationDb = db;
     return migration;
   }
 
-  Future<void> _runLegacyTaskQueueMigration(int migrationEpoch) async {
+  Future<void> _runLegacyTaskQueueMigration({
+    required AppDatabase migrationDb,
+  }) async {
     try {
-      await _buildMigrator()?.migrateIfNeeded();
-      await _buildCacheMigrator()?.migrateIfNeeded();
-      if (migrationEpoch == _sessionEpoch) {
+      final taskQueueMigrator = _buildMigrator();
+      final cacheMigrator = _buildCacheMigrator();
+      await taskQueueMigrator?.migrateIfNeeded();
+      await cacheMigrator?.migrateIfNeeded();
+      if (identical(_boundDb, migrationDb)) {
         _migrated = true;
       }
     } catch (error, stackTrace) {

--- a/lib/core/sync/sync_engine.dart
+++ b/lib/core/sync/sync_engine.dart
@@ -139,10 +139,13 @@ class SyncEngine extends _$SyncEngine {
   /// stays stable across non-auth dependency refreshes so preserved drainers can
   /// finish same-session work, but flips on login/logout boundaries.
   int _authEpoch = 0;
-  void Function()? _removeDisposeHook;
+  bool _disposeHookRegistered = false;
   bool _drainerStaleAfterDrain = false;
   final Map<OutboxDrainer, IdRemapper> _retiredDrainerRemappers =
       <OutboxDrainer, IdRemapper>{};
+  final Map<OutboxDrainer, StreamSubscription<RemapEvent>>
+  _retiredDrainerRemapForwards =
+      <OutboxDrainer, StreamSubscription<RemapEvent>>{};
 
   @override
   SyncStatus build() {
@@ -162,9 +165,12 @@ class SyncEngine extends _$SyncEngine {
   }
 
   void _registerDisposeForBuild() {
-    _removeDisposeHook?.call();
-    _removeDisposeHook = ref.onDispose(() {
-      _removeDisposeHook = null;
+    if (_disposeHookRegistered) {
+      return;
+    }
+    _disposeHookRegistered = true;
+    ref.onDispose(() {
+      _disposeHookRegistered = false;
       _resetSessionBoundState(
         completeJoinable: false,
         preserveDrainer: _drainer?.isDraining ?? false,
@@ -282,14 +288,7 @@ class SyncEngine extends _$SyncEngine {
       _drainerStaleAfterDrain = true;
     } else {
       if (retireActiveDrainerRemapper) {
-        final drainer = _drainer;
-        final remapper = _remapper;
-        if (drainer != null && remapper != null) {
-          _retiredDrainerRemappers[drainer] = remapper;
-        }
-        unawaited(_remapForward?.cancel());
-        _remapForward = null;
-        _remapper = null;
+        _retireActiveDrainerRemapperForCleanup();
       } else if (!preserveRemapper) {
         unawaited(_remapForward?.cancel());
         _remapForward = null;
@@ -646,12 +645,15 @@ class SyncEngine extends _$SyncEngine {
 
   void _clearStaleDrainerIfIdle(OutboxDrainer drainer) {
     final retiredRemapper = _retiredDrainerRemappers[drainer];
-    if (retiredRemapper != null) {
+    final retiredForward = _retiredDrainerRemapForwards[drainer];
+    if (retiredRemapper != null || retiredForward != null) {
       if (drainer.isDraining) {
         return;
       }
       _retiredDrainerRemappers.remove(drainer);
-      unawaited(retiredRemapper.dispose());
+      _retiredDrainerRemapForwards.remove(drainer);
+      unawaited(retiredForward?.cancel());
+      unawaited(retiredRemapper?.dispose());
       return;
     }
     if (!identical(_drainer, drainer) ||
@@ -663,12 +665,37 @@ class SyncEngine extends _$SyncEngine {
     _drainerStaleAfterDrain = false;
   }
 
+  void _retireActiveDrainerRemapperForCleanup() {
+    final drainer = _drainer;
+    final remapper = _remapper;
+    final forward = _remapForward;
+    if (drainer != null && remapper != null) {
+      _retiredDrainerRemappers[drainer] = remapper;
+      if (forward != null) {
+        _retiredDrainerRemapForwards[drainer] = forward;
+      }
+    } else {
+      unawaited(forward?.cancel());
+      unawaited(remapper?.dispose());
+    }
+    _remapForward = null;
+    _remapper = null;
+  }
+
   void _disposeRetiredDrainerRemappers() {
-    if (_retiredDrainerRemappers.isEmpty) {
+    if (_retiredDrainerRemappers.isEmpty &&
+        _retiredDrainerRemapForwards.isEmpty) {
       return;
     }
     final remappers = _retiredDrainerRemappers.values.toList(growable: false);
+    final forwards = _retiredDrainerRemapForwards.values.toList(
+      growable: false,
+    );
     _retiredDrainerRemappers.clear();
+    _retiredDrainerRemapForwards.clear();
+    for (final forward in forwards) {
+      unawaited(forward.cancel());
+    }
     for (final remapper in remappers) {
       unawaited(remapper.dispose());
     }

--- a/lib/core/sync/sync_engine.dart
+++ b/lib/core/sync/sync_engine.dart
@@ -420,6 +420,9 @@ class SyncEngine extends _$SyncEngine {
   @visibleForTesting
   bool get hasCachedRemapperForTesting => _remapper != null;
 
+  @visibleForTesting
+  void Function()? legacyMigrationJoinObserverForTesting;
+
   /// Connectivity-regained drain (Wiring, §A6/A7): resets backoff on pending
   /// ops then drains. Called from `sync_triggers` on the false->true edge.
   Future<void> drainNow() async {
@@ -783,6 +786,7 @@ class SyncEngine extends _$SyncEngine {
       final inFlight = _migrationInFlight;
       if (inFlight != null) {
         final inFlightDb = _migrationDb;
+        legacyMigrationJoinObserverForTesting?.call();
         await inFlight;
         if (_migrated && identical(inFlightDb, db) && identical(_boundDb, db)) {
           return;

--- a/lib/core/sync/sync_engine.dart
+++ b/lib/core/sync/sync_engine.dart
@@ -133,6 +133,11 @@ class SyncEngine extends _$SyncEngine {
   /// lock/clock/backoff/completion bindings change so in-flight cycles can
   /// abort before crossing work into a different server/session.
   int _sessionEpoch = 0;
+
+  /// Auth-only generation captured by drainers. Unlike [_sessionEpoch], this
+  /// stays stable across non-auth dependency refreshes so preserved drainers can
+  /// finish same-session work, but flips on login/logout boundaries.
+  int _authEpoch = 0;
   void Function()? _removeDisposeHook;
   bool _drainerStaleAfterDrain = false;
 
@@ -199,6 +204,7 @@ class SyncEngine extends _$SyncEngine {
     required Backoff backoff,
     required RequestCompletionRunner completionRunner,
   }) {
+    final authChanged = _boundAuthenticated != authenticated;
     final dependenciesChanged =
         !identical(_boundDb, db) ||
         !identical(_boundClient, client) ||
@@ -208,7 +214,7 @@ class SyncEngine extends _$SyncEngine {
         !identical(_boundClock, clock) ||
         !identical(_boundBackoff, backoff) ||
         !identical(_boundCompletionRunner, completionRunner) ||
-        _boundAuthenticated != authenticated;
+        authChanged;
     if (!dependenciesChanged) {
       // A reactive rebuild can follow an eager _refreshBoundDependencies() call
       // that already updated the snapshot. onDispose cancels the debounce but
@@ -219,8 +225,17 @@ class SyncEngine extends _$SyncEngine {
 
     final sameServerBinding =
         identical(_boundDb, db) && identical(_boundClient, client);
+    final authenticatedSameSession =
+        _boundAuthenticated == true && authenticated;
+    final activeDrainer = _drainer?.isDraining ?? false;
     final preserveActiveDrainer =
-        sameServerBinding && (_drainer?.isDraining ?? false);
+        sameServerBinding && authenticatedSameSession && activeDrainer;
+    // An auth-boundary rebind must drop the cached drainer, but an op that
+    // already started before the boundary can still return. Keep the DB-bound
+    // remapper alive so that result can settle without losing its local->server
+    // mapping; the drainer's captured auth epoch prevents it from claiming any
+    // further network work after logout/token invalidation.
+    final preserveRemapperForActiveDrainer = sameServerBinding && activeDrainer;
     final preserveJoinable =
         _joinable != null &&
         !_joinable!.isCompleted &&
@@ -230,9 +245,14 @@ class SyncEngine extends _$SyncEngine {
         authenticated;
 
     _sessionEpoch++;
+    if (authChanged) {
+      _authEpoch++;
+    }
     _resetSessionBoundState(
       completeJoinable: !preserveJoinable,
       preserveDrainer: preserveActiveDrainer,
+      preserveRemapper:
+          preserveActiveDrainer || preserveRemapperForActiveDrainer,
     );
     _boundDb = db;
     _boundClient = client;
@@ -251,16 +271,19 @@ class SyncEngine extends _$SyncEngine {
   void _resetSessionBoundState({
     bool completeJoinable = true,
     bool preserveDrainer = false,
+    bool preserveRemapper = false,
   }) {
     _debounce?.cancel();
     _debounce = null;
     if (preserveDrainer) {
       _drainerStaleAfterDrain = true;
     } else {
-      unawaited(_remapForward?.cancel());
-      _remapForward = null;
-      unawaited(_remapper?.dispose());
-      _remapper = null;
+      if (!preserveRemapper) {
+        unawaited(_remapForward?.cancel());
+        _remapForward = null;
+        unawaited(_remapper?.dispose());
+        _remapper = null;
+      }
       _drainer = null;
       _drainerStaleAfterDrain = false;
     }
@@ -366,6 +389,9 @@ class SyncEngine extends _$SyncEngine {
   /// remap and assert the [remapRouteSyncProvider] consumer reacts.
   @visibleForTesting
   IdRemapper? get remapperForTesting => _ensureRemapper();
+
+  @visibleForTesting
+  bool get hasCachedDrainerForTesting => _drainer != null;
 
   /// Connectivity-regained drain (Wiring, §A6/A7): resets backoff on pending
   /// ops then drains. Called from `sync_triggers` on the false->true edge.
@@ -584,11 +610,16 @@ class SyncEngine extends _$SyncEngine {
         adapters == null) {
       return null;
     }
+    final drainerAuthEpoch = _authEpoch;
     return _drainer = OutboxDrainer(
       db: db,
       clock: clock,
       backoff: backoff,
-      isOnline: () => ref.read(isOnlineProvider),
+      isOnline: () =>
+          ref.mounted &&
+          _boundAuthenticated == true &&
+          _authEpoch == drainerAuthEpoch &&
+          ref.read(isOnlineProvider),
       completion: completion,
       adapters: adapters,
     );
@@ -893,7 +924,14 @@ class SyncEngine extends _$SyncEngine {
 
     // Drain the outbox AFTER pull (W: pull-then-push ordering). Errors are
     // caught + logged by the enclosing `_startCycle` try.
-    await _ensureDrainer()?.drain();
+    final drainer = _ensureDrainer();
+    if (drainer != null) {
+      try {
+        await drainer.drain();
+      } finally {
+        _clearStaleDrainerIfIdle(drainer);
+      }
+    }
     if (!_cycleStillBound(cycleEpoch, 'after-outbox-drain')) return null;
 
     // §7.5 deletion reconcile (background reason; its own 24h throttle gates

--- a/lib/core/sync/sync_engine.dart
+++ b/lib/core/sync/sync_engine.dart
@@ -872,6 +872,7 @@ class SyncEngine extends _$SyncEngine {
       );
     } finally {
       _running = false;
+      _clearCachedDrainerIfIdle();
       if (ref.mounted) {
         final previousStateWatermark = state.lastSuccessUpdatedAtWatermark;
         var watermark = previousStateWatermark;
@@ -1072,6 +1073,14 @@ class SyncEngine extends _$SyncEngine {
       await _scheduleFtsBuildIfNeeded(db, cycleEpoch);
     }
     return result;
+  }
+
+  void _clearCachedDrainerIfIdle() {
+    final drainer = _drainer;
+    if (drainer == null) {
+      return;
+    }
+    _clearStaleDrainerIfIdle(drainer);
   }
 
   Future<void> _scheduleFtsBuildIfNeeded(AppDatabase db, int cycleEpoch) async {

--- a/lib/core/sync/sync_triggers.dart
+++ b/lib/core/sync/sync_triggers.dart
@@ -8,6 +8,7 @@ import '../database/database_provider.dart';
 import '../providers/app_providers.dart';
 import '../services/connectivity_service.dart';
 import '../utils/debug_logger.dart';
+import 'pull_sync.dart';
 import 'sync_api_client.dart';
 import 'sync_engine.dart';
 
@@ -126,10 +127,11 @@ class SyncTriggers extends _$SyncTriggers {
         identical(client, _startClient)) {
       return;
     }
-    _startFired = true;
-    _startDatabase = db;
-    _startClient = client;
-    _request('start');
+    if (_request('start')) {
+      _startFired = true;
+      _startDatabase = db;
+      _startClient = client;
+    }
   }
 
   void _queueMaybeFireStart() {
@@ -180,19 +182,42 @@ class SyncTriggers extends _$SyncTriggers {
     _periodic = null;
   }
 
-  void _request(String reason) {
+  bool _request(String reason) {
     DebugLogger.log(
       'trigger',
       scope: 'sync/triggers',
       data: {'reason': reason},
     );
-    _runEngineOperation(
-      'request-pull',
-      reason: reason,
-      run: (engine) async {
-        await engine.requestPull(reason: reason);
-      },
+    return _requestPull(reason);
+  }
+
+  bool _requestPull(String reason) {
+    Future<PullResult?> pull;
+    try {
+      pull = ref.read(syncEngineProvider.notifier).requestPull(reason: reason);
+    } catch (error, stackTrace) {
+      DebugLogger.error(
+        'engine-operation-failed',
+        scope: 'sync/triggers/request-pull',
+        error: error,
+        stackTrace: stackTrace,
+        data: {'operation': 'request-pull', 'reason': reason},
+      );
+      return false;
+    }
+    unawaited(
+      pull.catchError((Object error, StackTrace stackTrace) {
+        DebugLogger.error(
+          'engine-operation-failed',
+          scope: 'sync/triggers/request-pull',
+          error: error,
+          stackTrace: stackTrace,
+          data: {'operation': 'request-pull', 'reason': reason},
+        );
+        return null;
+      }),
     );
+    return true;
   }
 
   void _runEngineOperation(

--- a/lib/core/sync/sync_triggers.dart
+++ b/lib/core/sync/sync_triggers.dart
@@ -55,7 +55,11 @@ class SyncTriggers extends _$SyncTriggers {
     ref.listen(isOnlineProvider, (previous, next) {
       if (previous == false && next) {
         _request('online');
-        unawaited(ref.read(syncEngineProvider.notifier).drainNow());
+        _runEngineOperation(
+          'drain-now',
+          reason: 'online',
+          run: (engine) => engine.drainNow(),
+        );
       }
     });
 
@@ -68,7 +72,11 @@ class SyncTriggers extends _$SyncTriggers {
       final id = next?.id;
       if (id == null || id.isEmpty || isTemporaryChat(id)) return;
       if (previous?.id == id) return;
-      unawaited(ref.read(syncEngineProvider.notifier).drainOutbox());
+      _runEngineOperation(
+        'drain-outbox',
+        reason: 'active-conversation',
+        run: (engine) => engine.drainOutbox(),
+      );
     });
 
     // Foreground/background lifecycle + periodic timer.
@@ -178,17 +186,39 @@ class SyncTriggers extends _$SyncTriggers {
       scope: 'sync/triggers',
       data: {'reason': reason},
     );
+    _runEngineOperation(
+      'request-pull',
+      reason: reason,
+      run: (engine) async {
+        await engine.requestPull(reason: reason);
+      },
+    );
+  }
+
+  void _runEngineOperation(
+    String operation, {
+    required String reason,
+    required Future<void> Function(SyncEngine engine) run,
+  }) {
     unawaited(
-      ref.read(syncEngineProvider.notifier).requestPull(reason: reason),
+      Future<void>.microtask(() async {
+        if (!ref.mounted) return;
+        await run(ref.read(syncEngineProvider.notifier));
+      }).catchError((Object error, StackTrace stackTrace) {
+        DebugLogger.error(
+          'engine-operation-failed',
+          scope: 'sync/triggers/$operation',
+          error: error,
+          stackTrace: stackTrace,
+          data: {'operation': operation, 'reason': reason},
+        );
+      }),
     );
   }
 }
 
 class _SyncLifecycleObserver with WidgetsBindingObserver {
-  _SyncLifecycleObserver({
-    required this.onResumed,
-    required this.onSuspended,
-  });
+  _SyncLifecycleObserver({required this.onResumed, required this.onSuspended});
 
   final void Function() onResumed;
   final void Function() onSuspended;

--- a/lib/core/sync/sync_triggers.dart
+++ b/lib/core/sync/sync_triggers.dart
@@ -225,11 +225,21 @@ class SyncTriggers extends _$SyncTriggers {
     required String reason,
     required Future<void> Function(SyncEngine engine) run,
   }) {
+    Future<void> future;
+    try {
+      future = run(ref.read(syncEngineProvider.notifier));
+    } catch (error, stackTrace) {
+      DebugLogger.error(
+        'engine-operation-failed',
+        scope: 'sync/triggers/$operation',
+        error: error,
+        stackTrace: stackTrace,
+        data: {'operation': operation, 'reason': reason},
+      );
+      return;
+    }
     unawaited(
-      Future<void>.microtask(() async {
-        if (!ref.mounted) return;
-        await run(ref.read(syncEngineProvider.notifier));
-      }).catchError((Object error, StackTrace stackTrace) {
+      future.catchError((Object error, StackTrace stackTrace) {
         DebugLogger.error(
           'engine-operation-failed',
           scope: 'sync/triggers/$operation',

--- a/lib/features/notes/providers/notes_providers.dart
+++ b/lib/features/notes/providers/notes_providers.dart
@@ -172,7 +172,7 @@ Future<Note?> durableUpdateNote(
   // write, and read-back all key on the row the DAO actually mutates.
   final resolvedId = await db.notesDao.resolveNoteRemapTarget(id);
 
-  final noteLocks = ref.read(noteLocksProvider) as ChatLocks;
+  final noteLocks = ref.read(noteLocksProvider);
   await noteLocks.runExclusive(resolvedId, () async {
     // Merge a partial `data` patch onto the existing note data so an update that
     // only carries `content` doesn't silently drop `versions`/`files` (the patch
@@ -212,7 +212,7 @@ Future<Note?> durablePinNote(
   required bool desiredPinned,
 }) async {
   final resolvedId = await db.notesDao.resolveNoteRemapTarget(id);
-  final noteLocks = ref.read(noteLocksProvider) as ChatLocks;
+  final noteLocks = ref.read(noteLocksProvider);
   await noteLocks.runExclusive(resolvedId, () async {
     await db.notesDao.pinNoteWithOutbox(
       resolvedId,
@@ -229,7 +229,7 @@ Future<void> durableDeleteNote(
   required String id,
 }) async {
   final resolvedId = await db.notesDao.resolveNoteRemapTarget(id);
-  final noteLocks = ref.read(noteLocksProvider) as ChatLocks;
+  final noteLocks = ref.read(noteLocksProvider);
   await noteLocks.runExclusive(resolvedId, () async {
     await db.notesDao.tombstoneWithOutbox(resolvedId);
   });
@@ -259,7 +259,7 @@ Future<Note?> durableCreateNote(
     updatedAt: nowNs,
     rawExtra: Value(rawExtra),
   );
-  final noteLocks = ref.read(noteLocksProvider) as ChatLocks;
+  final noteLocks = ref.read(noteLocksProvider);
   await noteLocks.runExclusive(localId, () async {
     await db.notesDao.insertLocalNoteWithCreateOp(note: companion);
   });

--- a/test/core/providers/conversations_provider_test.dart
+++ b/test/core/providers/conversations_provider_test.dart
@@ -16,6 +16,7 @@ import 'package:conduit/core/models/conversation.dart';
 import 'package:conduit/core/models/server_config.dart';
 import 'package:conduit/core/providers/app_providers.dart';
 import 'package:conduit/core/services/socket_service.dart';
+import 'package:conduit/core/sync/pull_sync.dart';
 import 'package:conduit/core/sync/sync_api_client.dart';
 import 'package:conduit/core/sync/sync_engine.dart';
 import 'package:conduit/features/auth/providers/unified_auth_providers.dart';
@@ -26,6 +27,18 @@ import 'package:flutter_test/flutter_test.dart';
 
 import '../../support/fake_open_webui_server.dart';
 import '../../support/fake_sync_api_client.dart';
+
+class _RecordingSyncEngine extends SyncEngine {
+  _RecordingSyncEngine(this.pulls);
+
+  final List<String> pulls;
+
+  @override
+  Future<PullResult?> requestPull({required String reason}) {
+    pulls.add(reason);
+    return Future.value(null);
+  }
+}
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
@@ -354,6 +367,28 @@ void main() {
         check(
           container.read(conversationsProvider).requireValue.single.title,
         ).equals('Remote rename');
+      },
+    );
+
+    test(
+      'missing remote conversation update submits reconcile pull immediately',
+      () async {
+        final pulls = <String>[];
+        final container = makeContainer(
+          extraOverrides: [
+            syncEngineProvider.overrideWith(() => _RecordingSyncEngine(pulls)),
+          ],
+        );
+        await container.read(conversationsProvider.future);
+
+        container
+            .read(conversationsProvider.notifier)
+            .updateConversationFromRemote(
+              'missing-chat',
+              (_) => throw StateError('unexpected transform'),
+            );
+
+        check(pulls).deepEquals(['conversations-reconcile']);
       },
     );
 

--- a/test/core/providers/folders_provider_test.dart
+++ b/test/core/providers/folders_provider_test.dart
@@ -10,6 +10,7 @@ import 'package:conduit/core/database/app_database.dart';
 import 'package:conduit/core/database/database_provider.dart';
 import 'package:conduit/core/models/folder.dart';
 import 'package:conduit/core/providers/app_providers.dart';
+import 'package:conduit/core/sync/pull_sync.dart';
 import 'package:conduit/core/sync/sync_api_client.dart';
 import 'package:conduit/core/sync/sync_engine.dart';
 import 'package:conduit/features/auth/providers/unified_auth_providers.dart';
@@ -20,6 +21,18 @@ import 'package:flutter_test/flutter_test.dart';
 
 import '../../support/fake_open_webui_server.dart';
 import '../../support/fake_sync_api_client.dart';
+
+class _RecordingSyncEngine extends SyncEngine {
+  _RecordingSyncEngine(this.pulls);
+
+  final List<String> pulls;
+
+  @override
+  Future<PullResult?> requestPull({required String reason}) {
+    pulls.add(reason);
+    return Future.value(null);
+  }
+}
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
@@ -201,6 +214,28 @@ void main() {
           final rows = await folderRows();
           return rows.any((row) => row.name == 'Renamed');
         });
+      },
+    );
+
+    test(
+      'missing remote folder update submits reconcile pull immediately',
+      () async {
+        final pulls = <String>[];
+        final container = makeContainer(
+          extraOverrides: [
+            syncEngineProvider.overrideWith(() => _RecordingSyncEngine(pulls)),
+          ],
+        );
+        await container.read(foldersProvider.future);
+
+        container
+            .read(foldersProvider.notifier)
+            .updateFolderFromRemote(
+              'missing-folder',
+              (_) => throw StateError('unexpected transform'),
+            );
+
+        check(pulls).deepEquals(['folders-reconcile']);
       },
     );
 

--- a/test/core/sync/deletion_reconcile_test.dart
+++ b/test/core/sync/deletion_reconcile_test.dart
@@ -113,7 +113,7 @@ void main() {
   late FakeOpenWebUiServer server;
   late FakeSyncApiClient client;
   late AppDatabase db;
-  late ChatLocks locks;
+  late ConversationLocks locks;
   late FakeSyncClock clock;
   late DeletionReconcile reconcile;
 
@@ -121,7 +121,7 @@ void main() {
     server = FakeOpenWebUiServer(nowEpochSeconds: () => 7000);
     client = FakeSyncApiClient(server);
     db = AppDatabase(NativeDatabase.memory());
-    locks = ChatLocks();
+    locks = ConversationLocks();
     clock = FakeSyncClock()..now = 1_000_000;
     reconcile = DeletionReconcile(
       client: client,

--- a/test/core/sync/folder_sync_test.dart
+++ b/test/core/sync/folder_sync_test.dart
@@ -61,8 +61,8 @@ void main() {
   late FakeOpenWebUiServer server;
   late FakeSyncApiClient client;
   late AppDatabase db;
-  late ChatLocks chatLocks;
-  late ChatLocks folderLocks;
+  late ConversationLocks chatLocks;
+  late FolderLocks folderLocks;
   late IdRemapper remapper;
   late FakeSyncClock clock;
   late PushSync push;
@@ -71,8 +71,8 @@ void main() {
     server = FakeOpenWebUiServer(nowEpochSeconds: () => 7000);
     client = FakeSyncApiClient(server);
     db = AppDatabase(NativeDatabase.memory());
-    chatLocks = ChatLocks();
-    folderLocks = ChatLocks();
+    chatLocks = ConversationLocks();
+    folderLocks = FolderLocks();
     remapper = IdRemapper(db);
     clock = FakeSyncClock()..now = 7000;
     push = PushSync(

--- a/test/core/sync/note_deletion_reconcile_test.dart
+++ b/test/core/sync/note_deletion_reconcile_test.dart
@@ -88,13 +88,13 @@ Map<String, dynamic> serverNote(String id, int ns) => <String, dynamic>{
 void main() {
   late FakeOpenWebUiServer server;
   late AppDatabase db;
-  late ChatLocks locks;
+  late NoteLocks locks;
   late _Clock clock;
 
   setUp(() {
     server = FakeOpenWebUiServer();
     db = AppDatabase(NativeDatabase.memory());
-    locks = ChatLocks();
+    locks = NoteLocks();
     clock = _Clock();
   });
   tearDown(() => db.close());

--- a/test/core/sync/note_sync_test.dart
+++ b/test/core/sync/note_sync_test.dart
@@ -84,14 +84,14 @@ void main() {
   late FakeOpenWebUiServer server;
   late FakeSyncApiClient client;
   late AppDatabase db;
-  late ChatLocks locks;
+  late NoteLocks locks;
   late IdRemapper syncRemapper;
 
   setUp(() {
     server = FakeOpenWebUiServer();
     client = FakeSyncApiClient(server);
     db = AppDatabase(NativeDatabase.memory());
-    locks = ChatLocks();
+    locks = NoteLocks();
     syncRemapper = IdRemapper(db);
   });
   tearDown(() async {
@@ -1006,7 +1006,7 @@ void main() {
   });
 
   test('pushNoteCreate remaps while the local-id lock is still held', () async {
-    final recordingLocks = _RecordingChatLocks();
+    final recordingLocks = _RecordingNoteLocks();
     final remapper = IdRemapper(db);
     addTearDown(remapper.dispose);
     final push = NotePushSync(
@@ -1223,7 +1223,7 @@ void main() {
   );
 }
 
-class _RecordingChatLocks extends ChatLocks {
+class _RecordingNoteLocks extends NoteLocks {
   final List<Set<String>> activeSnapshots = <Set<String>>[];
   final Set<String> _active = <String>{};
 

--- a/test/core/sync/outbox_activation_test.dart
+++ b/test/core/sync/outbox_activation_test.dart
@@ -108,8 +108,8 @@ void main() {
   late OutboxDao dao;
   late FakeOpenWebUiServer server;
   late _LoggingClient client;
-  late ChatLocks chatLocks;
-  late ChatLocks folderLocks;
+  late ConversationLocks chatLocks;
+  late FolderLocks folderLocks;
   late IdRemapper remapper;
   late PushSync push;
   late _Clock clock;
@@ -123,8 +123,8 @@ void main() {
     server = FakeOpenWebUiServer();
     log = <String>[];
     client = _LoggingClient(server, log);
-    chatLocks = ChatLocks();
-    folderLocks = ChatLocks();
+    chatLocks = ConversationLocks();
+    folderLocks = FolderLocks();
     clock = _Clock(1000);
     remapper = IdRemapper(db);
     push = PushSync(

--- a/test/core/sync/outbox_drainer_test.dart
+++ b/test/core/sync/outbox_drainer_test.dart
@@ -235,8 +235,9 @@ void main() {
   late OutboxDao dao;
   late FakeOpenWebUiServer server;
   late RecordingSyncApiClient client;
-  late ChatLocks chatLocks;
-  late ChatLocks folderLocks;
+  late ConversationLocks chatLocks;
+  late FolderLocks folderLocks;
+  late NoteLocks noteLocks;
   late IdRemapper remapper;
   late PushSync push;
   late FakeSyncClock clock;
@@ -248,8 +249,9 @@ void main() {
     dao = db.outboxDao;
     server = FakeOpenWebUiServer();
     client = RecordingSyncApiClient(server);
-    chatLocks = ChatLocks();
-    folderLocks = ChatLocks();
+    chatLocks = ConversationLocks();
+    folderLocks = FolderLocks();
+    noteLocks = NoteLocks();
     clock = FakeSyncClock(1000);
     remapper = IdRemapper(db);
     push = PushSync(
@@ -298,13 +300,13 @@ void main() {
               pull: NotePullSync(
                 client: client,
                 db: db,
-                locks: chatLocks,
+                locks: noteLocks,
                 remapper: remapper,
               ),
               push: NotePushSync(
                 client: client,
                 db: db,
-                noteLocks: chatLocks,
+                noteLocks: noteLocks,
                 remapper: remapper,
               ),
             ),

--- a/test/core/sync/outbox_task_queue_migrator_test.dart
+++ b/test/core/sync/outbox_task_queue_migrator_test.dart
@@ -29,7 +29,7 @@ void main() {
   late Box<dynamic> attachmentQueue;
   late Box<dynamic> metadata;
   late AppDatabase db;
-  late ChatLocks chatLocks;
+  late ConversationLocks chatLocks;
 
   HiveBoxes boxes() => HiveBoxes(
     preferences: preferences,
@@ -56,7 +56,7 @@ void main() {
     attachmentQueue = await Hive.openBox<dynamic>('attachment_queue_v1');
     metadata = await Hive.openBox<dynamic>('metadata_v1');
     db = AppDatabase(NativeDatabase.memory());
-    chatLocks = ChatLocks();
+    chatLocks = ConversationLocks();
   });
 
   tearDown(() async {
@@ -378,41 +378,38 @@ void main() {
       },
     );
 
-    test(
-      'contentHash dedupe survives wall-clock advance across re-runs',
-      () async {
-        // Regression: the new-chat blob's per-message timestamps must NOT depend
-        // on the wall clock, or the contentHash drifts between a partial-failure
-        // run and a re-run on a LATER app launch -> dedupe misses -> duplicate
-        // chat POSTed. Use a shared advancing clock (7000 then 7050) across runs.
-        final clock = _FixedClock(7000);
-        OutboxTaskQueueMigrator migratorWith() => OutboxTaskQueueMigrator(
-          db: db,
-          hiveBoxes: boxes(),
-          chatLocks: chatLocks,
-          clock: clock,
-          resolveDefaultModel: () => 'default-model',
-        );
+    test('contentHash dedupe survives wall-clock advance across re-runs', () async {
+      // Regression: the new-chat blob's per-message timestamps must NOT depend
+      // on the wall clock, or the contentHash drifts between a partial-failure
+      // run and a re-run on a LATER app launch -> dedupe misses -> duplicate
+      // chat POSTed. Use a shared advancing clock (7000 then 7050) across runs.
+      final clock = _FixedClock(7000);
+      OutboxTaskQueueMigrator migratorWith() => OutboxTaskQueueMigrator(
+        db: db,
+        hiveBoxes: boxes(),
+        chatLocks: chatLocks,
+        clock: clock,
+        resolveDefaultModel: () => 'default-model',
+      );
 
-        final task = sendTextTask(id: 't1', text: 'dedupe me');
-        await caches.put('outbound_task_queue_v1', [task]);
+      final task = sendTextTask(id: 't1', text: 'dedupe me');
+      await caches.put('outbound_task_queue_v1', [task]);
 
-        await migratorWith().migrateIfNeeded();
-        await (db.delete(db.syncMeta)..where(
-              (t) => t.key.equals(OutboxTaskQueueMigrator.migratedFlagKey),
-            ))
-            .go();
+      await migratorWith().migrateIfNeeded();
+      await (db.delete(db.syncMeta)..where(
+            (t) => t.key.equals(OutboxTaskQueueMigrator.migratedFlagKey),
+          ))
+          .go();
 
-        // Advance the wall clock before the re-run.
-        clock.now = 7050;
-        await caches.put('outbound_task_queue_v1', [task]);
-        final report = await migratorWith().migrateIfNeeded();
+      // Advance the wall clock before the re-run.
+      clock.now = 7050;
+      await caches.put('outbound_task_queue_v1', [task]);
+      final report = await migratorWith().migrateIfNeeded();
 
-        check(report.skippedDuplicate).equals(1);
-        check(report.converted).equals(0);
-        check((await db.select(db.chats).get()).length).equals(1);
-      },
-    );
+      check(report.skippedDuplicate).equals(1);
+      check(report.converted).equals(0);
+      check((await db.select(db.chats).get()).length).equals(1);
+    });
 
     test(
       'durable contentHash marker dedupes after the create op drained',

--- a/test/core/sync/pull_sync_test.dart
+++ b/test/core/sync/pull_sync_test.dart
@@ -71,14 +71,14 @@ void main() {
   late FakeOpenWebUiServer server;
   late FakeSyncApiClient client;
   late AppDatabase db;
-  late ChatLocks locks;
+  late ConversationLocks locks;
   late PullSync pull;
 
   setUp(() {
     server = FakeOpenWebUiServer();
     client = FakeSyncApiClient(server);
     db = AppDatabase(NativeDatabase.memory());
-    locks = ChatLocks();
+    locks = ConversationLocks();
     pull = PullSync(client: client, db: db, locks: locks);
   });
 

--- a/test/core/sync/push_sync_test.dart
+++ b/test/core/sync/push_sync_test.dart
@@ -149,8 +149,8 @@ void main() {
   late FakeOpenWebUiServer server;
   late FakeSyncApiClient client;
   late AppDatabase db;
-  late ChatLocks chatLocks;
-  late ChatLocks folderLocks;
+  late ConversationLocks chatLocks;
+  late FolderLocks folderLocks;
   late IdRemapper remapper;
   late FakeSyncClock clock;
   late PushSync push;
@@ -159,8 +159,8 @@ void main() {
     server = FakeOpenWebUiServer(nowEpochSeconds: () => 7000);
     client = FakeSyncApiClient(server);
     db = AppDatabase(NativeDatabase.memory());
-    chatLocks = ChatLocks();
-    folderLocks = ChatLocks();
+    chatLocks = ConversationLocks();
+    folderLocks = FolderLocks();
     remapper = IdRemapper(db);
     clock = FakeSyncClock();
     push = PushSync(
@@ -1136,7 +1136,7 @@ void main() {
   });
 }
 
-class _RecordingChatLocks extends ChatLocks {
+class _RecordingChatLocks extends ConversationLocks {
   final List<String> keys = <String>[];
   final List<Set<String>> activeSnapshots = <Set<String>>[];
   final Set<String> _active = <String>{};

--- a/test/core/sync/read_path_acceptance_test.dart
+++ b/test/core/sync/read_path_acceptance_test.dart
@@ -72,21 +72,21 @@ void main() {
   });
 
   Map<String, dynamic> blobFor(String id, {String content = 'hello'}) => {
-        'title': 'Title $id',
-        'history': {
-          'messages': {
-            '$id-m1': {
-              'id': '$id-m1',
-              'parentId': null,
-              'childrenIds': <String>[],
-              'role': 'user',
-              'content': content,
-              'timestamp': 100,
-            },
-          },
-          'currentId': '$id-m1',
+    'title': 'Title $id',
+    'history': {
+      'messages': {
+        '$id-m1': {
+          'id': '$id-m1',
+          'parentId': null,
+          'childrenIds': <String>[],
+          'role': 'user',
+          'content': content,
+          'timestamp': 100,
         },
-      };
+      },
+      'currentId': '$id-m1',
+    },
+  };
 
   ProviderContainer makeContainer(SyncApiClient? client) {
     final container = ProviderContainer(
@@ -118,8 +118,7 @@ void main() {
     }
   }
 
-  test(
-      'acceptance (a): airplane-mode cold start renders list and chats from '
+  test('acceptance (a): airplane-mode cold start renders list and chats from '
       'the previously-synced database', () async {
     // 1. Online session: pull against the fake server.
     final server = FakeOpenWebUiServer();
@@ -135,7 +134,7 @@ void main() {
     final pull = PullSync(
       client: FakeSyncApiClient(server),
       db: db,
-      locks: ChatLocks(),
+      locks: ConversationLocks(),
     );
     check((await pull.run()).success).isTrue();
 
@@ -145,8 +144,9 @@ void main() {
     final container = makeContainer(offlineClient);
 
     final conversations = await container.read(conversationsProvider.future);
-    check(conversations.map((c) => c.id))
-        .deepEquals(['chat-3', 'chat-2', 'chat-1']);
+    check(
+      conversations.map((c) => c.id),
+    ).deepEquals(['chat-3', 'chat-2', 'chat-1']);
 
     final folders = await container.read(foldersProvider.future);
     check(folders.map((f) => f.id)).deepEquals(['folder-1']);
@@ -155,8 +155,7 @@ void main() {
     for (var i = 1; i <= 3; i++) {
       final conversation = await loadLocalConversation(container, 'chat-$i');
       check(conversation).isNotNull();
-      check(conversation!.messages.single.content)
-          .equals('message body $i');
+      check(conversation!.messages.single.content).equals('message body $i');
     }
 
     // Pulling while offline fails without corrupting the readable state.
@@ -169,8 +168,7 @@ void main() {
     check(after.map((c) => c.id)).deepEquals(['chat-3', 'chat-2', 'chat-1']);
   });
 
-  test(
-      'acceptance (c): edit-on-server then requestPull updates the list row '
+  test('acceptance (c): edit-on-server then requestPull updates the list row '
       'and the open chat body', () async {
     final server = FakeOpenWebUiServer();
     server.seedChat(
@@ -222,8 +220,7 @@ void main() {
     check(after!.messages.single.content).equals('edited body');
   });
 
-  test(
-      'acceptance (d): a 1,000-chat pull emits at most changedChats + 1 '
+  test('acceptance (d): a 1,000-chat pull emits at most changedChats + 1 '
       'narrow list emissions', () async {
     final server = FakeOpenWebUiServer();
     const chatCount = 1000;
@@ -246,7 +243,7 @@ void main() {
     final pull = PullSync(
       client: FakeSyncApiClient(server),
       db: db,
-      locks: ChatLocks(),
+      locks: ConversationLocks(),
     );
     final result = await pull.run();
 

--- a/test/core/sync/sync_engine_test.dart
+++ b/test/core/sync/sync_engine_test.dart
@@ -8,6 +8,7 @@ import 'package:conduit/core/database/mappers/chat_blob_mapper.dart';
 import 'package:conduit/core/persistence/persistence_providers.dart';
 import 'package:conduit/core/providers/app_providers.dart';
 import 'package:conduit/core/services/connectivity_service.dart';
+import 'package:conduit/core/sync/clock.dart';
 import 'package:conduit/core/sync/sync_api_client.dart';
 import 'package:conduit/core/sync/sync_engine.dart';
 import 'package:conduit/features/auth/providers/unified_auth_providers.dart';
@@ -51,6 +52,15 @@ class _MutableValue<T> extends Notifier<T> {
   void set(T value) => state = value;
 }
 
+class _FixedClock implements SyncClock {
+  const _FixedClock(this.now);
+
+  final int now;
+
+  @override
+  int nowEpochSeconds() => now;
+}
+
 class _FailFinalPullWatermarkRead extends QueryInterceptor {
   int pullWatermarkReads = 0;
 
@@ -90,13 +100,18 @@ void main() {
   ProviderContainer makeContainer({
     bool authenticated = true,
     bool online = true,
+    bool Function(Ref ref)? authBuilder,
+    SyncClock Function(Ref ref)? clockBuilder,
     void Function()? onHiveBoxesRead,
   }) {
     final container = ProviderContainer(
       overrides: [
         appDatabaseProvider.overrideWith((ref) => db),
         syncApiClientProvider.overrideWith((ref) => client),
-        isAuthenticatedProvider2.overrideWith((ref) => authenticated),
+        isAuthenticatedProvider2.overrideWith(
+          (ref) => authBuilder?.call(ref) ?? authenticated,
+        ),
+        if (clockBuilder != null) syncClockProvider.overrideWith(clockBuilder),
         isOnlineProvider.overrideWith((ref) => online),
         legacyConversationCachePurgerProvider.overrideWith(
           (ref) => () async {
@@ -277,6 +292,61 @@ void main() {
         check(container.read(syncEngineProvider).phase).equals(SyncPhase.idle);
       },
     );
+
+    test(
+      'requestPull observes login and survives rebuild after being armed',
+      () async {
+        seedChat('chat-after-login', 100);
+        final authProvider = NotifierProvider<_MutableValue<bool>, bool>(
+          () => _MutableValue<bool>(false),
+        );
+        final container = makeContainer(
+          authBuilder: (ref) => ref.watch(authProvider),
+        );
+
+        final engine = container.read(syncEngineProvider.notifier);
+        check(await engine.requestPull(reason: 'before-login')).isNull();
+        check(client.chatListPageRequests).equals(0);
+
+        container.read(authProvider.notifier).set(true);
+
+        final resultFuture = engine.requestPull(reason: 'after-login');
+        // Force the reactive build after requestPull has armed its debounce.
+        // The same joined pull must still complete, not get reset to null.
+        container.read(syncEngineProvider);
+        final result = await resultFuture;
+
+        check(result).isNotNull();
+        check(result!.success).isTrue();
+        check(client.chatListPageRequests).equals(1);
+        check(await db.chatsDao.getChat('chat-after-login')).isNotNull();
+      },
+    );
+
+    test('armed requestPull survives a non-inert dependency rebind', () async {
+      seedChat('chat-after-rebind', 100);
+      final clockProvider =
+          NotifierProvider<_MutableValue<SyncClock>, SyncClock>(
+            () => _MutableValue<SyncClock>(const _FixedClock(1)),
+          );
+      final container = makeContainer(
+        clockBuilder: (ref) => ref.watch(clockProvider),
+      );
+      final engine = container.read(syncEngineProvider.notifier);
+
+      final resultFuture = engine.requestPull(reason: 'before-clock-rebind');
+      container.read(clockProvider.notifier).set(const _FixedClock(2));
+      // Force the reactive rebuild while the debounce joinable is still armed.
+      // The waiter must be carried into the post-rebind cycle, not completed
+      // early with null.
+      container.read(syncEngineProvider);
+      final result = await resultFuture;
+
+      check(result).isNotNull();
+      check(result!.success).isTrue();
+      check(client.chatListPageRequests).equals(1);
+      check(await db.chatsDao.getChat('chat-after-rebind')).isNotNull();
+    });
 
     test('section 9.3 legacy-cache purge fires exactly once', () async {
       seedChat('chat-1', 100);
@@ -671,5 +741,38 @@ void main() {
       // The op was consumed (remapped + marked done), nothing left pending.
       check(await db.outboxDao.pendingForChat('local:c1')).isEmpty();
     });
+
+    test(
+      'dependency refresh during an active drain keeps the same drainer',
+      () async {
+        await seedLocalCreate('local:c2', contentHash: 'h2');
+        final clockProvider =
+            NotifierProvider<_MutableValue<SyncClock>, SyncClock>(
+              () => _MutableValue<SyncClock>(const _FixedClock(1)),
+            );
+        final container = makeContainer(
+          clockBuilder: (ref) => ref.watch(clockProvider),
+        );
+        final engine = container.read(syncEngineProvider.notifier);
+
+        final gate = Completer<void>();
+        client.createChatGate = gate.future;
+
+        final firstDrain = engine.drainOutbox();
+        await waitFor(() => client.createChatStarts.isNotEmpty);
+        check(client.createChatCalls).equals(1);
+
+        container.read(clockProvider.notifier).set(const _FixedClock(2));
+        final secondDrain = engine.drainNow();
+
+        gate.complete();
+        await firstDrain;
+        await secondDrain;
+        await engine.drainNow();
+
+        check(client.createChatCalls).equals(1);
+        check(await db.outboxDao.pendingForChat('local:c2')).isEmpty();
+      },
+    );
   });
 }

--- a/test/core/sync/sync_engine_test.dart
+++ b/test/core/sync/sync_engine_test.dart
@@ -674,8 +674,14 @@ void main() {
 
         final firstDrain = engine.drainOutbox();
         await migrationGate.firstReadStarted.future;
+        final joinObserved = Completer<void>();
+        engine.legacyMigrationJoinObserverForTesting = () {
+          if (!joinObserved.isCompleted) {
+            joinObserved.complete();
+          }
+        };
         final joinedDrain = engine.drainNow();
-        await Future<void>.delayed(Duration.zero);
+        await joinObserved.future;
 
         migrationGate.releaseFirstRead.complete();
         await firstDrain;

--- a/test/core/sync/sync_engine_test.dart
+++ b/test/core/sync/sync_engine_test.dart
@@ -641,6 +641,72 @@ void main() {
       },
     );
 
+    test(
+      'database switch waits for active task queue migration before retrying',
+      () async {
+        await db.close();
+        final firstMigrationGate = _GateTaskMigrationFlagRead();
+        final secondMigrationGate = _GateTaskMigrationFlagRead();
+        final firstDb = AppDatabase(
+          NativeDatabase.memory().interceptWith(firstMigrationGate),
+        );
+        db = firstDb;
+        final secondDb = AppDatabase(
+          NativeDatabase.memory().interceptWith(secondMigrationGate),
+        );
+        final activeDbProvider =
+            NotifierProvider<_MutableValue<AppDatabase?>, AppDatabase?>(
+              () => _MutableValue<AppDatabase?>(firstDb),
+            );
+        final boxes = HiveBoxes(
+          preferences: emptyHiveBox(),
+          caches: emptyHiveBox(),
+          attachmentQueue: emptyHiveBox(),
+          metadata: emptyHiveBox(),
+        );
+        final storage = _MockOptimizedStorageService();
+        when(
+          () => storage.getActiveServerId(),
+        ).thenAnswer((_) async => 'server-1');
+        final container = ProviderContainer(
+          overrides: [
+            appDatabaseProvider.overrideWith(
+              (ref) => ref.watch(activeDbProvider),
+            ),
+            syncApiClientProvider.overrideWith((ref) => client),
+            isAuthenticatedProvider2.overrideWith((ref) => true),
+            isOnlineProvider.overrideWith((ref) => true),
+            hiveBoxesProvider.overrideWith((ref) => boxes),
+            optimizedStorageServiceProvider.overrideWithValue(storage),
+          ],
+        );
+        addTearDown(() async {
+          container.dispose();
+          await secondDb.close();
+        });
+
+        final engine = container.read(syncEngineProvider.notifier);
+        final firstDrain = engine.drainOutbox();
+        await firstMigrationGate.firstReadStarted.future;
+
+        container.read(activeDbProvider.notifier).set(secondDb);
+        container.read(syncEngineProvider);
+        final secondDrain = engine.drainNow();
+        await Future<void>.delayed(Duration.zero);
+
+        check(firstMigrationGate.taskMigrationFlagReads).equals(1);
+        check(secondMigrationGate.taskMigrationFlagReads).equals(0);
+
+        firstMigrationGate.releaseFirstRead.complete();
+        await secondMigrationGate.firstReadStarted.future;
+        secondMigrationGate.releaseFirstRead.complete();
+        await firstDrain;
+        await secondDrain;
+
+        check(secondMigrationGate.taskMigrationFlagReads).equals(1);
+      },
+    );
+
     test('folders 403 result flips foldersFeatureEnabledProvider', () async {
       seedChat('chat-1', 100);
       client.foldersFeatureEnabled = false;
@@ -1015,6 +1081,94 @@ void main() {
       check(client.createChatCalls).equals(1);
       check(completionRunner.calls).isEmpty();
     });
+
+    test(
+      'completion runner rebind keeps preserved drainer from using stale runner',
+      () async {
+        await seedLocalCreate(
+          'local:runner-rebind',
+          contentHash: 'h-runner-rebind',
+          completion: const RequestCompletionPayload(
+            assistantMessageId: 'assistant-1',
+            model: 'model-1',
+          ),
+        );
+        final firstRunner = _RecordingCompletionRunner();
+        final secondRunner = _RecordingCompletionRunner();
+        final completionProvider =
+            NotifierProvider<
+              _MutableValue<RequestCompletionRunner>,
+              RequestCompletionRunner
+            >(() => _MutableValue<RequestCompletionRunner>(firstRunner));
+        final container = ProviderContainer(
+          overrides: [
+            appDatabaseProvider.overrideWith((ref) => db),
+            syncApiClientProvider.overrideWith((ref) => client),
+            isAuthenticatedProvider2.overrideWith((ref) => true),
+            isOnlineProvider.overrideWith((ref) => true),
+            requestCompletionRunnerProvider.overrideWith(
+              (ref) => ref.watch(completionProvider),
+            ),
+          ],
+        );
+        addTearDown(container.dispose);
+        final engine = container.read(syncEngineProvider.notifier);
+
+        final gate = Completer<void>();
+        client.createChatGate = gate.future;
+        final drain = engine.drainOutbox();
+        await waitFor(() => client.createChatStarts.isNotEmpty);
+
+        container.read(completionProvider.notifier).set(secondRunner);
+        container.read(syncEngineProvider);
+        gate.complete();
+        await drain;
+
+        check(firstRunner.calls).isEmpty();
+        check(secondRunner.calls).isEmpty();
+
+        await engine.drainNow();
+
+        check(firstRunner.calls).isEmpty();
+        check(secondRunner.calls).length.equals(1);
+      },
+    );
+
+    test(
+      'disposing during an active create keeps remap forwarding until drain ends',
+      () async {
+        await seedLocalCreate(
+          'local:dispose-remap',
+          contentHash: 'h-dispose-remap',
+        );
+        final container = ProviderContainer(
+          overrides: [
+            appDatabaseProvider.overrideWith((ref) => db),
+            syncApiClientProvider.overrideWith((ref) => client),
+            isAuthenticatedProvider2.overrideWith((ref) => true),
+            isOnlineProvider.overrideWith((ref) => true),
+          ],
+        );
+        final engine = container.read(syncEngineProvider.notifier);
+        final remapEvents = <RemapEvent>[];
+        final remapSub = engine.remapEvents.listen(remapEvents.add);
+        addTearDown(remapSub.cancel);
+
+        final gate = Completer<void>();
+        client.createChatGate = gate.future;
+        final drain = engine.drainOutbox();
+        await waitFor(() => client.createChatStarts.isNotEmpty);
+
+        container.dispose();
+        gate.complete();
+        await drain;
+
+        check(remapEvents).length.equals(1);
+        check(remapEvents.single.fromId).equals('local:dispose-remap');
+        check(engine.hasCachedDrainerForTesting).isFalse();
+        check(engine.hasCachedRemapperForTesting).isFalse();
+      },
+    );
 
     test(
       'pull-cycle drain clears a stale drainer after dependency refresh',

--- a/test/core/sync/sync_engine_test.dart
+++ b/test/core/sync/sync_engine_test.dart
@@ -704,6 +704,12 @@ void main() {
         await secondDrain;
 
         check(secondMigrationGate.taskMigrationFlagReads).equals(1);
+        check(
+          await firstDb.syncMetaDao.getValue('hive_caches_migrated'),
+        ).isNull();
+        check(
+          await secondDb.syncMetaDao.getValue('hive_caches_migrated'),
+        ).equals('1');
       },
     );
 

--- a/test/core/sync/sync_engine_test.dart
+++ b/test/core/sync/sync_engine_test.dart
@@ -642,6 +642,55 @@ void main() {
     );
 
     test(
+      'same-db migration joiner retries after active migration failure',
+      () async {
+        await db.close();
+        final migrationGate = _GateTaskMigrationFlagRead();
+        db = AppDatabase(NativeDatabase.memory().interceptWith(migrationGate));
+        final caches = _MockHiveBox();
+        var taskQueueProbes = 0;
+        when(() => caches.containsKey(HiveStoreKeys.taskQueue)).thenAnswer((_) {
+          taskQueueProbes++;
+          if (taskQueueProbes == 1) {
+            throw StateError('transient task queue probe');
+          }
+          return false;
+        });
+        when(() => caches.get(any<dynamic>())).thenReturn(null);
+        when(() => caches.delete(any<dynamic>())).thenAnswer((_) async {});
+        final boxes = HiveBoxes(
+          preferences: emptyHiveBox(),
+          caches: caches,
+          attachmentQueue: emptyHiveBox(),
+          metadata: emptyHiveBox(),
+        );
+        final storage = _MockOptimizedStorageService();
+        when(() => storage.getActiveServerId()).thenAnswer((_) async => null);
+        final container = makeContainer(
+          hiveBoxes: boxes,
+          storageService: storage,
+        );
+        final engine = container.read(syncEngineProvider.notifier);
+
+        final firstDrain = engine.drainOutbox();
+        await migrationGate.firstReadStarted.future;
+        final joinedDrain = engine.drainNow();
+        await Future<void>.delayed(Duration.zero);
+
+        migrationGate.releaseFirstRead.complete();
+        await firstDrain;
+        await joinedDrain;
+
+        check(taskQueueProbes).equals(2);
+        check(
+          await db.syncMetaDao.getValue(
+            OutboxTaskQueueMigrator.migratedFlagKey,
+          ),
+        ).equals('1');
+      },
+    );
+
+    test(
       'database switch waits for active task queue migration before retrying',
       () async {
         await db.close();

--- a/test/core/sync/sync_engine_test.dart
+++ b/test/core/sync/sync_engine_test.dart
@@ -12,6 +12,7 @@ import 'package:conduit/core/services/optimized_storage_service.dart';
 import 'package:conduit/core/providers/app_providers.dart';
 import 'package:conduit/core/services/connectivity_service.dart';
 import 'package:conduit/core/sync/clock.dart';
+import 'package:conduit/core/sync/id_remapper.dart';
 import 'package:conduit/core/sync/outbox_drainer.dart';
 import 'package:conduit/core/sync/outbox_task_queue_migrator.dart';
 import 'package:conduit/core/sync/request_completion_runner_provider.dart';
@@ -907,6 +908,9 @@ void main() {
         completionRunner: completionRunner,
       );
       final engine = container.read(syncEngineProvider.notifier);
+      final remapEvents = <RemapEvent>[];
+      final remapSub = engine.remapEvents.listen(remapEvents.add);
+      addTearDown(remapSub.cancel);
 
       final gate = Completer<void>();
       client.createChatGate = gate.future;
@@ -925,6 +929,9 @@ void main() {
       gate.complete();
       await drain;
 
+      check(remapEvents).length.equals(1);
+      check(remapEvents.single.fromId).equals('local:auth-flip');
+      check(remapEvents.single.entityKind).equals('chat');
       container.read(authProvider.notifier).set(true);
       container.read(syncEngineProvider);
       final secondRemapper = engine.remapperForTesting;

--- a/test/core/sync/sync_engine_test.dart
+++ b/test/core/sync/sync_engine_test.dart
@@ -1226,6 +1226,45 @@ void main() {
     );
 
     test(
+      'disposing after auth flip keeps retired remap forwarding until drain ends',
+      () async {
+        await seedLocalCreate(
+          'local:auth-dispose-remap',
+          contentHash: 'h-auth-dispose-remap',
+        );
+        final authProvider = NotifierProvider<_MutableValue<bool>, bool>(
+          () => _MutableValue<bool>(true),
+        );
+        final container = makeContainer(
+          authBuilder: (ref) => ref.watch(authProvider),
+        );
+        final engine = container.read(syncEngineProvider.notifier);
+        final remapEvents = <RemapEvent>[];
+        final remapSub = engine.remapEvents.listen(remapEvents.add);
+        addTearDown(remapSub.cancel);
+
+        final gate = Completer<void>();
+        client.createChatGate = gate.future;
+        final drain = engine.drainOutbox();
+        await waitFor(() => client.createChatStarts.isNotEmpty);
+
+        container.read(authProvider.notifier).set(false);
+        container.read(syncEngineProvider);
+        check(engine.hasCachedDrainerForTesting).isFalse();
+        check(engine.hasCachedRemapperForTesting).isFalse();
+
+        container.dispose();
+        gate.complete();
+        await drain;
+
+        check(remapEvents).length.equals(1);
+        check(remapEvents.single.fromId).equals('local:auth-dispose-remap');
+        check(engine.hasCachedDrainerForTesting).isFalse();
+        check(engine.hasCachedRemapperForTesting).isFalse();
+      },
+    );
+
+    test(
       'pull-cycle drain clears a stale drainer after dependency refresh',
       () async {
         await seedLocalCreate('local:pull-stale', contentHash: 'h-pull-stale');

--- a/test/core/sync/sync_engine_test.dart
+++ b/test/core/sync/sync_engine_test.dart
@@ -6,11 +6,14 @@ import 'package:conduit/core/database/daos/outbox_dao.dart';
 import 'package:conduit/core/database/database_provider.dart';
 import 'package:conduit/core/database/fts/fts_ddl.dart';
 import 'package:conduit/core/database/mappers/chat_blob_mapper.dart';
+import 'package:conduit/core/persistence/hive_boxes.dart';
 import 'package:conduit/core/persistence/persistence_providers.dart';
+import 'package:conduit/core/services/optimized_storage_service.dart';
 import 'package:conduit/core/providers/app_providers.dart';
 import 'package:conduit/core/services/connectivity_service.dart';
 import 'package:conduit/core/sync/clock.dart';
 import 'package:conduit/core/sync/outbox_drainer.dart';
+import 'package:conduit/core/sync/outbox_task_queue_migrator.dart';
 import 'package:conduit/core/sync/request_completion_runner_provider.dart';
 import 'package:conduit/core/sync/sync_api_client.dart';
 import 'package:conduit/core/sync/sync_engine.dart';
@@ -19,6 +22,8 @@ import 'package:drift/drift.dart';
 import 'package:drift/native.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:hive_ce/hive.dart';
+import 'package:mocktail/mocktail.dart';
 
 import '../../support/fake_open_webui_server.dart';
 import '../../support/fake_sync_api_client.dart';
@@ -83,6 +88,28 @@ class _FailFinalPullWatermarkRead extends QueryInterceptor {
   }
 }
 
+class _GateTaskMigrationFlagRead extends QueryInterceptor {
+  int taskMigrationFlagReads = 0;
+  final firstReadStarted = Completer<void>();
+  final releaseFirstRead = Completer<void>();
+
+  @override
+  Future<List<Map<String, Object?>>> runSelect(
+    QueryExecutor executor,
+    String statement,
+    List<Object?> args,
+  ) async {
+    if (args.contains(OutboxTaskQueueMigrator.migratedFlagKey)) {
+      taskMigrationFlagReads++;
+      if (taskMigrationFlagReads == 1) {
+        firstReadStarted.complete();
+        await releaseFirstRead.future;
+      }
+    }
+    return executor.runSelect(statement, args);
+  }
+}
+
 class _RecordingCompletionRunner implements RequestCompletionRunner {
   final calls = <String>[];
 
@@ -94,6 +121,11 @@ class _RecordingCompletionRunner implements RequestCompletionRunner {
     calls.add(chatId);
   }
 }
+
+class _MockHiveBox extends Mock implements Box<dynamic> {}
+
+class _MockOptimizedStorageService extends Mock
+    implements OptimizedStorageService {}
 
 void main() {
   late FakeOpenWebUiServer server;
@@ -118,6 +150,8 @@ void main() {
     bool Function(Ref ref)? authBuilder,
     SyncClock Function(Ref ref)? clockBuilder,
     RequestCompletionRunner? completionRunner,
+    HiveBoxes? hiveBoxes,
+    OptimizedStorageService? storageService,
     void Function()? onHiveBoxesRead,
   }) {
     final container = ProviderContainer(
@@ -132,15 +166,20 @@ void main() {
           requestCompletionRunnerProvider.overrideWith(
             (ref) => completionRunner,
           ),
+        if (storageService != null)
+          optimizedStorageServiceProvider.overrideWithValue(storageService),
         isOnlineProvider.overrideWith((ref) => online),
         legacyConversationCachePurgerProvider.overrideWith(
           (ref) => () async {
             purgeCalls++;
           },
         ),
-        if (onHiveBoxesRead != null)
+        if (hiveBoxes != null || onHiveBoxesRead != null)
           hiveBoxesProvider.overrideWith((ref) {
-            onHiveBoxesRead();
+            onHiveBoxesRead?.call();
+            if (hiveBoxes != null) {
+              return hiveBoxes;
+            }
             throw StateError('transient hive read');
           }),
       ],
@@ -238,6 +277,14 @@ void main() {
       createdAt: updatedAt,
       updatedAt: updatedAt,
     );
+  }
+
+  _MockHiveBox emptyHiveBox() {
+    final box = _MockHiveBox();
+    when(() => box.containsKey(any<dynamic>())).thenReturn(false);
+    when(() => box.get(any<dynamic>())).thenReturn(null);
+    when(() => box.delete(any<dynamic>())).thenAnswer((_) async {});
+    return box;
   }
 
   group('SyncEngine.requestPull', () {
@@ -523,6 +570,51 @@ void main() {
       check(migrationBuildAttempts).equals(2);
       check(client.createChatCalls).equals(2);
     });
+
+    test(
+      'same-db dependency rebind preserves task queue migration single-flight',
+      () async {
+        await db.close();
+        final migrationGate = _GateTaskMigrationFlagRead();
+        db = AppDatabase(NativeDatabase.memory().interceptWith(migrationGate));
+        final boxes = HiveBoxes(
+          preferences: emptyHiveBox(),
+          caches: emptyHiveBox(),
+          attachmentQueue: emptyHiveBox(),
+          metadata: emptyHiveBox(),
+        );
+        final storage = _MockOptimizedStorageService();
+        when(
+          () => storage.getActiveServerId(),
+        ).thenAnswer((_) async => 'server-1');
+        final clockProvider =
+            NotifierProvider<_MutableValue<SyncClock>, SyncClock>(
+              () => _MutableValue<SyncClock>(const _FixedClock(1)),
+            );
+        final container = makeContainer(
+          clockBuilder: (ref) => ref.watch(clockProvider),
+          hiveBoxes: boxes,
+          storageService: storage,
+        );
+        final engine = container.read(syncEngineProvider.notifier);
+
+        final firstDrain = engine.drainOutbox();
+        await migrationGate.firstReadStarted.future;
+
+        container.read(clockProvider.notifier).set(const _FixedClock(2));
+        container.read(syncEngineProvider);
+        final secondDrain = engine.drainNow();
+        await Future<void>.delayed(Duration.zero);
+
+        check(migrationGate.taskMigrationFlagReads).equals(1);
+
+        migrationGate.releaseFirstRead.complete();
+        await firstDrain;
+        await secondDrain;
+
+        check(migrationGate.taskMigrationFlagReads).equals(1);
+      },
+    );
 
     test('folders 403 result flips foldersFeatureEnabledProvider', () async {
       seedChat('chat-1', 100);
@@ -821,15 +913,23 @@ void main() {
 
       final drain = engine.drainOutbox();
       await waitFor(() => client.createChatStarts.isNotEmpty);
+      final firstRemapper = engine.remapperForTesting;
+      check(firstRemapper).isNotNull();
       check(engine.hasCachedDrainerForTesting).isTrue();
 
       container.read(authProvider.notifier).set(false);
       container.read(syncEngineProvider);
 
       check(engine.hasCachedDrainerForTesting).isFalse();
+      check(engine.hasCachedRemapperForTesting).isFalse();
       gate.complete();
       await drain;
 
+      container.read(authProvider.notifier).set(true);
+      container.read(syncEngineProvider);
+      final secondRemapper = engine.remapperForTesting;
+      check(secondRemapper).isNotNull();
+      check(identical(firstRemapper, secondRemapper)).isFalse();
       check(client.createChatCalls).equals(1);
       check(completionRunner.calls).isEmpty();
     });

--- a/test/core/sync/sync_engine_test.dart
+++ b/test/core/sync/sync_engine_test.dart
@@ -111,6 +111,30 @@ class _GateTaskMigrationFlagRead extends QueryInterceptor {
   }
 }
 
+class _GateFirstOutboxClaim extends QueryInterceptor {
+  final claimStarted = Completer<void>();
+  final releaseClaim = Completer<void>();
+  bool _gated = false;
+
+  @override
+  Future<int> runUpdate(
+    QueryExecutor executor,
+    String statement,
+    List<Object?> args,
+  ) async {
+    final isClaim =
+        !_gated &&
+        statement.contains('outbox_ops') &&
+        args.contains(OutboxStatus.inFlight);
+    if (isClaim) {
+      _gated = true;
+      claimStarted.complete();
+      await releaseClaim.future;
+    }
+    return executor.runUpdate(statement, args);
+  }
+}
+
 class _RecordingCompletionRunner implements RequestCompletionRunner {
   final calls = <String>[];
 
@@ -887,6 +911,57 @@ void main() {
 
         check(client.createChatCalls).equals(1);
         check(await db.outboxDao.pendingForChat('local:c2')).isEmpty();
+      },
+    );
+
+    test(
+      'database switch during an active claim does not post stale outbox work',
+      () async {
+        await db.close();
+        final claimGate = _GateFirstOutboxClaim();
+        final firstDb = AppDatabase(
+          NativeDatabase.memory().interceptWith(claimGate),
+        );
+        db = firstDb;
+        final secondDb = AppDatabase(NativeDatabase.memory());
+        final activeDbProvider =
+            NotifierProvider<_MutableValue<AppDatabase?>, AppDatabase?>(
+              () => _MutableValue<AppDatabase?>(firstDb),
+            );
+        final container = ProviderContainer(
+          overrides: [
+            appDatabaseProvider.overrideWith(
+              (ref) => ref.watch(activeDbProvider),
+            ),
+            syncApiClientProvider.overrideWith((ref) => client),
+            isAuthenticatedProvider2.overrideWith((ref) => true),
+            isOnlineProvider.overrideWith((ref) => true),
+          ],
+        );
+        addTearDown(() async {
+          container.dispose();
+          await secondDb.close();
+        });
+
+        await seedLocalCreate('local:stale-db', contentHash: 'h-stale-db');
+        final engine = container.read(syncEngineProvider.notifier);
+
+        final drain = engine.drainOutbox();
+        await claimGate.claimStarted.future;
+
+        container.read(activeDbProvider.notifier).set(secondDb);
+        container.read(syncEngineProvider);
+        check(engine.hasCachedDrainerForTesting).isFalse();
+
+        claimGate.releaseClaim.complete();
+        await drain;
+
+        check(client.createChatCalls).equals(0);
+        final pending = await firstDb.outboxDao.pendingForChat(
+          'local:stale-db',
+        );
+        check(pending).length.equals(1);
+        check(pending.single.lastError).equals('offline');
       },
     );
 

--- a/test/core/sync/sync_engine_test.dart
+++ b/test/core/sync/sync_engine_test.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 
 import 'package:checks/checks.dart';
 import 'package:conduit/core/database/app_database.dart';
+import 'package:conduit/core/database/daos/outbox_dao.dart';
 import 'package:conduit/core/database/database_provider.dart';
 import 'package:conduit/core/database/fts/fts_ddl.dart';
 import 'package:conduit/core/database/mappers/chat_blob_mapper.dart';
@@ -9,6 +10,8 @@ import 'package:conduit/core/persistence/persistence_providers.dart';
 import 'package:conduit/core/providers/app_providers.dart';
 import 'package:conduit/core/services/connectivity_service.dart';
 import 'package:conduit/core/sync/clock.dart';
+import 'package:conduit/core/sync/outbox_drainer.dart';
+import 'package:conduit/core/sync/request_completion_runner_provider.dart';
 import 'package:conduit/core/sync/sync_api_client.dart';
 import 'package:conduit/core/sync/sync_engine.dart';
 import 'package:conduit/features/auth/providers/unified_auth_providers.dart';
@@ -80,6 +83,18 @@ class _FailFinalPullWatermarkRead extends QueryInterceptor {
   }
 }
 
+class _RecordingCompletionRunner implements RequestCompletionRunner {
+  final calls = <String>[];
+
+  @override
+  Future<void> run({
+    required String chatId,
+    required Map<String, dynamic> payload,
+  }) async {
+    calls.add(chatId);
+  }
+}
+
 void main() {
   late FakeOpenWebUiServer server;
   late FakeSyncApiClient client;
@@ -102,6 +117,7 @@ void main() {
     bool online = true,
     bool Function(Ref ref)? authBuilder,
     SyncClock Function(Ref ref)? clockBuilder,
+    RequestCompletionRunner? completionRunner,
     void Function()? onHiveBoxesRead,
   }) {
     final container = ProviderContainer(
@@ -112,6 +128,10 @@ void main() {
           (ref) => authBuilder?.call(ref) ?? authenticated,
         ),
         if (clockBuilder != null) syncClockProvider.overrideWith(clockBuilder),
+        if (completionRunner != null)
+          requestCompletionRunnerProvider.overrideWith(
+            (ref) => completionRunner,
+          ),
         isOnlineProvider.overrideWith((ref) => online),
         legacyConversationCachePurgerProvider.overrideWith(
           (ref) => () async {
@@ -136,6 +156,7 @@ void main() {
     String localId, {
     required String contentHash,
     AppDatabase? targetDb,
+    RequestCompletionPayload? completion,
   }) {
     final target = targetDb ?? db;
     final rows = ChatBlobMapper.blobToRows(
@@ -165,6 +186,7 @@ void main() {
       messages: rows.messages,
       blobRows: rows,
       contentHash: contentHash,
+      completion: completion,
     );
   }
 
@@ -772,6 +794,76 @@ void main() {
 
         check(client.createChatCalls).equals(1);
         check(await db.outboxDao.pendingForChat('local:c2')).isEmpty();
+      },
+    );
+
+    test('auth flip during an active drain drops the cached drainer', () async {
+      await seedLocalCreate(
+        'local:auth-flip',
+        contentHash: 'h-auth-flip',
+        completion: const RequestCompletionPayload(
+          assistantMessageId: 'assistant-1',
+          model: 'model-1',
+        ),
+      );
+      final authProvider = NotifierProvider<_MutableValue<bool>, bool>(
+        () => _MutableValue<bool>(true),
+      );
+      final completionRunner = _RecordingCompletionRunner();
+      final container = makeContainer(
+        authBuilder: (ref) => ref.watch(authProvider),
+        completionRunner: completionRunner,
+      );
+      final engine = container.read(syncEngineProvider.notifier);
+
+      final gate = Completer<void>();
+      client.createChatGate = gate.future;
+
+      final drain = engine.drainOutbox();
+      await waitFor(() => client.createChatStarts.isNotEmpty);
+      check(engine.hasCachedDrainerForTesting).isTrue();
+
+      container.read(authProvider.notifier).set(false);
+      container.read(syncEngineProvider);
+
+      check(engine.hasCachedDrainerForTesting).isFalse();
+      gate.complete();
+      await drain;
+
+      check(client.createChatCalls).equals(1);
+      check(completionRunner.calls).isEmpty();
+    });
+
+    test(
+      'pull-cycle drain clears a stale drainer after dependency refresh',
+      () async {
+        await seedLocalCreate('local:pull-stale', contentHash: 'h-pull-stale');
+        final clockProvider =
+            NotifierProvider<_MutableValue<SyncClock>, SyncClock>(
+              () => _MutableValue<SyncClock>(const _FixedClock(1)),
+            );
+        final container = makeContainer(
+          clockBuilder: (ref) => ref.watch(clockProvider),
+        );
+        final engine = container.read(syncEngineProvider.notifier);
+
+        final gate = Completer<void>();
+        client.createChatGate = gate.future;
+
+        final pull = engine.requestPull(reason: 'pull-cycle-stale-drainer');
+        await waitFor(() => client.createChatStarts.isNotEmpty);
+        check(engine.hasCachedDrainerForTesting).isTrue();
+
+        container.read(clockProvider.notifier).set(const _FixedClock(2));
+        container.read(syncEngineProvider);
+        check(engine.hasCachedDrainerForTesting).isTrue();
+
+        gate.complete();
+        final result = await pull;
+
+        check(result).isNull();
+        check(engine.hasCachedDrainerForTesting).isFalse();
+        check(client.createChatCalls).equals(1);
       },
     );
   });

--- a/test/core/sync/sync_triggers_test.dart
+++ b/test/core/sync/sync_triggers_test.dart
@@ -96,7 +96,7 @@ void main() {
     container.listen(syncApiClientProvider, (_, _) {});
   }
 
-  ProviderContainer makeContainer() {
+  ProviderContainer makeContainer({bool autoDispose = true}) {
     final container = ProviderContainer(
       overrides: [
         isAuthenticatedProvider2.overrideWith(
@@ -108,7 +108,9 @@ void main() {
         syncEngineProvider.overrideWith(() => _RecordingSyncEngine(pulls)),
       ],
     );
-    addTearDown(container.dispose);
+    if (autoDispose) {
+      addTearDown(container.dispose);
+    }
     materializeReadiness(container);
     return container;
   }
@@ -170,11 +172,24 @@ void main() {
         container.read(_clientProvider.notifier).set(client);
 
         container.read(syncTriggersProvider);
+        check(countOf('start')).equals(1);
         await flushMicrotasks();
 
         check(countOf('start')).equals(1);
       },
     );
+
+    test('start pull is submitted before immediate disposal can skip it', () {
+      final container = makeContainer(autoDispose: false);
+      container.read(_authProvider.notifier).set(true);
+      container.read(_dbProvider.notifier).set(db);
+      container.read(_clientProvider.notifier).set(client);
+
+      container.read(syncTriggersProvider);
+      container.dispose();
+
+      check(countOf('start')).equals(1);
+    });
 
     test(
       'start fires again when the ready database/client pair changes',

--- a/test/core/sync/sync_triggers_test.dart
+++ b/test/core/sync/sync_triggers_test.dart
@@ -9,6 +9,8 @@ library;
 import 'package:checks/checks.dart';
 import 'package:conduit/core/database/app_database.dart';
 import 'package:conduit/core/database/database_provider.dart';
+import 'package:conduit/core/models/conversation.dart';
+import 'package:conduit/core/providers/app_providers.dart';
 import 'package:conduit/core/services/connectivity_service.dart';
 import 'package:conduit/core/sync/pull_sync.dart';
 import 'package:conduit/core/sync/sync_api_client.dart';
@@ -55,14 +57,25 @@ final _clientProvider =
 /// Recreated (with the same shared list) whenever its watched dependencies
 /// flap, exactly like the production engine.
 class _RecordingSyncEngine extends SyncEngine {
-  _RecordingSyncEngine(this.pulls);
+  _RecordingSyncEngine(this.pulls, this.drains);
 
   final List<String> pulls;
+  final List<String> drains;
 
   @override
   Future<PullResult?> requestPull({required String reason}) {
     pulls.add(reason);
     return Future.value(null);
+  }
+
+  @override
+  Future<void> drainNow() async {
+    drains.add('now');
+  }
+
+  @override
+  Future<void> drainOutbox() async {
+    drains.add('outbox');
   }
 }
 
@@ -72,11 +85,13 @@ void main() {
   late AppDatabase db;
   late FakeSyncApiClient client;
   late List<String> pulls;
+  late List<String> drains;
 
   setUp(() {
     db = AppDatabase(NativeDatabase.memory());
     client = FakeSyncApiClient(FakeOpenWebUiServer());
     pulls = <String>[];
+    drains = <String>[];
   });
 
   tearDown(() async {
@@ -105,7 +120,9 @@ void main() {
         isOnlineProvider.overrideWith((ref) => ref.watch(_onlineProvider)),
         appDatabaseProvider.overrideWith((ref) => ref.watch(_dbProvider)),
         syncApiClientProvider.overrideWith((ref) => ref.watch(_clientProvider)),
-        syncEngineProvider.overrideWith(() => _RecordingSyncEngine(pulls)),
+        syncEngineProvider.overrideWith(
+          () => _RecordingSyncEngine(pulls, drains),
+        ),
       ],
     );
     if (autoDispose) {
@@ -245,6 +262,28 @@ void main() {
     );
   });
 
+  group('active conversation edge', () {
+    test(
+      'chat-open drain is submitted before immediate disposal can skip it',
+      () {
+        final container = makeContainer(autoDispose: false);
+        container.read(_authProvider.notifier).set(true);
+        container.read(_dbProvider.notifier).set(db);
+        container.read(_clientProvider.notifier).set(client);
+        container.read(syncTriggersProvider);
+        pulls.clear();
+        drains.clear();
+
+        container
+            .read(activeConversationProvider.notifier)
+            .set(_conversation('chat-open'));
+        container.dispose();
+
+        check(drains).deepEquals(['outbox']);
+      },
+    );
+  });
+
   group('lifecycle observer + periodic timer', () {
     test('resume fires a foreground pull and restarts the timer; pause '
         'cancels it; dispose removes the observer', () {
@@ -259,7 +298,9 @@ void main() {
             syncApiClientProvider.overrideWith(
               (ref) => ref.watch(_clientProvider),
             ),
-            syncEngineProvider.overrideWith(() => _RecordingSyncEngine(pulls)),
+            syncEngineProvider.overrideWith(
+              () => _RecordingSyncEngine(pulls, drains),
+            ),
           ],
         );
         materializeReadiness(container);
@@ -334,7 +375,9 @@ void main() {
             syncApiClientProvider.overrideWith(
               (ref) => ref.watch(_clientProvider),
             ),
-            syncEngineProvider.overrideWith(() => _RecordingSyncEngine(pulls)),
+            syncEngineProvider.overrideWith(
+              () => _RecordingSyncEngine(pulls, drains),
+            ),
           ],
         );
         materializeReadiness(container);
@@ -368,4 +411,14 @@ void main() {
       });
     });
   });
+}
+
+Conversation _conversation(String id) {
+  final now = DateTime.fromMillisecondsSinceEpoch(1000);
+  return Conversation(
+    id: id,
+    title: 'Title $id',
+    createdAt: now,
+    updatedAt: now,
+  );
 }

--- a/test/core/sync/write_path_acceptance_test.dart
+++ b/test/core/sync/write_path_acceptance_test.dart
@@ -35,7 +35,7 @@ class _Clock implements SyncClock {
 class StubCompletionRunner implements RequestCompletionRunner {
   StubCompletionRunner(this.db, this.locks);
   final AppDatabase db;
-  final ChatLocks locks;
+  final ConversationLocks locks;
   final List<String> ranForChats = <String>[];
 
   @override
@@ -90,8 +90,8 @@ void main() {
   late AppDatabase db;
   late FakeOpenWebUiServer server;
   late FakeSyncApiClient client;
-  late ChatLocks chatLocks;
-  late ChatLocks folderLocks;
+  late ConversationLocks chatLocks;
+  late FolderLocks folderLocks;
   late IdRemapper remapper;
   late PushSync push;
   late _Clock clock;
@@ -124,8 +124,8 @@ void main() {
   );
 
   void wire() {
-    chatLocks = ChatLocks();
-    folderLocks = ChatLocks();
+    chatLocks = ConversationLocks();
+    folderLocks = FolderLocks();
     remapper = IdRemapper(db);
     clock = _Clock(7000);
     push = PushSync(


### PR DESCRIPTION
## Summary
- refresh `SyncEngine` dependencies from public sync entry points so login/auth changes are observed before Riverpod rebuilds settle
- preserve pull joinables across non-server rebuilds and harden drainer/remapper reuse during dependency refreshes
- split sync lock domains for chats, folders, and notes, with focused regression coverage for initial-login and outbox edge cases

## Verification
- `flutter pub get`
- `dart run build_runner build --delete-conflicting-outputs`
- `flutter analyze`
- `flutter test test/core/sync`
- CodeRabbit: final pass returned 0 findings
- Greptile: latest completed review was 3/5; its remaining actionable findings were fixed, but follow-up reviews `33d80d55-699d-4a39-ae9d-89f10903dd05` and `d6bd3bc1-7704-4e22-a76c-20f2fb1faf29` remained stuck in `Reviewing files`

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix initial login sync refresh by hardening SyncEngine dependency rebinding and error handling
> - `SyncEngine` now preserves or retires the cached `OutboxDrainer` and `IdRemapper` across dependency rebinds based on session/auth continuity, preventing stale drainer reuse when auth epoch or bound dependencies change.
> - Serializes legacy task queue migration per active database so concurrent callers await the same in-flight work rather than running duplicate migrations.
> - `SyncTriggers` and reconcile pull callers in [app_providers.dart](https://github.com/cogwheel0/conduit/pull/529/files#diff-09d0818b68d5a1a0ec161c7f5b5a4dd163466be28adae31c3c7bc8ff3a945e40) now catch synchronous errors from `requestPull`/`drainNow`/`drainOutbox` and log them instead of throwing, fixing crashes during initial login.
> - Adds distinct `ConversationLocks`, `FolderLocks`, and `NoteLocks` subtypes (replacing raw `ChatLocks`) to prevent cross-domain lock wiring at compile time across sync classes.
> - Expands test coverage in [sync_engine_test.dart](https://github.com/cogwheel0/conduit/pull/529/files#diff-4c9c9a750dd84b52dc2936b15fe8b5d8920003ac6df8795fc9602312e51e34e1) and [sync_triggers_test.dart](https://github.com/cogwheel0/conduit/pull/529/files#diff-d5460c882def8ff54f15d26a995106cb17fb638a3aa9c8a7c0baaed31d71bc03) for rebind, migration single-flight, drain race, and disposal scenarios.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e39176d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved sync behavior so conversation, folder, and note operations use more targeted locking domains.
  * Enhanced background sync reliability with safer engine operation execution around drain and pull triggers.
* **Bug Fixes**
  * Rebuilds and connectivity changes are less likely to interrupt syncing or lose in-progress work.
  * Reconcile pulls now handle synchronous and async failures more safely, reducing broken chat and folder recovery.
  * Outbox draining and task migration are more stable across app state changes and retries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes the initial-login sync gap by having `SyncEngine`'s public entry points eagerly call `_refreshBoundDependencies()` before acting, so auth/login changes are visible before Riverpod's reactive rebuild settles. It also introduces `_authEpoch` to guard drainers across auth boundaries while allowing non-auth dependency refreshes to reuse an active drain, and adds dedicated `ConversationLocks`/`FolderLocks`/`NoteLocks` subtypes to prevent cross-domain lock wiring at compile time.

- `SyncEngine` now tracks `_authEpoch` separately from `_sessionEpoch`; active drainers capture their epoch in the `isOnline` closure and go offline immediately when auth flips, while non-auth rebinds can preserve them — retired drainer remappers/forwards are tracked in side-maps and cleaned up in drain `finally` blocks.
- `_migrateLegacyTaskQueueIfNeeded` is rewritten as a serializing `while` loop keyed on `_migrationDb` so concurrent drain callers join the same in-flight work and retry if the DB switches mid-migration.
- `SyncTriggers._request` now returns `bool` and sets `_startFired` only on success; drain calls use `_runEngineOperation` which submits the engine call synchronously (no microtask gap), fixing crashes and silent skips during initial login.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the previous blocking findings have all been addressed with correct implementations and matching regression tests.

Every concern raised in prior reviews has a direct fix backed by a targeted test: the auth-epoch guard on the drainer's isOnline closure, the retired-remapper side-maps with cleanup in drain finally blocks, the serializing migration while-loop, the synchronous start-pull submission, and the preserved-joinable rescheduling across non-auth rebuilds. No new correctness issues were found in the changed code.

No files require special attention — sync_engine.dart is the most complex, but its new state machine is well-exercised by the expanded test suite.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| lib/core/sync/sync_engine.dart | Core change — adds _authEpoch, _retiredDrainerRemappers/Forwards maps, two-phase dispose hook, preserved-joinable scheduling, and a serializing while-loop migration guard; the complex state machine correctly handles auth flips, non-auth dependency refreshes, and concurrent drain/migrate callers. |
| lib/core/sync/sync_triggers.dart | _request now returns bool and sets _startFired only on success; drain calls wrapped in _runEngineOperation which invokes the engine synchronously — no microtask gap that could let an immediate disposal skip the start pull or chat-open drain. |
| lib/core/sync/chat_locks.dart | Adds ConversationLocks, FolderLocks, NoteLocks as distinct ChatLocks subclasses; provider return types updated accordingly, eliminating the as-cast in notes_providers.dart and enforcing correct domain at compile time. |
| lib/core/providers/app_providers.dart | _submitReconcilePull helper de-duplicates conversation/folder reconcile pull error handling; synchronous throw from requestPull is now caught and logged rather than propagating, fixing crashes during initial login. |
| test/core/sync/sync_engine_test.dart | Adds comprehensive regression tests for login-observable pull, non-auth rebind joinable preservation, migration single-flight (same-db), migration joiner retry on failure, DB-switch migration ordering, auth-flip drainer teardown, completion-runner rebind, and dispose-during-drain remap forwarding. |
| test/core/sync/sync_triggers_test.dart | Adds drains tracking to _RecordingSyncEngine; new tests verify that the start pull and chat-open drain are submitted synchronously before an immediate container disposal can skip them. |
| lib/features/notes/providers/notes_providers.dart | Removes four unsafe as ChatLocks casts — now that noteLocksProvider returns NoteLocks directly, casts are unnecessary and their removal is correct. |

</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `lib/core/sync/sync_engine.dart`, line 896-897 ([link](https://github.com/cogwheel0/conduit/blob/5ce7031351469b9b925b6bcd02c925a5d0fadd3e/lib/core/sync/sync_engine.dart#L896-L897)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Clear stale drainer**

   When a dependency refresh marks an active drainer stale, the public drain entry points clear it in a `finally` block after the drain completes. The pull-cycle drain path skips that cleanup, so a drainer preserved during `_runOnce()` can stay cached after it becomes idle. A later sync operation can then keep observing the stale drainer/remapper state until another `_ensureDrainer()` call happens to replace it.
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (22): Last reviewed commit: ["Make migration join regression explicit"](https://github.com/cogwheel0/conduit/commit/e39176d9de3bf42fa1683dd9ace89cf3d2ae37aa) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39390001)</sub>

<!-- /greptile_comment -->