### PR TITLE
Add native voice pipeline and voice UI polish

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -73,6 +73,8 @@ android {
 dependencies {
     // Core library desugaring for flutter_local_notifications
     coreLibraryDesugaring("com.android.tools:desugar_jdk_libs:2.1.4")
+    implementation("com.google.mlkit:genai-speech-recognition:1.0.0-alpha1")
+    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.7.3")
 }
 
 flutter {

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,5 +1,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
+
+    <uses-sdk tools:overrideLibrary="com.google.mlkit.genai.speechrecognition,com.google.mlkit.genai.common"/>
     
     <uses-permission android:name="android.permission.INTERNET"/>
     
@@ -15,8 +17,9 @@
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION"/>
     <!-- No broad media/storage permissions; use Android Photo Picker (API 33+) and SAF/share intents -->
 
-    <!-- Bluetooth permissions for audio routing (Android 12+) -->
-    <uses-permission android:name="android.permission.BLUETOOTH_CONNECT" android:maxSdkVersion="32" />
+    <!-- Bluetooth permissions for hands-free/car audio routing. -->
+    <uses-permission android:name="android.permission.BLUETOOTH" android:maxSdkVersion="30"/>
+    <uses-permission android:name="android.permission.BLUETOOTH_CONNECT"/>
 
     <!-- Background streaming permissions -->
     <uses-permission android:name="android.permission.WAKE_LOCK"/>

--- a/android/app/src/main/kotlin/app/cogwheel/conduit/MainActivity.kt
+++ b/android/app/src/main/kotlin/app/cogwheel/conduit/MainActivity.kt
@@ -24,6 +24,8 @@ import org.json.JSONObject
 
 class MainActivity : FlutterActivity() {
     private lateinit var backgroundStreamingHandler: BackgroundStreamingHandler
+    private lateinit var nativeSttBridge: NativeSttBridge
+    private lateinit var nativeTtsBridge: NativeTtsBridge
 
     override fun onCreate(savedInstanceState: Bundle?) {
         sanitizeLaunchIntent(intent)?.let { setIntent(it) }
@@ -68,6 +70,10 @@ class MainActivity : FlutterActivity() {
         // Initialize background streaming handler
         backgroundStreamingHandler = BackgroundStreamingHandler(this)
         backgroundStreamingHandler.setup(flutterEngine)
+        nativeSttBridge = NativeSttBridge(this)
+        nativeSttBridge.setup(flutterEngine)
+        nativeTtsBridge = NativeTtsBridge(this)
+        nativeTtsBridge.setup(flutterEngine)
 
         methodChannel = MethodChannel(flutterEngine.dartExecutor.binaryMessenger, ASSISTANT_CHANNEL)
         shareChannel = MethodChannel(
@@ -727,9 +733,15 @@ class MainActivity : FlutterActivity() {
     }
     
     override fun onDestroy() {
-        super.onDestroy()
+        if (::nativeSttBridge.isInitialized) {
+            nativeSttBridge.dispose()
+        }
+        if (::nativeTtsBridge.isInitialized) {
+            nativeTtsBridge.dispose()
+        }
         if (::backgroundStreamingHandler.isInitialized) {
             backgroundStreamingHandler.cleanup()
         }
+        super.onDestroy()
     }
 }

--- a/android/app/src/main/kotlin/app/cogwheel/conduit/NativeSttBridge.kt
+++ b/android/app/src/main/kotlin/app/cogwheel/conduit/NativeSttBridge.kt
@@ -1,0 +1,587 @@
+package app.cogwheel.conduit
+
+import android.content.Intent
+import android.os.Build
+import android.os.Bundle
+import android.speech.RecognitionListener
+import android.speech.RecognizerIntent
+import android.speech.SpeechRecognizer as AndroidSpeechRecognizer
+import android.util.Log
+import com.google.mlkit.genai.common.DownloadStatus
+import com.google.mlkit.genai.common.FeatureStatus
+import com.google.mlkit.genai.common.audio.AudioSource
+import com.google.mlkit.genai.speechrecognition.SpeechRecognition
+import com.google.mlkit.genai.speechrecognition.SpeechRecognizer as MlKitSpeechRecognizer
+import com.google.mlkit.genai.speechrecognition.SpeechRecognizerOptions
+import com.google.mlkit.genai.speechrecognition.SpeechRecognizerResponse
+import com.google.mlkit.genai.speechrecognition.speechRecognizerOptions
+import com.google.mlkit.genai.speechrecognition.speechRecognizerRequest
+import io.flutter.embedding.engine.FlutterEngine
+import io.flutter.plugin.common.EventChannel
+import io.flutter.plugin.common.MethodCall
+import io.flutter.plugin.common.MethodChannel
+import java.util.Locale
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeoutOrNull
+
+class NativeSttBridge(private val activity: MainActivity) : MethodChannel.MethodCallHandler,
+    EventChannel.StreamHandler {
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)
+    private var eventSink: EventChannel.EventSink? = null
+    private var activeMlKitRecognizer: MlKitSpeechRecognizer? = null
+    private var activePlatformRecognizer: AndroidSpeechRecognizer? = null
+    private var recognitionJob: kotlinx.coroutines.Job? = null
+    private var platformRestartJob: kotlinx.coroutines.Job? = null
+    private var platformStopRequested = false
+    private var platformEmitPartialResults = true
+    private var platformAccumulateResults = true
+    private var platformAllowOnlineFallback = true
+    private var platformLocaleId: String? = null
+    private var platformCommittedText = ""
+
+    fun setup(flutterEngine: FlutterEngine) {
+        MethodChannel(
+            flutterEngine.dartExecutor.binaryMessenger,
+            METHOD_CHANNEL
+        ).setMethodCallHandler(this)
+        EventChannel(
+            flutterEngine.dartExecutor.binaryMessenger,
+            EVENT_CHANNEL
+        ).setStreamHandler(this)
+    }
+
+    override fun onMethodCall(call: MethodCall, result: MethodChannel.Result) {
+        when (call.method) {
+            "checkAvailability" -> {
+                val localeId = call.argument<String>("localeId")
+                scope.launch {
+                    result.success(checkAvailability(localeId))
+                }
+            }
+            "getLocales" -> {
+                val deviceLocaleId = call.argument<String>("deviceLocaleId")
+                result.success(localesPayload(deviceLocaleId))
+            }
+            "start" -> {
+                val localeId = call.argument<String>("localeId")
+                val emitPartialResults = call.argument<Boolean>("emitPartialResults") ?: true
+                val accumulateResults = call.argument<Boolean>("accumulateResults") ?: true
+                val allowOnlineFallback = call.argument<Boolean>("allowOnlineFallback") ?: true
+                scope.launch {
+                    start(
+                        localeId,
+                        emitPartialResults,
+                        accumulateResults,
+                        allowOnlineFallback,
+                        result
+                    )
+                }
+            }
+            "stop" -> {
+                scope.launch {
+                    stopInternal(emitDone = false, awaitCompletion = true)
+                    result.success(null)
+                }
+            }
+            else -> result.notImplemented()
+        }
+    }
+
+    override fun onListen(arguments: Any?, events: EventChannel.EventSink?) {
+        eventSink = events
+    }
+
+    override fun onCancel(arguments: Any?) {
+        eventSink = null
+    }
+
+    fun dispose() {
+        scope.launch {
+            stopInternal(emitDone = false, awaitCompletion = false)
+            scope.cancel()
+        }
+    }
+
+    private suspend fun checkAvailability(localeId: String?): Map<String, Any?> {
+        val mlKitAvailability = checkMlKitAvailability(localeId)
+        if (mlKitAvailability["available"] == true) {
+            return mlKitAvailability
+        }
+
+        return if (AndroidSpeechRecognizer.isRecognitionAvailable(activity.applicationContext)) {
+            available("android_speech")
+        } else {
+            unavailable(mlKitAvailability["reason"] as? String ?: "Android speech recognition unavailable")
+        }
+    }
+
+    private suspend fun checkMlKitAvailability(localeId: String?): Map<String, Any?> {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.S) {
+            return unavailable("Android 12/API 31 is required for ML Kit microphone input")
+        }
+
+        return withContext(Dispatchers.IO) {
+            val advanced = createRecognizer(localeId, SpeechRecognizerOptions.Mode.MODE_ADVANCED)
+            try {
+                val advancedStatus = advanced.checkStatus()
+                if (isUsableStatus(advancedStatus)) {
+                    return@withContext available("mlkit_advanced")
+                }
+            } catch (error: Throwable) {
+                Log.w(TAG, "Advanced ML Kit STT status check failed", error)
+            } finally {
+                advanced.close()
+            }
+
+            val basic = createRecognizer(localeId, SpeechRecognizerOptions.Mode.MODE_BASIC)
+            try {
+                val basicStatus = basic.checkStatus()
+                if (isUsableStatus(basicStatus)) {
+                    available("mlkit_basic")
+                } else {
+                    unavailable("ML Kit speech recognition unavailable: $basicStatus")
+                }
+            } catch (error: Throwable) {
+                unavailable(error.message ?: "ML Kit speech recognition unavailable")
+            } finally {
+                basic.close()
+            }
+        }
+    }
+
+    private suspend fun start(
+        localeId: String?,
+        emitPartialResults: Boolean,
+        accumulateResults: Boolean,
+        allowOnlineFallback: Boolean,
+        result: MethodChannel.Result
+    ) {
+        stopInternal(emitDone = false, awaitCompletion = false)
+        val prepared = withContext(Dispatchers.IO) {
+            prepareRecognizer(localeId)
+        }
+        if (prepared == null) {
+            if (AndroidSpeechRecognizer.isRecognitionAvailable(activity.applicationContext)) {
+                startPlatformRecognizer(
+                    localeId,
+                    emitPartialResults,
+                    accumulateResults,
+                    allowOnlineFallback
+                )
+                result.success(available("android_speech"))
+            } else {
+                result.success(unavailable("Speech recognition is not available"))
+            }
+            return
+        }
+
+        val (recognizer, engineName) = prepared
+        activeMlKitRecognizer = recognizer
+        emitStatus("listening", engineName)
+        recognitionJob = scope.launch(Dispatchers.IO) {
+            var committedText = ""
+            var doneEmitted = false
+            try {
+                val request = speechRecognizerRequest {
+                    audioSource = AudioSource.fromMic()
+                }
+                recognizer.startRecognition(request).collect { response ->
+                    when (response) {
+                        is SpeechRecognizerResponse.PartialTextResponse -> {
+                            if (emitPartialResults) {
+                                val text = if (accumulateResults) {
+                                    mergeText(committedText, response.text)
+                                } else {
+                                    response.text.trim()
+                                }
+                                emitResult(text, false, engineName)
+                            }
+                        }
+                        is SpeechRecognizerResponse.FinalTextResponse -> {
+                            val text = if (accumulateResults) {
+                                committedText = mergeText(committedText, response.text)
+                                committedText
+                            } else {
+                                response.text.trim()
+                            }
+                            emitResult(text, true, engineName)
+                        }
+                        is SpeechRecognizerResponse.ErrorResponse -> {
+                            emitError(
+                                "MLKIT_ERROR_${response.e.errorCode}",
+                                response.e.message ?: "ML Kit speech recognition failed",
+                                engineName
+                            )
+                        }
+                        is SpeechRecognizerResponse.CompletedResponse -> {
+                            doneEmitted = true
+                            emitDone(engineName)
+                        }
+                    }
+                }
+                if (!doneEmitted) {
+                    emitDone(engineName)
+                }
+            } catch (error: CancellationException) {
+                throw error
+            } catch (error: Throwable) {
+                emitError("MLKIT_ERROR", error.message ?: error.toString(), engineName)
+            } finally {
+                if (activeMlKitRecognizer === recognizer) {
+                    activeMlKitRecognizer = null
+                    runCatching { recognizer.close() }
+                }
+            }
+        }
+        result.success(available(engineName))
+    }
+
+    private suspend fun prepareRecognizer(localeId: String?): Pair<MlKitSpeechRecognizer, String>? {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.S) {
+            return null
+        }
+
+        val advanced = createRecognizer(localeId, SpeechRecognizerOptions.Mode.MODE_ADVANCED)
+        if (ensureReady(advanced, "mlkit_advanced")) {
+            return advanced to "mlkit_advanced"
+        }
+        advanced.close()
+
+        val basic = createRecognizer(localeId, SpeechRecognizerOptions.Mode.MODE_BASIC)
+        if (ensureReady(basic, "mlkit_basic")) {
+            return basic to "mlkit_basic"
+        }
+        basic.close()
+        return null
+    }
+
+    private fun createRecognizer(localeId: String?, mode: Int): MlKitSpeechRecognizer {
+        val locale = parseLocale(localeId)
+        val options = speechRecognizerOptions {
+            this.locale = locale
+            preferredMode = mode
+        }
+        return SpeechRecognition.getClient(options)
+    }
+
+    private suspend fun ensureReady(recognizer: MlKitSpeechRecognizer, engineName: String): Boolean {
+        return when (val status = recognizer.checkStatus()) {
+            FeatureStatus.AVAILABLE -> true
+            FeatureStatus.DOWNLOADABLE, FeatureStatus.DOWNLOADING -> {
+                emitStatus("downloading", engineName)
+                var ready = false
+                recognizer.download().collect { downloadStatus ->
+                    when (downloadStatus) {
+                        is DownloadStatus.DownloadStarted -> {
+                            emitStatus("downloading", engineName)
+                        }
+                        is DownloadStatus.DownloadCompleted -> {
+                            ready = true
+                            emitStatus("downloaded", engineName)
+                        }
+                        is DownloadStatus.DownloadProgress -> {
+                            emit(
+                                mapOf(
+                                    "type" to "status",
+                                    "message" to "downloading",
+                                    "engine" to engineName,
+                                    "bytesDownloaded" to downloadStatus.totalBytesDownloaded
+                                )
+                            )
+                        }
+                        is DownloadStatus.DownloadFailed -> {
+                            emitError(
+                                "MLKIT_DOWNLOAD_${downloadStatus.e.errorCode}",
+                                downloadStatus.e.message ?: "ML Kit speech model download failed",
+                                engineName
+                            )
+                        }
+                    }
+                }
+                ready || recognizer.checkStatus() == FeatureStatus.AVAILABLE
+            }
+            else -> {
+                Log.i(TAG, "ML Kit STT $engineName status unavailable: $status")
+                false
+            }
+        }
+    }
+
+    private fun startPlatformRecognizer(
+        localeId: String?,
+        emitPartialResults: Boolean,
+        accumulateResults: Boolean,
+        allowOnlineFallback: Boolean
+    ) {
+        platformStopRequested = false
+        platformEmitPartialResults = emitPartialResults
+        platformAccumulateResults = accumulateResults
+        platformAllowOnlineFallback = allowOnlineFallback
+        platformLocaleId = localeId
+        platformCommittedText = ""
+        activePlatformRecognizer = AndroidSpeechRecognizer.createSpeechRecognizer(
+            activity.applicationContext
+        ).also { recognizer ->
+            recognizer.setRecognitionListener(platformRecognitionListener)
+            recognizer.startListening(platformRecognizerIntent())
+        }
+        emitStatus("listening", "android_speech")
+    }
+
+    private val platformRecognitionListener = object : RecognitionListener {
+        override fun onReadyForSpeech(params: Bundle?) {
+            emitStatus("listening", "android_speech")
+        }
+
+        override fun onBeginningOfSpeech() {}
+
+        override fun onRmsChanged(rmsdB: Float) {}
+
+        override fun onBufferReceived(buffer: ByteArray?) {}
+
+        override fun onEndOfSpeech() {}
+
+        override fun onPartialResults(partialResults: Bundle?) {
+            if (!platformEmitPartialResults) return
+            val text = firstRecognitionText(partialResults) ?: return
+            val emitted = if (platformAccumulateResults) {
+                mergeText(platformCommittedText, text)
+            } else {
+                text.trim()
+            }
+            emitResult(emitted, false, "android_speech")
+        }
+
+        override fun onResults(results: Bundle?) {
+            val text = firstRecognitionText(results)
+            if (text != null) {
+                val emitted = if (platformAccumulateResults) {
+                    platformCommittedText = mergeText(platformCommittedText, text)
+                    platformCommittedText
+                } else {
+                    text.trim()
+                }
+                emitResult(emitted, true, "android_speech")
+            }
+            restartPlatformRecognizerIfActive()
+        }
+
+        override fun onError(error: Int) {
+            if (platformStopRequested || activePlatformRecognizer == null) {
+                emitDone("android_speech")
+                return
+            }
+            if (isRestartablePlatformError(error)) {
+                restartPlatformRecognizerIfActive(delayMs = 300L)
+                return
+            }
+            emitError(
+                "ANDROID_SPEECH_$error",
+                platformSpeechErrorMessage(error),
+                "android_speech"
+            )
+            emitDone("android_speech")
+        }
+
+        override fun onEvent(eventType: Int, params: Bundle?) {}
+    }
+
+    private fun restartPlatformRecognizerIfActive(delayMs: Long = 200L) {
+        val recognizer = activePlatformRecognizer ?: return
+        if (platformStopRequested) {
+            emitDone("android_speech")
+            return
+        }
+
+        platformRestartJob?.cancel()
+        platformRestartJob = scope.launch {
+            if (delayMs > 0) {
+                kotlinx.coroutines.delay(delayMs)
+            }
+            if (platformStopRequested || activePlatformRecognizer !== recognizer) {
+                return@launch
+            }
+            runCatching { recognizer.startListening(platformRecognizerIntent()) }
+        }
+    }
+
+    private fun platformRecognizerIntent(): Intent {
+        val locale = parseLocale(platformLocaleId)
+        return Intent(RecognizerIntent.ACTION_RECOGNIZE_SPEECH).apply {
+            putExtra(
+                RecognizerIntent.EXTRA_LANGUAGE_MODEL,
+                RecognizerIntent.LANGUAGE_MODEL_FREE_FORM
+            )
+            putExtra(RecognizerIntent.EXTRA_LANGUAGE, locale.toLanguageTag())
+            putExtra(RecognizerIntent.EXTRA_LANGUAGE_PREFERENCE, locale.toLanguageTag())
+            putExtra(RecognizerIntent.EXTRA_ONLY_RETURN_LANGUAGE_PREFERENCE, false)
+            putExtra(RecognizerIntent.EXTRA_PARTIAL_RESULTS, platformEmitPartialResults)
+            putExtra(RecognizerIntent.EXTRA_MAX_RESULTS, 1)
+            putExtra(RecognizerIntent.EXTRA_PREFER_OFFLINE, !platformAllowOnlineFallback)
+        }
+    }
+
+    private fun firstRecognitionText(results: Bundle?): String? {
+        val matches = results?.getStringArrayList(AndroidSpeechRecognizer.RESULTS_RECOGNITION)
+        return matches?.firstOrNull()?.trim()?.takeIf { it.isNotEmpty() }
+    }
+
+    private fun isRestartablePlatformError(error: Int): Boolean {
+        return error == AndroidSpeechRecognizer.ERROR_NO_MATCH ||
+            error == AndroidSpeechRecognizer.ERROR_SPEECH_TIMEOUT ||
+            error == AndroidSpeechRecognizer.ERROR_RECOGNIZER_BUSY
+    }
+
+    private fun platformSpeechErrorMessage(error: Int): String {
+        return when (error) {
+            AndroidSpeechRecognizer.ERROR_AUDIO -> "Audio recording error"
+            AndroidSpeechRecognizer.ERROR_CLIENT -> "Speech recognition client error"
+            AndroidSpeechRecognizer.ERROR_INSUFFICIENT_PERMISSIONS ->
+                "Speech recognition permission was not granted"
+            AndroidSpeechRecognizer.ERROR_NETWORK -> "Speech recognition network error"
+            AndroidSpeechRecognizer.ERROR_NETWORK_TIMEOUT -> "Speech recognition network timeout"
+            AndroidSpeechRecognizer.ERROR_NO_MATCH -> "No speech was recognized"
+            AndroidSpeechRecognizer.ERROR_RECOGNIZER_BUSY -> "Speech recognizer is busy"
+            AndroidSpeechRecognizer.ERROR_SERVER -> "Speech recognition server error"
+            AndroidSpeechRecognizer.ERROR_SPEECH_TIMEOUT -> "No speech input"
+            else -> "Android speech recognition failed"
+        }
+    }
+
+    private suspend fun stopInternal(emitDone: Boolean, awaitCompletion: Boolean) {
+        val platformRecognizer = activePlatformRecognizer
+        activePlatformRecognizer = null
+        platformStopRequested = true
+        platformRestartJob?.cancel()
+        platformRestartJob = null
+        if (platformRecognizer != null) {
+            withContext(Dispatchers.Main.immediate) {
+                runCatching { platformRecognizer.cancel() }
+                runCatching { platformRecognizer.destroy() }
+            }
+        }
+
+        val recognizer = activeMlKitRecognizer
+        val job = recognitionJob
+        activeMlKitRecognizer = null
+        if (recognizer != null) {
+            withContext(Dispatchers.IO) {
+                runCatching { recognizer.stopRecognition() }
+            }
+        }
+        if (awaitCompletion && job != null) {
+            val completed = withTimeoutOrNull(STOP_GRACE_PERIOD_MS) {
+                job.join()
+                true
+            } ?: false
+            if (!completed) {
+                job.cancelAndJoin()
+            }
+        } else {
+            job?.cancelAndJoin()
+        }
+        recognitionJob = null
+        recognizer?.close()
+        if (emitDone) {
+            emitDone(if (platformRecognizer != null) "android_speech" else "mlkit")
+        }
+    }
+
+    private fun localesPayload(deviceLocaleId: String?): Map<String, Any?> {
+        val systemLocale = parseLocale(deviceLocaleId)
+        val locales = Locale.getAvailableLocales()
+            .filter { it.language.isNotBlank() }
+            .distinctBy { localeIdentifier(it) }
+            .sortedBy { localeIdentifier(it) }
+            .map { localePayload(it) }
+        return mapOf(
+            "systemLocale" to localeIdentifier(systemLocale),
+            "locales" to locales
+        )
+    }
+
+    private fun localePayload(locale: Locale): Map<String, Any?> {
+        val identifier = localeIdentifier(locale)
+        val displayName = locale.getDisplayName(locale).takeIf { it.isNotBlank() }
+            ?: locale.getDisplayName().takeIf { it.isNotBlank() }
+            ?: identifier
+        return mapOf(
+            "localeId" to identifier,
+            "name" to displayName
+        )
+    }
+
+    private fun localeIdentifier(locale: Locale): String {
+        val tag = locale.toLanguageTag()
+        return if (tag.isNullOrBlank() || tag == "und") {
+            locale.toString().replace('_', '-')
+        } else {
+            tag
+        }
+    }
+
+    private fun parseLocale(localeId: String?): Locale {
+        val normalized = localeId
+            ?.takeIf { it.isNotBlank() }
+            ?.replace('_', '-')
+        return if (normalized == null) Locale.getDefault() else Locale.forLanguageTag(normalized)
+    }
+
+    private fun isUsableStatus(status: Int): Boolean {
+        return status == FeatureStatus.AVAILABLE ||
+            status == FeatureStatus.DOWNLOADABLE ||
+            status == FeatureStatus.DOWNLOADING
+    }
+
+    private fun mergeText(committed: String, next: String): String {
+        val trimmedNext = next.trim()
+        if (trimmedNext.isEmpty()) return committed
+        if (committed.isBlank()) return trimmedNext
+        if (committed.endsWith(trimmedNext)) return committed
+        return "$committed $trimmedNext".trim()
+    }
+
+    private fun available(engine: String): Map<String, Any?> {
+        return mapOf("available" to true, "engine" to engine)
+    }
+
+    private fun unavailable(reason: String): Map<String, Any?> {
+        return mapOf("available" to false, "reason" to reason)
+    }
+
+    private fun emitStatus(message: String, engine: String) {
+        emit(mapOf("type" to "status", "message" to message, "engine" to engine))
+    }
+
+    private fun emitResult(text: String, isFinal: Boolean, engine: String) {
+        emit(mapOf("type" to "result", "text" to text, "final" to isFinal, "engine" to engine))
+    }
+
+    private fun emitError(code: String, message: String, engine: String) {
+        emit(mapOf("type" to "error", "code" to code, "message" to message, "engine" to engine))
+    }
+
+    private fun emitDone(engine: String) {
+        emit(mapOf("type" to "done", "engine" to engine))
+    }
+
+    private fun emit(event: Map<String, Any?>) {
+        activity.runOnUiThread {
+            eventSink?.success(event)
+        }
+    }
+
+    companion object {
+        private const val TAG = "NativeSttBridge"
+        private const val METHOD_CHANNEL = "app.cogwheel.conduit/native_stt"
+        private const val EVENT_CHANNEL = "app.cogwheel.conduit/native_stt/events"
+        private const val STOP_GRACE_PERIOD_MS = 1500L
+    }
+}

--- a/android/app/src/main/kotlin/app/cogwheel/conduit/NativeSttBridge.kt
+++ b/android/app/src/main/kotlin/app/cogwheel/conduit/NativeSttBridge.kt
@@ -37,6 +37,7 @@ class NativeSttBridge(private val activity: MainActivity) : MethodChannel.Method
     EventChannel.StreamHandler {
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)
     private var eventSink: EventChannel.EventSink? = null
+    @Volatile
     private var activeMlKitRecognizer: MlKitSpeechRecognizer? = null
     private var activePlatformRecognizer: AndroidSpeechRecognizer? = null
     private var recognitionJob: kotlinx.coroutines.Job? = null

--- a/android/app/src/main/kotlin/app/cogwheel/conduit/NativeSttBridge.kt
+++ b/android/app/src/main/kotlin/app/cogwheel/conduit/NativeSttBridge.kt
@@ -45,6 +45,8 @@ class NativeSttBridge(private val activity: MainActivity) : MethodChannel.Method
     private var platformAllowOnlineFallback = true
     private var platformLocaleId: String? = null
     private var platformCommittedText = ""
+    @Volatile
+    private var recognitionGeneration = 0
 
     fun setup(flutterEngine: FlutterEngine) {
         MethodChannel(
@@ -86,6 +88,7 @@ class NativeSttBridge(private val activity: MainActivity) : MethodChannel.Method
             }
             "stop" -> {
                 scope.launch {
+                    recognitionGeneration += 1
                     stopInternal(emitDone = false, awaitCompletion = true)
                     result.success(null)
                 }
@@ -100,9 +103,14 @@ class NativeSttBridge(private val activity: MainActivity) : MethodChannel.Method
 
     override fun onCancel(arguments: Any?) {
         eventSink = null
+        recognitionGeneration += 1
+        scope.launch {
+            stopInternal(emitDone = false, awaitCompletion = false)
+        }
     }
 
     fun dispose() {
+        recognitionGeneration += 1
         scope.launch {
             stopInternal(emitDone = false, awaitCompletion = false)
             scope.cancel()
@@ -163,9 +171,27 @@ class NativeSttBridge(private val activity: MainActivity) : MethodChannel.Method
         allowOnlineFallback: Boolean,
         result: MethodChannel.Result
     ) {
+        val generation = recognitionGeneration + 1
+        recognitionGeneration = generation
         stopInternal(emitDone = false, awaitCompletion = false)
-        val prepared = withContext(Dispatchers.IO) {
-            prepareRecognizer(localeId)
+        val prepared = try {
+            withContext(Dispatchers.IO) {
+                prepareRecognizer(localeId, generation)
+            }
+        } catch (error: CancellationException) {
+            throw error
+        } catch (error: Throwable) {
+            if (!isCurrentGeneration(generation)) {
+                result.success(unavailable("Speech recognition start was cancelled"))
+                return
+            }
+            Log.w(TAG, "ML Kit STT startup failed", error)
+            null
+        }
+        if (!isCurrentGeneration(generation)) {
+            prepared?.first?.close()
+            result.success(unavailable("Speech recognition start was cancelled"))
+            return
         }
         if (prepared == null) {
             if (AndroidSpeechRecognizer.isRecognitionAvailable(activity.applicationContext)) {
@@ -193,6 +219,7 @@ class NativeSttBridge(private val activity: MainActivity) : MethodChannel.Method
                     audioSource = AudioSource.fromMic()
                 }
                 recognizer.startRecognition(request).collect { response ->
+                    if (!isCurrentGeneration(generation)) return@collect
                     when (response) {
                         is SpeechRecognizerResponse.PartialTextResponse -> {
                             if (emitPartialResults) {
@@ -243,19 +270,30 @@ class NativeSttBridge(private val activity: MainActivity) : MethodChannel.Method
         result.success(available(engineName))
     }
 
-    private suspend fun prepareRecognizer(localeId: String?): Pair<MlKitSpeechRecognizer, String>? {
+    private suspend fun prepareRecognizer(
+        localeId: String?,
+        generation: Int
+    ): Pair<MlKitSpeechRecognizer, String>? {
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.S) {
             return null
         }
 
         val advanced = createRecognizer(localeId, SpeechRecognizerOptions.Mode.MODE_ADVANCED)
-        if (ensureReady(advanced, "mlkit_advanced")) {
+        if (!isCurrentGeneration(generation)) {
+            advanced.close()
+            return null
+        }
+        if (ensureReady(advanced, "mlkit_advanced", generation)) {
             return advanced to "mlkit_advanced"
         }
         advanced.close()
 
         val basic = createRecognizer(localeId, SpeechRecognizerOptions.Mode.MODE_BASIC)
-        if (ensureReady(basic, "mlkit_basic")) {
+        if (!isCurrentGeneration(generation)) {
+            basic.close()
+            return null
+        }
+        if (ensureReady(basic, "mlkit_basic", generation)) {
             return basic to "mlkit_basic"
         }
         basic.close()
@@ -271,13 +309,23 @@ class NativeSttBridge(private val activity: MainActivity) : MethodChannel.Method
         return SpeechRecognition.getClient(options)
     }
 
-    private suspend fun ensureReady(recognizer: MlKitSpeechRecognizer, engineName: String): Boolean {
+    private suspend fun ensureReady(
+        recognizer: MlKitSpeechRecognizer,
+        engineName: String,
+        generation: Int
+    ): Boolean {
+        if (!isCurrentGeneration(generation)) {
+            return false
+        }
         return when (val status = recognizer.checkStatus()) {
             FeatureStatus.AVAILABLE -> true
             FeatureStatus.DOWNLOADABLE, FeatureStatus.DOWNLOADING -> {
-                emitStatus("downloading", engineName)
+                if (isCurrentGeneration(generation)) {
+                    emitStatus("downloading", engineName)
+                }
                 var ready = false
                 recognizer.download().collect { downloadStatus ->
+                    if (!isCurrentGeneration(generation)) return@collect
                     when (downloadStatus) {
                         is DownloadStatus.DownloadStarted -> {
                             emitStatus("downloading", engineName)
@@ -312,6 +360,10 @@ class NativeSttBridge(private val activity: MainActivity) : MethodChannel.Method
                 false
             }
         }
+    }
+
+    private fun isCurrentGeneration(generation: Int): Boolean {
+        return recognitionGeneration == generation
     }
 
     private fun startPlatformRecognizer(
@@ -544,7 +596,8 @@ class NativeSttBridge(private val activity: MainActivity) : MethodChannel.Method
         val trimmedNext = next.trim()
         if (trimmedNext.isEmpty()) return committed
         if (committed.isBlank()) return trimmedNext
-        if (committed.endsWith(trimmedNext)) return committed
+        if (committed == trimmedNext || committed.endsWith(trimmedNext)) return committed
+        if (trimmedNext.startsWith(committed)) return trimmedNext
         return "$committed $trimmedNext".trim()
     }
 

--- a/android/app/src/main/kotlin/app/cogwheel/conduit/NativeSttBridge.kt
+++ b/android/app/src/main/kotlin/app/cogwheel/conduit/NativeSttBridge.kt
@@ -27,6 +27,8 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeoutOrNull
@@ -324,34 +326,65 @@ class NativeSttBridge(private val activity: MainActivity) : MethodChannel.Method
                     emitStatus("downloading", engineName)
                 }
                 var ready = false
-                recognizer.download().collect { downloadStatus ->
-                    if (!isCurrentGeneration(generation)) return@collect
-                    when (downloadStatus) {
-                        is DownloadStatus.DownloadStarted -> {
-                            emitStatus("downloading", engineName)
+                try {
+                    coroutineScope {
+                        val downloadJob = launch {
+                            recognizer.download().collect { downloadStatus ->
+                                if (!isCurrentGeneration(generation)) {
+                                    throw CancellationException("Stale recognition generation")
+                                }
+                                when (downloadStatus) {
+                                    is DownloadStatus.DownloadStarted -> {
+                                        emitStatus("downloading", engineName)
+                                    }
+                                    is DownloadStatus.DownloadCompleted -> {
+                                        ready = true
+                                        emitStatus("downloaded", engineName)
+                                    }
+                                    is DownloadStatus.DownloadProgress -> {
+                                        emit(
+                                            mapOf(
+                                                "type" to "status",
+                                                "message" to "downloading",
+                                                "engine" to engineName,
+                                                "bytesDownloaded" to downloadStatus.totalBytesDownloaded
+                                            )
+                                        )
+                                    }
+                                    is DownloadStatus.DownloadFailed -> {
+                                        emitError(
+                                            "MLKIT_DOWNLOAD_${downloadStatus.e.errorCode}",
+                                            downloadStatus.e.message ?: "ML Kit speech model download failed",
+                                            engineName
+                                        )
+                                    }
+                                }
+                            }
                         }
-                        is DownloadStatus.DownloadCompleted -> {
-                            ready = true
-                            emitStatus("downloaded", engineName)
-                        }
-                        is DownloadStatus.DownloadProgress -> {
-                            emit(
-                                mapOf(
-                                    "type" to "status",
-                                    "message" to "downloading",
-                                    "engine" to engineName,
-                                    "bytesDownloaded" to downloadStatus.totalBytesDownloaded
+                        val staleGenerationJob = launch {
+                            while (downloadJob.isActive && isCurrentGeneration(generation)) {
+                                delay(STALE_GENERATION_CHECK_MS)
+                            }
+                            if (downloadJob.isActive) {
+                                downloadJob.cancel(
+                                    CancellationException("Stale recognition generation")
                                 )
-                            )
+                            }
                         }
-                        is DownloadStatus.DownloadFailed -> {
-                            emitError(
-                                "MLKIT_DOWNLOAD_${downloadStatus.e.errorCode}",
-                                downloadStatus.e.message ?: "ML Kit speech model download failed",
-                                engineName
-                            )
+                        try {
+                            downloadJob.join()
+                        } finally {
+                            staleGenerationJob.cancel()
                         }
                     }
+                    if (!isCurrentGeneration(generation)) {
+                        return false
+                    }
+                } catch (error: CancellationException) {
+                    if (!isCurrentGeneration(generation)) {
+                        return false
+                    }
+                    throw error
                 }
                 ready || recognizer.checkStatus() == FeatureStatus.AVAILABLE
             }
@@ -636,5 +669,6 @@ class NativeSttBridge(private val activity: MainActivity) : MethodChannel.Method
         private const val METHOD_CHANNEL = "app.cogwheel.conduit/native_stt"
         private const val EVENT_CHANNEL = "app.cogwheel.conduit/native_stt/events"
         private const val STOP_GRACE_PERIOD_MS = 1500L
+        private const val STALE_GENERATION_CHECK_MS = 50L
     }
 }

--- a/android/app/src/main/kotlin/app/cogwheel/conduit/NativeTtsBridge.kt
+++ b/android/app/src/main/kotlin/app/cogwheel/conduit/NativeTtsBridge.kt
@@ -188,6 +188,11 @@ class NativeTtsBridge(private val activity: MainActivity) : MethodChannel.Method
         override fun onError(utteranceId: String, errorCode: Int) {
             mainHandler.post {
                 if (activeUtterance?.id == utteranceId) {
+                    activeUtterance = null
+                    pausedRequest = null
+                    pausedOffset = 0
+                    lastProgressStart = 0
+                    resumeUtteranceIds.remove(utteranceId)
                     emit(
                         mapOf(
                             "type" to "error",

--- a/android/app/src/main/kotlin/app/cogwheel/conduit/NativeTtsBridge.kt
+++ b/android/app/src/main/kotlin/app/cogwheel/conduit/NativeTtsBridge.kt
@@ -1,0 +1,389 @@
+package app.cogwheel.conduit
+
+import android.os.Build
+import android.os.Bundle
+import android.os.Handler
+import android.os.Looper
+import android.speech.tts.TextToSpeech
+import android.speech.tts.UtteranceProgressListener
+import android.speech.tts.Voice
+import io.flutter.embedding.engine.FlutterEngine
+import io.flutter.plugin.common.EventChannel
+import io.flutter.plugin.common.MethodCall
+import io.flutter.plugin.common.MethodChannel
+import java.util.Locale
+import java.util.UUID
+
+class NativeTtsBridge(private val activity: MainActivity) : MethodChannel.MethodCallHandler,
+    EventChannel.StreamHandler {
+    private enum class InitState {
+        NOT_STARTED,
+        INITIALIZING,
+        READY,
+        FAILED
+    }
+
+    private data class SpeakRequest(
+        val text: String,
+        val voiceIdentifier: String?,
+        val rate: Float,
+        val pitch: Float,
+        val volume: Float
+    )
+
+    private data class ActiveUtterance(
+        val id: String,
+        val request: SpeakRequest,
+        val baseOffset: Int
+    )
+
+    private val mainHandler = Handler(Looper.getMainLooper())
+    private val pendingInitCallbacks = mutableListOf<(Boolean) -> Unit>()
+    private var eventSink: EventChannel.EventSink? = null
+    private var tts: TextToSpeech? = null
+    private var initState = InitState.NOT_STARTED
+    private var activeUtterance: ActiveUtterance? = null
+    private var pausedRequest: SpeakRequest? = null
+    private var pausedOffset = 0
+    private var lastProgressStart = 0
+    private var suppressStopForUtteranceId: String? = null
+    private val resumeUtteranceIds = mutableSetOf<String>()
+
+    fun setup(flutterEngine: FlutterEngine) {
+        MethodChannel(
+            flutterEngine.dartExecutor.binaryMessenger,
+            METHOD_CHANNEL
+        ).setMethodCallHandler(this)
+        EventChannel(
+            flutterEngine.dartExecutor.binaryMessenger,
+            EVENT_CHANNEL
+        ).setStreamHandler(this)
+    }
+
+    override fun onMethodCall(call: MethodCall, result: MethodChannel.Result) {
+        when (call.method) {
+            "isAvailable" -> ensureInitialized { available ->
+                result.success(available)
+            }
+            "getVoices" -> ensureInitialized { available ->
+                if (!available) {
+                    result.success(emptyList<Map<String, Any?>>())
+                    return@ensureInitialized
+                }
+                result.success(voicesPayload())
+            }
+            "speak" -> ensureInitialized { available ->
+                if (!available) {
+                    result.success(false)
+                    return@ensureInitialized
+                }
+                val text = call.argument<String>("text")?.trim()
+                if (text.isNullOrEmpty()) {
+                    result.success(false)
+                    return@ensureInitialized
+                }
+                val request = SpeakRequest(
+                    text = text,
+                    voiceIdentifier = call.argument<String>("voiceIdentifier")
+                        ?.trim()
+                        ?.takeIf { it.isNotEmpty() },
+                    rate = floatArgument(call, "rate", 0.5f, 0.1f, 3.0f),
+                    pitch = floatArgument(call, "pitch", 1.0f, 0.1f, 2.0f),
+                    volume = floatArgument(call, "volume", 1.0f, 0.0f, 1.0f)
+                )
+                result.success(speakRequest(request, baseOffset = 0, isResume = false))
+            }
+            "stop" -> {
+                val stopped = stopInternal(emitCancel = true)
+                result.success(stopped)
+            }
+            "pause" -> {
+                result.success(pauseInternal())
+            }
+            "resume" -> {
+                result.success(resumeInternal())
+            }
+            else -> result.notImplemented()
+        }
+    }
+
+    override fun onListen(arguments: Any?, events: EventChannel.EventSink?) {
+        eventSink = events
+    }
+
+    override fun onCancel(arguments: Any?) {
+        eventSink = null
+    }
+
+    fun dispose() {
+        stopInternal(emitCancel = false)
+        tts?.shutdown()
+        tts = null
+        initState = InitState.NOT_STARTED
+        pendingInitCallbacks.clear()
+    }
+
+    private fun ensureInitialized(callback: (Boolean) -> Unit) {
+        when (initState) {
+            InitState.READY -> {
+                callback(true)
+                return
+            }
+            InitState.INITIALIZING -> {
+                pendingInitCallbacks.add(callback)
+                return
+            }
+            InitState.FAILED -> {
+                tts?.shutdown()
+                tts = null
+                initState = InitState.NOT_STARTED
+            }
+            InitState.NOT_STARTED -> Unit
+        }
+
+        initState = InitState.INITIALIZING
+        pendingInitCallbacks.add(callback)
+        tts = TextToSpeech(activity.applicationContext) { status ->
+            mainHandler.post {
+                val ready = status == TextToSpeech.SUCCESS
+                initState = if (ready) InitState.READY else InitState.FAILED
+                if (ready) {
+                    tts?.setOnUtteranceProgressListener(progressListener)
+                }
+                val callbacks = pendingInitCallbacks.toList()
+                pendingInitCallbacks.clear()
+                callbacks.forEach { it(ready) }
+            }
+        }
+    }
+
+    private val progressListener = object : UtteranceProgressListener() {
+        override fun onStart(utteranceId: String) {
+            mainHandler.post {
+                if (resumeUtteranceIds.remove(utteranceId)) {
+                    emit(mapOf("type" to "continue"))
+                } else {
+                    emit(mapOf("type" to "start"))
+                }
+            }
+        }
+
+        override fun onDone(utteranceId: String) {
+            mainHandler.post {
+                if (activeUtterance?.id == utteranceId) {
+                    activeUtterance = null
+                    pausedRequest = null
+                    pausedOffset = 0
+                    lastProgressStart = 0
+                    emit(mapOf("type" to "complete"))
+                }
+            }
+        }
+
+        @Deprecated("Deprecated in Android framework")
+        override fun onError(utteranceId: String) {
+            onError(utteranceId, TextToSpeech.ERROR)
+        }
+
+        override fun onError(utteranceId: String, errorCode: Int) {
+            mainHandler.post {
+                if (activeUtterance?.id == utteranceId) {
+                    emit(
+                        mapOf(
+                            "type" to "error",
+                            "message" to "Android TTS failed with code $errorCode"
+                        )
+                    )
+                }
+            }
+        }
+
+        override fun onStop(utteranceId: String, interrupted: Boolean) {
+            mainHandler.post {
+                if (suppressStopForUtteranceId == utteranceId) {
+                    suppressStopForUtteranceId = null
+                    return@post
+                }
+                if (activeUtterance?.id == utteranceId) {
+                    activeUtterance = null
+                    emit(mapOf("type" to "cancel"))
+                }
+            }
+        }
+
+        override fun onRangeStart(
+            utteranceId: String,
+            start: Int,
+            end: Int,
+            frame: Int
+        ) {
+            mainHandler.post {
+                val active = activeUtterance ?: return@post
+                if (active.id != utteranceId) return@post
+                val absoluteStart = active.baseOffset + start
+                val absoluteEnd = active.baseOffset + end
+                lastProgressStart = absoluteStart.coerceAtLeast(0)
+                emit(
+                    mapOf(
+                        "type" to "progress",
+                        "start" to absoluteStart,
+                        "end" to absoluteEnd
+                    )
+                )
+            }
+        }
+    }
+
+    private fun speakRequest(request: SpeakRequest, baseOffset: Int, isResume: Boolean): Boolean {
+        val engine = tts ?: return false
+        activeUtterance?.id?.let { suppressStopForUtteranceId = it }
+        engine.stop()
+
+        request.voiceIdentifier?.let { requested ->
+            resolveVoice(engine, requested)?.let { engine.voice = it }
+                ?: parseLocale(requested)?.let { engine.language = it }
+        }
+
+        engine.setSpeechRate(request.rate)
+        engine.setPitch(request.pitch)
+
+        val text = request.text.substring(baseOffset.coerceIn(0, request.text.length))
+        if (text.isBlank()) {
+            emit(mapOf("type" to "complete"))
+            return true
+        }
+
+        val utteranceId = UUID.randomUUID().toString()
+        activeUtterance = ActiveUtterance(utteranceId, request, baseOffset)
+        lastProgressStart = baseOffset
+        if (isResume) {
+            resumeUtteranceIds.add(utteranceId)
+        }
+
+        val params = Bundle().apply {
+            putFloat(TextToSpeech.Engine.KEY_PARAM_VOLUME, request.volume)
+        }
+        val started = engine.speak(text, TextToSpeech.QUEUE_FLUSH, params, utteranceId) ==
+            TextToSpeech.SUCCESS
+        if (!started && activeUtterance?.id == utteranceId) {
+            activeUtterance = null
+            resumeUtteranceIds.remove(utteranceId)
+        }
+        return started
+    }
+
+    private fun stopInternal(emitCancel: Boolean): Boolean {
+        val engine = tts ?: return false
+        activeUtterance = null
+        pausedRequest = null
+        pausedOffset = 0
+        lastProgressStart = 0
+        suppressStopForUtteranceId = null
+        resumeUtteranceIds.clear()
+        val stopped = engine.stop() != TextToSpeech.ERROR
+        if (emitCancel && stopped) {
+            emit(mapOf("type" to "cancel"))
+        }
+        return stopped
+    }
+
+    private fun pauseInternal(): Boolean {
+        val engine = tts ?: return false
+        val active = activeUtterance ?: return false
+        pausedRequest = active.request
+        pausedOffset = lastProgressStart.coerceIn(0, active.request.text.length)
+        suppressStopForUtteranceId = active.id
+        val stopped = engine.stop() != TextToSpeech.ERROR
+        if (stopped) {
+            activeUtterance = null
+            emit(mapOf("type" to "pause"))
+        }
+        return stopped
+    }
+
+    private fun resumeInternal(): Boolean {
+        val request = pausedRequest ?: return false
+        val offset = pausedOffset.coerceIn(0, request.text.length)
+        pausedRequest = null
+        pausedOffset = 0
+        return speakRequest(request, baseOffset = offset, isResume = true)
+    }
+
+    private fun voicesPayload(): List<Map<String, Any?>> {
+        val voices = tts?.voices ?: return emptyList()
+        return voices
+            .sortedWith(compareBy<Voice> { it.locale.toLanguageTag() }.thenBy { it.name })
+            .map { voice ->
+                mapOf(
+                    "id" to voice.name,
+                    "identifier" to voice.name,
+                    "name" to voice.name,
+                    "locale" to voice.locale.toLanguageTag(),
+                    "language" to voice.locale.toLanguageTag(),
+                    "quality" to voice.quality,
+                    "qualityName" to qualityName(voice.quality),
+                    "latency" to voice.latency,
+                    "requiresNetwork" to voice.isNetworkConnectionRequired,
+                    "features" to voice.features?.toList().orEmpty()
+                )
+            }
+    }
+
+    private fun resolveVoice(engine: TextToSpeech, requested: String): Voice? {
+        val normalized = requested.trim()
+        if (normalized.isEmpty()) return null
+        return engine.voices?.firstOrNull { voice ->
+            voice.name.equals(normalized, ignoreCase = true) ||
+                voice.locale.toLanguageTag().equals(normalized, ignoreCase = true) ||
+                voice.locale.toString().equals(normalized, ignoreCase = true)
+        }
+    }
+
+    private fun parseLocale(value: String): Locale? {
+        val trimmed = value.trim()
+        if (trimmed.isEmpty()) return null
+        val locale = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+            Locale.forLanguageTag(trimmed.replace('_', '-'))
+        } else {
+            Locale(trimmed)
+        }
+        return if (locale.language.isNullOrEmpty()) null else locale
+    }
+
+    private fun floatArgument(
+        call: MethodCall,
+        key: String,
+        fallback: Float,
+        min: Float,
+        max: Float
+    ): Float {
+        val value = when (val raw = call.argument<Any>(key)) {
+            is Number -> raw.toFloat()
+            is String -> raw.toFloatOrNull()
+            else -> null
+        } ?: fallback
+        return value.coerceIn(min, max)
+    }
+
+    private fun qualityName(quality: Int): String {
+        return when (quality) {
+            Voice.QUALITY_VERY_LOW -> "Very Low"
+            Voice.QUALITY_LOW -> "Low"
+            Voice.QUALITY_NORMAL -> "Normal"
+            Voice.QUALITY_HIGH -> "High"
+            Voice.QUALITY_VERY_HIGH -> "Very High"
+            else -> "Unknown"
+        }
+    }
+
+    private fun emit(event: Map<String, Any?>) {
+        mainHandler.post {
+            eventSink?.success(event)
+        }
+    }
+
+    companion object {
+        private const val METHOD_CHANNEL = "app.cogwheel.conduit/native_android_tts"
+        private const val EVENT_CHANNEL = "app.cogwheel.conduit/native_android_tts/events"
+    }
+}

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -6,9 +6,6 @@ PODS:
   - connectivity_plus (0.0.1):
     - Flutter
   - CryptoSwift (1.8.4)
-  - CwlCatchException (2.2.1):
-    - CwlCatchExceptionSupport (~> 2.2.1)
-  - CwlCatchExceptionSupport (2.2.1)
   - file_picker (0.0.1):
     - Flutter
     - FlutterMacOS
@@ -34,8 +31,6 @@ PODS:
     - Flutter
     - FlutterMacOS
   - flutter_sharing_intent (1.0.1):
-    - Flutter
-  - flutter_tts (0.0.1):
     - Flutter
   - gaimon (0.0.1):
     - Flutter
@@ -92,10 +87,6 @@ PODS:
   - shared_preferences_foundation (0.0.1):
     - Flutter
     - FlutterMacOS
-  - speech_to_text (7.2.0):
-    - CwlCatchException
-    - Flutter
-    - FlutterMacOS
   - sqflite_darwin (0.0.4):
     - Flutter
     - FlutterMacOS
@@ -122,7 +113,6 @@ DEPENDENCIES:
   - flutter_local_notifications (from `.symlinks/plugins/flutter_local_notifications/ios`)
   - flutter_secure_storage_darwin (from `.symlinks/plugins/flutter_secure_storage_darwin/darwin`)
   - flutter_sharing_intent (from `.symlinks/plugins/flutter_sharing_intent/ios`)
-  - flutter_tts (from `.symlinks/plugins/flutter_tts/ios`)
   - gaimon (from `.symlinks/plugins/gaimon/ios`)
   - geolocator_apple (from `.symlinks/plugins/geolocator_apple/darwin`)
   - home_widget (from `.symlinks/plugins/home_widget/ios`)
@@ -135,7 +125,6 @@ DEPENDENCIES:
   - record_ios (from `.symlinks/plugins/record_ios/ios`)
   - share_plus (from `.symlinks/plugins/share_plus/ios`)
   - shared_preferences_foundation (from `.symlinks/plugins/shared_preferences_foundation/darwin`)
-  - speech_to_text (from `.symlinks/plugins/speech_to_text/darwin`)
   - sqflite_darwin (from `.symlinks/plugins/sqflite_darwin/darwin`)
   - url_launcher_ios (from `.symlinks/plugins/url_launcher_ios/ios`)
   - vad (from `.symlinks/plugins/vad/ios`)
@@ -145,8 +134,6 @@ DEPENDENCIES:
 SPEC REPOS:
   trunk:
     - CryptoSwift
-    - CwlCatchException
-    - CwlCatchExceptionSupport
     - libwebp
     - Mantle
     - onnxruntime-c
@@ -178,8 +165,6 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/flutter_secure_storage_darwin/darwin"
   flutter_sharing_intent:
     :path: ".symlinks/plugins/flutter_sharing_intent/ios"
-  flutter_tts:
-    :path: ".symlinks/plugins/flutter_tts/ios"
   gaimon:
     :path: ".symlinks/plugins/gaimon/ios"
   geolocator_apple:
@@ -204,8 +189,6 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/share_plus/ios"
   shared_preferences_foundation:
     :path: ".symlinks/plugins/shared_preferences_foundation/darwin"
-  speech_to_text:
-    :path: ".symlinks/plugins/speech_to_text/darwin"
   sqflite_darwin:
     :path: ".symlinks/plugins/sqflite_darwin/darwin"
   url_launcher_ios:
@@ -222,8 +205,6 @@ SPEC CHECKSUMS:
   audio_session: 9bb7f6c970f21241b19f5a3658097ae459681ba0
   connectivity_plus: cb623214f4e1f6ef8fe7403d580fdad517d2f7dd
   CryptoSwift: e64e11850ede528a02a0f3e768cec8e9d92ecb90
-  CwlCatchException: 7acc161b299a6de7f0a46a6ed741eae2c8b4d75a
-  CwlCatchExceptionSupport: 54ccab8d8c78907b57f99717fb19d4cc3bce02dc
   file_picker: 70164d9778c42c47218d6cd79ce435de0856b11a
   Flutter: cabc95a1d2626b1b06e7179b784ebcf0c0cde467
   flutter_callkit_incoming: a143995975818a3717524decd3566d5ca7a8c608
@@ -232,7 +213,6 @@ SPEC CHECKSUMS:
   flutter_local_notifications: 643a3eda1ce1c0599413ca31672536d423dee214
   flutter_secure_storage_darwin: acdb3f316ed05a3e68f856e0353b133eec373a23
   flutter_sharing_intent: 0c1e53949f09fa8df8ac2268505687bde8ff264c
-  flutter_tts: 35ac3c7d42412733e795ea96ad2d7e05d0a75113
   gaimon: 1979ed07cdcfd0bf0d208f255f550936a196cf5a
   geolocator_apple: ab36aa0e8b7d7a2d7639b3b4e48308394e8cef5e
   home_widget: 54b4f6b36ed8d64cfee594a476225c35c3e45091
@@ -252,7 +232,6 @@ SPEC CHECKSUMS:
   SDWebImageWebPCoder: 0e06e365080397465cc73a7a9b472d8a3bd0f377
   share_plus: 50da8cb520a8f0f65671c6c6a99b3617ed10a58a
   shared_preferences_foundation: 7036424c3d8ec98dfe75ff1667cb0cd531ec82bb
-  speech_to_text: 3b313d98516d3d0406cea424782ec25470c59d19
   sqflite_darwin: 20b2a3a3b70e43edae938624ce550a3cbf66a3d0
   url_launcher_ios: 7a95fa5b60cc718a708b8f2966718e93db0cef1b
   vad: 7934867589afe53567f492df66fb1615f2185822

--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -19,6 +19,7 @@
 		D2A0B1D42F5E4D6C7B8A9012 /* NativeKeyboardAttachmentBridge.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2A0B1D32F5E4D6C7B8A9012 /* NativeKeyboardAttachmentBridge.swift */; };
 		D2A0B1E42F5E4D6C7B8A9012 /* NativeSheetBridge.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2A0B1E32F5E4D6C7B8A9012 /* NativeSheetBridge.swift */; };
 		D2A0B1F42F5E4D6C7B8A9012 /* NativeDropdownBridge.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2A0B1F32F5E4D6C7B8A9012 /* NativeDropdownBridge.swift */; };
+		D2A0B2042F5E4D6C7B8A9012 /* NativeSttBridge.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2A0B2032F5E4D6C7B8A9012 /* NativeSttBridge.swift */; };
 		D2A0B2062F5E4D6C7B8A9012 /* ConduitSceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2A0B2052F5E4D6C7B8A9012 /* ConduitSceneDelegate.swift */; };
 		D2A0B2142F5E4D6C7B8A9012 /* ConduitPlatformApis.g.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2A0B2132F5E4D6C7B8A9012 /* ConduitPlatformApis.g.swift */; };
 		D2A0B2242F5E4D6C7B8A9012 /* ConduitCarPlayBridge.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2A0B2222F5E4D6C7B8A9012 /* ConduitCarPlayBridge.swift */; };
@@ -107,6 +108,7 @@
 		D2A0B1D32F5E4D6C7B8A9012 /* NativeKeyboardAttachmentBridge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NativeKeyboardAttachmentBridge.swift; sourceTree = "<group>"; };
 		D2A0B1E32F5E4D6C7B8A9012 /* NativeSheetBridge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NativeSheetBridge.swift; sourceTree = "<group>"; };
 		D2A0B1F32F5E4D6C7B8A9012 /* NativeDropdownBridge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NativeDropdownBridge.swift; sourceTree = "<group>"; };
+		D2A0B2032F5E4D6C7B8A9012 /* NativeSttBridge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NativeSttBridge.swift; sourceTree = "<group>"; };
 		D2A0B2052F5E4D6C7B8A9012 /* ConduitSceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConduitSceneDelegate.swift; sourceTree = "<group>"; };
 		D2A0B2132F5E4D6C7B8A9012 /* ConduitPlatformApis.g.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConduitPlatformApis.g.swift; sourceTree = "<group>"; };
 		D2A0B2212F5E4D6C7B8A9012 /* CarPlay.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CarPlay.framework; path = System/Library/Frameworks/CarPlay.framework; sourceTree = SDKROOT; };
@@ -325,6 +327,7 @@
 				D2A0B1D32F5E4D6C7B8A9012 /* NativeKeyboardAttachmentBridge.swift */,
 				D2A0B1E32F5E4D6C7B8A9012 /* NativeSheetBridge.swift */,
 				D2A0B1F32F5E4D6C7B8A9012 /* NativeDropdownBridge.swift */,
+				D2A0B2032F5E4D6C7B8A9012 /* NativeSttBridge.swift */,
 				D2A0B2052F5E4D6C7B8A9012 /* ConduitSceneDelegate.swift */,
 				D2A0B2222F5E4D6C7B8A9012 /* ConduitCarPlayBridge.swift */,
 				D2A0B2232F5E4D6C7B8A9012 /* ConduitCarPlaySceneDelegate.swift */,
@@ -642,6 +645,7 @@
 				D2A0B2242F5E4D6C7B8A9012 /* ConduitCarPlayBridge.swift in Sources */,
 				D2A0B2252F5E4D6C7B8A9012 /* ConduitCarPlaySceneDelegate.swift in Sources */,
 				D2A0B1E42F5E4D6C7B8A9012 /* NativeSheetBridge.swift in Sources */,
+				D2A0B2042F5E4D6C7B8A9012 /* NativeSttBridge.swift in Sources */,
 				D2A0B1D42F5E4D6C7B8A9012 /* NativeKeyboardAttachmentBridge.swift in Sources */,
 				D2A0B1C42F5E4D6C7B8A9012 /* NativePasteBridge.swift in Sources */,
 				74858FAF1ED2DC5600515810 /* AppDelegate.swift in Sources */,

--- a/ios/Runner/AppDelegate.swift
+++ b/ios/Runner/AppDelegate.swift
@@ -134,6 +134,8 @@ final class VoiceAudioRouteBridge {
 
     private init() {}
 
+    deinit {}
+
     func configure(messenger: FlutterBinaryMessenger) {
         let channel = FlutterMethodChannel(
             name: conduitVoiceAudioRouteChannelName,
@@ -231,7 +233,6 @@ final class VoiceAudioRouteBridge {
 
     private func portPayload(_ port: AVAudioSessionPortDescription) -> [String: Any] {
         [
-            "name": port.portName,
             "type": port.portType.rawValue,
             "uid": port.uid,
         ]
@@ -249,6 +250,8 @@ final class NativeIosTtsBridge: NSObject, FlutterStreamHandler, AVSpeechSynthesi
         super.init()
         synthesizer.delegate = self
     }
+
+    deinit {}
 
     func configure(messenger: FlutterBinaryMessenger) {
         let methodChannel = FlutterMethodChannel(

--- a/ios/Runner/AppDelegate.swift
+++ b/ios/Runner/AppDelegate.swift
@@ -14,13 +14,16 @@ private let conduitShareUserDefaultsKey = "SharingKey"
 private let conduitShareMessageKey = "SharingMessageKey"
 private let conduitShareImportStatusKey = "ShareImportStatusKey"
 private let conduitShareAppGroupIdKey = "AppGroupId"
+private let conduitVoiceAudioRouteChannelName = "app.cogwheel.conduit/voice_audio_route"
+private let nativeIosTtsMethodChannelName = "app.cogwheel.conduit/native_ios_tts"
+private let nativeIosTtsEventChannelName = "app.cogwheel.conduit/native_ios_tts/events"
 
 /// Manages AVAudioSession for voice calls in the background.
 ///
 /// IMPORTANT: This manager is ONLY used for server-side STT (speech-to-text).
-/// When using local STT via speech_to_text plugin, that plugin manages its own
-/// audio session. Do NOT activate this manager when local STT is in use to
-/// avoid audio session conflicts.
+/// When using local STT, the native recognizer path manages its own audio
+/// session. Do NOT activate this manager when local STT is in use to avoid
+/// audio session conflicts.
 ///
 /// The voice_call_service.dart checks `useServerMic` before calling
 /// startBackgroundExecution with requiresMicrophone:true.
@@ -30,13 +33,13 @@ final class VoiceBackgroundAudioManager {
     private var isActive = false
     private let lock = NSLock()
     
-    /// Flag indicating another component (e.g., speech_to_text plugin) owns the audio session.
+    /// Flag indicating another component owns the audio session.
     /// When true, this manager will skip activation to avoid conflicts.
     private var externalSessionOwner = false
 
     private init() {}
     
-    /// Mark that an external component (e.g., speech_to_text) is managing the audio session.
+    /// Mark that an external component is managing the audio session.
     /// Call this before starting local STT to prevent conflicts.
     func setExternalSessionOwner(_ isExternal: Bool) {
         lock.lock()
@@ -70,7 +73,7 @@ final class VoiceBackgroundAudioManager {
         let session = AVAudioSession.sharedInstance()
         do {
             // Check current category to avoid unnecessary reconfiguration
-            // This helps prevent conflicts if speech_to_text already configured the session
+            // This helps prevent conflicts if local STT already configured the session.
             let currentCategory = session.category
             let needsReconfiguration = currentCategory != .playAndRecord
             
@@ -121,6 +124,393 @@ final class VoiceBackgroundAudioManager {
         lock.lock()
         defer { lock.unlock() }
         return isActive
+    }
+}
+
+final class VoiceAudioRouteBridge {
+    static let shared = VoiceAudioRouteBridge()
+
+    private var methodChannel: FlutterMethodChannel?
+
+    private init() {}
+
+    func configure(messenger: FlutterBinaryMessenger) {
+        let channel = FlutterMethodChannel(
+            name: conduitVoiceAudioRouteChannelName,
+            binaryMessenger: messenger
+        )
+        methodChannel = channel
+        channel.setMethodCallHandler { [weak self] call, result in
+            guard let self else {
+                result(nil)
+                return
+            }
+
+            switch call.method {
+            case "preferBluetoothHfpInput":
+                result(self.preferBluetoothHfpInput())
+            case "clearPreferredInput":
+                result(self.clearPreferredInput())
+            case "currentRoute":
+                result(self.currentRoutePayload(operation: "currentRoute"))
+            default:
+                result(FlutterMethodNotImplemented)
+            }
+        }
+    }
+
+    private func preferBluetoothHfpInput() -> [String: Any] {
+        let session = AVAudioSession.sharedInstance()
+        let availableInputs = session.availableInputs ?? []
+        guard let bluetoothInput = availableInputs.first(where: { $0.portType == .bluetoothHFP }) else {
+            var payload = currentRoutePayload(operation: "preferBluetoothHfpInput")
+            payload["selected"] = false
+            payload["reason"] = "bluetooth-hfp-input-unavailable"
+            payload["availableInputs"] = availableInputs.map { portPayload($0) }
+            return payload
+        }
+
+        do {
+            try session.setPreferredInput(bluetoothInput)
+            var payload = currentRoutePayload(
+                operation: "preferBluetoothHfpInput",
+                preferredInput: bluetoothInput
+            )
+            payload["selected"] = true
+            payload["availableInputs"] = availableInputs.map { portPayload($0) }
+            return payload
+        } catch {
+            var payload = currentRoutePayload(
+                operation: "preferBluetoothHfpInput",
+                preferredInput: bluetoothInput
+            )
+            payload["selected"] = false
+            payload["error"] = error.localizedDescription
+            payload["availableInputs"] = availableInputs.map { portPayload($0) }
+            return payload
+        }
+    }
+
+    private func clearPreferredInput() -> [String: Any] {
+        let session = AVAudioSession.sharedInstance()
+        do {
+            try session.setPreferredInput(nil)
+            var payload = currentRoutePayload(operation: "clearPreferredInput")
+            payload["cleared"] = true
+            return payload
+        } catch {
+            var payload = currentRoutePayload(operation: "clearPreferredInput")
+            payload["cleared"] = false
+            payload["error"] = error.localizedDescription
+            return payload
+        }
+    }
+
+    private func currentRoutePayload(
+        operation: String,
+        preferredInput: AVAudioSessionPortDescription? = nil
+    ) -> [String: Any] {
+        let session = AVAudioSession.sharedInstance()
+        var payload: [String: Any] = [
+            "operation": operation,
+            "category": session.category.rawValue,
+            "mode": session.mode.rawValue,
+            "sampleRate": session.sampleRate,
+            "currentInputs": session.currentRoute.inputs.map { portPayload($0) },
+            "currentOutputs": session.currentRoute.outputs.map { portPayload($0) },
+        ]
+
+        if let preferredInput {
+            payload["preferredInput"] = portPayload(preferredInput)
+        } else if let preferredInput = session.preferredInput {
+            payload["preferredInput"] = portPayload(preferredInput)
+        }
+
+        return payload
+    }
+
+    private func portPayload(_ port: AVAudioSessionPortDescription) -> [String: Any] {
+        [
+            "name": port.portName,
+            "type": port.portType.rawValue,
+            "uid": port.uid,
+        ]
+    }
+}
+
+final class NativeIosTtsBridge: NSObject, FlutterStreamHandler, AVSpeechSynthesizerDelegate {
+    static let shared = NativeIosTtsBridge()
+
+    private let synthesizer = AVSpeechSynthesizer()
+    private var methodChannel: FlutterMethodChannel?
+    private var eventSink: FlutterEventSink?
+
+    private override init() {
+        super.init()
+        synthesizer.delegate = self
+    }
+
+    func configure(messenger: FlutterBinaryMessenger) {
+        let methodChannel = FlutterMethodChannel(
+            name: nativeIosTtsMethodChannelName,
+            binaryMessenger: messenger
+        )
+        self.methodChannel = methodChannel
+        methodChannel.setMethodCallHandler { [weak self] call, result in
+            self?.handle(call: call, result: result)
+        }
+
+        FlutterEventChannel(
+            name: nativeIosTtsEventChannelName,
+            binaryMessenger: messenger
+        ).setStreamHandler(self)
+    }
+
+    func onListen(withArguments arguments: Any?, eventSink events: @escaping FlutterEventSink) -> FlutterError? {
+        eventSink = events
+        return nil
+    }
+
+    func onCancel(withArguments arguments: Any?) -> FlutterError? {
+        eventSink = nil
+        return nil
+    }
+
+    private func handle(call: FlutterMethodCall, result: @escaping FlutterResult) {
+        switch call.method {
+        case "isAvailable":
+            result(true)
+        case "getVoices":
+            loadVoicesForPicker(result: result)
+        case "speak":
+            guard let arguments = call.arguments as? [String: Any],
+                  let text = arguments["text"] as? String,
+                  !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+            else {
+                result(false)
+                return
+            }
+
+            if synthesizer.isSpeaking || synthesizer.isPaused {
+                synthesizer.stopSpeaking(at: .immediate)
+            }
+
+            let utterance = AVSpeechUtterance(string: text)
+            if let identifier = arguments["voiceIdentifier"] as? String,
+               !identifier.isEmpty,
+               let voice = resolveVoice(identifier) {
+                utterance.voice = voice
+            }
+            utterance.rate = Self.speechRate(from: arguments["rate"])
+            utterance.pitchMultiplier = Self.floatValue(
+                arguments["pitch"],
+                fallback: 1.0,
+                min: 0.5,
+                max: 2.0
+            )
+            utterance.volume = Self.floatValue(
+                arguments["volume"],
+                fallback: 1.0,
+                min: 0.0,
+                max: 1.0
+            )
+            synthesizer.speak(utterance)
+            result(true)
+        case "stop":
+            result(synthesizer.stopSpeaking(at: .immediate))
+        case "pause":
+            result(synthesizer.pauseSpeaking(at: .word))
+        case "resume":
+            result(synthesizer.continueSpeaking())
+        default:
+            result(FlutterMethodNotImplemented)
+        }
+    }
+
+    private func loadVoicesForPicker(result: @escaping FlutterResult) {
+        if #available(iOS 17.0, *),
+           AVSpeechSynthesizer.personalVoiceAuthorizationStatus == .notDetermined {
+            AVSpeechSynthesizer.requestPersonalVoiceAuthorization { [weak self] _ in
+                DispatchQueue.main.async {
+                    result(self?.availableVoicePayloads() ?? [])
+                }
+            }
+            return
+        }
+
+        result(availableVoicePayloads())
+    }
+
+    private func availableVoicePayloads() -> [[String: Any]] {
+        AVSpeechSynthesisVoice.speechVoices()
+            .sorted { left, right in
+                let leftLanguage = left.language.localizedCaseInsensitiveCompare(right.language)
+                if leftLanguage != .orderedSame {
+                    return leftLanguage == .orderedAscending
+                }
+
+                let leftName = left.name.localizedCaseInsensitiveCompare(right.name)
+                if leftName != .orderedSame {
+                    return leftName == .orderedAscending
+                }
+
+                return left.identifier.localizedCaseInsensitiveCompare(right.identifier) == .orderedAscending
+            }
+            .map(voicePayload)
+    }
+
+    private func voicePayload(_ voice: AVSpeechSynthesisVoice) -> [String: Any] {
+        var payload: [String: Any] = [
+            "id": voice.identifier,
+            "identifier": voice.identifier,
+            "name": voice.name,
+            "displayName": displayName(for: voice),
+            "locale": voice.language,
+            "language": voice.language,
+            "languageName": Locale.current.localizedString(forIdentifier: voice.language) ?? voice.language,
+            "quality": voice.quality.rawValue,
+            "qualityName": qualityName(voice.quality),
+            "gender": voice.gender.rawValue,
+        ]
+
+        if #available(iOS 17.0, *) {
+            let traits = voice.voiceTraits
+            let isPersonalVoice = traits.contains(.isPersonalVoice)
+            let isNoveltyVoice = traits.contains(.isNoveltyVoice)
+            payload["isPersonalVoice"] = isPersonalVoice
+            payload["isNoveltyVoice"] = isNoveltyVoice
+            payload["traits"] = voiceTraitNames(
+                isPersonalVoice: isPersonalVoice,
+                isNoveltyVoice: isNoveltyVoice
+            )
+        }
+
+        return payload
+    }
+
+    private func displayName(for voice: AVSpeechSynthesisVoice) -> String {
+        if #available(iOS 17.0, *) {
+            if voice.voiceTraits.contains(.isPersonalVoice) {
+                return "\(voice.name) (Personal Voice)"
+            }
+            if voice.voiceTraits.contains(.isNoveltyVoice) {
+                return "\(voice.name) (Novelty)"
+            }
+        }
+
+        return voice.name
+    }
+
+    private func voiceTraitNames(isPersonalVoice: Bool, isNoveltyVoice: Bool) -> [String] {
+        var names: [String] = []
+        if isPersonalVoice {
+            names.append("personal")
+        }
+        if isNoveltyVoice {
+            names.append("novelty")
+        }
+        return names
+    }
+
+    private func resolveVoice(_ requested: String) -> AVSpeechSynthesisVoice? {
+        let trimmed = requested.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return nil }
+
+        if let voice = AVSpeechSynthesisVoice(identifier: trimmed) {
+            return voice
+        }
+
+        let normalized = trimmed.lowercased()
+        if let exact = AVSpeechSynthesisVoice.speechVoices().first(where: { voice in
+            voice.identifier.lowercased() == normalized ||
+                voice.name.lowercased() == normalized ||
+                voice.language.lowercased() == normalized
+        }) {
+            return exact
+        }
+
+        return AVSpeechSynthesisVoice(language: trimmed)
+    }
+
+    private func qualityName(_ quality: AVSpeechSynthesisVoiceQuality) -> String {
+        switch quality {
+        case .default:
+            return "Default"
+        case .enhanced:
+            return "Enhanced"
+        @unknown default:
+            if quality.rawValue == 3 {
+                return "Premium"
+            }
+            return "Unknown"
+        }
+    }
+
+    private static func speechRate(from raw: Any?) -> Float {
+        let requested = floatValue(
+            raw,
+            fallback: AVSpeechUtteranceDefaultSpeechRate,
+            min: AVSpeechUtteranceMinimumSpeechRate,
+            max: AVSpeechUtteranceMaximumSpeechRate
+        )
+        return requested
+    }
+
+    private static func floatValue(
+        _ raw: Any?,
+        fallback: Float,
+        min: Float,
+        max: Float
+    ) -> Float {
+        let value: Float
+        if let number = raw as? NSNumber {
+            value = number.floatValue
+        } else if let double = raw as? Double {
+            value = Float(double)
+        } else if let string = raw as? String, let parsed = Float(string) {
+            value = parsed
+        } else {
+            value = fallback
+        }
+        return Swift.min(Swift.max(value, min), max)
+    }
+
+    private func emit(_ event: [String: Any]) {
+        DispatchQueue.main.async { [weak self] in
+            self?.eventSink?(event)
+        }
+    }
+
+    func speechSynthesizer(_ synthesizer: AVSpeechSynthesizer, didStart utterance: AVSpeechUtterance) {
+        emit(["type": "start"])
+    }
+
+    func speechSynthesizer(_ synthesizer: AVSpeechSynthesizer, didFinish utterance: AVSpeechUtterance) {
+        emit(["type": "complete"])
+    }
+
+    func speechSynthesizer(_ synthesizer: AVSpeechSynthesizer, didCancel utterance: AVSpeechUtterance) {
+        emit(["type": "cancel"])
+    }
+
+    func speechSynthesizer(_ synthesizer: AVSpeechSynthesizer, didPause utterance: AVSpeechUtterance) {
+        emit(["type": "pause"])
+    }
+
+    func speechSynthesizer(_ synthesizer: AVSpeechSynthesizer, didContinue utterance: AVSpeechUtterance) {
+        emit(["type": "continue"])
+    }
+
+    func speechSynthesizer(
+        _ synthesizer: AVSpeechSynthesizer,
+        willSpeakRangeOfSpeechString characterRange: NSRange,
+        utterance: AVSpeechUtterance
+    ) {
+        emit([
+            "type": "progress",
+            "start": characterRange.location,
+            "end": characterRange.location + characterRange.length,
+        ])
     }
 }
 
@@ -1097,6 +1487,9 @@ struct AppShortcuts: AppShortcutsProvider {
     NativeKeyboardAttachmentBridge.shared.configure(messenger: messenger)
     NativeSheetBridge.shared.configure(messenger: messenger)
     NativeDropdownBridge.shared.configure(messenger: messenger)
+    NativeSttBridge.shared.configure(messenger: messenger)
+    VoiceAudioRouteBridge.shared.configure(messenger: messenger)
+    NativeIosTtsBridge.shared.configure(messenger: messenger)
     backgroundStreamingHandler?.setup(messenger: messenger)
 
     let shareImportChannel = FlutterMethodChannel(

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -99,6 +99,8 @@
 		<string>Conduit needs access to your photo library so you can select existing images or videos to share in chats. For example, you can pick a screenshot to include in a conversation.</string>
 		<key>NSSpeechRecognitionUsageDescription</key>
 		<string>Conduit uses on-device speech recognition so you can dictate messages hands‑free. Your speech is converted to text on your device when available.</string>
+		<key>NSPersonalVoiceUsageDescription</key>
+		<string>Conduit can use your Personal Voice for on-device text-to-speech when you choose it in audio settings.</string>
 		<key>UIApplicationSupportsIndirectInputEvents</key>
 		<true/>
 		<key>UIBackgroundModes</key>

--- a/ios/Runner/NativeSttBridge.swift
+++ b/ios/Runner/NativeSttBridge.swift
@@ -175,9 +175,14 @@ final class NativeSttBridge: NSObject, FlutterStreamHandler {
         }
         return NativeSttAvailability.available("speechAnalyzer")
       } catch is CancellationError {
-        await stopCurrentSession(invalidateStart: false)
+        if isCurrentGeneration(generation) {
+          await stopCurrentSession(invalidateStart: false)
+        }
         return NativeSttAvailability.unavailable("Speech recognition start was cancelled")
       } catch {
+        guard isCurrentGeneration(generation) else {
+          return NativeSttAvailability.unavailable("Speech recognition start was cancelled")
+        }
         await stopCurrentSession(invalidateStart: false)
         speechAnalyzerFailure = error
       }
@@ -208,6 +213,9 @@ final class NativeSttBridge: NSObject, FlutterStreamHandler {
     } catch is CancellationError {
       return NativeSttAvailability.unavailable("Speech recognition start was cancelled")
     } catch {
+      guard isCurrentGeneration(generation) else {
+        return NativeSttAvailability.unavailable("Speech recognition start was cancelled")
+      }
       await stopCurrentSession(invalidateStart: false)
       let analyzerMessage = speechAnalyzerFailure.map { "; SpeechAnalyzer: \($0.localizedDescription)" } ?? ""
       return NativeSttAvailability.unavailable("\(error.localizedDescription)\(analyzerMessage)")
@@ -845,14 +853,23 @@ private final class SFSpeechNativeSttSession: NativeSttSession {
     let inputFormat = inputNode.outputFormat(forBus: 0)
     try Self.validateInputFormat(inputFormat)
     inputNode.installTap(onBus: 0, bufferSize: 1024, format: inputFormat) { [weak self] buffer, _ in
-      guard let self, !self.stopped, self.isCurrent() else { return }
+      guard
+        let self,
+        !self.stopped,
+        self.isCurrent(),
+        self.recognitionRequest === request
+      else { return }
       request.append(buffer)
     }
     tapInstalled = true
 
     recognitionTask = recognizer.recognitionTask(with: request) { [weak self] result, error in
       guard let self else { return }
-      guard !self.stopped, self.isCurrent() else { return }
+      guard
+        !self.stopped,
+        self.isCurrent(),
+        self.recognitionRequest === request
+      else { return }
       if let result {
         self.handleRecognitionResult(result)
       }

--- a/ios/Runner/NativeSttBridge.swift
+++ b/ios/Runner/NativeSttBridge.swift
@@ -25,7 +25,8 @@ private enum NativeSttText {
     let trimmed = next.trimmingCharacters(in: .whitespacesAndNewlines)
     guard !trimmed.isEmpty else { return committed }
     guard !committed.isEmpty else { return trimmed }
-    if committed.hasSuffix(trimmed) { return committed }
+    if committed == trimmed || committed.hasSuffix(trimmed) { return committed }
+    if trimmed.hasPrefix(committed) { return trimmed }
     return "\(committed) \(trimmed)".trimmingCharacters(in: .whitespacesAndNewlines)
   }
 }
@@ -36,9 +37,17 @@ final class NativeSttBridge: NSObject, FlutterStreamHandler {
   private var methodChannel: FlutterMethodChannel?
   private var eventSink: FlutterEventSink?
   private var session: NativeSttSession?
+  private var lifecycleGeneration = 0
 
   private override init() {
     super.init()
+  }
+
+  deinit {
+    let session = session
+    Task {
+      await session?.stop()
+    }
   }
 
   func configure(messenger: FlutterBinaryMessenger) {
@@ -64,6 +73,9 @@ final class NativeSttBridge: NSObject, FlutterStreamHandler {
 
   func onCancel(withArguments arguments: Any?) -> FlutterError? {
     eventSink = nil
+    Task {
+      await stopCurrentSession()
+    }
     return nil
   }
 
@@ -74,11 +86,15 @@ final class NativeSttBridge: NSObject, FlutterStreamHandler {
     let preserveAudioSession = arguments?["preserveAudioSession"] as? Bool ?? false
     let emitPartialResults = arguments?["emitPartialResults"] as? Bool ?? true
     let accumulateResults = arguments?["accumulateResults"] as? Bool ?? true
+    let allowOnlineFallback = arguments?["allowOnlineFallback"] as? Bool ?? true
 
     switch call.method {
     case "checkAvailability":
       Task {
-        let availability = await checkAvailability(localeId: localeId)
+        let availability = await checkAvailability(
+          localeId: localeId,
+          allowOnlineFallback: allowOnlineFallback
+        )
         await MainActor.run { result(availability) }
       }
     case "getLocales":
@@ -89,7 +105,8 @@ final class NativeSttBridge: NSObject, FlutterStreamHandler {
           localeId: localeId,
           preserveAudioSession: preserveAudioSession,
           emitPartialResults: emitPartialResults,
-          accumulateResults: accumulateResults
+          accumulateResults: accumulateResults,
+          allowOnlineFallback: allowOnlineFallback
         )
         await MainActor.run { result(availability) }
       }
@@ -103,15 +120,23 @@ final class NativeSttBridge: NSObject, FlutterStreamHandler {
     }
   }
 
-  private func checkAvailability(localeId: String?) async -> [String: Any] {
+  private func checkAvailability(
+    localeId: String?,
+    allowOnlineFallback: Bool
+  ) async -> [String: Any] {
     if #available(iOS 26.0, *) {
       if await SpeechAnalyzerSttSession.isAvailable(localeId: localeId) {
         return NativeSttAvailability.available("speechAnalyzer")
       }
     }
 
-    if sfSpeechRecognizer(localeId: localeId)?.supportsOnDeviceRecognition == true {
-      return NativeSttAvailability.available("sfSpeech")
+    if let recognizer = sfSpeechRecognizer(localeId: localeId) {
+      if allowOnlineFallback, recognizer.isAvailable {
+        return NativeSttAvailability.available("sfSpeech")
+      }
+      if recognizer.supportsOnDeviceRecognition {
+        return NativeSttAvailability.available("sfSpeech")
+      }
     }
 
     return NativeSttAvailability.unavailable(
@@ -123,9 +148,12 @@ final class NativeSttBridge: NSObject, FlutterStreamHandler {
     localeId: String?,
     preserveAudioSession: Bool,
     emitPartialResults: Bool,
-    accumulateResults: Bool
+    accumulateResults: Bool,
+    allowOnlineFallback: Bool
   ) async -> [String: Any] {
-    await stopCurrentSession()
+    let generation = nextLifecycleGeneration()
+    await stopCurrentSession(invalidateStart: false)
+    var speechAnalyzerFailure: Error?
 
     if #available(iOS 26.0, *) {
       do {
@@ -134,18 +162,24 @@ final class NativeSttBridge: NSObject, FlutterStreamHandler {
           preserveAudioSession: preserveAudioSession,
           emitPartialResults: emitPartialResults,
           accumulateResults: accumulateResults,
-          emit: emit
+          emit: emit,
+          isCurrent: { [weak self] in
+            self?.isCurrentGeneration(generation) == true
+          }
         )
         session = speechAnalyzerSession
         try await speechAnalyzerSession.start()
+        guard isCurrentGeneration(generation) else {
+          await clearSessionIfCurrent(speechAnalyzerSession)
+          return NativeSttAvailability.unavailable("Speech recognition start was cancelled")
+        }
         return NativeSttAvailability.available("speechAnalyzer")
+      } catch is CancellationError {
+        await stopCurrentSession(invalidateStart: false)
+        return NativeSttAvailability.unavailable("Speech recognition start was cancelled")
       } catch {
-        await stopCurrentSession()
-        emitError(
-          code: "SPEECH_ANALYZER_START_FAILED",
-          message: error.localizedDescription,
-          engine: "speechAnalyzer"
-        )
+        await stopCurrentSession(invalidateStart: false)
+        speechAnalyzerFailure = error
       }
     }
 
@@ -155,24 +189,56 @@ final class NativeSttBridge: NSObject, FlutterStreamHandler {
         preserveAudioSession: preserveAudioSession,
         emitPartialResults: emitPartialResults,
         accumulateResults: accumulateResults,
+        allowOnlineFallback: allowOnlineFallback,
         emit: emit,
+        isCurrent: { [weak self] in
+          self?.isCurrentGeneration(generation) == true
+        },
         onFinished: { [weak self] in
           Task { await self?.stopCurrentSession() }
         }
       )
       session = fallbackSession
       try await fallbackSession.start()
+      guard isCurrentGeneration(generation) else {
+        await clearSessionIfCurrent(fallbackSession)
+        return NativeSttAvailability.unavailable("Speech recognition start was cancelled")
+      }
       return NativeSttAvailability.available("sfSpeech")
+    } catch is CancellationError {
+      return NativeSttAvailability.unavailable("Speech recognition start was cancelled")
     } catch {
-      await stopCurrentSession()
-      return NativeSttAvailability.unavailable(error.localizedDescription)
+      await stopCurrentSession(invalidateStart: false)
+      let analyzerMessage = speechAnalyzerFailure.map { "; SpeechAnalyzer: \($0.localizedDescription)" } ?? ""
+      return NativeSttAvailability.unavailable("\(error.localizedDescription)\(analyzerMessage)")
     }
   }
 
-  private func stopCurrentSession() async {
+  private func stopCurrentSession(invalidateStart: Bool = true) async {
+    if invalidateStart {
+      lifecycleGeneration += 1
+    }
     let current = session
     session = nil
     await current?.stop()
+  }
+
+  private func clearSessionIfCurrent(_ current: NativeSttSession) async {
+    guard let active = session, active === current else {
+      await current.stop()
+      return
+    }
+    session = nil
+    await current.stop()
+  }
+
+  private func nextLifecycleGeneration() -> Int {
+    lifecycleGeneration += 1
+    return lifecycleGeneration
+  }
+
+  private func isCurrentGeneration(_ generation: Int) -> Bool {
+    lifecycleGeneration == generation
   }
 
   private func sfSpeechRecognizer(localeId: String?) -> SFSpeechRecognizer? {
@@ -242,6 +308,7 @@ private final class SpeechAnalyzerSttSession: NativeSttSession {
   private let emitPartialResults: Bool
   private let accumulateResults: Bool
   private let emit: ([String: Any]) -> Void
+  private let isCurrent: () -> Bool
   private let audioEngine = AVAudioEngine()
   private var analyzer: SpeechAnalyzer?
   private var inputContinuation: AsyncStream<AnalyzerInput>.Continuation?
@@ -255,13 +322,19 @@ private final class SpeechAnalyzerSttSession: NativeSttSession {
     preserveAudioSession: Bool,
     emitPartialResults: Bool,
     accumulateResults: Bool,
-    emit: @escaping ([String: Any]) -> Void
+    emit: @escaping ([String: Any]) -> Void,
+    isCurrent: @escaping () -> Bool
   ) async throws {
     self.localeId = localeId
     self.preserveAudioSession = preserveAudioSession
     self.emitPartialResults = emitPartialResults
     self.accumulateResults = accumulateResults
     self.emit = emit
+    self.isCurrent = isCurrent
+  }
+
+  deinit {
+    cleanupForDeinit()
   }
 
   static func isAvailable(localeId: String?) async -> Bool {
@@ -274,6 +347,7 @@ private final class SpeechAnalyzerSttSession: NativeSttSession {
 
   func start() async throws {
     let requestedLocale = try await Self.requiredSupportedLocale(localeId: localeId)
+    try checkActive()
     let transcriber = Self.makeTranscriber(locale: requestedLocale)
     let modules: [any SpeechModule] = [transcriber]
 
@@ -282,6 +356,7 @@ private final class SpeechAnalyzerSttSession: NativeSttSession {
     ) {
       emit(["type": "status", "message": "downloading", "engine": "speechAnalyzer"])
       try await installationRequest.downloadAndInstall()
+      try checkActive()
     }
 
     let analyzer = SpeechAnalyzer(
@@ -297,7 +372,9 @@ private final class SpeechAnalyzerSttSession: NativeSttSession {
         userInfo: [NSLocalizedDescriptionKey: "Speech recognition permission was not granted"]
       )
     }
+    try checkActive()
     try await Self.requestMicrophonePermission()
+    try checkActive()
     try configureAudioSession()
     let inputNode = audioEngine.inputNode
     Self.enableVoiceProcessingIfAvailable(inputNode, preserveAudioSession: preserveAudioSession)
@@ -309,6 +386,7 @@ private final class SpeechAnalyzerSttSession: NativeSttSession {
     )
     let converter = try Self.makeConverter(from: inputFormat, to: analyzerFormat)
     try await analyzer.prepareToAnalyze(in: analyzerFormat)
+    try checkActive()
 
     let inputStream = AsyncStream<AnalyzerInput> { continuation in
       self.inputContinuation = continuation
@@ -319,6 +397,7 @@ private final class SpeechAnalyzerSttSession: NativeSttSession {
       guard let self else { return }
       do {
         for try await result in transcriber.results {
+          guard !self.stopped, self.isCurrent() else { return }
           let text = String(result.text.characters)
           if result.isFinal {
             let emittedText: String
@@ -336,9 +415,12 @@ private final class SpeechAnalyzerSttSession: NativeSttSession {
             self.emitResult(emittedText, isFinal: false)
           }
         }
-        self.emitDone()
+        if !self.stopped, self.isCurrent() {
+          self.emitDone()
+        }
       } catch is CancellationError {
       } catch {
+        guard !self.stopped, self.isCurrent() else { return }
         self.emitError(code: "SPEECH_ANALYZER_ERROR", message: error.localizedDescription)
       }
     }
@@ -349,12 +431,15 @@ private final class SpeechAnalyzerSttSession: NativeSttSession {
         try await analyzer.start(inputSequence: inputStream)
       } catch is CancellationError {
       } catch {
+        guard !self.stopped, self.isCurrent() else { return }
         self.emitError(code: "SPEECH_ANALYZER_ERROR", message: error.localizedDescription)
       }
     }
 
     inputNode.installTap(onBus: 0, bufferSize: 1024, format: inputFormat) { [weak self] buffer, _ in
       guard let self,
+            !self.stopped,
+            self.isCurrent(),
             let analyzerBuffer = Self.copyOrConvert(
               buffer: buffer,
               targetFormat: analyzerFormat,
@@ -368,6 +453,7 @@ private final class SpeechAnalyzerSttSession: NativeSttSession {
     tapInstalled = true
 
     do {
+      try checkActive()
       audioEngine.prepare()
       try audioEngine.start()
       emit(["type": "status", "message": "listening", "engine": "speechAnalyzer"])
@@ -394,6 +480,25 @@ private final class SpeechAnalyzerSttSession: NativeSttSession {
     analyzer = nil
     if !preserveAudioSession {
       try? AVAudioSession.sharedInstance().setActive(false, options: .notifyOthersOnDeactivation)
+    }
+  }
+
+  private func cleanupForDeinit() {
+    stopped = true
+    if tapInstalled {
+      audioEngine.inputNode.removeTap(onBus: 0)
+      tapInstalled = false
+    }
+    audioEngine.stop()
+    inputContinuation?.finish()
+    inputContinuation = nil
+    analyzerTask?.cancel()
+    resultTask?.cancel()
+  }
+
+  private func checkActive() throws {
+    if stopped || !isCurrent() || Task.isCancelled {
+      throw CancellationError()
     }
   }
 
@@ -626,9 +731,12 @@ private final class SFSpeechNativeSttSession: NativeSttSession {
   private let preserveAudioSession: Bool
   private let emitPartialResults: Bool
   private let accumulateResults: Bool
+  private let allowOnlineFallback: Bool
   private let emit: ([String: Any]) -> Void
+  private let isCurrent: () -> Bool
   private let onFinished: () -> Void
   private let audioEngine = AVAudioEngine()
+  private var recognizer: SFSpeechRecognizer?
   private var recognitionRequest: SFSpeechAudioBufferRecognitionRequest?
   private var recognitionTask: SFSpeechRecognitionTask?
   private var finalizationWorkItem: DispatchWorkItem?
@@ -643,15 +751,23 @@ private final class SFSpeechNativeSttSession: NativeSttSession {
     preserveAudioSession: Bool,
     emitPartialResults: Bool,
     accumulateResults: Bool,
+    allowOnlineFallback: Bool,
     emit: @escaping ([String: Any]) -> Void,
+    isCurrent: @escaping () -> Bool,
     onFinished: @escaping () -> Void
   ) throws {
     self.localeId = localeId
     self.preserveAudioSession = preserveAudioSession
     self.emitPartialResults = emitPartialResults
     self.accumulateResults = accumulateResults
+    self.allowOnlineFallback = allowOnlineFallback
     self.emit = emit
+    self.isCurrent = isCurrent
     self.onFinished = onFinished
+  }
+
+  deinit {
+    cleanupForDeinit()
   }
 
   func start() async throws {
@@ -662,48 +778,19 @@ private final class SFSpeechNativeSttSession: NativeSttSession {
         userInfo: [NSLocalizedDescriptionKey: "Speech recognition permission was not granted"]
       )
     }
+    try checkActive()
 
     let recognizer = try makeRecognizer()
+    self.recognizer = recognizer
     try await Self.requestMicrophonePermission()
-    let request = SFSpeechAudioBufferRecognitionRequest()
-    request.shouldReportPartialResults = emitPartialResults
-    request.requiresOnDeviceRecognition = true
-    if #available(iOS 16.0, *) {
-      request.addsPunctuation = true
-    }
-    recognitionRequest = request
+    try checkActive()
 
     try configureAudioSession()
-    let inputNode = audioEngine.inputNode
-    Self.enableVoiceProcessingIfAvailable(inputNode, preserveAudioSession: preserveAudioSession)
-    let inputFormat = inputNode.outputFormat(forBus: 0)
-    try Self.validateInputFormat(inputFormat)
-    inputNode.installTap(onBus: 0, bufferSize: 1024, format: inputFormat) { buffer, _ in
-      request.append(buffer)
-    }
-    tapInstalled = true
-
-    recognitionTask = recognizer.recognitionTask(with: request) { [weak self] result, error in
-      guard let self else { return }
-      guard !self.stopped else { return }
-      if let result {
-        self.handleRecognitionResult(result)
-      }
-
-      if let error {
-        self.cancelSegmentFinalization()
-        self.emit([
-          "type": "error",
-          "code": "SFSPEECH_ERROR",
-          "message": error.localizedDescription,
-          "engine": "sfSpeech",
-        ])
-        self.emit(["type": "done", "engine": "sfSpeech"])
-        self.onFinished()
-      }
-    }
+    try checkActive()
+    try startRecognitionTask(recognizer)
 
     do {
+      try checkActive()
       audioEngine.prepare()
       try audioEngine.start()
       emit(["type": "status", "message": "listening", "engine": "sfSpeech"])
@@ -727,8 +814,52 @@ private final class SFSpeechNativeSttSession: NativeSttSession {
     recognitionTask?.cancel()
     recognitionRequest = nil
     recognitionTask = nil
+    recognizer = nil
     if !preserveAudioSession {
       try? AVAudioSession.sharedInstance().setActive(false, options: .notifyOthersOnDeactivation)
+    }
+  }
+
+  private func startRecognitionTask(_ recognizer: SFSpeechRecognizer) throws {
+    try checkActive()
+    cancelSegmentFinalization()
+    recognitionTask?.cancel()
+    recognitionRequest?.endAudio()
+    recognitionTask = nil
+    recognitionRequest = nil
+    if tapInstalled {
+      audioEngine.inputNode.removeTap(onBus: 0)
+      tapInstalled = false
+    }
+
+    let request = SFSpeechAudioBufferRecognitionRequest()
+    request.shouldReportPartialResults = emitPartialResults
+    request.requiresOnDeviceRecognition = !allowOnlineFallback
+    if #available(iOS 16.0, *) {
+      request.addsPunctuation = true
+    }
+    recognitionRequest = request
+
+    let inputNode = audioEngine.inputNode
+    Self.enableVoiceProcessingIfAvailable(inputNode, preserveAudioSession: preserveAudioSession)
+    let inputFormat = inputNode.outputFormat(forBus: 0)
+    try Self.validateInputFormat(inputFormat)
+    inputNode.installTap(onBus: 0, bufferSize: 1024, format: inputFormat) { [weak self] buffer, _ in
+      guard let self, !self.stopped, self.isCurrent() else { return }
+      request.append(buffer)
+    }
+    tapInstalled = true
+
+    recognitionTask = recognizer.recognitionTask(with: request) { [weak self] result, error in
+      guard let self else { return }
+      guard !self.stopped, self.isCurrent() else { return }
+      if let result {
+        self.handleRecognitionResult(result)
+      }
+
+      if let error {
+        self.handleRecognitionError(error)
+      }
     }
   }
 
@@ -752,8 +883,7 @@ private final class SFSpeechNativeSttSession: NativeSttSession {
       cancelSegmentFinalization()
       emitResult(emittedText, isFinal: true)
       commitPendingSegment()
-      emit(["type": "done", "engine": "sfSpeech"])
-      onFinished()
+      restartRecognitionAfterFinal()
       return
     }
 
@@ -761,6 +891,41 @@ private final class SFSpeechNativeSttSession: NativeSttSession {
       emitResult(emittedText, isFinal: false)
     }
     scheduleSegmentFinalization()
+  }
+
+  private func restartRecognitionAfterFinal() {
+    guard !stopped, isCurrent() else { return }
+    DispatchQueue.main.async { [weak self] in
+      guard let self, !self.stopped, self.isCurrent() else { return }
+      guard let recognizer = self.recognizer else {
+        self.emit(["type": "done", "engine": "sfSpeech"])
+        self.onFinished()
+        return
+      }
+      do {
+        try self.startRecognitionTask(recognizer)
+        if !self.audioEngine.isRunning {
+          self.audioEngine.prepare()
+          try self.audioEngine.start()
+        }
+        self.emit(["type": "status", "message": "listening", "engine": "sfSpeech"])
+      } catch {
+        self.handleRecognitionError(error)
+      }
+    }
+  }
+
+  private func handleRecognitionError(_ error: Error) {
+    guard !stopped, isCurrent() else { return }
+    cancelSegmentFinalization()
+    emit([
+      "type": "error",
+      "code": "SFSPEECH_ERROR",
+      "message": error.localizedDescription,
+      "engine": "sfSpeech",
+    ])
+    emit(["type": "done", "engine": "sfSpeech"])
+    onFinished()
   }
 
   private func scheduleSegmentFinalization() {
@@ -796,6 +961,27 @@ private final class SFSpeechNativeSttSession: NativeSttSession {
     pendingFinalText = ""
     pendingFormattedText = ""
     finalizationWorkItem = nil
+  }
+
+  private func cleanupForDeinit() {
+    stopped = true
+    cancelSegmentFinalization()
+    if tapInstalled {
+      audioEngine.inputNode.removeTap(onBus: 0)
+      tapInstalled = false
+    }
+    audioEngine.stop()
+    recognitionRequest?.endAudio()
+    recognitionTask?.cancel()
+    recognitionRequest = nil
+    recognitionTask = nil
+    recognizer = nil
+  }
+
+  private func checkActive() throws {
+    if stopped || !isCurrent() || Task.isCancelled {
+      throw CancellationError()
+    }
   }
 
   private func emitResult(_ text: String, isFinal: Bool) {
@@ -840,7 +1026,7 @@ private final class SFSpeechNativeSttSession: NativeSttSession {
         userInfo: [NSLocalizedDescriptionKey: "SFSpeechRecognizer is unavailable"]
       )
     }
-    guard recognizer.supportsOnDeviceRecognition else {
+    guard allowOnlineFallback || recognizer.supportsOnDeviceRecognition else {
       throw NSError(
         domain: "NativeSttBridge",
         code: 4,

--- a/ios/Runner/NativeSttBridge.swift
+++ b/ios/Runner/NativeSttBridge.swift
@@ -810,6 +810,10 @@ private final class SFSpeechNativeSttSession: NativeSttSession {
   }
 
   func stop() async {
+    stopRecognitionResources(deactivateAudioSession: !preserveAudioSession)
+  }
+
+  private func stopRecognitionResources(deactivateAudioSession: Bool) {
     guard !stopped else { return }
     stopped = true
     cancelSegmentFinalization()
@@ -823,7 +827,7 @@ private final class SFSpeechNativeSttSession: NativeSttSession {
     recognitionRequest = nil
     recognitionTask = nil
     recognizer = nil
-    if !preserveAudioSession {
+    if deactivateAudioSession {
       try? AVAudioSession.sharedInstance().setActive(false, options: .notifyOthersOnDeactivation)
     }
   }
@@ -934,7 +938,7 @@ private final class SFSpeechNativeSttSession: NativeSttSession {
 
   private func handleRecognitionError(_ error: Error) {
     guard !stopped, isCurrent() else { return }
-    cancelSegmentFinalization()
+    stopRecognitionResources(deactivateAudioSession: !preserveAudioSession)
     emit([
       "type": "error",
       "code": "SFSPEECH_ERROR",
@@ -981,18 +985,7 @@ private final class SFSpeechNativeSttSession: NativeSttSession {
   }
 
   private func cleanupForDeinit() {
-    stopped = true
-    cancelSegmentFinalization()
-    if tapInstalled {
-      audioEngine.inputNode.removeTap(onBus: 0)
-      tapInstalled = false
-    }
-    audioEngine.stop()
-    recognitionRequest?.endAudio()
-    recognitionTask?.cancel()
-    recognitionRequest = nil
-    recognitionTask = nil
-    recognizer = nil
+    stopRecognitionResources(deactivateAudioSession: false)
   }
 
   private func checkActive() throws {

--- a/ios/Runner/NativeSttBridge.swift
+++ b/ios/Runner/NativeSttBridge.swift
@@ -963,7 +963,7 @@ private final class SFSpeechNativeSttSession: NativeSttSession {
   }
 
   private func finalizePendingSegment() {
-    guard !stopped else { return }
+    guard !stopped, isCurrent() else { return }
     let text = pendingFinalText.trimmingCharacters(in: .whitespacesAndNewlines)
     guard !text.isEmpty else { return }
 

--- a/ios/Runner/NativeSttBridge.swift
+++ b/ios/Runner/NativeSttBridge.swift
@@ -1,0 +1,906 @@
+import AVFoundation
+import Flutter
+import Speech
+import UIKit
+
+private let nativeSttMethodChannelName = "app.cogwheel.conduit/native_stt"
+private let nativeSttEventChannelName = "app.cogwheel.conduit/native_stt/events"
+
+private protocol NativeSttSession: AnyObject {
+  func stop() async
+}
+
+private enum NativeSttAvailability {
+  static func available(_ engine: String) -> [String: Any] {
+    ["available": true, "engine": engine]
+  }
+
+  static func unavailable(_ reason: String) -> [String: Any] {
+    ["available": false, "reason": reason]
+  }
+}
+
+private enum NativeSttText {
+  static func merge(_ committed: String, _ next: String) -> String {
+    let trimmed = next.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard !trimmed.isEmpty else { return committed }
+    guard !committed.isEmpty else { return trimmed }
+    if committed.hasSuffix(trimmed) { return committed }
+    return "\(committed) \(trimmed)".trimmingCharacters(in: .whitespacesAndNewlines)
+  }
+}
+
+final class NativeSttBridge: NSObject, FlutterStreamHandler {
+  static let shared = NativeSttBridge()
+
+  private var methodChannel: FlutterMethodChannel?
+  private var eventSink: FlutterEventSink?
+  private var session: NativeSttSession?
+
+  private override init() {
+    super.init()
+  }
+
+  func configure(messenger: FlutterBinaryMessenger) {
+    let methodChannel = FlutterMethodChannel(
+      name: nativeSttMethodChannelName,
+      binaryMessenger: messenger
+    )
+    self.methodChannel = methodChannel
+    methodChannel.setMethodCallHandler { [weak self] call, result in
+      self?.handle(call: call, result: result)
+    }
+
+    FlutterEventChannel(
+      name: nativeSttEventChannelName,
+      binaryMessenger: messenger
+    ).setStreamHandler(self)
+  }
+
+  func onListen(withArguments arguments: Any?, eventSink events: @escaping FlutterEventSink) -> FlutterError? {
+    eventSink = events
+    return nil
+  }
+
+  func onCancel(withArguments arguments: Any?) -> FlutterError? {
+    eventSink = nil
+    return nil
+  }
+
+  private func handle(call: FlutterMethodCall, result: @escaping FlutterResult) {
+    let arguments = call.arguments as? [String: Any]
+    let localeId = arguments?["localeId"] as? String
+    let deviceLocaleId = arguments?["deviceLocaleId"] as? String
+    let preserveAudioSession = arguments?["preserveAudioSession"] as? Bool ?? false
+    let emitPartialResults = arguments?["emitPartialResults"] as? Bool ?? true
+    let accumulateResults = arguments?["accumulateResults"] as? Bool ?? true
+
+    switch call.method {
+    case "checkAvailability":
+      Task {
+        let availability = await checkAvailability(localeId: localeId)
+        await MainActor.run { result(availability) }
+      }
+    case "getLocales":
+      result(localesPayload(deviceLocaleId: deviceLocaleId ?? localeId))
+    case "start":
+      Task {
+        let availability = await start(
+          localeId: localeId,
+          preserveAudioSession: preserveAudioSession,
+          emitPartialResults: emitPartialResults,
+          accumulateResults: accumulateResults
+        )
+        await MainActor.run { result(availability) }
+      }
+    case "stop":
+      Task {
+        await stopCurrentSession()
+        await MainActor.run { result(nil) }
+      }
+    default:
+      result(FlutterMethodNotImplemented)
+    }
+  }
+
+  private func checkAvailability(localeId: String?) async -> [String: Any] {
+    if #available(iOS 26.0, *) {
+      if await SpeechAnalyzerSttSession.isAvailable(localeId: localeId) {
+        return NativeSttAvailability.available("speechAnalyzer")
+      }
+    }
+
+    if sfSpeechRecognizer(localeId: localeId)?.supportsOnDeviceRecognition == true {
+      return NativeSttAvailability.available("sfSpeech")
+    }
+
+    return NativeSttAvailability.unavailable(
+      "No on-device iOS speech recognizer is available for this locale"
+    )
+  }
+
+  private func start(
+    localeId: String?,
+    preserveAudioSession: Bool,
+    emitPartialResults: Bool,
+    accumulateResults: Bool
+  ) async -> [String: Any] {
+    await stopCurrentSession()
+
+    if #available(iOS 26.0, *) {
+      do {
+        let speechAnalyzerSession = try await SpeechAnalyzerSttSession(
+          localeId: localeId,
+          preserveAudioSession: preserveAudioSession,
+          emitPartialResults: emitPartialResults,
+          accumulateResults: accumulateResults,
+          emit: emit
+        )
+        session = speechAnalyzerSession
+        try await speechAnalyzerSession.start()
+        return NativeSttAvailability.available("speechAnalyzer")
+      } catch {
+        await stopCurrentSession()
+        emitError(
+          code: "SPEECH_ANALYZER_START_FAILED",
+          message: error.localizedDescription,
+          engine: "speechAnalyzer"
+        )
+      }
+    }
+
+    do {
+      let fallbackSession = try SFSpeechNativeSttSession(
+        localeId: localeId,
+        preserveAudioSession: preserveAudioSession,
+        emitPartialResults: emitPartialResults,
+        accumulateResults: accumulateResults,
+        emit: emit,
+        onFinished: { [weak self] in
+          Task { await self?.stopCurrentSession() }
+        }
+      )
+      session = fallbackSession
+      try await fallbackSession.start()
+      return NativeSttAvailability.available("sfSpeech")
+    } catch {
+      await stopCurrentSession()
+      return NativeSttAvailability.unavailable(error.localizedDescription)
+    }
+  }
+
+  private func stopCurrentSession() async {
+    let current = session
+    session = nil
+    await current?.stop()
+  }
+
+  private func sfSpeechRecognizer(localeId: String?) -> SFSpeechRecognizer? {
+    let locale = locale(from: localeId)
+    return SFSpeechRecognizer(locale: locale)
+  }
+
+  private func locale(from localeId: String?) -> Locale {
+    guard let localeId, !localeId.isEmpty else {
+      return Locale.current
+    }
+    return Locale(identifier: localeId.replacingOccurrences(of: "-", with: "_"))
+  }
+
+  private func localesPayload(deviceLocaleId: String?) -> [String: Any] {
+    let systemLocale = locale(from: deviceLocaleId)
+    var locales = Array(SFSpeechRecognizer.supportedLocales()).filter { locale in
+      SFSpeechRecognizer(locale: locale)?.supportsOnDeviceRecognition == true
+    }
+    if !locales.contains(where: { $0.identifier == systemLocale.identifier }),
+       SFSpeechRecognizer(locale: systemLocale)?.supportsOnDeviceRecognition == true {
+      locales.append(systemLocale)
+    }
+    locales.sort { localeIdentifier($0) < localeIdentifier($1) }
+
+    return [
+      "systemLocale": localeIdentifier(systemLocale),
+      "locales": locales.map(localePayload),
+    ]
+  }
+
+  private func localePayload(_ locale: Locale) -> [String: Any] {
+    let identifier = localeIdentifier(locale)
+    let displayName = Locale.current.localizedString(forIdentifier: locale.identifier) ??
+      locale.localizedString(forIdentifier: locale.identifier) ??
+      identifier
+    return [
+      "localeId": identifier,
+      "name": displayName,
+    ]
+  }
+
+  private func localeIdentifier(_ locale: Locale) -> String {
+    locale.identifier.replacingOccurrences(of: "_", with: "-")
+  }
+
+  private func emit(_ event: [String: Any]) {
+    DispatchQueue.main.async { [weak self] in
+      self?.eventSink?(event)
+    }
+  }
+
+  private func emitError(code: String, message: String, engine: String) {
+    emit([
+      "type": "error",
+      "code": code,
+      "message": message,
+      "engine": engine,
+    ])
+  }
+}
+
+@available(iOS 26.0, *)
+private final class SpeechAnalyzerSttSession: NativeSttSession {
+  private let localeId: String?
+  private let preserveAudioSession: Bool
+  private let emitPartialResults: Bool
+  private let accumulateResults: Bool
+  private let emit: ([String: Any]) -> Void
+  private let audioEngine = AVAudioEngine()
+  private var analyzer: SpeechAnalyzer?
+  private var inputContinuation: AsyncStream<AnalyzerInput>.Continuation?
+  private var resultTask: Task<Void, Never>?
+  private var analyzerTask: Task<Void, Never>?
+  private var stopped = false
+  private var tapInstalled = false
+
+  init(
+    localeId: String?,
+    preserveAudioSession: Bool,
+    emitPartialResults: Bool,
+    accumulateResults: Bool,
+    emit: @escaping ([String: Any]) -> Void
+  ) async throws {
+    self.localeId = localeId
+    self.preserveAudioSession = preserveAudioSession
+    self.emitPartialResults = emitPartialResults
+    self.accumulateResults = accumulateResults
+    self.emit = emit
+  }
+
+  static func isAvailable(localeId: String?) async -> Bool {
+    guard let supportedLocale = await supportedLocale(localeId: localeId) else {
+      return false
+    }
+    let transcriber = makeTranscriber(locale: supportedLocale)
+    return await AssetInventory.status(forModules: [transcriber]) != .unsupported
+  }
+
+  func start() async throws {
+    let requestedLocale = try await Self.requiredSupportedLocale(localeId: localeId)
+    let transcriber = Self.makeTranscriber(locale: requestedLocale)
+    let modules: [any SpeechModule] = [transcriber]
+
+    if let installationRequest = try await AssetInventory.assetInstallationRequest(
+      supporting: modules
+    ) {
+      emit(["type": "status", "message": "downloading", "engine": "speechAnalyzer"])
+      try await installationRequest.downloadAndInstall()
+    }
+
+    let analyzer = SpeechAnalyzer(
+      modules: modules,
+      options: SpeechAnalyzer.Options(priority: .userInitiated, modelRetention: .whileInUse)
+    )
+    self.analyzer = analyzer
+
+    guard await Self.requestSpeechAuthorization() else {
+      throw NSError(
+        domain: "NativeSttBridge",
+        code: 8,
+        userInfo: [NSLocalizedDescriptionKey: "Speech recognition permission was not granted"]
+      )
+    }
+    try await Self.requestMicrophonePermission()
+    try configureAudioSession()
+    let inputNode = audioEngine.inputNode
+    Self.enableVoiceProcessingIfAvailable(inputNode, preserveAudioSession: preserveAudioSession)
+    let inputFormat = inputNode.outputFormat(forBus: 0)
+    try Self.validateInputFormat(inputFormat)
+    let analyzerFormat = try await Self.analyzerFormat(
+      compatibleWith: modules,
+      naturalFormat: inputFormat
+    )
+    let converter = try Self.makeConverter(from: inputFormat, to: analyzerFormat)
+    try await analyzer.prepareToAnalyze(in: analyzerFormat)
+
+    let inputStream = AsyncStream<AnalyzerInput> { continuation in
+      self.inputContinuation = continuation
+    }
+
+    var committedText = ""
+    resultTask = Task { [weak self] in
+      guard let self else { return }
+      do {
+        for try await result in transcriber.results {
+          let text = String(result.text.characters)
+          if result.isFinal {
+            let emittedText: String
+            if self.accumulateResults {
+              committedText = NativeSttText.merge(committedText, text)
+              emittedText = committedText
+            } else {
+              emittedText = text.trimmingCharacters(in: .whitespacesAndNewlines)
+            }
+            self.emitResult(emittedText, isFinal: true)
+          } else if self.emitPartialResults {
+            let emittedText = self.accumulateResults
+              ? NativeSttText.merge(committedText, text)
+              : text.trimmingCharacters(in: .whitespacesAndNewlines)
+            self.emitResult(emittedText, isFinal: false)
+          }
+        }
+        self.emitDone()
+      } catch is CancellationError {
+      } catch {
+        self.emitError(code: "SPEECH_ANALYZER_ERROR", message: error.localizedDescription)
+      }
+    }
+
+    analyzerTask = Task { [weak self] in
+      guard let self else { return }
+      do {
+        try await analyzer.start(inputSequence: inputStream)
+      } catch is CancellationError {
+      } catch {
+        self.emitError(code: "SPEECH_ANALYZER_ERROR", message: error.localizedDescription)
+      }
+    }
+
+    inputNode.installTap(onBus: 0, bufferSize: 1024, format: inputFormat) { [weak self] buffer, _ in
+      guard let self,
+            let analyzerBuffer = Self.copyOrConvert(
+              buffer: buffer,
+              targetFormat: analyzerFormat,
+              converter: converter
+            )
+      else {
+        return
+      }
+      self.inputContinuation?.yield(AnalyzerInput(buffer: analyzerBuffer))
+    }
+    tapInstalled = true
+
+    do {
+      audioEngine.prepare()
+      try audioEngine.start()
+      emit(["type": "status", "message": "listening", "engine": "speechAnalyzer"])
+    } catch {
+      audioEngine.inputNode.removeTap(onBus: 0)
+      tapInstalled = false
+      throw error
+    }
+  }
+
+  func stop() async {
+    guard !stopped else { return }
+    stopped = true
+    if tapInstalled {
+      audioEngine.inputNode.removeTap(onBus: 0)
+      tapInstalled = false
+    }
+    audioEngine.stop()
+    inputContinuation?.finish()
+    inputContinuation = nil
+    analyzerTask?.cancel()
+    resultTask?.cancel()
+    await analyzer?.cancelAndFinishNow()
+    analyzer = nil
+    if !preserveAudioSession {
+      try? AVAudioSession.sharedInstance().setActive(false, options: .notifyOthersOnDeactivation)
+    }
+  }
+
+  private static func supportedLocale(localeId: String?) async -> Locale? {
+    let locale = localeId
+      .map { Locale(identifier: $0.replacingOccurrences(of: "-", with: "_")) } ?? Locale.current
+    return await DictationTranscriber.supportedLocale(equivalentTo: locale)
+  }
+
+  private static func requiredSupportedLocale(localeId: String?) async throws -> Locale {
+    if let locale = await supportedLocale(localeId: localeId) {
+      return locale
+    }
+    throw NSError(
+      domain: "NativeSttBridge",
+      code: 1,
+      userInfo: [NSLocalizedDescriptionKey: "SpeechAnalyzer does not support this locale"]
+    )
+  }
+
+  private static func makeTranscriber(locale: Locale) -> DictationTranscriber {
+    var preset = DictationTranscriber.Preset.progressiveLongDictation
+    preset.reportingOptions.insert(.volatileResults)
+    preset.reportingOptions.insert(.frequentFinalization)
+    preset.transcriptionOptions.insert(.punctuation)
+    return DictationTranscriber(locale: locale, preset: preset)
+  }
+
+  private func configureAudioSession() throws {
+    guard !preserveAudioSession else { return }
+    let session = AVAudioSession.sharedInstance()
+    try session.setCategory(
+      .playAndRecord,
+      mode: .measurement,
+      options: [.allowBluetooth, .defaultToSpeaker]
+    )
+    try session.setActive(true, options: .notifyOthersOnDeactivation)
+  }
+
+  private static func enableVoiceProcessingIfAvailable(
+    _ inputNode: AVAudioInputNode,
+    preserveAudioSession: Bool
+  ) {
+    guard preserveAudioSession else { return }
+    if #available(iOS 13.0, *) {
+      try? inputNode.setVoiceProcessingEnabled(true)
+    }
+  }
+
+  private static func requestSpeechAuthorization() async -> Bool {
+    await withCheckedContinuation { continuation in
+      SFSpeechRecognizer.requestAuthorization { status in
+        continuation.resume(returning: status == .authorized)
+      }
+    }
+  }
+
+  private static func requestMicrophonePermission() async throws {
+    let granted = await withCheckedContinuation { continuation in
+      AVAudioSession.sharedInstance().requestRecordPermission { granted in
+        continuation.resume(returning: granted)
+      }
+    }
+    guard granted else {
+      throw NSError(
+        domain: "NativeSttBridge",
+        code: 5,
+        userInfo: [NSLocalizedDescriptionKey: "Microphone permission was not granted"]
+      )
+    }
+  }
+
+  private static func analyzerFormat(
+    compatibleWith modules: [any SpeechModule],
+    naturalFormat: AVAudioFormat
+  ) async throws -> AVAudioFormat {
+    if let format = await SpeechAnalyzer.bestAvailableAudioFormat(
+      compatibleWith: modules,
+      considering: naturalFormat
+    ) {
+      return format
+    }
+    if let format = await SpeechAnalyzer.bestAvailableAudioFormat(
+      compatibleWith: modules
+    ) {
+      return format
+    }
+    throw NSError(
+      domain: "NativeSttBridge",
+      code: 9,
+      userInfo: [NSLocalizedDescriptionKey: "SpeechAnalyzer has no compatible audio format"]
+    )
+  }
+
+  private static func validateInputFormat(_ format: AVAudioFormat) throws {
+    guard format.sampleRate > 0, format.channelCount > 0 else {
+      throw NSError(
+        domain: "NativeSttBridge",
+        code: 6,
+        userInfo: [NSLocalizedDescriptionKey: "Microphone input format is unavailable"]
+      )
+    }
+  }
+
+  private static func makeConverter(
+    from inputFormat: AVAudioFormat,
+    to outputFormat: AVAudioFormat
+  ) throws -> AVAudioConverter? {
+    guard !formatsMatch(inputFormat, outputFormat) else {
+      return nil
+    }
+    guard let converter = AVAudioConverter(from: inputFormat, to: outputFormat) else {
+      throw NSError(
+        domain: "NativeSttBridge",
+        code: 10,
+        userInfo: [NSLocalizedDescriptionKey: "Unable to convert microphone audio for SpeechAnalyzer"]
+      )
+    }
+    return converter
+  }
+
+  private static func formatsMatch(_ lhs: AVAudioFormat, _ rhs: AVAudioFormat) -> Bool {
+    lhs.sampleRate == rhs.sampleRate &&
+      lhs.channelCount == rhs.channelCount &&
+      lhs.commonFormat == rhs.commonFormat &&
+      lhs.isInterleaved == rhs.isInterleaved
+  }
+
+  private func emitResult(_ text: String, isFinal: Bool) {
+    emit([
+      "type": "result",
+      "text": text,
+      "final": isFinal,
+      "engine": "speechAnalyzer",
+    ])
+  }
+
+  private func emitError(code: String, message: String) {
+    emit([
+      "type": "error",
+      "code": code,
+      "message": message,
+      "engine": "speechAnalyzer",
+    ])
+  }
+
+  private func emitDone() {
+    emit(["type": "done", "engine": "speechAnalyzer"])
+  }
+
+  private static func copyOrConvert(
+    buffer: AVAudioPCMBuffer,
+    targetFormat: AVAudioFormat,
+    converter: AVAudioConverter?
+  ) -> AVAudioPCMBuffer? {
+    guard let converter else {
+      return copy(buffer: buffer)
+    }
+    return convert(buffer: buffer, to: targetFormat, using: converter)
+  }
+
+  private static func convert(
+    buffer: AVAudioPCMBuffer,
+    to outputFormat: AVAudioFormat,
+    using converter: AVAudioConverter
+  ) -> AVAudioPCMBuffer? {
+    let ratio = outputFormat.sampleRate / buffer.format.sampleRate
+    let frameCapacity = max(
+      AVAudioFrameCount(1),
+      AVAudioFrameCount(ceil(Double(buffer.frameLength) * ratio)) + 32
+    )
+    guard let outputBuffer = AVAudioPCMBuffer(
+      pcmFormat: outputFormat,
+      frameCapacity: frameCapacity
+    ) else {
+      return nil
+    }
+
+    var didProvideInput = false
+    var conversionError: NSError?
+    let status = converter.convert(to: outputBuffer, error: &conversionError) { _, outStatus in
+      if didProvideInput {
+        outStatus.pointee = .noDataNow
+        return nil
+      }
+      didProvideInput = true
+      outStatus.pointee = .haveData
+      return buffer
+    }
+
+    guard status != .error, outputBuffer.frameLength > 0 else {
+      return nil
+    }
+    return outputBuffer
+  }
+
+  private static func copy(buffer: AVAudioPCMBuffer) -> AVAudioPCMBuffer? {
+    guard let copy = AVAudioPCMBuffer(
+      pcmFormat: buffer.format,
+      frameCapacity: buffer.frameLength
+    ) else {
+      return nil
+    }
+    copy.frameLength = buffer.frameLength
+
+    let channelCount = Int(buffer.format.channelCount)
+    let frameLength = Int(buffer.frameLength)
+    if let source = buffer.floatChannelData, let destination = copy.floatChannelData {
+      for channel in 0..<channelCount {
+        memcpy(destination[channel], source[channel], frameLength * MemoryLayout<Float>.size)
+      }
+    } else if let source = buffer.int16ChannelData, let destination = copy.int16ChannelData {
+      for channel in 0..<channelCount {
+        memcpy(destination[channel], source[channel], frameLength * MemoryLayout<Int16>.size)
+      }
+    } else if let source = buffer.int32ChannelData, let destination = copy.int32ChannelData {
+      for channel in 0..<channelCount {
+        memcpy(destination[channel], source[channel], frameLength * MemoryLayout<Int32>.size)
+      }
+    }
+
+    return copy
+  }
+}
+
+private final class SFSpeechNativeSttSession: NativeSttSession {
+  private static let segmentFinalizationDelay: TimeInterval = 1.2
+
+  private let localeId: String?
+  private let preserveAudioSession: Bool
+  private let emitPartialResults: Bool
+  private let accumulateResults: Bool
+  private let emit: ([String: Any]) -> Void
+  private let onFinished: () -> Void
+  private let audioEngine = AVAudioEngine()
+  private var recognitionRequest: SFSpeechAudioBufferRecognitionRequest?
+  private var recognitionTask: SFSpeechRecognitionTask?
+  private var finalizationWorkItem: DispatchWorkItem?
+  private var committedFormattedText = ""
+  private var pendingFinalText = ""
+  private var pendingFormattedText = ""
+  private var stopped = false
+  private var tapInstalled = false
+
+  init(
+    localeId: String?,
+    preserveAudioSession: Bool,
+    emitPartialResults: Bool,
+    accumulateResults: Bool,
+    emit: @escaping ([String: Any]) -> Void,
+    onFinished: @escaping () -> Void
+  ) throws {
+    self.localeId = localeId
+    self.preserveAudioSession = preserveAudioSession
+    self.emitPartialResults = emitPartialResults
+    self.accumulateResults = accumulateResults
+    self.emit = emit
+    self.onFinished = onFinished
+  }
+
+  func start() async throws {
+    guard await requestSpeechAuthorization() else {
+      throw NSError(
+        domain: "NativeSttBridge",
+        code: 2,
+        userInfo: [NSLocalizedDescriptionKey: "Speech recognition permission was not granted"]
+      )
+    }
+
+    let recognizer = try makeRecognizer()
+    try await Self.requestMicrophonePermission()
+    let request = SFSpeechAudioBufferRecognitionRequest()
+    request.shouldReportPartialResults = emitPartialResults
+    request.requiresOnDeviceRecognition = true
+    if #available(iOS 16.0, *) {
+      request.addsPunctuation = true
+    }
+    recognitionRequest = request
+
+    try configureAudioSession()
+    let inputNode = audioEngine.inputNode
+    Self.enableVoiceProcessingIfAvailable(inputNode, preserveAudioSession: preserveAudioSession)
+    let inputFormat = inputNode.outputFormat(forBus: 0)
+    try Self.validateInputFormat(inputFormat)
+    inputNode.installTap(onBus: 0, bufferSize: 1024, format: inputFormat) { buffer, _ in
+      request.append(buffer)
+    }
+    tapInstalled = true
+
+    recognitionTask = recognizer.recognitionTask(with: request) { [weak self] result, error in
+      guard let self else { return }
+      guard !self.stopped else { return }
+      if let result {
+        self.handleRecognitionResult(result)
+      }
+
+      if let error {
+        self.cancelSegmentFinalization()
+        self.emit([
+          "type": "error",
+          "code": "SFSPEECH_ERROR",
+          "message": error.localizedDescription,
+          "engine": "sfSpeech",
+        ])
+        self.emit(["type": "done", "engine": "sfSpeech"])
+        self.onFinished()
+      }
+    }
+
+    do {
+      audioEngine.prepare()
+      try audioEngine.start()
+      emit(["type": "status", "message": "listening", "engine": "sfSpeech"])
+    } catch {
+      audioEngine.inputNode.removeTap(onBus: 0)
+      tapInstalled = false
+      throw error
+    }
+  }
+
+  func stop() async {
+    guard !stopped else { return }
+    stopped = true
+    cancelSegmentFinalization()
+    if tapInstalled {
+      audioEngine.inputNode.removeTap(onBus: 0)
+      tapInstalled = false
+    }
+    audioEngine.stop()
+    recognitionRequest?.endAudio()
+    recognitionTask?.cancel()
+    recognitionRequest = nil
+    recognitionTask = nil
+    if !preserveAudioSession {
+      try? AVAudioSession.sharedInstance().setActive(false, options: .notifyOthersOnDeactivation)
+    }
+  }
+
+  private func handleRecognitionResult(_ result: SFSpeechRecognitionResult) {
+    let transcription = result.bestTranscription
+    let formattedText = transcription.formattedString.trimmingCharacters(
+      in: .whitespacesAndNewlines
+    )
+    let segmentText = uncommittedText(from: formattedText)
+    guard !segmentText.isEmpty else { return }
+
+    let emittedText = accumulateResults
+      ? formattedText
+      : segmentText
+    guard !emittedText.isEmpty else { return }
+
+    pendingFinalText = emittedText
+    pendingFormattedText = formattedText
+
+    if result.isFinal {
+      cancelSegmentFinalization()
+      emitResult(emittedText, isFinal: true)
+      commitPendingSegment()
+      emit(["type": "done", "engine": "sfSpeech"])
+      onFinished()
+      return
+    }
+
+    if emitPartialResults {
+      emitResult(emittedText, isFinal: false)
+    }
+    scheduleSegmentFinalization()
+  }
+
+  private func scheduleSegmentFinalization() {
+    cancelSegmentFinalization()
+    let workItem = DispatchWorkItem { [weak self] in
+      self?.finalizePendingSegment()
+    }
+    finalizationWorkItem = workItem
+    DispatchQueue.main.asyncAfter(
+      deadline: .now() + Self.segmentFinalizationDelay,
+      execute: workItem
+    )
+  }
+
+  private func cancelSegmentFinalization() {
+    finalizationWorkItem?.cancel()
+    finalizationWorkItem = nil
+  }
+
+  private func finalizePendingSegment() {
+    guard !stopped else { return }
+    let text = pendingFinalText.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard !text.isEmpty else { return }
+
+    emitResult(text, isFinal: true)
+    commitPendingSegment()
+  }
+
+  private func commitPendingSegment() {
+    if !pendingFormattedText.isEmpty {
+      committedFormattedText = pendingFormattedText
+    }
+    pendingFinalText = ""
+    pendingFormattedText = ""
+    finalizationWorkItem = nil
+  }
+
+  private func emitResult(_ text: String, isFinal: Bool) {
+    emit([
+      "type": "result",
+      "text": text,
+      "final": isFinal,
+      "engine": "sfSpeech",
+    ])
+  }
+
+  private func uncommittedText(from formatted: String) -> String {
+    guard !formatted.isEmpty else { return "" }
+    guard !committedFormattedText.isEmpty else { return formatted }
+    if formatted == committedFormattedText {
+      return ""
+    }
+
+    let prefixRange = formatted.range(
+      of: committedFormattedText,
+      options: [.anchored, .caseInsensitive]
+    )
+    guard let prefixRange else {
+      // SFSpeech can reset its formatted string between utterances. Treat a
+      // non-prefixed result as a fresh turn instead of blocking future finals.
+      return formatted
+    }
+
+    return String(formatted[prefixRange.upperBound...])
+      .trimmingCharacters(
+        in: CharacterSet.whitespacesAndNewlines.union(.punctuationCharacters)
+      )
+  }
+
+  private func makeRecognizer() throws -> SFSpeechRecognizer {
+    let locale = localeId
+      .map { Locale(identifier: $0.replacingOccurrences(of: "-", with: "_")) } ?? Locale.current
+    guard let recognizer = SFSpeechRecognizer(locale: locale), recognizer.isAvailable else {
+      throw NSError(
+        domain: "NativeSttBridge",
+        code: 3,
+        userInfo: [NSLocalizedDescriptionKey: "SFSpeechRecognizer is unavailable"]
+      )
+    }
+    guard recognizer.supportsOnDeviceRecognition else {
+      throw NSError(
+        domain: "NativeSttBridge",
+        code: 4,
+        userInfo: [NSLocalizedDescriptionKey: "SFSpeechRecognizer does not support on-device recognition for this locale"]
+      )
+    }
+    return recognizer
+  }
+
+  private func configureAudioSession() throws {
+    guard !preserveAudioSession else { return }
+    let session = AVAudioSession.sharedInstance()
+    try session.setCategory(
+      .playAndRecord,
+      mode: .measurement,
+      options: [.allowBluetooth, .defaultToSpeaker]
+    )
+    try session.setActive(true, options: .notifyOthersOnDeactivation)
+  }
+
+  private static func enableVoiceProcessingIfAvailable(
+    _ inputNode: AVAudioInputNode,
+    preserveAudioSession: Bool
+  ) {
+    guard preserveAudioSession else { return }
+    if #available(iOS 13.0, *) {
+      try? inputNode.setVoiceProcessingEnabled(true)
+    }
+  }
+
+  private func requestSpeechAuthorization() async -> Bool {
+    await withCheckedContinuation { continuation in
+      SFSpeechRecognizer.requestAuthorization { status in
+        continuation.resume(returning: status == .authorized)
+      }
+    }
+  }
+
+  private static func requestMicrophonePermission() async throws {
+    let granted = await withCheckedContinuation { continuation in
+      AVAudioSession.sharedInstance().requestRecordPermission { granted in
+        continuation.resume(returning: granted)
+      }
+    }
+    guard granted else {
+      throw NSError(
+        domain: "NativeSttBridge",
+        code: 7,
+        userInfo: [NSLocalizedDescriptionKey: "Microphone permission was not granted"]
+      )
+    }
+  }
+
+  private static func validateInputFormat(_ format: AVAudioFormat) throws {
+    guard format.sampleRate > 0, format.channelCount > 0 else {
+      throw NSError(
+        domain: "NativeSttBridge",
+        code: 8,
+        userInfo: [NSLocalizedDescriptionKey: "Microphone input format is unavailable"]
+      )
+    }
+  }
+}

--- a/lib/core/persistence/persistence_keys.dart
+++ b/lib/core/persistence/persistence_keys.dart
@@ -26,6 +26,7 @@ final class PreferenceKeys {
   static const String localeCode = 'locale_code_v1';
   static const String reviewerMode = 'reviewer_mode_v1';
   static const String ttsVoice = 'tts_voice';
+  static const String ttsVoiceName = 'tts_voice_name';
   static const String ttsSpeechRate = 'tts_speech_rate';
   static const String ttsPitch = 'tts_pitch';
   static const String ttsVolume = 'tts_volume';

--- a/lib/core/services/api_service.dart
+++ b/lib/core/services/api_service.dart
@@ -5582,6 +5582,15 @@ class ApiService {
     }
   }
 
+  Future<void> stopTasksByChat(String chatId) async {
+    try {
+      final encodedChatId = Uri.encodeComponent(chatId);
+      await _dio.post('/api/tasks/chat/$encodedChatId/stop');
+    } catch (e) {
+      rethrow;
+    }
+  }
+
   Future<List<String>> getTaskIdsByChat(String chatId) async {
     try {
       final resp = await _dio.get('/api/tasks/chat/$chatId');

--- a/lib/core/services/background_streaming_handler.dart
+++ b/lib/core/services/background_streaming_handler.dart
@@ -473,11 +473,11 @@ class BackgroundStreamingHandler implements BackgroundStreamingFlutterApi {
   /// Get list of active stream IDs
   List<String> get activeStreamIds => _activeLeases.keys.toList();
 
-  /// Notify the native layer that an external component (e.g., speech_to_text
-  /// plugin) is managing the audio session.
+  /// Notify the native layer that local speech recognition is managing the
+  /// audio session.
   ///
   /// On iOS, this prevents VoiceBackgroundAudioManager from conflicting with
-  /// the speech_to_text plugin's audio session management.
+  /// the native STT audio session management.
   /// On Android, this is a no-op as audio session management is different.
   Future<void> setExternalAudioSessionOwner(bool isExternal) async {
     if (!Platform.isIOS) return;

--- a/lib/core/services/native_sheet_hydration_service.dart
+++ b/lib/core/services/native_sheet_hydration_service.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../features/tools/providers/tools_providers.dart';
+import '../../features/chat/providers/text_to_speech_provider.dart';
 import '../../l10n/app_localizations.dart';
 import '../../shared/theme/tweakcn_themes.dart';
 import '../models/model.dart';
@@ -557,7 +558,23 @@ class NativeSheetHydrationService {
 
   Future<void> _hydrateNativeVoiceDetail(AppLocalizations l10n) async {
     final appSettings = _ref.read(appSettingsProvider);
-    final nativeAudio = buildNativeAudioSheetParts(l10n, appSettings);
+    var ttsVoices = const <Map<String, dynamic>>[];
+    try {
+      final ttsService = _ref.read(textToSpeechServiceProvider);
+      await ttsService.updateSettings(engine: appSettings.ttsEngine);
+      ttsVoices = await ttsService.getAvailableVoices();
+    } catch (error, stackTrace) {
+      DebugLogger.warning(
+        'native-tts-voices-load-failed',
+        scope: 'native-sheet',
+        data: {'error': error, 'stackTrace': stackTrace},
+      );
+    }
+    final nativeAudio = buildNativeAudioSheetParts(
+      l10n,
+      appSettings,
+      ttsVoices: ttsVoices,
+    );
     await _applyNativeDetail(
       NativeSheetDetailConfig(
         id: NativeSheetRoutes.voice,

--- a/lib/core/services/settings_service.dart
+++ b/lib/core/services/settings_service.dart
@@ -76,7 +76,8 @@ class SettingsService {
       PreferenceKeys.notificationSoundAlways;
   static const String _notificationInAppBannerKey =
       PreferenceKeys.notificationInAppBanner;
-  static const String _notificationSystemKey = PreferenceKeys.notificationSystem;
+  static const String _notificationSystemKey =
+      PreferenceKeys.notificationSystem;
   static const String _notificationChatEnabledKey =
       PreferenceKeys.notificationChatEnabled;
   static const String _notificationChannelEnabledKey =
@@ -302,6 +303,12 @@ class SettingsService {
     await _putOrRemove(
       PreferenceKeys.ttsVoice,
       (settings.ttsVoice?.isNotEmpty ?? false) ? settings.ttsVoice : null,
+    );
+    await _putOrRemove(
+      PreferenceKeys.ttsVoiceName,
+      (settings.ttsVoiceName?.isNotEmpty ?? false)
+          ? settings.ttsVoiceName
+          : null,
     );
     await _putOrRemove(
       PreferenceKeys.ttsServerVoiceId,
@@ -591,19 +598,23 @@ class SettingsService {
       socketTransportMode:
           PreferencesStore.get<String>(_socketTransportModeKey) ?? 'ws',
       quickPills: PreferencesStore.getStringList(_quickPillsKey) ?? const [],
-      chatWebSearchEnabled: PreferencesStore.get<bool>(_chatWebSearchEnabledKey),
+      chatWebSearchEnabled: PreferencesStore.get<bool>(
+        _chatWebSearchEnabledKey,
+      ),
       chatImageGenerationEnabled: PreferencesStore.get<bool>(
         _chatImageGenerationEnabledKey,
       ),
       sendOnEnter: PreferencesStore.get<bool>(_sendOnEnterKey) ?? false,
       ttsVoice: PreferencesStore.get<String>(PreferenceKeys.ttsVoice),
+      ttsVoiceName: PreferencesStore.get<String>(PreferenceKeys.ttsVoiceName),
       ttsSpeechRate:
           PreferencesStore.get<num>(PreferenceKeys.ttsSpeechRate)?.toDouble() ??
           0.5,
       ttsPitch:
           PreferencesStore.get<num>(PreferenceKeys.ttsPitch)?.toDouble() ?? 1.0,
       ttsVolume:
-          PreferencesStore.get<num>(PreferenceKeys.ttsVolume)?.toDouble() ?? 1.0,
+          PreferencesStore.get<num>(PreferenceKeys.ttsVolume)?.toDouble() ??
+          1.0,
       ttsEngine: _parseTtsEngine(
         PreferencesStore.get<String>(PreferenceKeys.ttsEngine),
       ),
@@ -675,6 +686,7 @@ class AppSettings {
   final SttPreference sttPreference;
   final String? sttLanguageCode;
   final String? ttsVoice;
+  final String? ttsVoiceName;
   final double ttsSpeechRate;
   final double ttsPitch;
   final double ttsVolume;
@@ -712,6 +724,7 @@ class AppSettings {
     this.sttPreference = SttPreference.deviceOnly,
     this.sttLanguageCode,
     this.ttsVoice,
+    this.ttsVoiceName,
     this.ttsSpeechRate = 0.5,
     this.ttsPitch = 1.0,
     this.ttsVolume = 1.0,
@@ -750,6 +763,7 @@ class AppSettings {
     SttPreference? sttPreference,
     Object? sttLanguageCode = const _DefaultValue(),
     Object? ttsVoice = const _DefaultValue(),
+    Object? ttsVoiceName = const _DefaultValue(),
     double? ttsSpeechRate,
     double? ttsPitch,
     double? ttsVolume,
@@ -795,6 +809,9 @@ class AppSettings {
           ? this.sttLanguageCode
           : sttLanguageCode as String?,
       ttsVoice: ttsVoice is _DefaultValue ? this.ttsVoice : ttsVoice as String?,
+      ttsVoiceName: ttsVoiceName is _DefaultValue
+          ? this.ttsVoiceName
+          : ttsVoiceName as String?,
       ttsSpeechRate: ttsSpeechRate ?? this.ttsSpeechRate,
       ttsPitch: ttsPitch ?? this.ttsPitch,
       ttsVolume: ttsVolume ?? this.ttsVolume,
@@ -845,6 +862,7 @@ class AppSettings {
         other.sttLanguageCode == sttLanguageCode &&
         other.sendOnEnter == sendOnEnter &&
         other.ttsVoice == ttsVoice &&
+        other.ttsVoiceName == ttsVoiceName &&
         other.ttsSpeechRate == ttsSpeechRate &&
         other.ttsPitch == ttsPitch &&
         other.ttsVolume == ttsVolume &&
@@ -885,6 +903,7 @@ class AppSettings {
       sttLanguageCode,
       sendOnEnter,
       ttsVoice,
+      ttsVoiceName,
       ttsSpeechRate,
       ttsPitch,
       ttsVolume,
@@ -1138,6 +1157,11 @@ class AppSettingsNotifier extends _$AppSettingsNotifier {
 
   Future<void> setTtsVoice(String? voice) async {
     state = state.copyWith(ttsVoice: voice);
+    await SettingsService.saveSettings(state);
+  }
+
+  Future<void> setTtsVoiceName(String? name) async {
+    state = state.copyWith(ttsVoiceName: name);
     await SettingsService.saveSettings(state);
   }
 

--- a/lib/core/services/settings_service.dart
+++ b/lib/core/services/settings_service.dart
@@ -1165,6 +1165,11 @@ class AppSettingsNotifier extends _$AppSettingsNotifier {
     await SettingsService.saveSettings(state);
   }
 
+  Future<void> setTtsDeviceVoiceSelection(String? id, String? name) async {
+    state = state.copyWith(ttsVoice: id, ttsVoiceName: name);
+    await SettingsService.saveSettings(state);
+  }
+
   Future<void> setTtsSpeechRate(double rate) async {
     state = state.copyWith(ttsSpeechRate: rate);
     await SettingsService.saveSettings(state);
@@ -1185,6 +1190,13 @@ class AppSettingsNotifier extends _$AppSettingsNotifier {
     await SettingsService.saveSettings(state);
   }
 
+  Future<void> setTtsEngineSelection(TtsEngine engine) async {
+    state = engine == TtsEngine.server
+        ? state.copyWith(ttsEngine: engine, ttsVoice: null, ttsVoiceName: null)
+        : state.copyWith(ttsEngine: engine);
+    await SettingsService.saveSettings(state);
+  }
+
   Future<void> setTtsServerVoiceName(String? name) async {
     state = state.copyWith(ttsServerVoiceName: name);
     await SettingsService.saveSettings(state);
@@ -1192,6 +1204,11 @@ class AppSettingsNotifier extends _$AppSettingsNotifier {
 
   Future<void> setTtsServerVoiceId(String? id) async {
     state = state.copyWith(ttsServerVoiceId: id);
+    await SettingsService.saveSettings(state);
+  }
+
+  Future<void> setTtsServerVoiceSelection(String? id, String? name) async {
+    state = state.copyWith(ttsServerVoiceId: id, ttsServerVoiceName: name);
     await SettingsService.saveSettings(state);
   }
 

--- a/lib/core/utils/native_sheet_utils.dart
+++ b/lib/core/utils/native_sheet_utils.dart
@@ -6,6 +6,7 @@ import '../models/server_memory.dart';
 import '../models/socket_health.dart';
 import '../services/native_sheet_bridge.dart';
 import '../services/settings_service.dart';
+import 'tts_voice_utils.dart';
 
 String nativeQuickActionsTitle(AppLocalizations l10n) {
   return l10n.quickActionsDescription;
@@ -92,8 +93,9 @@ class NativeAudioSheetParts {
 
 NativeAudioSheetParts buildNativeAudioSheetParts(
   AppLocalizations l10n,
-  AppSettings appSettings,
-) {
+  AppSettings appSettings, {
+  List<Map<String, dynamic>> ttsVoices = const <Map<String, dynamic>>[],
+}) {
   final sttSegment = NativeSheetItemConfig(
     id: 'stt-engine',
     title: l10n.sttSettings,
@@ -151,11 +153,33 @@ NativeAudioSheetParts buildNativeAudioSheetParts(
     ],
   );
 
+  final voiceOptions = buildTtsVoiceOptions(
+    l10n,
+    appSettings.ttsEngine,
+    ttsVoices,
+  );
+  final selectedVoiceId = selectedTtsVoiceOptionId(appSettings, ttsVoices);
+
   final voicePickerNav = NativeSheetItemConfig(
     id: 'tts-voice-picker',
     title: l10n.ttsVoice,
     subtitle: _nativeVoiceSubtitle(l10n, appSettings),
     sfSymbol: 'person.wave.2',
+    kind: NativeSheetItemKind.searchablePicker,
+    value: selectedVoiceId,
+    options: [
+      NativeSheetOptionConfig(
+        id: ttsSystemDefaultVoiceId,
+        label: l10n.ttsSystemDefault,
+      ),
+      for (final option in voiceOptions)
+        NativeSheetOptionConfig(
+          id: option.id,
+          label: option.label,
+          subtitle: option.subtitle,
+          sfSymbol: 'person.wave.2',
+        ),
+    ],
   );
 
   final speechRateSlider = NativeSheetItemConfig(
@@ -197,14 +221,7 @@ NativeAudioSheetParts buildNativeAudioSheetParts(
     id: 'tts-voice-picker',
     title: l10n.ttsSelectVoice,
     subtitle: l10n.ttsVoice,
-    items: [
-      NativeSheetItemConfig(
-        id: 'tts-voice-pick:${Uri.encodeComponent('__default__')}',
-        title: l10n.ttsSystemDefault,
-        sfSymbol: 'sparkles',
-        value: '',
-      ),
-    ],
+    items: const [],
   );
 
   return NativeAudioSheetParts(
@@ -215,11 +232,15 @@ NativeAudioSheetParts buildNativeAudioSheetParts(
 
 String _nativeVoiceSubtitle(AppLocalizations l10n, AppSettings settings) {
   if (settings.ttsEngine == TtsEngine.server) {
-    return settings.ttsServerVoiceName ??
+    final voice =
+        settings.ttsServerVoiceName ??
         settings.ttsServerVoiceId ??
         l10n.ttsSystemDefault;
+    return formatTtsVoiceDisplayName(voice);
   }
-  return settings.ttsVoice ?? l10n.ttsSystemDefault;
+  final voice =
+      settings.ttsVoiceName ?? settings.ttsVoice ?? l10n.ttsSystemDefault;
+  return formatTtsVoiceDisplayName(voice);
 }
 
 NativeSheetDetailConfig buildNativePasswordDetail(

--- a/lib/core/utils/tts_voice_utils.dart
+++ b/lib/core/utils/tts_voice_utils.dart
@@ -1,0 +1,253 @@
+import '../../l10n/app_localizations.dart';
+import '../services/settings_service.dart';
+
+const ttsSystemDefaultVoiceId = '__system_default__';
+
+class TtsVoiceOptionData {
+  const TtsVoiceOptionData({
+    required this.id,
+    required this.label,
+    required this.voice,
+    this.subtitle,
+  });
+
+  final String id;
+  final String label;
+  final String? subtitle;
+  final Map<String, dynamic> voice;
+}
+
+List<TtsVoiceOptionData> buildTtsVoiceOptions(
+  AppLocalizations l10n,
+  TtsEngine engine,
+  Iterable<Map<String, dynamic>> voices,
+) {
+  final seen = <String>{};
+  final options = <TtsVoiceOptionData>[];
+  for (final voice in voices) {
+    final id = ttsVoiceIdFor(engine, voice);
+    if (id.isEmpty || !seen.add(id)) {
+      continue;
+    }
+    options.add(
+      TtsVoiceOptionData(
+        id: id,
+        label: ttsVoiceNameFor(l10n, voice),
+        subtitle: ttsVoiceSubtitleFor(voice),
+        voice: voice,
+      ),
+    );
+  }
+  return options;
+}
+
+String selectedTtsVoiceOptionId(
+  AppSettings settings,
+  Iterable<Map<String, dynamic>> voices,
+) {
+  final storedId = _selectedStoredVoiceId(settings);
+  if (storedId == null || storedId.isEmpty) {
+    return ttsSystemDefaultVoiceId;
+  }
+
+  for (final voice in voices) {
+    if (ttsVoiceMatchesSettings(settings, voice)) {
+      return ttsVoiceIdFor(settings.ttsEngine, voice);
+    }
+  }
+
+  return storedId;
+}
+
+bool ttsVoiceMatchesSettings(AppSettings settings, Map<String, dynamic> voice) {
+  final storedId = _selectedStoredVoiceId(settings);
+  final storedName = _selectedStoredVoiceName(settings);
+  return ttsVoiceMatches(
+    settings.ttsEngine,
+    voice,
+    storedId: storedId,
+    storedName: storedName,
+  );
+}
+
+bool ttsVoiceMatches(
+  TtsEngine engine,
+  Map<String, dynamic> voice, {
+  String? storedId,
+  String? storedName,
+}) {
+  final aliases = ttsVoiceAliasesFor(engine, voice);
+  final normalizedId = _normalizeVoiceKey(storedId);
+  if (normalizedId != null && aliases.contains(normalizedId)) {
+    return true;
+  }
+
+  final normalizedName = _normalizeVoiceKey(storedName);
+  return normalizedName != null && aliases.contains(normalizedName);
+}
+
+TtsVoiceOptionData? findTtsVoiceOption(
+  AppLocalizations l10n,
+  TtsEngine engine,
+  Iterable<Map<String, dynamic>> voices,
+  String selectedId,
+) {
+  for (final voice in voices) {
+    if (ttsVoiceMatches(engine, voice, storedId: selectedId)) {
+      return TtsVoiceOptionData(
+        id: ttsVoiceIdFor(engine, voice),
+        label: ttsVoiceNameFor(l10n, voice),
+        subtitle: ttsVoiceSubtitleFor(voice),
+        voice: voice,
+      );
+    }
+  }
+  return null;
+}
+
+Set<String> ttsVoiceAliasesFor(TtsEngine engine, Map<String, dynamic> voice) {
+  final keys = switch (engine) {
+    TtsEngine.server => const <String>[
+      'id',
+      'name',
+      'identifier',
+      'voiceIdentifier',
+    ],
+    TtsEngine.device => const <String>[
+      'identifier',
+      'id',
+      'voiceIdentifier',
+      'name',
+      'displayName',
+      'locale',
+      'language',
+    ],
+  };
+
+  return {for (final key in keys) ?_normalizeVoiceKey(voice[key]?.toString())};
+}
+
+String ttsVoiceIdFor(TtsEngine engine, Map<String, dynamic> voice) {
+  final id = _cleanVoiceValue(voice['id']);
+  final name = _cleanVoiceValue(voice['name']);
+  final identifier = _cleanVoiceValue(voice['identifier']);
+  final voiceIdentifier = _cleanVoiceValue(voice['voiceIdentifier']);
+  final locale = _cleanVoiceValue(voice['locale'] ?? voice['language']);
+
+  return switch (engine) {
+    TtsEngine.server =>
+      id ?? name ?? identifier ?? voiceIdentifier ?? locale ?? '',
+    TtsEngine.device =>
+      identifier ?? id ?? voiceIdentifier ?? name ?? locale ?? '',
+  };
+}
+
+String ttsVoiceNameFor(AppLocalizations l10n, Map<String, dynamic> voice) {
+  final raw =
+      _cleanVoiceValue(voice['displayName']) ??
+      _cleanVoiceValue(voice['name']) ??
+      _cleanVoiceValue(voice['id']) ??
+      _cleanVoiceValue(voice['identifier']) ??
+      _cleanVoiceValue(voice['voiceIdentifier']) ??
+      l10n.unknownLabel;
+  return formatTtsVoiceDisplayName(raw);
+}
+
+String? ttsVoiceSubtitleFor(Map<String, dynamic> voice) {
+  final languageName = _cleanVoiceValue(voice['languageName']);
+  final locale = _cleanVoiceValue(voice['locale'] ?? voice['language']);
+  final quality = _cleanVoiceValue(voice['qualityName']);
+  final parts = <String>[
+    ?languageName,
+    if (languageName == null) ?locale,
+    ?quality,
+    if (voice['isPersonalVoice'] == true) 'Personal Voice',
+    if (voice['isNoveltyVoice'] == true) 'Novelty',
+  ];
+  return parts.isEmpty ? null : parts.join(' · ');
+}
+
+String formatTtsVoiceDisplayName(String voiceName) {
+  if (voiceName.isEmpty) {
+    return voiceName;
+  }
+
+  if (voiceName.contains('#')) {
+    final parts = voiceName.split('#');
+    if (parts.length > 1) {
+      final friendlyName = _friendlyAndroidVoiceSuffix(parts[1]);
+      final localeInfo = parts[0].toUpperCase().replaceAll('_', '-');
+      return localeInfo.isEmpty ? friendlyName : '$localeInfo - $friendlyName';
+    }
+  }
+
+  if (voiceName.contains('-x-') ||
+      voiceName.endsWith('-local') ||
+      voiceName.endsWith('-network') ||
+      voiceName.endsWith('-language')) {
+    var localePart = '';
+    var qualityPart = '';
+
+    if (voiceName.contains('-x-')) {
+      final xParts = voiceName.split('-x-');
+      localePart = xParts[0];
+      qualityPart = xParts.length > 1 ? xParts[1] : '';
+    } else if (voiceName.contains('-language')) {
+      localePart = voiceName.replaceAll('-language', '');
+    } else {
+      final dashIndex = voiceName.indexOf('-', 3);
+      localePart = dashIndex > 0
+          ? voiceName.substring(0, dashIndex)
+          : voiceName;
+    }
+
+    final formattedLocale = localePart.toUpperCase();
+    if (qualityPart.isEmpty) {
+      return formattedLocale;
+    }
+
+    final formattedQuality = qualityPart
+        .replaceAll('-local', '')
+        .replaceAll('-network', '')
+        .toUpperCase();
+    return '$formattedLocale ($formattedQuality)';
+  }
+
+  return voiceName;
+}
+
+String? _selectedStoredVoiceId(AppSettings settings) {
+  return switch (settings.ttsEngine) {
+    TtsEngine.server => _cleanVoiceValue(settings.ttsServerVoiceId),
+    TtsEngine.device => _cleanVoiceValue(settings.ttsVoice),
+  };
+}
+
+String? _selectedStoredVoiceName(AppSettings settings) {
+  return switch (settings.ttsEngine) {
+    TtsEngine.server => _cleanVoiceValue(settings.ttsServerVoiceName),
+    TtsEngine.device => _cleanVoiceValue(settings.ttsVoiceName),
+  };
+}
+
+String _friendlyAndroidVoiceSuffix(String suffix) {
+  return suffix
+      .replaceAll('-local', '')
+      .replaceAll('-network', '')
+      .replaceAll('_', ' ')
+      .split(' ')
+      .map(
+        (word) => word.isEmpty ? '' : word[0].toUpperCase() + word.substring(1),
+      )
+      .join(' ');
+}
+
+String? _cleanVoiceValue(Object? value) {
+  final text = value?.toString().trim();
+  return text == null || text.isEmpty ? null : text;
+}
+
+String? _normalizeVoiceKey(String? value) {
+  final cleaned = _cleanVoiceValue(value);
+  return cleaned?.toLowerCase();
+}

--- a/lib/features/chat/providers/chat_providers.dart
+++ b/lib/features/chat/providers/chat_providers.dart
@@ -1633,10 +1633,7 @@ class ChatMessagesNotifier extends Notifier<List<ChatMessage>> {
     final modelItem =
         (selectedModel != null && selectedModel.id == resolvedModelId)
         ? _buildLocalModelItem(selectedModel)
-        : <String, dynamic>{
-            'id': resolvedModelId,
-            'name': resolvedModelId,
-          };
+        : <String, dynamic>{'id': resolvedModelId, 'name': resolvedModelId};
 
     DebugLogger.log(
       'Attaching socket resume stream for in-flight chat',
@@ -5775,7 +5772,10 @@ Future<void> _sendMessageInternal(
     // `dynamic` — without it Dart infers (dynamic) => dynamic at runtime.
     final ChatMessagesNotifier notifier =
         ref.read(chatMessagesProvider.notifier) as ChatMessagesNotifier;
-    notifier.failLastStreamingAssistant(e, assistantMessageId: assistantMessageId);
+    notifier.failLastStreamingAssistant(
+      e,
+      assistantMessageId: assistantMessageId,
+    );
     if (e.toString().contains('401') || e.toString().contains('403')) {
       // Authentication errors - clear auth state and redirect to login.
       ref.invalidate(authStateManagerProvider);
@@ -6180,12 +6180,7 @@ final stopGenerationProvider = Provider<void Function()>((ref) {
       if (api != null && activeConv != null) {
         unawaited(() async {
           try {
-            final ids = await api.getTaskIdsByChat(activeConv.id);
-            for (final t in ids) {
-              try {
-                await api.stopTask(t);
-              } catch (_) {}
-            }
+            await api.stopTasksByChat(activeConv.id);
           } catch (_) {}
         }());
 

--- a/lib/features/chat/services/chat_transport_dispatch.dart
+++ b/lib/features/chat/services/chat_transport_dispatch.dart
@@ -155,7 +155,12 @@ void stopActiveTransport(ChatMessage message, ApiService? api) {
   // Stop background task
   final taskId = meta?['taskId']?.toString();
   if (taskId != null && taskId.isNotEmpty) {
-    unawaited(api?.stopTask(taskId));
+    final taskConversationId = meta?['taskConversationId']?.toString();
+    if (taskConversationId != null && taskConversationId.isNotEmpty) {
+      unawaited(api?.stopTasksByChat(taskConversationId));
+    } else {
+      unawaited(api?.stopTask(taskId));
+    }
   }
 }
 
@@ -356,7 +361,10 @@ Future<void> dispatchChatTransport({
       // fallback can still resolve server content if the socket later dies.
       ref
           .read(chatMessagesProvider.notifier)
-          .recordResumeBoundRemoteMessageId(assistantMessageId, remoteMessageId);
+          .recordResumeBoundRemoteMessageId(
+            assistantMessageId,
+            remoteMessageId,
+          );
     },
     onChatActiveChanged: (chatId, active) {
       if (chatId == null || chatId.isEmpty) return;
@@ -408,9 +416,7 @@ Future<void> dispatchChatTransport({
       // CDT-RFC-001 Phase 1 (E2): the post-stream snapshot refresh persists
       // through the sync engine (upsertServerChat under the chat lock).
       try {
-        return await ref
-            .read(syncEngineProvider.notifier)
-            .pullChatNow(chatId);
+        return await ref.read(syncEngineProvider.notifier).pullChatNow(chatId);
       } catch (error, stackTrace) {
         // Engine unavailable (no database / reviewer mode): the helper falls
         // back to the direct fetch.

--- a/lib/features/chat/services/chat_transport_dispatch.dart
+++ b/lib/features/chat/services/chat_transport_dispatch.dart
@@ -154,13 +154,11 @@ void stopActiveTransport(ChatMessage message, ApiService? api) {
 
   // Stop background task
   final taskId = meta?['taskId']?.toString();
-  if (taskId != null && taskId.isNotEmpty) {
-    final taskConversationId = meta?['taskConversationId']?.toString();
-    if (taskConversationId != null && taskConversationId.isNotEmpty) {
-      unawaited(api?.stopTasksByChat(taskConversationId));
-    } else {
-      unawaited(api?.stopTask(taskId));
-    }
+  final taskConversationId = meta?['taskConversationId']?.toString();
+  if (taskConversationId != null && taskConversationId.isNotEmpty) {
+    unawaited(api?.stopTasksByChat(taskConversationId));
+  } else if (taskId != null && taskId.isNotEmpty) {
+    unawaited(api?.stopTask(taskId));
   }
 }
 

--- a/lib/features/chat/services/native_stt_service.dart
+++ b/lib/features/chat/services/native_stt_service.dart
@@ -130,7 +130,10 @@ class NativeSttService {
 
   bool get isSupportedPlatform => Platform.isAndroid || Platform.isIOS;
 
-  Future<NativeSttAvailability> checkAvailability({String? localeId}) async {
+  Future<NativeSttAvailability> checkAvailability({
+    String? localeId,
+    bool allowOnlineFallback = true,
+  }) async {
     if (!isSupportedPlatform) {
       return const NativeSttAvailability(
         available: false,
@@ -141,7 +144,10 @@ class NativeSttService {
     try {
       final response = await _methodChannel.invokeMapMethod<Object?, Object?>(
         'checkAvailability',
-        <String, Object?>{'localeId': localeId},
+        <String, Object?>{
+          'localeId': localeId,
+          'allowOnlineFallback': allowOnlineFallback,
+        },
       );
       return NativeSttAvailability.fromMap(response);
     } on MissingPluginException {

--- a/lib/features/chat/services/native_stt_service.dart
+++ b/lib/features/chat/services/native_stt_service.dart
@@ -1,0 +1,246 @@
+import 'dart:async';
+import 'dart:io' show Platform;
+
+import 'package:flutter/services.dart';
+
+class NativeSttAvailability {
+  const NativeSttAvailability({
+    required this.available,
+    this.engine,
+    this.reason,
+  });
+
+  final bool available;
+  final String? engine;
+  final String? reason;
+
+  factory NativeSttAvailability.fromMap(Map<Object?, Object?>? map) {
+    if (map == null) {
+      return const NativeSttAvailability(
+        available: false,
+        reason: 'No native STT response',
+      );
+    }
+
+    return NativeSttAvailability(
+      available: map['available'] == true,
+      engine: map['engine'] as String?,
+      reason: map['reason'] as String?,
+    );
+  }
+}
+
+class NativeSttEvent {
+  const NativeSttEvent({
+    required this.type,
+    this.text,
+    this.isFinal = false,
+    this.engine,
+    this.code,
+    this.message,
+  });
+
+  final String type;
+  final String? text;
+  final bool isFinal;
+  final String? engine;
+  final String? code;
+  final String? message;
+
+  factory NativeSttEvent.fromMap(Map<Object?, Object?> map) {
+    return NativeSttEvent(
+      type: (map['type'] as String?) ?? 'unknown',
+      text: map['text'] as String?,
+      isFinal: map['final'] == true,
+      engine: map['engine'] as String?,
+      code: map['code'] as String?,
+      message: map['message'] as String?,
+    );
+  }
+}
+
+class NativeSttLocales {
+  const NativeSttLocales({required this.locales, this.systemLocaleId});
+
+  final List<NativeSttLocale> locales;
+  final String? systemLocaleId;
+
+  factory NativeSttLocales.fromMap(Map<Object?, Object?>? map) {
+    if (map == null) {
+      return const NativeSttLocales(locales: <NativeSttLocale>[]);
+    }
+    final rawLocales = map['locales'];
+    final locales = rawLocales is List
+        ? rawLocales
+              .whereType<Map>()
+              .map(
+                (entry) =>
+                    NativeSttLocale.fromMap(entry.cast<Object?, Object?>()),
+              )
+              .where((locale) => locale.localeId.isNotEmpty)
+              .toList(growable: false)
+        : const <NativeSttLocale>[];
+    return NativeSttLocales(
+      locales: locales,
+      systemLocaleId: map['systemLocale'] as String?,
+    );
+  }
+}
+
+class NativeSttLocale {
+  const NativeSttLocale({required this.localeId, required this.name});
+
+  final String localeId;
+  final String name;
+
+  factory NativeSttLocale.fromMap(Map<Object?, Object?> map) {
+    final localeId = (map['localeId'] as String?) ?? '';
+    return NativeSttLocale(
+      localeId: localeId,
+      name: (map['name'] as String?)?.trim().isNotEmpty == true
+          ? (map['name'] as String).trim()
+          : localeId,
+    );
+  }
+}
+
+class NativeSttException implements Exception {
+  const NativeSttException(this.message, {this.code});
+
+  final String message;
+  final String? code;
+
+  @override
+  String toString() {
+    final prefix = code == null ? 'Native STT' : 'Native STT $code';
+    return '$prefix: $message';
+  }
+}
+
+class NativeSttService {
+  static const MethodChannel _methodChannel = MethodChannel(
+    'app.cogwheel.conduit/native_stt',
+  );
+  static const EventChannel _eventChannel = EventChannel(
+    'app.cogwheel.conduit/native_stt/events',
+  );
+
+  StreamSubscription<dynamic>? _eventSub;
+  StreamController<NativeSttEvent>? _eventController;
+
+  bool get isSupportedPlatform => Platform.isAndroid || Platform.isIOS;
+
+  Future<NativeSttAvailability> checkAvailability({String? localeId}) async {
+    if (!isSupportedPlatform) {
+      return const NativeSttAvailability(
+        available: false,
+        reason: 'Unsupported platform',
+      );
+    }
+
+    try {
+      final response = await _methodChannel.invokeMapMethod<Object?, Object?>(
+        'checkAvailability',
+        <String, Object?>{'localeId': localeId},
+      );
+      return NativeSttAvailability.fromMap(response);
+    } on MissingPluginException {
+      return const NativeSttAvailability(
+        available: false,
+        reason: 'Native STT bridge is not registered',
+      );
+    } on PlatformException catch (error) {
+      return NativeSttAvailability(
+        available: false,
+        reason: error.message ?? error.code,
+      );
+    }
+  }
+
+  Future<NativeSttLocales> getLocales({String? deviceLocaleId}) async {
+    if (!isSupportedPlatform) {
+      return const NativeSttLocales(locales: <NativeSttLocale>[]);
+    }
+
+    try {
+      final response = await _methodChannel.invokeMapMethod<Object?, Object?>(
+        'getLocales',
+        <String, Object?>{'deviceLocaleId': deviceLocaleId},
+      );
+      return NativeSttLocales.fromMap(response);
+    } on MissingPluginException {
+      return const NativeSttLocales(locales: <NativeSttLocale>[]);
+    } on PlatformException {
+      return const NativeSttLocales(locales: <NativeSttLocale>[]);
+    }
+  }
+
+  Future<Stream<NativeSttEvent>> startListening({
+    String? localeId,
+    bool preserveAudioSession = false,
+    bool emitPartialResults = true,
+    bool accumulateResults = true,
+    bool allowOnlineFallback = true,
+  }) async {
+    if (!isSupportedPlatform) {
+      throw const NativeSttException('Unsupported platform');
+    }
+
+    await stopListening();
+    final controller = StreamController<NativeSttEvent>.broadcast();
+    _eventController = controller;
+    _eventSub = _eventChannel.receiveBroadcastStream().listen(
+      (event) {
+        if (event is Map) {
+          controller.add(NativeSttEvent.fromMap(event));
+        }
+      },
+      onError: (Object error, StackTrace stackTrace) {
+        controller.addError(error, stackTrace);
+      },
+      onDone: () {
+        controller.close();
+      },
+    );
+
+    try {
+      final response = await _methodChannel
+          .invokeMapMethod<Object?, Object?>('start', <String, Object?>{
+            'localeId': localeId,
+            'preserveAudioSession': preserveAudioSession,
+            'emitPartialResults': emitPartialResults,
+            'accumulateResults': accumulateResults,
+            'allowOnlineFallback': allowOnlineFallback,
+          });
+      final availability = NativeSttAvailability.fromMap(response);
+      if (!availability.available) {
+        throw NativeSttException(
+          availability.reason ?? 'Native STT unavailable',
+          code: availability.engine,
+        );
+      }
+      return controller.stream;
+    } catch (_) {
+      await stopListening();
+      rethrow;
+    }
+  }
+
+  Future<void> stopListening() async {
+    try {
+      await _methodChannel.invokeMethod<void>('stop');
+    } on MissingPluginException {
+      // Ignore; the bridge is optional and only present on mobile targets.
+    } on PlatformException {
+      // Stop is best-effort because callers may already be unwinding errors.
+    }
+
+    await _eventSub?.cancel();
+    _eventSub = null;
+    final controller = _eventController;
+    _eventController = null;
+    if (controller != null && !controller.isClosed) {
+      await controller.close();
+    }
+  }
+}

--- a/lib/features/chat/services/native_tts_service.dart
+++ b/lib/features/chat/services/native_tts_service.dart
@@ -1,0 +1,161 @@
+import 'dart:async';
+import 'dart:io' show Platform;
+
+import 'package:flutter/services.dart';
+
+class NativeTtsEvent {
+  const NativeTtsEvent({
+    required this.type,
+    this.message,
+    this.start,
+    this.end,
+  });
+
+  final String type;
+  final String? message;
+  final int? start;
+  final int? end;
+
+  factory NativeTtsEvent.fromMap(Map<Object?, Object?> map) {
+    return NativeTtsEvent(
+      type: (map['type'] as String?) ?? 'unknown',
+      message: map['message'] as String?,
+      start: (map['start'] as num?)?.toInt(),
+      end: (map['end'] as num?)?.toInt(),
+    );
+  }
+}
+
+class NativeTtsService {
+  static const MethodChannel _iosMethodChannel = MethodChannel(
+    'app.cogwheel.conduit/native_ios_tts',
+  );
+  static const EventChannel _iosEventChannel = EventChannel(
+    'app.cogwheel.conduit/native_ios_tts/events',
+  );
+  static const MethodChannel _androidMethodChannel = MethodChannel(
+    'app.cogwheel.conduit/native_android_tts',
+  );
+  static const EventChannel _androidEventChannel = EventChannel(
+    'app.cogwheel.conduit/native_android_tts/events',
+  );
+
+  bool get isSupportedPlatform => Platform.isIOS || Platform.isAndroid;
+
+  MethodChannel? get _methodChannel {
+    if (Platform.isIOS) return _iosMethodChannel;
+    if (Platform.isAndroid) return _androidMethodChannel;
+    return null;
+  }
+
+  EventChannel? get _eventChannel {
+    if (Platform.isIOS) return _iosEventChannel;
+    if (Platform.isAndroid) return _androidEventChannel;
+    return null;
+  }
+
+  Stream<NativeTtsEvent> get events {
+    final channel = _eventChannel;
+    if (!isSupportedPlatform || channel == null) {
+      return const Stream<NativeTtsEvent>.empty();
+    }
+    return channel.receiveBroadcastStream().where((entry) => entry is Map).map((
+      entry,
+    ) {
+      return NativeTtsEvent.fromMap((entry as Map).cast<Object?, Object?>());
+    });
+  }
+
+  Future<bool> isAvailable() async {
+    final channel = _methodChannel;
+    if (!isSupportedPlatform || channel == null) {
+      return false;
+    }
+    try {
+      return await channel.invokeMethod<bool>('isAvailable') ?? false;
+    } on MissingPluginException {
+      return false;
+    } on PlatformException {
+      return false;
+    }
+  }
+
+  Future<List<Map<String, dynamic>>> getVoices() async {
+    final channel = _methodChannel;
+    if (!isSupportedPlatform || channel == null) {
+      return const <Map<String, dynamic>>[];
+    }
+    try {
+      final raw = await channel.invokeListMethod<Object?>('getVoices');
+      if (raw == null) {
+        return const <Map<String, dynamic>>[];
+      }
+      return raw
+          .whereType<Map>()
+          .map(_normalizeVoiceEntry)
+          .where((voice) => voice.isNotEmpty)
+          .toList(growable: false);
+    } on MissingPluginException {
+      return const <Map<String, dynamic>>[];
+    } on PlatformException {
+      return const <Map<String, dynamic>>[];
+    }
+  }
+
+  Future<bool> speak({
+    required String text,
+    String? voiceIdentifier,
+    required double rate,
+    required double pitch,
+    required double volume,
+  }) async {
+    final channel = _methodChannel;
+    if (!isSupportedPlatform || channel == null) {
+      return false;
+    }
+    try {
+      return await channel.invokeMethod<bool>('speak', {
+            'text': text,
+            'voiceIdentifier': voiceIdentifier,
+            'rate': rate,
+            'pitch': pitch,
+            'volume': volume,
+          }) ??
+          false;
+    } on MissingPluginException {
+      return false;
+    } on PlatformException {
+      return false;
+    }
+  }
+
+  Future<bool> stop() => _invokeBool('stop');
+
+  Future<bool> pause() => _invokeBool('pause');
+
+  Future<bool> resume() => _invokeBool('resume');
+
+  Future<bool> _invokeBool(String method) async {
+    final channel = _methodChannel;
+    if (!isSupportedPlatform || channel == null) {
+      return false;
+    }
+    try {
+      return await channel.invokeMethod<bool>(method) ?? false;
+    } on MissingPluginException {
+      return false;
+    } on PlatformException {
+      return false;
+    }
+  }
+
+  Map<String, dynamic> _normalizeVoiceEntry(Map<dynamic, dynamic> entry) {
+    final normalized = <String, dynamic>{};
+    entry.forEach((key, value) {
+      if (key != null) {
+        normalized[key.toString()] = value;
+      }
+    });
+    return normalized;
+  }
+}

--- a/lib/features/chat/services/text_to_speech_service.dart
+++ b/lib/features/chat/services/text_to_speech_service.dart
@@ -235,11 +235,18 @@ class TextToSpeechService {
 
   /// Gets available voices from the device TTS engine.
   Future<List<Map<String, dynamic>>> getAvailableVoices() async {
+    final config = TtsManager.instance.config;
     if (!_initialized) {
-      await initialize();
+      await initialize(
+        deviceVoice: config.voice,
+        serverVoice: config.serverVoice,
+        speechRate: config.speechRate,
+        pitch: config.pitch,
+        volume: config.volume,
+        engine: config.preferServer ? TtsEngine.server : TtsEngine.device,
+      );
     }
 
-    final config = TtsManager.instance.config;
     if (config.preferServer && TtsManager.instance.serverAvailable) {
       return _getServerVoices();
     }

--- a/lib/features/chat/services/tts_manager.dart
+++ b/lib/features/chat/services/tts_manager.dart
@@ -3,7 +3,6 @@ import 'dart:io' show Directory, File, Platform;
 
 import 'package:dio/dio.dart';
 import 'package:flutter/foundation.dart';
-import 'package:flutter_tts/flutter_tts.dart';
 import 'package:just_audio/just_audio.dart';
 import 'package:path/path.dart' as p;
 import 'package:path_provider/path_provider.dart';
@@ -12,6 +11,7 @@ import '../../../core/models/backend_config.dart';
 import '../../../core/services/api_service.dart';
 import '../../../core/services/background_streaming_handler.dart';
 import '../../../shared/widgets/markdown/markdown_preprocessor.dart';
+import 'native_tts_service.dart';
 
 // =============================================================================
 // TTS Events
@@ -165,7 +165,7 @@ class TtsConfig {
 
 /// Single global manager for all TTS operations.
 ///
-/// This manager owns the FlutterTts and AudioPlayer instances and ensures
+/// This manager owns native device TTS and AudioPlayer instances and ensures
 /// only one playback session is active at a time. Events are emitted via
 /// a stream that consumers can listen to.
 class TtsManager {
@@ -183,11 +183,11 @@ class TtsManager {
   TtsManager._();
   static final instance = TtsManager._();
 
-  // FlutterTts instance (lazy initialized)
-  FlutterTts? _tts;
   bool _ttsInitialized = false;
-  bool _handlersSet = false;
   Completer<void>? _initCompleter;
+  final NativeTtsService _nativeTts = NativeTtsService();
+  StreamSubscription<NativeTtsEvent>? _nativeTtsSub;
+  bool _nativeTtsAvailable = false;
 
   // AudioPlayer for server TTS (using just_audio)
   final AudioPlayer _player = AudioPlayer();
@@ -263,16 +263,10 @@ class TtsManager {
 
   /// Updates the TTS configuration.
   Future<void> updateConfig(TtsConfig config) async {
+    final voiceChanged = config.voice != _config.voice;
     _config = config;
-
-    if (_tts != null && _ttsInitialized) {
-      await _tts!.setVolume(config.volume);
-      await _tts!.setSpeechRate(config.speechRate);
-      await _tts!.setPitch(config.pitch);
-
-      if (config.voice != null) {
-        await _setVoiceByName(config.voice);
-      }
+    if (voiceChanged) {
+      _voiceConfigured = false;
     }
 
     if (_playerConfigured) {
@@ -298,7 +292,7 @@ class TtsManager {
       _config = config;
     }
 
-    // Initialize FlutterTts
+    // Initialize native device TTS.
     await _ensureTtsInitialized();
 
     // Configure AudioPlayer for all platforms (using just_audio)
@@ -436,7 +430,7 @@ class TtsManager {
       await _player.stop();
       await _player.clearAudioSources();
     } else {
-      if (!_deviceEngineAvailable || _tts == null) {
+      if (!_deviceEngineAvailable) {
         throw StateError('Device TTS is not available');
       }
       if (!_voiceConfigured) {
@@ -502,7 +496,7 @@ class TtsManager {
       if (session.useServerTts) {
         await _player.pause();
       } else {
-        await _tts?.pause();
+        await _nativeTts.pause();
       }
     } catch (e) {
       _emitEvent(TtsError(e.toString()));
@@ -519,7 +513,7 @@ class TtsManager {
         await _player.play();
         _emitEvent(const TtsResumed());
       } else {
-        // Device TTS resume is handled by the native handler
+        await _nativeTts.resume();
       }
     } catch (e) {
       _emitEvent(TtsError(e.toString()));
@@ -537,7 +531,7 @@ class TtsManager {
       if (session.useServerTts) {
         await _player.stop();
       } else {
-        await _tts?.stop();
+        await _nativeTts.stop();
       }
       _resetPlaybackState();
       _emitEvent(const TtsCancelled());
@@ -571,6 +565,8 @@ class TtsManager {
   /// Disposes the manager and releases resources.
   Future<void> dispose() async {
     await stop();
+    await _nativeTtsSub?.cancel();
+    _nativeTtsSub = null;
     await _playerStateSub?.cancel();
     await _playerIndexSub?.cancel();
     await _player.dispose();
@@ -691,21 +687,37 @@ class TtsManager {
   /// Gets available voices from the device TTS engine.
   Future<List<Map<String, dynamic>>> getDeviceVoices() async {
     await _ensureTtsInitialized();
-    if (_tts == null) return [];
+    final voices = await _nativeTts.getVoices();
+    final engine = !kIsWeb && Platform.isIOS ? 'AVSpeech' : 'AndroidTTS';
+    return _mergeDeviceVoices([
+      voices.map((voice) => {...voice, 'engine': engine}).toList(),
+    ]);
+  }
 
-    try {
-      final voicesRaw = await _tts!.getVoices;
-      if (voicesRaw is! List) return [];
-
-      return voicesRaw
-          .whereType<Map>()
-          .map((e) => _normalizeVoiceEntry(e))
-          .where((e) => e.isNotEmpty)
-          .toList();
-    } catch (e) {
-      _emitEvent(TtsError(e.toString()));
-      return [];
+  List<Map<String, dynamic>> _mergeDeviceVoices(
+    List<List<Map<String, dynamic>>> groups,
+  ) {
+    final merged = <String, Map<String, dynamic>>{};
+    for (final group in groups) {
+      for (final voice in group) {
+        final key = _voiceDedupeKey(voice);
+        if (key == null || merged.containsKey(key)) {
+          continue;
+        }
+        merged[key] = voice;
+      }
     }
+    return merged.values.toList(growable: false);
+  }
+
+  String? _voiceDedupeKey(Map<String, dynamic> voice) {
+    for (final key in const ['identifier', 'id', 'voiceIdentifier', 'name']) {
+      final value = voice[key]?.toString().trim();
+      if (value != null && value.isNotEmpty) {
+        return value.toLowerCase();
+      }
+    }
+    return null;
   }
 
   String _normalizeSplitOn(String? splitOn) {
@@ -774,9 +786,10 @@ class TtsManager {
     if (_currentChunkIndex < 0) {
       _currentChunkIndex = 0;
       _emitEvent(const TtsChunkStarted(0));
-      final result = await _tts!.speak(chunk);
-      if (result is int && result != 1) {
-        _emitEvent(TtsError('TTS engine returned error code $result'));
+      try {
+        await _speakDeviceChunk(chunk);
+      } catch (error) {
+        _emitEvent(TtsError(error.toString()));
       }
       return;
     }
@@ -826,7 +839,6 @@ class TtsManager {
   Future<void> _ensureTtsInitialized() async {
     if (_ttsInitialized) return;
 
-    // Prevent concurrent initialization
     if (_initCompleter != null) {
       await _initCompleter!.future;
       return;
@@ -835,20 +847,6 @@ class TtsManager {
     _initCompleter = Completer<void>();
 
     try {
-      final tts = FlutterTts();
-      _tts = tts;
-
-      // Wait for native TTS to be fully initialized before setting handlers.
-      // The flutter_tts plugin has a bug where setting handlers during onInit
-      // causes ConcurrentModificationException.
-      await Future<void>.delayed(const Duration(milliseconds: 500));
-
-      if (!_handlersSet) {
-        _setupTtsHandlers(tts);
-        _handlersSet = true;
-      }
-
-      // Configure device engine
       await _configureDeviceEngine();
 
       _ttsInitialized = true;
@@ -860,80 +858,48 @@ class TtsManager {
     }
   }
 
-  void _setupTtsHandlers(FlutterTts tts) {
-    tts.setStartHandler(() {
-      if (_activeSession != null && !_activeSession!.useServerTts) {
+  Future<void> _configureDeviceEngine() async {
+    _deviceEngineAvailable = false;
+    _nativeTtsAvailable = await _nativeTts.isAvailable();
+    if (_nativeTtsAvailable && _nativeTtsSub == null) {
+      _nativeTtsSub = _nativeTts.events.listen(
+        _handleNativeTtsEvent,
+        onError: (Object error) {
+          _emitEvent(TtsError(error.toString()));
+        },
+      );
+    }
+
+    _deviceEngineAvailable = _nativeTtsAvailable;
+  }
+
+  void _handleNativeTtsEvent(NativeTtsEvent event) {
+    final session = _activeSession;
+    if (session == null || session.useServerTts) {
+      return;
+    }
+
+    switch (event.type) {
+      case 'start':
         _emitEvent(const TtsStarted());
-      }
-    });
-
-    tts.setCompletionHandler(() {
-      _onDeviceChunkComplete();
-    });
-
-    tts.setCancelHandler(() {
-      if (_activeSession != null && !_activeSession!.useServerTts) {
+      case 'complete':
+        _onDeviceChunkComplete();
+      case 'cancel':
         _activeSession = null;
         _resetPlaybackState();
         _emitEvent(const TtsCancelled());
-      }
-    });
-
-    tts.setPauseHandler(() {
-      if (_activeSession != null && !_activeSession!.useServerTts) {
+      case 'pause':
         _emitEvent(const TtsPaused());
-      }
-    });
-
-    tts.setContinueHandler(() {
-      if (_activeSession != null && !_activeSession!.useServerTts) {
+      case 'continue':
         _emitEvent(const TtsResumed());
-      }
-    });
-
-    tts.setErrorHandler((msg) {
-      _emitEvent(TtsError(msg.toString()));
-    });
-
-    try {
-      tts.setProgressHandler((String text, int start, int end, String word) {
-        if (_activeSession != null && !_activeSession!.useServerTts) {
+      case 'progress':
+        final start = event.start;
+        final end = event.end;
+        if (start != null && end != null) {
           _emitEvent(TtsWordProgress(start, end));
         }
-      });
-    } catch (_) {
-      // Some platforms may not support progress handler
-    }
-  }
-
-  Future<void> _configureDeviceEngine() async {
-    if (_tts == null) return;
-
-    _deviceEngineAvailable = false;
-    try {
-      // Set default engine on Android
-      if (!kIsWeb && Platform.isAndroid) {
-        try {
-          final engine = await _tts!.getDefaultEngine;
-          if (engine is String && engine.isNotEmpty) {
-            await _tts!.setEngine(engine);
-          }
-        } catch (_) {}
-      }
-
-      await _tts!.awaitSpeakCompletion(true);
-      await _tts!.setVolume(_config.volume);
-      await _tts!.setSpeechRate(_config.speechRate);
-      await _tts!.setPitch(_config.pitch);
-
-      if (!kIsWeb && Platform.isIOS) {
-        await _tts!.setSharedInstance(true);
-      }
-
-      _deviceEngineAvailable = true;
-    } catch (e) {
-      _deviceEngineAvailable = false;
-      _emitEvent(TtsError(e.toString()));
+      case 'error':
+        _emitEvent(TtsError(event.message ?? 'Native TTS failed'));
     }
   }
 
@@ -942,7 +908,7 @@ class TtsManager {
   // ===========================================================================
 
   Future<void> _startDevicePlayback(TtsPlaybackSession session) async {
-    if (!_deviceEngineAvailable || _tts == null) {
+    if (!_deviceEngineAvailable) {
       throw StateError('Device TTS is not available');
     }
 
@@ -955,10 +921,7 @@ class TtsManager {
 
     // Speak first chunk
     _emitEvent(const TtsChunkStarted(0));
-    final result = await _tts!.speak(session.chunks.first);
-    if (result is int && result != 1) {
-      throw StateError('TTS engine returned error code $result');
-    }
+    await _speakDeviceChunk(session.chunks.first);
   }
 
   void _onDeviceChunkComplete() {
@@ -983,11 +946,22 @@ class TtsManager {
     _currentChunkIndex = nextIndex;
     _emitEvent(TtsChunkStarted(nextIndex));
 
-    _tts?.speak(session.chunks[nextIndex]).then((result) {
-      if (result is int && result != 1) {
-        _emitEvent(TtsError('TTS engine returned error code $result'));
-      }
+    _speakDeviceChunk(session.chunks[nextIndex]).catchError((Object error) {
+      _emitEvent(TtsError(error.toString()));
     });
+  }
+
+  Future<void> _speakDeviceChunk(String chunk) async {
+    final started = await _nativeTts.speak(
+      text: chunk,
+      voiceIdentifier: _config.voice,
+      rate: _config.speechRate,
+      pitch: _config.pitch,
+      volume: _config.volume,
+    );
+    if (!started) {
+      throw StateError('Native TTS failed to start');
+    }
   }
 
   // ===========================================================================
@@ -1462,78 +1436,9 @@ class TtsManager {
     }
   }
 
-  Future<void> _setVoiceByName(String? voiceName) async {
-    if (_tts == null || voiceName == null) return;
-    if (kIsWeb || (!Platform.isIOS && !Platform.isAndroid)) return;
-
-    try {
-      final voicesRaw = await _tts!.getVoices;
-      if (voicesRaw is! List) return;
-
-      for (final entry in voicesRaw) {
-        if (entry is Map) {
-          final normalized = _normalizeVoiceEntry(entry);
-          final name = normalized['name'] as String?;
-          if (name == voiceName) {
-            await _tts!.setVoice(_voiceCommandFrom(normalized));
-            _voiceConfigured = true;
-            return;
-          }
-        }
-      }
-    } catch (e) {
-      _emitEvent(TtsError(e.toString()));
-    }
-  }
-
   Future<void> _configurePreferredVoice() async {
-    if (_voiceConfigured || _tts == null) return;
-    if (kIsWeb || (!Platform.isIOS && !Platform.isAndroid)) {
-      _voiceConfigured = true;
-      return;
-    }
-
-    try {
-      // Try to use configured voice
-      if (_config.voice != null) {
-        await _setVoiceByName(_config.voice);
-        if (_voiceConfigured) return;
-      }
-
-      // Fall back to system default
-      _voiceConfigured = true;
-    } catch (e) {
-      _emitEvent(TtsError(e.toString()));
-      _voiceConfigured = true;
-    }
-  }
-
-  Map<String, dynamic> _normalizeVoiceEntry(Map<dynamic, dynamic> entry) {
-    final normalized = <String, dynamic>{};
-    entry.forEach((key, value) {
-      if (key != null) {
-        normalized[key.toString()] = value;
-      }
-    });
-    return normalized;
-  }
-
-  Map<String, String> _voiceCommandFrom(Map<String, dynamic> voice) {
-    final command = <String, String>{};
-    for (final key in [
-      'name',
-      'locale',
-      'identifier',
-      'id',
-      'voiceIdentifier',
-      'engine',
-    ]) {
-      final value = voice[key];
-      if (value != null) {
-        command[key] = value.toString();
-      }
-    }
-    return command;
+    if (_voiceConfigured) return;
+    _voiceConfigured = true;
   }
 }
 

--- a/lib/features/chat/services/tts_manager.dart
+++ b/lib/features/chat/services/tts_manager.dart
@@ -789,7 +789,7 @@ class TtsManager {
       try {
         await _speakDeviceChunk(chunk);
       } catch (error) {
-        _emitEvent(TtsError(error.toString()));
+        _failDevicePlayback(session, error);
       }
       return;
     }
@@ -899,6 +899,8 @@ class TtsManager {
           _emitEvent(TtsWordProgress(start, end));
         }
       case 'error':
+        _activeSession = null;
+        _resetPlaybackState();
         _emitEvent(TtsError(event.message ?? 'Native TTS failed'));
     }
   }
@@ -947,7 +949,7 @@ class TtsManager {
     _emitEvent(TtsChunkStarted(nextIndex));
 
     _speakDeviceChunk(session.chunks[nextIndex]).catchError((Object error) {
-      _emitEvent(TtsError(error.toString()));
+      _failDevicePlayback(session, error);
     });
   }
 
@@ -962,6 +964,14 @@ class TtsManager {
     if (!started) {
       throw StateError('Native TTS failed to start');
     }
+  }
+
+  void _failDevicePlayback(TtsPlaybackSession session, Object error) {
+    if (_activeSession?.id == session.id) {
+      _activeSession = null;
+      _resetPlaybackState();
+    }
+    _emitEvent(TtsError(error.toString()));
   }
 
   // ===========================================================================

--- a/lib/features/chat/services/voice_input_service.dart
+++ b/lib/features/chat/services/voice_input_service.dart
@@ -9,15 +9,14 @@ import 'package:flutter/widgets.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:permission_handler/permission_handler.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
-import 'package:speech_to_text/speech_recognition_result.dart';
-import 'package:speech_to_text/speech_to_text.dart';
 import 'package:vad/vad.dart';
 
 import '../../../core/providers/app_providers.dart';
 import '../../../core/services/api_service.dart';
 import '../../../core/services/background_streaming_handler.dart';
 import '../../../core/services/settings_service.dart';
-import 'voice_transcript_accumulator.dart';
+import '../../../core/utils/debug_logger.dart';
+import 'native_stt_service.dart';
 
 part 'voice_input_service.g.dart';
 
@@ -26,6 +25,13 @@ class LocaleName {
   final String localeId;
   final String name;
   const LocaleName(this.localeId, this.name);
+}
+
+class VoiceTranscriptEvent {
+  const VoiceTranscriptEvent({required this.text, required this.isFinal});
+
+  final String text;
+  final bool isFinal;
 }
 
 class VoiceInputService {
@@ -46,6 +52,9 @@ class VoiceInputService {
   static const String _backgroundSttStreamId = 'voice-input-stt';
   static const Duration _vadDisposeCooldown = Duration(milliseconds: 140);
   static const Duration _localRecognitionMaxDuration = Duration(minutes: 5);
+  static const Duration _nativeDictationFinalSettleDelay = Duration(
+    milliseconds: 900,
+  );
   static const String _bundledVadAssetBasePath = 'assets/vad/';
   static const List<IosAudioCategoryOption> _iosServerVadCategoryOptions = [
     // A2DP is output-only on iOS and can break duplex mic capture when the
@@ -64,27 +73,51 @@ class VoiceInputService {
         manageAudioSession: false,
       );
 
+  @visibleForTesting
+  static AndroidRecordConfig androidServerVadRecordConfigForTesting({
+    required bool voiceCallSession,
+  }) => _androidServerVadRecordConfig(voiceCallSession: voiceCallSession);
+
+  static AndroidRecordConfig _androidServerVadRecordConfig({
+    required bool voiceCallSession,
+  }) {
+    return AndroidRecordConfig(
+      audioSource: voiceCallSession
+          ? AndroidAudioSource.voiceCommunication
+          : AndroidAudioSource.voiceRecognition,
+      audioManagerMode: voiceCallSession
+          ? AudioManagerMode.modeInCommunication
+          : AudioManagerMode.modeNormal,
+      speakerphone: false,
+      manageBluetooth: true,
+      useLegacy: false,
+    );
+  }
+
   VadHandler? _vadHandler;
-  final SpeechToText _speech = SpeechToText();
+  final NativeSttService _nativeStt;
   final ApiService? _api;
   final Ref? _ref;
   bool _isInitialized = false;
   bool _didAttemptLocalInitialization = false;
   bool _isListening = false;
   bool _localSttAvailable = false;
+  bool _nativeLocalSttAvailable = false;
   bool _localSttActive = false;
   SttPreference _preference = SttPreference.deviceOnly;
   bool _usingServerStt = false;
+  bool _usingNativeLocalStt = false;
+  bool _nativeAccumulateResultsForCurrentListen = true;
   String? _selectedLocaleId;
   List<LocaleName> _locales = const [];
   bool _usingFallbackLocales = false;
   Future<void>? _startingLocalStt;
   Future<Stream<String>>? _startListeningInFlight;
   StreamController<String>? _textStreamController;
+  StreamController<VoiceTranscriptEvent>? _transcriptEventController;
   String _currentText = '';
-  final VoiceTranscriptAccumulator _transcriptAccumulator =
-      VoiceTranscriptAccumulator();
   bool _receivedFinalResult = false;
+  bool _completedTranscriptIsSendable = false;
   StreamController<int>? _intensityController;
   Stream<int> get intensityStream =>
       _intensityController?.stream ?? const Stream<int>.empty();
@@ -92,16 +125,19 @@ class VoiceInputService {
   Timer? _intensityDecayTimer;
   List<double>? _vadPendingSamples;
   bool _backgroundMicPinned = false;
-  bool _recoveringFromBusyError = false;
-  bool _recoveringFromListenFailedError = false;
 
   Stream<String> get textStream =>
       _textStreamController?.stream ?? const Stream<String>.empty();
+  Stream<VoiceTranscriptEvent> get transcriptEvents =>
+      _transcriptEventController?.stream ??
+      const Stream<VoiceTranscriptEvent>.empty();
   Timer? _autoStopTimer;
   StreamSubscription<List<double>>? _vadSpeechEndSub;
   StreamSubscription<({double isSpeech, double notSpeech, List<double> frame})>?
   _vadFrameSub;
   StreamSubscription<String>? _vadErrorSub;
+  StreamSubscription<NativeSttEvent>? _nativeSttSub;
+  Timer? _nativeDictationSettleTimer;
 
   bool get isSupportedPlatform => Platform.isAndroid || Platform.isIOS;
   bool get hasServerStt => _api != null;
@@ -112,7 +148,10 @@ class VoiceInputService {
       Platform.isIOS &&
       Platform.environment.containsKey('SIMULATOR_DEVICE_NAME');
 
-  VoiceInputService({ApiService? api, Ref? ref}) : _api = api, _ref = ref;
+  VoiceInputService({ApiService? api, Ref? ref, NativeSttService? nativeStt})
+    : _api = api,
+      _ref = ref,
+      _nativeStt = nativeStt ?? NativeSttService();
 
   void updatePreference(SttPreference preference) {
     _preference = preference;
@@ -134,147 +173,47 @@ class VoiceInputService {
     final shouldPrepareLocalStt =
         forceLocalStt || _preference != SttPreference.serverOnly;
     if (shouldPrepareLocalStt && !_didAttemptLocalInitialization) {
-      await _initializeLocalStt(deviceTag);
+      await _loadLocales(deviceTag);
+      await _initializeNativeLocalStt(deviceTag);
+      _localSttAvailable = _nativeLocalSttAvailable;
+      _didAttemptLocalInitialization = true;
     }
 
     _isInitialized = true;
     return true;
   }
 
-  Future<void> _initializeLocalStt(String deviceTag) async {
-    _didAttemptLocalInitialization = true;
+  Future<void> _initializeNativeLocalStt(String deviceTag) async {
+    if (!_nativeStt.isSupportedPlatform) {
+      _nativeLocalSttAvailable = false;
+      return;
+    }
+
     try {
-      _localSttAvailable = await _speech.initialize(
-        onStatus: _handleSttStatus,
-        onError: _handleSttError,
+      final availability = await _nativeStt.checkAvailability(
+        localeId: _selectedLocaleId ?? deviceTag,
       );
-      if (_localSttAvailable) {
-        await _loadLocales(deviceTag);
+      _nativeLocalSttAvailable = availability.available;
+      if (availability.available) {
+        DebugLogger.info(
+          'native-stt-available',
+          scope: 'voice/stt',
+          data: {'engine': availability.engine ?? 'unknown'},
+        );
+      } else if (availability.reason != null) {
+        DebugLogger.info(
+          'native-stt-unavailable',
+          scope: 'voice/stt',
+          data: {'reason': availability.reason},
+        );
       }
-    } catch (_) {
-      _localSttAvailable = false;
-    }
-  }
-
-  void _handleSttStatus(String status) {
-    debugPrint('Local STT Status: $status');
-    if (status == 'listening') {
-      _localSttActive = true;
-    } else if (status == 'notListening' || status == 'done') {
-      final wasActive = _localSttActive;
-      _localSttActive = false;
-      // If we were actively listening and the platform stopped us,
-      // properly close the stream so voice call service can restart
-      if (wasActive && _isListening && !_usingServerStt) {
-        debugPrint('Platform stopped listening, closing stream');
-        // On Android, the 'done' status often fires BEFORE the final result
-        // callback arrives. Wait for the final result to avoid cutting off
-        // the last word.
-        if (Platform.isAndroid && !_receivedFinalResult) {
-          _waitForFinalResultThenStop();
-        } else {
-          unawaited(_stopListening());
-        }
-      }
-    }
-  }
-
-  /// Waits briefly for Android to deliver the final STT result before stopping.
-  void _waitForFinalResultThenStop() {
-    Future(() async {
-      // Wait up to 300ms for the final result to arrive
-      for (var i = 0; i < 6; i++) {
-        await Future.delayed(const Duration(milliseconds: 50));
-        if (_receivedFinalResult || !_isListening) break;
-      }
-      if (_isListening) {
-        await _stopListening();
-      }
-    });
-  }
-
-  void _handleSttError(dynamic error) {
-    debugPrint('Local STT Error: $error');
-    final errorStr = error.toString().toLowerCase();
-
-    if (errorStr.contains('error_busy')) {
-      debugPrint('Local STT busy, attempting recognizer reset');
-      unawaited(_recoverFromBusyError());
-      return;
-    }
-
-    if (errorStr.contains('error_listen_failed')) {
-      debugPrint('Local STT listen failed, attempting recognizer recovery');
-      unawaited(_recoverFromListenFailedErrorFlow());
-      return;
-    }
-
-    // These errors are non-fatal - they just mean no speech was detected
-    // or the session timed out. The status handler will close the stream
-    // and voice call service will restart listening.
-    final nonFatalErrors = ['error_no_match', 'error_speech_timeout'];
-
-    final isNonFatal = nonFatalErrors.any((e) => errorStr.contains(e));
-    if (isNonFatal) {
-      debugPrint('Non-fatal STT error, allowing normal stream close');
-      // Let the status handler / auto-stop timer close the stream.
-      // We do not treat this as a fatal failure for the current session.
-      return;
-    }
-
-    // Fatal errors - mark STT as unavailable
-    _handleLocalRecognizerError(error);
-  }
-
-  Future<void> _recoverFromBusyError() async {
-    if (_recoveringFromBusyError) {
-      return;
-    }
-    if (!_isListening || _usingServerStt) {
-      return;
-    }
-
-    _recoveringFromBusyError = true;
-    try {
-      await _ensureLocalSttReset();
-      await Future.delayed(const Duration(milliseconds: 200));
-      if (!_isListening || _usingServerStt || !_localSttAvailable) {
-        return;
-      }
-      try {
-        await _startLocalRecognition(allowOnlineFallback: !prefersDeviceOnly);
-      } catch (error) {
-        _handleLocalRecognizerError(error);
-      }
-    } finally {
-      _recoveringFromBusyError = false;
-    }
-  }
-
-  Future<void> _recoverFromListenFailedErrorFlow() async {
-    if (_recoveringFromListenFailedError) {
-      return;
-    }
-    if (!_isListening || _usingServerStt) {
-      return;
-    }
-
-    _recoveringFromListenFailedError = true;
-    try {
-      await _ensureLocalSttReset();
-      await Future.delayed(const Duration(milliseconds: 250));
-      if (!_isListening || _usingServerStt || !_localSttAvailable) {
-        return;
-      }
-      try {
-        await _startLocalRecognition(allowOnlineFallback: !prefersDeviceOnly);
-      } catch (_) {
-        if (_isListening) {
-          await _stopListening();
-        }
-      }
-    } finally {
-      _recoveringFromListenFailedError = false;
+    } catch (error) {
+      DebugLogger.warning(
+        'native-stt-availability-failed',
+        scope: 'voice/stt',
+        data: {'error': error},
+      );
+      _nativeLocalSttAvailable = false;
     }
   }
 
@@ -283,10 +222,6 @@ class VoiceInputService {
     if (!micGranted) {
       return false;
     }
-    // Note: Don't disable _localSttAvailable based on hasPermission check
-    // The permission might be granted lazily when listen() is called on iOS,
-    // and the check can be unreliable. Let speech_to_text handle permissions
-    // during the actual listen() call.
     return true;
   }
 
@@ -294,6 +229,8 @@ class VoiceInputService {
   bool get isAvailable =>
       _isInitialized && (_localSttAvailable || hasServerStt);
   bool get hasLocalStt => _localSttAvailable;
+  bool get isUsingNativeLocalStt => _usingNativeLocalStt;
+  bool get lastCompletedTranscriptSendable => _completedTranscriptIsSendable;
   bool get localeMetadataIncomplete => _usingFallbackLocales;
 
   /// Checks if on-device STT is properly supported.
@@ -303,13 +240,7 @@ class VoiceInputService {
       final initialized = await initialize(forceLocalStt: true);
       if (!initialized) return false;
     }
-    try {
-      // speech_to_text isAvailable is set after initialize()
-      return _speech.isAvailable;
-    } catch (e) {
-      // ignore errors checking on-device support
-      return false;
-    }
+    return _nativeLocalSttAvailable;
   }
 
   /// Test method to verify on-device STT functionality.
@@ -322,27 +253,29 @@ class VoiceInputService {
         return 'Local STT not available. Available: $_localSttAvailable';
       }
 
-      // Check microphone permission
       final hasMic = await checkPermissions();
       if (!hasMic) {
         return 'Microphone permission not granted';
       }
 
-      // Test if speech recognition is available
-      if (!_speech.isAvailable) {
-        return 'Speech recognition service is not available on this device';
+      final availability = await _nativeStt.checkAvailability(
+        localeId: _selectedLocaleId,
+      );
+      if (!availability.available) {
+        return 'Native on-device STT unavailable: '
+            '${availability.reason ?? 'unknown reason'}';
       }
 
-      // Start and stop quickly to test
-      await _speech.listen(
-        onResult: (_) {},
-        listenOptions: SpeechListenOptions(localeId: _selectedLocaleId),
+      await _nativeStt.startListening(
+        localeId: _selectedLocaleId,
+        emitPartialResults: false,
+        accumulateResults: false,
       );
       await Future.delayed(const Duration(milliseconds: 100));
-      await _speech.stop();
+      await _nativeStt.stopListening();
 
       return 'On-device STT test completed successfully. '
-          'Local STT available: $_localSttAvailable, '
+          'Engine: ${availability.engine ?? 'unknown'}, '
           'Selected locale: $_selectedLocaleId';
     } catch (e) {
       return 'On-device STT test failed: $e';
@@ -359,23 +292,23 @@ class VoiceInputService {
   Future<void> _loadLocales(String deviceTag) async {
     _ensureFallbackLocale(deviceTag);
     try {
-      final sttLocales = await Future.value(
-        _speech.locales(),
-      ).timeout(_localeFetchTimeout, onTimeout: () => const []);
-      if (sttLocales.isEmpty) {
+      final nativeLocales = await _nativeStt
+          .getLocales(deviceLocaleId: deviceTag)
+          .timeout(
+            _localeFetchTimeout,
+            onTimeout: () =>
+                const NativeSttLocales(locales: <NativeSttLocale>[]),
+          );
+      if (nativeLocales.locales.isEmpty) {
         return;
       }
 
-      // Map speech_to_text LocaleName to our own LocaleName class
-      _locales = sttLocales
+      _locales = nativeLocales.locales
           .map((loc) => LocaleName(loc.localeId, loc.name))
           .toList();
       _usingFallbackLocales = false;
 
-      // Prefer the STT engine's own system locale when available, since
-      // it may differ from Flutter's UI locale on some Android devices.
-      final systemLocale = await _speech.systemLocale();
-      final systemTag = systemLocale?.localeId;
+      final systemTag = nativeLocales.systemLocaleId;
       final tagForMatch = (systemTag != null && systemTag.isNotEmpty)
           ? systemTag
           : deviceTag;
@@ -465,6 +398,8 @@ class VoiceInputService {
 
   Future<void> _startLocalRecognition({
     required bool allowOnlineFallback,
+    bool iosAudioSessionManagedExternally = false,
+    bool nativeAccumulateResults = true,
   }) async {
     if (_startingLocalStt != null) {
       await _startingLocalStt;
@@ -473,34 +408,19 @@ class VoiceInputService {
     _startingLocalStt = completer.future;
     _localSttActive = false;
 
-    // Only reset if there's an active session to avoid startup delay
-    if (_speech.isListening) {
+    if (_usingNativeLocalStt || _localSttActive) {
       await _ensureLocalSttReset();
-      // Give the platform a moment to fully release the audio session
       await Future.delayed(const Duration(milliseconds: 100));
     }
 
-    // Use user's configured silence duration for pause detection
-    final settings = _ref?.read(appSettingsProvider);
-    final pauseDuration = Duration(
-      milliseconds:
-          settings?.voiceSilenceDuration ??
-          SettingsService.defaultVoiceSilenceDurationMs,
-    );
-
     try {
-      await _speech.listen(
-        onResult: _handleSttResult,
-        listenOptions: SpeechListenOptions(
-          localeId: _selectedLocaleId,
-          listenFor: _localRecognitionMaxDuration,
-          pauseFor: pauseDuration,
-          listenMode: ListenMode.dictation,
-          cancelOnError: false,
-          partialResults: true,
-          autoPunctuation: true,
-          enableHapticFeedback: false,
-        ),
+      if (!_nativeLocalSttAvailable) {
+        throw Exception('On-device speech recognition unavailable');
+      }
+      await _startNativeLocalRecognition(
+        preserveAudioSession: iosAudioSessionManagedExternally,
+        accumulateResults: nativeAccumulateResults,
+        allowOnlineFallback: allowOnlineFallback,
       );
       _localSttActive = true;
     } catch (error) {
@@ -513,16 +433,81 @@ class VoiceInputService {
     }
   }
 
-  void _handleSttResult(SpeechRecognitionResult result) {
-    if (!_isListening) return;
-    final prevLen = _currentText.length;
-    _currentText = _transcriptAccumulator.applyResult(
-      recognizedWords: result.recognizedWords,
-      isFinalResult: result.finalResult,
+  Future<void> _startNativeLocalRecognition({
+    required bool preserveAudioSession,
+    required bool accumulateResults,
+    required bool allowOnlineFallback,
+  }) async {
+    await _nativeSttSub?.cancel();
+    _nativeSttSub = null;
+    _usingNativeLocalStt = true;
+    final stream = await _nativeStt.startListening(
+      localeId: _selectedLocaleId,
+      preserveAudioSession: preserveAudioSession,
+      emitPartialResults: true,
+      accumulateResults: accumulateResults,
+      allowOnlineFallback: allowOnlineFallback,
     );
-    _textStreamController?.add(_currentText);
-    if (result.finalResult) {
+    _nativeSttSub = stream.listen(
+      _handleNativeSttEvent,
+      onError: (Object error, StackTrace stackTrace) {
+        if (!_isListening || !_usingNativeLocalStt) return;
+        _handleLocalRecognizerError(error);
+      },
+      onDone: () {
+        if (_isListening && _usingNativeLocalStt && !_usingServerStt) {
+          unawaited(_stopListening());
+        }
+      },
+    );
+  }
+
+  void _handleNativeSttEvent(NativeSttEvent event) {
+    if (!_isListening || !_usingNativeLocalStt) return;
+
+    switch (event.type) {
+      case 'status':
+        if (event.message == 'listening') {
+          _localSttActive = true;
+        }
+      case 'result':
+        final text = event.text;
+        if (text == null) return;
+        _handleNativeSttResult(text, event.isFinal);
+      case 'error':
+        _handleLocalRecognizerError(
+          NativeSttException(
+            event.message ?? 'Native speech recognition failed',
+            code: event.code,
+          ),
+        );
+      case 'done':
+        if (_isListening && !_usingServerStt) {
+          unawaited(_stopListening());
+        }
+    }
+  }
+
+  void _handleNativeSttResult(String text, bool isFinal) {
+    final prevLen = _currentText.length;
+    _currentText = text;
+    if (_currentText.isNotEmpty) {
+      _textStreamController?.add(_currentText);
+      _transcriptEventController?.add(
+        VoiceTranscriptEvent(text: _currentText, isFinal: isFinal),
+      );
+    }
+    if (isFinal) {
       _receivedFinalResult = true;
+      if (_shouldSettleNativeDictation(
+        isFinal: true,
+        nativeAccumulateResults: _nativeAccumulateResultsForCurrentListen,
+        usingServerStt: _usingServerStt,
+      )) {
+        _scheduleNativeDictationSettle();
+      }
+    } else {
+      _cancelNativeDictationSettle();
     }
     final delta = (_currentText.length - prevLen).clamp(0, 50);
     final mapped = (delta / 5.0).ceil();
@@ -532,8 +517,27 @@ class VoiceInputService {
     } catch (_) {}
   }
 
+  void _scheduleNativeDictationSettle() {
+    _nativeDictationSettleTimer?.cancel();
+    _nativeDictationSettleTimer = Timer(_nativeDictationFinalSettleDelay, () {
+      if (!_isListening ||
+          !_usingNativeLocalStt ||
+          !_nativeAccumulateResultsForCurrentListen ||
+          _usingServerStt) {
+        return;
+      }
+      unawaited(_stopListening());
+    });
+  }
+
+  void _cancelNativeDictationSettle() {
+    _nativeDictationSettleTimer?.cancel();
+    _nativeDictationSettleTimer = null;
+  }
+
   Future<Stream<String>> startListening({
     bool iosAudioSessionManagedExternally = false,
+    bool nativeAccumulateResults = true,
   }) async {
     final inFlight = _startListeningInFlight;
     if (inFlight != null) {
@@ -542,6 +546,7 @@ class VoiceInputService {
 
     final startFuture = _startListeningInternal(
       iosAudioSessionManagedExternally: iosAudioSessionManagedExternally,
+      nativeAccumulateResults: nativeAccumulateResults,
     );
     _startListeningInFlight = startFuture;
     try {
@@ -555,6 +560,7 @@ class VoiceInputService {
 
   Future<Stream<String>> _startListeningInternal({
     required bool iosAudioSessionManagedExternally,
+    required bool nativeAccumulateResults,
   }) async {
     if (!_isInitialized) {
       throw Exception('Voice input not initialized');
@@ -571,13 +577,17 @@ class VoiceInputService {
     }
 
     _textStreamController = StreamController<String>.broadcast();
+    _transcriptEventController =
+        StreamController<VoiceTranscriptEvent>.broadcast();
     _currentText = '';
-    _transcriptAccumulator.reset();
     _isListening = true;
     _receivedFinalResult = false;
+    _completedTranscriptIsSendable = false;
+    _cancelNativeDictationSettle();
     _intensityController = StreamController<int>.broadcast();
     _lastIntensity = 0;
     _usingServerStt = false;
+    _nativeAccumulateResultsForCurrentListen = nativeAccumulateResults;
 
     // Optional haptic feedback when listening starts
     final hapticsEnabled = _ref?.read(hapticEnabledProvider) ?? false;
@@ -606,20 +616,12 @@ class VoiceInputService {
         }
       });
       try {
-        if (!_speech.isAvailable && _isListening) {
-          _textStreamController?.addError(
-            Exception('On-device speech recognition unavailable'),
-          );
-          await _stopListening();
-          return _textStreamController!.stream;
-        }
-      } catch (_) {
-        // ignore availability check errors
-      }
-
-      try {
         debugPrint('Starting local recognition...');
-        await _startLocalRecognition(allowOnlineFallback: !prefersDeviceOnly);
+        await _startLocalRecognition(
+          allowOnlineFallback: !prefersDeviceOnly,
+          iosAudioSessionManagedExternally: iosAudioSessionManagedExternally,
+          nativeAccumulateResults: nativeAccumulateResults,
+        );
         debugPrint('Local recognition started');
       } catch (error) {
         debugPrint('Failed to start local recognition: $error');
@@ -672,6 +674,7 @@ class VoiceInputService {
   /// Ensures initialization and microphone permission before starting.
   Future<Stream<String>> beginListening({
     bool iosAudioSessionManagedExternally = false,
+    bool nativeAccumulateResults = true,
   }) async {
     await initialize();
     // For on-device STT we preflight the microphone permission so we can
@@ -689,7 +692,18 @@ class VoiceInputService {
     }
     return await startListening(
       iosAudioSessionManagedExternally: iosAudioSessionManagedExternally,
+      nativeAccumulateResults: nativeAccumulateResults,
     );
+  }
+
+  Future<Stream<VoiceTranscriptEvent>> beginListeningEvents({
+    bool iosAudioSessionManagedExternally = false,
+  }) async {
+    await beginListening(
+      iosAudioSessionManagedExternally: iosAudioSessionManagedExternally,
+      nativeAccumulateResults: false,
+    );
+    return transcriptEvents;
   }
 
   Future<void> stopListening() async {
@@ -697,10 +711,13 @@ class VoiceInputService {
   }
 
   Future<void> _stopListening() async {
-    if (!_isListening) return;
+    if (!_isListening) {
+      return;
+    }
 
     _autoStopTimer?.cancel();
     _autoStopTimer = null;
+    _cancelNativeDictationSettle();
 
     if (_usingServerStt) {
       _isListening = false;
@@ -712,19 +729,13 @@ class VoiceInputService {
         await _processVadSamples(samples);
       }
     } else {
-      // On Android, stop() triggers a final result with any buffered words.
-      // Keep _isListening true until after stop() so _handleSttResult accepts it.
-      await _stopLocalStt();
-      // Wait for Android's STT engine to deliver the final result callback
-      if (Platform.isAndroid && !_receivedFinalResult) {
-        for (var i = 0; i < 6; i++) {
-          await Future.delayed(const Duration(milliseconds: 50));
-          if (_receivedFinalResult) break;
-        }
-      }
+      final wasUsingNativeLocalStt = _usingNativeLocalStt;
+      await _stopNativeLocalStt();
+      _completedTranscriptIsSendable =
+          _currentText.trim().isNotEmpty && _receivedFinalResult;
       _isListening = false;
-      _currentText = _transcriptAccumulator.finalizePending();
-      if (_currentText.isNotEmpty) {
+      if (_currentText.isNotEmpty &&
+          (!wasUsingNativeLocalStt || !_receivedFinalResult)) {
         _textStreamController?.add(_currentText);
       }
     }
@@ -739,7 +750,7 @@ class VoiceInputService {
     await _releaseBackgroundMicrophone();
   }
 
-  Future<void> _stopLocalStt() async {
+  Future<void> _stopNativeLocalStt() async {
     final pendingStart = _startingLocalStt;
     if (pendingStart != null) {
       try {
@@ -747,13 +758,13 @@ class VoiceInputService {
       } catch (_) {}
     }
 
-    final shouldStopStt = _localSttActive && _localSttAvailable;
     _localSttActive = false;
-    if (shouldStopStt) {
-      try {
-        await _speech.stop();
-      } catch (_) {}
-    }
+    try {
+      await _nativeStt.stopListening();
+    } catch (_) {}
+    await _nativeSttSub?.cancel();
+    _nativeSttSub = null;
+    _usingNativeLocalStt = false;
   }
 
   Future<void> _releaseBackgroundMicrophone() async {
@@ -767,9 +778,13 @@ class VoiceInputService {
   }
 
   Future<void> _ensureLocalSttReset() async {
+    _cancelNativeDictationSettle();
     try {
-      await _speech.cancel();
+      await _nativeStt.stopListening();
     } catch (_) {}
+    await _nativeSttSub?.cancel();
+    _nativeSttSub = null;
+    _usingNativeLocalStt = false;
   }
 
   Future<void> _startServerRecording({
@@ -816,14 +831,9 @@ class VoiceInputService {
           echoCancel: true,
           autoGain: false,
           noiseSuppress: true,
-          androidConfig: AndroidRecordConfig(
-            audioSource: AndroidAudioSource.voiceRecognition,
-            // Use normal mode instead of modeInCommunication to avoid
-            // audio routing conflicts with TTS playback after recording stops.
-            audioManagerMode: AudioManagerMode.modeNormal,
-            speakerphone: false,
-            manageBluetooth: true,
-            useLegacy: false,
+          androidConfig: _androidServerVadRecordConfig(
+            voiceCallSession:
+                Platform.isAndroid && iosAudioSessionManagedExternally,
           ),
           iosConfig: iosAudioSessionManagedExternally
               ? _iosManagedServerVadRecordConfig
@@ -861,7 +871,11 @@ class VoiceInputService {
           await _stopVadRecording();
         } catch (_) {}
         try {
-          await _startLocalRecognition(allowOnlineFallback: !prefersDeviceOnly);
+          await _startLocalRecognition(
+            allowOnlineFallback: !prefersDeviceOnly,
+            iosAudioSessionManagedExternally: iosAudioSessionManagedExternally,
+            nativeAccumulateResults: _nativeAccumulateResultsForCurrentListen,
+          );
           return;
         } catch (fallbackError) {
           _textStreamController?.addError(fallbackError);
@@ -951,7 +965,11 @@ class VoiceInputService {
       final transcript = _extractTranscriptionText(response);
       if (transcript != null && transcript.trim().isNotEmpty) {
         _currentText = transcript.trim();
+        _completedTranscriptIsSendable = true;
         _textStreamController?.add(_currentText);
+        _transcriptEventController?.add(
+          VoiceTranscriptEvent(text: _currentText, isFinal: true),
+        );
       } else {
         throw StateError('Empty transcription result');
       }
@@ -991,6 +1009,27 @@ class VoiceInputService {
 
     final fallback = fallbackLocale?.languageCode.toLowerCase();
     return fallback == null || fallback.isEmpty ? null : fallback;
+  }
+
+  @visibleForTesting
+  static bool shouldSettleNativeDictationForTesting({
+    required bool isFinal,
+    required bool nativeAccumulateResults,
+    required bool usingServerStt,
+  }) {
+    return _shouldSettleNativeDictation(
+      isFinal: isFinal,
+      nativeAccumulateResults: nativeAccumulateResults,
+      usingServerStt: usingServerStt,
+    );
+  }
+
+  static bool _shouldSettleNativeDictation({
+    required bool isFinal,
+    required bool nativeAccumulateResults,
+    required bool usingServerStt,
+  }) {
+    return isFinal && nativeAccumulateResults && !usingServerStt;
   }
 
   static String? _primaryLanguageFromLocaleId(String? localeId) {
@@ -1162,6 +1201,12 @@ class VoiceInputService {
       } catch (_) {}
       _textStreamController = null;
     }
+    if (_transcriptEventController != null) {
+      try {
+        await _transcriptEventController?.close();
+      } catch (_) {}
+      _transcriptEventController = null;
+    }
     if (_intensityController != null) {
       try {
         await _intensityController?.close();
@@ -1186,9 +1231,12 @@ class VoiceInputService {
 
   Future<void> dispose() async {
     await stopListening();
+    _cancelNativeDictationSettle();
     await _disposeVadHandler();
+    await _nativeSttSub?.cancel();
+    _nativeSttSub = null;
     try {
-      await _speech.stop();
+      await _nativeStt.stopListening();
     } catch (_) {}
   }
 }

--- a/lib/features/chat/services/voice_input_service.dart
+++ b/lib/features/chat/services/voice_input_service.dart
@@ -192,6 +192,7 @@ class VoiceInputService {
     try {
       final availability = await _nativeStt.checkAvailability(
         localeId: _selectedLocaleId ?? deviceTag,
+        allowOnlineFallback: _preference != SttPreference.deviceOnly,
       );
       _nativeLocalSttAvailable = availability.available;
       if (availability.available) {
@@ -260,6 +261,7 @@ class VoiceInputService {
 
       final availability = await _nativeStt.checkAvailability(
         localeId: _selectedLocaleId,
+        allowOnlineFallback: false,
       );
       if (!availability.available) {
         return 'Native on-device STT unavailable: '
@@ -759,12 +761,13 @@ class VoiceInputService {
     }
 
     _localSttActive = false;
+    _usingNativeLocalStt = false;
+    final subscription = _nativeSttSub;
+    _nativeSttSub = null;
+    await subscription?.cancel();
     try {
       await _nativeStt.stopListening();
     } catch (_) {}
-    await _nativeSttSub?.cancel();
-    _nativeSttSub = null;
-    _usingNativeLocalStt = false;
   }
 
   Future<void> _releaseBackgroundMicrophone() async {
@@ -779,12 +782,14 @@ class VoiceInputService {
 
   Future<void> _ensureLocalSttReset() async {
     _cancelNativeDictationSettle();
+    _localSttActive = false;
+    _usingNativeLocalStt = false;
+    final subscription = _nativeSttSub;
+    _nativeSttSub = null;
+    await subscription?.cancel();
     try {
       await _nativeStt.stopListening();
     } catch (_) {}
-    await _nativeSttSub?.cancel();
-    _nativeSttSub = null;
-    _usingNativeLocalStt = false;
   }
 
   Future<void> _startServerRecording({

--- a/lib/features/chat/services/voice_input_service.dart
+++ b/lib/features/chat/services/voice_input_service.dart
@@ -192,7 +192,7 @@ class VoiceInputService {
     try {
       final availability = await _nativeStt.checkAvailability(
         localeId: _selectedLocaleId ?? deviceTag,
-        allowOnlineFallback: _preference != SttPreference.deviceOnly,
+        allowOnlineFallback: false,
       );
       _nativeLocalSttAvailable = availability.available;
       if (availability.available) {
@@ -272,6 +272,7 @@ class VoiceInputService {
         localeId: _selectedLocaleId,
         emitPartialResults: false,
         accumulateResults: false,
+        allowOnlineFallback: false,
       );
       await Future.delayed(const Duration(milliseconds: 100));
       await _nativeStt.stopListening();

--- a/lib/features/chat/views/chat_page.dart
+++ b/lib/features/chat/views/chat_page.dart
@@ -1846,6 +1846,9 @@ class _ChatPageState extends ConsumerState<ChatPage> {
     // Watch models once here instead of per-message in the item builder.
     final modelsAsync = watchRef.watch(modelsProvider);
     final models = modelsAsync.hasValue ? modelsAsync.value : null;
+    final suppressAssistantStreamingHaptics = watchRef.watch(
+      chatVoiceModeControllerProvider.select((voice) => voice.isActive),
+    );
     final layoutMetadata = _resolveChatListStableLayoutMetadata(
       messages: messages,
       models: models,
@@ -2025,6 +2028,8 @@ class _ChatPageState extends ConsumerState<ChatPage> {
                           versionModelNames: rowMetadata.versionModelNames,
                           versionModelIconUrls:
                               rowMetadata.versionModelIconUrls,
+                          suppressStreamingHaptics:
+                              suppressAssistantStreamingHaptics,
                           onCopy: () {
                             final currentMessage = rowRef.read(
                               chatMessageByIdProvider(messageId),

--- a/lib/features/chat/voice_mode/chat_voice_audio_session_coordinator.dart
+++ b/lib/features/chat/voice_mode/chat_voice_audio_session_coordinator.dart
@@ -118,11 +118,14 @@ class ChatVoiceAudioSessionCoordinator {
 
   Future<void> deactivate() async {
     final session = _session;
-    await _clearIosVoiceRoute();
-    if (session != null) {
-      await _setActive(session, active: false, phase: 'deactivate');
+    try {
+      await _clearIosVoiceRoute();
+      if (session != null) {
+        await _setActive(session, active: false, phase: 'deactivate');
+      }
+    } finally {
+      await _restoreAndroidVoiceRoute();
     }
-    await _restoreAndroidVoiceRoute();
   }
 
   Future<void> _configureAndroidVoiceRoute({required String phase}) async {
@@ -194,7 +197,7 @@ class ChatVoiceAudioSessionCoordinator {
         () => manager.setCommunicationDevice(device),
         operation: 'set-communication-device',
         phase: phase,
-        data: {'deviceId': device.id, 'deviceName': device.productName},
+        data: {'deviceId': device.id, 'deviceType': device.type.toString()},
       );
       if (selected == true) {
         return true;
@@ -383,11 +386,7 @@ class ChatVoiceAudioSessionCoordinator {
       return '';
     }
     final type = port['type']?.toString() ?? 'unknown';
-    final name = port['name']?.toString() ?? '';
-    if (name.isEmpty) {
-      return type;
-    }
-    return '$type:$name';
+    return type;
   }
 
   Future<void> _configureSession(

--- a/lib/features/chat/voice_mode/chat_voice_audio_session_coordinator.dart
+++ b/lib/features/chat/voice_mode/chat_voice_audio_session_coordinator.dart
@@ -5,8 +5,20 @@ import 'package:audio_session/audio_session.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import '../../../core/utils/debug_logger.dart';
+
 class ChatVoiceAudioSessionCoordinator {
+  static const Duration _iosSpeakingRouteSettleDelay = Duration(
+    milliseconds: 160,
+  );
+  static const MethodChannel _iosVoiceAudioRouteChannel = MethodChannel(
+    'app.cogwheel.conduit/voice_audio_route',
+  );
+
   AudioSession? _session;
+  AndroidAudioManager? _androidAudioManager;
+  AndroidAudioHardwareMode? _previousAndroidMode;
+  bool? _previousAndroidSpeakerphone;
 
   Future<AudioSession> _ensureSession() async {
     final session = _session;
@@ -42,6 +54,8 @@ class ChatVoiceAudioSessionCoordinator {
       'listening',
     );
     await _setActive(session, active: true, phase: 'listening');
+    await _configureAndroidVoiceRoute(phase: 'listening');
+    await _configureIosVoiceRoute(phase: 'listening');
   }
 
   Future<void> configureForSpeaking() async {
@@ -60,23 +74,320 @@ class ChatVoiceAudioSessionCoordinator {
             AVAudioSessionSetActiveOptions.notifyOthersOnDeactivation,
         androidAudioAttributes: const AndroidAudioAttributes(
           contentType: AndroidAudioContentType.speech,
-          usage: AndroidAudioUsage.media,
+          usage: AndroidAudioUsage.voiceCommunication,
         ),
-        androidAudioFocusGainType:
-            AndroidAudioFocusGainType.gainTransientMayDuck,
+        androidAudioFocusGainType: AndroidAudioFocusGainType.gainTransient,
         androidWillPauseWhenDucked: false,
       ),
       'speaking',
     );
     await _setActive(session, active: true, phase: 'speaking');
+    await _configureAndroidVoiceRoute(phase: 'speaking');
+    await _configureIosVoiceRoute(phase: 'speaking');
+    await _settleIosSpeakingRoute();
+  }
+
+  Future<void> configureForBargeInSpeaking() async {
+    final session = await _ensureSession();
+    await _configureSession(
+      session,
+      AudioSessionConfiguration(
+        avAudioSessionCategory: AVAudioSessionCategory.playAndRecord,
+        avAudioSessionCategoryOptions:
+            AVAudioSessionCategoryOptions.allowBluetooth |
+            AVAudioSessionCategoryOptions.defaultToSpeaker,
+        avAudioSessionMode: AVAudioSessionMode.voiceChat,
+        avAudioSessionRouteSharingPolicy:
+            AVAudioSessionRouteSharingPolicy.defaultPolicy,
+        avAudioSessionSetActiveOptions:
+            AVAudioSessionSetActiveOptions.notifyOthersOnDeactivation,
+        androidAudioAttributes: const AndroidAudioAttributes(
+          contentType: AndroidAudioContentType.speech,
+          usage: AndroidAudioUsage.voiceCommunication,
+        ),
+        androidAudioFocusGainType: AndroidAudioFocusGainType.gainTransient,
+        androidWillPauseWhenDucked: false,
+      ),
+      'barge-in-speaking',
+    );
+    await _setActive(session, active: true, phase: 'barge-in-speaking');
+    await _configureAndroidVoiceRoute(phase: 'barge-in-speaking');
+    await _configureIosVoiceRoute(phase: 'barge-in-speaking');
+    await _settleIosSpeakingRoute();
   }
 
   Future<void> deactivate() async {
     final session = _session;
-    if (session == null) {
+    await _clearIosVoiceRoute();
+    if (session != null) {
+      await _setActive(session, active: false, phase: 'deactivate');
+    }
+    await _restoreAndroidVoiceRoute();
+  }
+
+  Future<void> _configureAndroidVoiceRoute({required String phase}) async {
+    if (!Platform.isAndroid) {
       return;
     }
-    await _setActive(session, active: false, phase: 'deactivate');
+
+    final manager = _androidAudioManager ??= AndroidAudioManager();
+
+    _previousAndroidMode ??= await _safeAndroidRouteCall(
+      () => manager.getMode(),
+      operation: 'get-mode',
+      phase: phase,
+    );
+    _previousAndroidSpeakerphone ??= await _safeAndroidRouteCall(
+      () => manager.isSpeakerphoneOn(),
+      operation: 'get-speakerphone',
+      phase: phase,
+    );
+
+    await _safeAndroidRouteCall(
+      () => manager.setMode(AndroidAudioHardwareMode.inCommunication),
+      operation: 'set-in-communication',
+      phase: phase,
+    );
+    await _safeAndroidRouteCall(
+      () => manager.setSpeakerphoneOn(false),
+      operation: 'disable-speakerphone',
+      phase: phase,
+    );
+
+    final selected = await _selectBluetoothScoCommunicationDevice(
+      manager,
+      phase: phase,
+    );
+    if (selected) {
+      return;
+    }
+
+    await _safeAndroidRouteCall(
+      () async {
+        await manager.startBluetoothSco();
+        await manager.setBluetoothScoOn(true);
+      },
+      operation: 'start-bluetooth-sco',
+      phase: phase,
+    );
+  }
+
+  Future<bool> _selectBluetoothScoCommunicationDevice(
+    AndroidAudioManager manager, {
+    required String phase,
+  }) async {
+    final devices = await _safeAndroidRouteCall(
+      () => manager.getAvailableCommunicationDevices(),
+      operation: 'get-communication-devices',
+      phase: phase,
+    );
+    if (devices == null) {
+      return false;
+    }
+
+    for (final device in devices) {
+      if (device.type != AndroidAudioDeviceType.bluetoothSco) {
+        continue;
+      }
+
+      final selected = await _safeAndroidRouteCall(
+        () => manager.setCommunicationDevice(device),
+        operation: 'set-communication-device',
+        phase: phase,
+        data: {'deviceId': device.id, 'deviceName': device.productName},
+      );
+      if (selected == true) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  Future<void> _restoreAndroidVoiceRoute() async {
+    if (!Platform.isAndroid) {
+      return;
+    }
+
+    final manager = _androidAudioManager;
+    if (manager == null) {
+      return;
+    }
+
+    await _safeAndroidRouteCall(
+      () => manager.clearCommunicationDevice(),
+      operation: 'clear-communication-device',
+      phase: 'deactivate',
+    );
+    await _safeAndroidRouteCall(
+      () async {
+        await manager.setBluetoothScoOn(false);
+        await manager.stopBluetoothSco();
+      },
+      operation: 'stop-bluetooth-sco',
+      phase: 'deactivate',
+    );
+
+    final previousSpeakerphone = _previousAndroidSpeakerphone;
+    if (previousSpeakerphone != null) {
+      await _safeAndroidRouteCall(
+        () => manager.setSpeakerphoneOn(previousSpeakerphone),
+        operation: 'restore-speakerphone',
+        phase: 'deactivate',
+      );
+    }
+
+    final previousMode = _previousAndroidMode;
+    if (previousMode != null) {
+      await _safeAndroidRouteCall(
+        () => manager.setMode(previousMode),
+        operation: 'restore-mode',
+        phase: 'deactivate',
+      );
+    }
+
+    _previousAndroidMode = null;
+    _previousAndroidSpeakerphone = null;
+  }
+
+  Future<T?> _safeAndroidRouteCall<T>(
+    Future<T> Function() action, {
+    required String operation,
+    required String phase,
+    Map<String, Object?> data = const <String, Object?>{},
+  }) async {
+    try {
+      return await action();
+    } catch (error, stackTrace) {
+      DebugLogger.error(
+        'android-audio-route-$operation-failed',
+        scope: 'chat/voice_audio',
+        error: error,
+        stackTrace: stackTrace,
+        data: {'phase': phase, ...data},
+      );
+      return null;
+    }
+  }
+
+  Future<void> _configureIosVoiceRoute({required String phase}) async {
+    if (!Platform.isIOS) {
+      return;
+    }
+
+    final payload = await _safeIosRouteCall(
+      () => _iosVoiceAudioRouteChannel.invokeMapMethod<Object?, Object?>(
+        'preferBluetoothHfpInput',
+      ),
+      operation: 'prefer-bluetooth-hfp-input',
+      phase: phase,
+    );
+    if (payload == null) {
+      return;
+    }
+
+    final selected = payload['selected'] == true;
+    DebugLogger.info(
+      selected ? 'ios-bluetooth-hfp-selected' : 'ios-audio-route',
+      scope: 'chat/voice_audio',
+      data: _iosRouteLogData(payload, phase: phase),
+    );
+  }
+
+  Future<void> _clearIosVoiceRoute() async {
+    if (!Platform.isIOS) {
+      return;
+    }
+
+    final payload = await _safeIosRouteCall(
+      () => _iosVoiceAudioRouteChannel.invokeMapMethod<Object?, Object?>(
+        'clearPreferredInput',
+      ),
+      operation: 'clear-preferred-input',
+      phase: 'deactivate',
+    );
+    if (payload == null) {
+      return;
+    }
+
+    DebugLogger.info(
+      'ios-audio-route-cleared',
+      scope: 'chat/voice_audio',
+      data: _iosRouteLogData(payload, phase: 'deactivate'),
+    );
+  }
+
+  Future<void> _settleIosSpeakingRoute() async {
+    if (!Platform.isIOS) {
+      return;
+    }
+    await Future<void>.delayed(_iosSpeakingRouteSettleDelay);
+  }
+
+  Future<Map<Object?, Object?>?> _safeIosRouteCall(
+    Future<Map<Object?, Object?>?> Function() action, {
+    required String operation,
+    required String phase,
+  }) async {
+    try {
+      return await action();
+    } on MissingPluginException {
+      DebugLogger.warning(
+        'ios-audio-route-bridge-missing',
+        scope: 'chat/voice_audio',
+        data: {'operation': operation, 'phase': phase},
+      );
+      return null;
+    } catch (error, stackTrace) {
+      DebugLogger.error(
+        'ios-audio-route-$operation-failed',
+        scope: 'chat/voice_audio',
+        error: error,
+        stackTrace: stackTrace,
+        data: {'phase': phase},
+      );
+      return null;
+    }
+  }
+
+  Map<String, Object?> _iosRouteLogData(
+    Map<Object?, Object?> payload, {
+    required String phase,
+  }) {
+    return {
+      'phase': phase,
+      'selected': payload['selected'],
+      'cleared': payload['cleared'],
+      'reason': payload['reason'],
+      'error': payload['error'],
+      'category': payload['category'],
+      'mode': payload['mode'],
+      'preferred': _iosPortSummary(payload['preferredInput']),
+      'inputs': _iosPortsSummary(payload['currentInputs']),
+      'outputs': _iosPortsSummary(payload['currentOutputs']),
+      'available': _iosPortsSummary(payload['availableInputs']),
+    };
+  }
+
+  String _iosPortsSummary(Object? ports) {
+    if (ports is! List) {
+      return '';
+    }
+    return ports
+        .map(_iosPortSummary)
+        .where((port) => port.isNotEmpty)
+        .join(',');
+  }
+
+  String _iosPortSummary(Object? port) {
+    if (port is! Map) {
+      return '';
+    }
+    final type = port['type']?.toString() ?? 'unknown';
+    final name = port['name']?.toString() ?? '';
+    if (name.isEmpty) {
+      return type;
+    }
+    return '$type:$name';
   }
 
   Future<void> _configureSession(

--- a/lib/features/chat/voice_mode/chat_voice_mode_controller.dart
+++ b/lib/features/chat/voice_mode/chat_voice_mode_controller.dart
@@ -206,6 +206,8 @@ class ChatVoiceModeController extends Notifier<ChatVoiceModeSnapshot> {
   bool _assistantFinalizationDeferred = false;
   String? _pendingPausedAssistantText;
   String? _pendingPausedAssistantFinalText;
+  String? _pendingFinalTranscript;
+  String? _lastSubmittedTranscript;
   bool _stoppingFromCallKit = false;
   bool _sendingTranscript = false;
   List<String> _assistantSpeechChunks = const <String>[];
@@ -697,8 +699,7 @@ class ChatVoiceModeController extends Notifier<ChatVoiceModeSnapshot> {
   Future<void> _handleFinalTranscript(String text, int token) async {
     if (token != _token ||
         state.isMuted ||
-        state.phase == ChatVoiceModePhase.paused ||
-        _sendingTranscript) {
+        state.phase == ChatVoiceModePhase.paused) {
       return;
     }
 
@@ -707,19 +708,12 @@ class ChatVoiceModeController extends Notifier<ChatVoiceModeSnapshot> {
       return;
     }
 
-    _sendingTranscript = true;
-    try {
-      _emptyTranscriptRestarts = 0;
-      if (_awaitingAssistant ||
-          state.phase == ChatVoiceModePhase.sending ||
-          state.phase == ChatVoiceModePhase.speaking) {
-        await _interruptAssistantForBargeIn(token);
-      }
-      if (token != _token || state.isMuted) return;
-      await _sendTranscript(transcript, token);
-    } finally {
-      _sendingTranscript = false;
+    if (_sendingTranscript) {
+      _pendingFinalTranscript = transcript;
+      return;
     }
+
+    await _drainFinalTranscripts(transcript, token);
   }
 
   Future<void> _handleListeningDone(int token) async {
@@ -737,7 +731,61 @@ class ChatVoiceModeController extends Notifier<ChatVoiceModeSnapshot> {
     }
 
     _emptyTranscriptRestarts = 0;
-    await _sendTranscript(transcript, token);
+    await _handleFinalTranscript(transcript, token);
+  }
+
+  Future<void> _drainFinalTranscripts(
+    String initialTranscript,
+    int token,
+  ) async {
+    var transcript = initialTranscript;
+
+    while (true) {
+      if (token != _token ||
+          state.isMuted ||
+          state.phase == ChatVoiceModePhase.paused) {
+        return;
+      }
+
+      if (transcript == _lastSubmittedTranscript) {
+        final pending = _takePendingFinalTranscript();
+        if (pending == null) {
+          return;
+        }
+        transcript = pending;
+        continue;
+      }
+
+      _sendingTranscript = true;
+      try {
+        _emptyTranscriptRestarts = 0;
+        if (_awaitingAssistant ||
+            state.phase == ChatVoiceModePhase.sending ||
+            state.phase == ChatVoiceModePhase.speaking) {
+          await _interruptAssistantForBargeIn(token);
+        }
+        if (token != _token || state.isMuted) return;
+        _lastSubmittedTranscript = transcript;
+        await _sendTranscript(transcript, token);
+      } finally {
+        _sendingTranscript = false;
+      }
+
+      final pending = _takePendingFinalTranscript();
+      if (pending == null || pending == transcript) {
+        return;
+      }
+      transcript = pending;
+    }
+  }
+
+  String? _takePendingFinalTranscript() {
+    final pending = _pendingFinalTranscript?.trim();
+    _pendingFinalTranscript = null;
+    if (pending == null || pending.isEmpty) {
+      return null;
+    }
+    return pending;
   }
 
   Future<void> _restartAfterEmptyTranscript(int token) async {
@@ -984,6 +1032,8 @@ class ChatVoiceModeController extends Notifier<ChatVoiceModeSnapshot> {
 
     _awaitingAssistant = false;
     _streamingTtsStarted = false;
+    _pendingFinalTranscript = null;
+    _lastSubmittedTranscript = null;
     _activeAssistantMessageId = null;
     _lastFedAssistantText = '';
     _assistantSpeechChunks = const <String>[];
@@ -1140,6 +1190,8 @@ class ChatVoiceModeController extends Notifier<ChatVoiceModeSnapshot> {
     _assistantFinalizationDeferred = false;
     _pendingPausedAssistantText = null;
     _pendingPausedAssistantFinalText = null;
+    _pendingFinalTranscript = null;
+    _lastSubmittedTranscript = null;
     _sendingTranscript = false;
     _assistantSpeechChunks = const <String>[];
     _activeAssistantSpeechChunkIndex = -1;

--- a/lib/features/chat/voice_mode/chat_voice_mode_controller.dart
+++ b/lib/features/chat/voice_mode/chat_voice_mode_controller.dart
@@ -4,6 +4,7 @@ import 'dart:io' show Platform;
 import 'package:flutter/foundation.dart';
 import 'package:flutter_callkit_incoming/entities/call_event.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:permission_handler/permission_handler.dart';
 
 import '../../../core/models/chat_message.dart';
 import '../../../core/providers/app_providers.dart';
@@ -38,6 +39,9 @@ class ChatVoiceModeSnapshot {
     this.phase = ChatVoiceModePhase.idle,
     this.transcript = '',
     this.assistantPreview = '',
+    this.spokenResponse = '',
+    this.spokenWordStart,
+    this.spokenWordEnd,
     this.intensity = 0,
     this.elapsed = Duration.zero,
     this.startedAt,
@@ -50,6 +54,9 @@ class ChatVoiceModeSnapshot {
   final ChatVoiceModePhase phase;
   final String transcript;
   final String assistantPreview;
+  final String spokenResponse;
+  final int? spokenWordStart;
+  final int? spokenWordEnd;
   final int intensity;
   final Duration elapsed;
   final DateTime? startedAt;
@@ -82,6 +89,11 @@ class ChatVoiceModeSnapshot {
     ChatVoiceModePhase? phase,
     String? transcript,
     String? assistantPreview,
+    String? spokenResponse,
+    bool clearSpokenResponse = false,
+    int? spokenWordStart,
+    int? spokenWordEnd,
+    bool clearSpokenProgress = false,
     int? intensity,
     Duration? elapsed,
     DateTime? startedAt,
@@ -97,6 +109,15 @@ class ChatVoiceModeSnapshot {
       phase: phase ?? this.phase,
       transcript: transcript ?? this.transcript,
       assistantPreview: assistantPreview ?? this.assistantPreview,
+      spokenResponse: clearSpokenResponse
+          ? ''
+          : spokenResponse ?? this.spokenResponse,
+      spokenWordStart: clearSpokenResponse || clearSpokenProgress
+          ? null
+          : spokenWordStart ?? this.spokenWordStart,
+      spokenWordEnd: clearSpokenResponse || clearSpokenProgress
+          ? null
+          : spokenWordEnd ?? this.spokenWordEnd,
       intensity: intensity ?? this.intensity,
       elapsed: elapsed ?? this.elapsed,
       startedAt: clearStartedAt ? null : startedAt ?? this.startedAt,
@@ -161,7 +182,7 @@ class ChatVoiceModeController extends Notifier<ChatVoiceModeSnapshot> {
   int _token = 0;
   int _emptyTranscriptRestarts = 0;
 
-  StreamSubscription<String>? _transcriptSub;
+  StreamSubscription<VoiceTranscriptEvent>? _transcriptSub;
   StreamSubscription<int>? _intensitySub;
   StreamSubscription<TtsEvent>? _ttsSub;
   StreamSubscription<CallEvent>? _callKitSub;
@@ -186,6 +207,9 @@ class ChatVoiceModeController extends Notifier<ChatVoiceModeSnapshot> {
   String? _pendingPausedAssistantText;
   String? _pendingPausedAssistantFinalText;
   bool _stoppingFromCallKit = false;
+  bool _sendingTranscript = false;
+  List<String> _assistantSpeechChunks = const <String>[];
+  int _activeAssistantSpeechChunkIndex = -1;
 
   @override
   ChatVoiceModeSnapshot build() {
@@ -263,6 +287,7 @@ class ChatVoiceModeController extends Notifier<ChatVoiceModeSnapshot> {
           throw StateError('Voice input initialization failed.');
         }
 
+        await _requestAndroidVoiceRoutingPermission();
         await _initializeTts(tts, settings);
         _listenForTtsEvents(tts, token);
         await _startCallKit(model.name, token);
@@ -279,6 +304,35 @@ class ChatVoiceModeController extends Notifier<ChatVoiceModeSnapshot> {
         await _fail(error.toString(), token);
       }
     });
+  }
+
+  Future<void> _requestAndroidVoiceRoutingPermission() async {
+    if (!Platform.isAndroid) {
+      return;
+    }
+
+    try {
+      final status = await Permission.bluetoothConnect.status;
+      if (status.isGranted) {
+        return;
+      }
+
+      final requested = await Permission.bluetoothConnect.request();
+      if (!requested.isGranted) {
+        DebugLogger.warning(
+          'bluetooth-connect-denied',
+          scope: 'chat/voice_mode',
+          data: {'status': requested.name},
+        );
+      }
+    } catch (error, stackTrace) {
+      DebugLogger.error(
+        'bluetooth-connect-request-failed',
+        scope: 'chat/voice_mode',
+        error: error,
+        stackTrace: stackTrace,
+      );
+    }
   }
 
   Future<void> stop() {
@@ -455,6 +509,10 @@ class ChatVoiceModeController extends Notifier<ChatVoiceModeSnapshot> {
       switch (event) {
         case TtsStarted():
           if (_awaitingAssistant && state.phase != ChatVoiceModePhase.paused) {
+            if (_activeAssistantSpeechChunkIndex < 0 &&
+                _assistantSpeechChunks.isNotEmpty) {
+              _handleTtsChunkStarted(0);
+            }
             state = state.copyWith(phase: ChatVoiceModePhase.speaking);
           }
         case TtsCompleted():
@@ -467,9 +525,11 @@ class ChatVoiceModeController extends Notifier<ChatVoiceModeSnapshot> {
           state = state.copyWith(errorMessage: message);
         case TtsPaused():
         case TtsResumed():
-        case TtsChunkStarted():
-        case TtsWordProgress():
           break;
+        case TtsChunkStarted(:final chunkIndex):
+          _handleTtsChunkStarted(chunkIndex);
+        case TtsWordProgress(:final start, :final end):
+          _handleTtsWordProgress(start, end);
       }
     });
   }
@@ -564,7 +624,9 @@ class ChatVoiceModeController extends Notifier<ChatVoiceModeSnapshot> {
     }
 
     final input = ref.read(voiceInputServiceProvider);
-    await _cancelListening();
+    if (_transcriptSub == null || !input.isListening) {
+      await _cancelListening();
+    }
     await _audioSessionCoordinator?.configureForListening();
 
     _currentTranscript = '';
@@ -572,6 +634,7 @@ class ChatVoiceModeController extends Notifier<ChatVoiceModeSnapshot> {
       phase: ChatVoiceModePhase.listening,
       transcript: '',
       assistantPreview: '',
+      clearSpokenResponse: true,
       intensity: 0,
       clearErrorMessage: true,
     );
@@ -582,32 +645,33 @@ class ChatVoiceModeController extends Notifier<ChatVoiceModeSnapshot> {
       unawaited(ref.read(callKitServiceProvider).markCallConnected(callId));
     }
 
-    final stream = await input.beginListening(
-      iosAudioSessionManagedExternally: _iosAudioSessionManagedExternally,
-    );
-    if (token != _token) return;
+    if (_transcriptSub == null || !input.isListening) {
+      final stream = await input.beginListeningEvents(
+        iosAudioSessionManagedExternally: _iosAudioSessionManagedExternally,
+      );
+      if (token != _token) return;
 
-    await _transcriptSub?.cancel();
-    _transcriptSub = stream.listen(
-      (text) {
-        if (token != _token) return;
-        _currentTranscript = text;
-        state = state.copyWith(transcript: text);
-      },
-      onError: (Object error, StackTrace stackTrace) {
-        if (token != _token) return;
-        DebugLogger.error(
-          'listen-failed',
-          scope: 'chat/voice_mode',
-          error: error,
-          stackTrace: stackTrace,
-        );
-        unawaited(_fail(error.toString(), token));
-      },
-      onDone: () {
-        unawaited(_handleListeningDone(token));
-      },
-    );
+      await _transcriptSub?.cancel();
+      _transcriptSub = stream.listen(
+        (event) {
+          _handleTranscriptEvent(event, token);
+        },
+        onError: (Object error, StackTrace stackTrace) {
+          if (token != _token) return;
+          DebugLogger.error(
+            'listen-failed',
+            scope: 'chat/voice_mode',
+            error: error,
+            stackTrace: stackTrace,
+          );
+          unawaited(_fail(error.toString(), token));
+        },
+        onDone: () {
+          _transcriptSub = null;
+          unawaited(_handleListeningDone(token));
+        },
+      );
+    }
 
     await _intensitySub?.cancel();
     _intensitySub = input.intensityStream.listen((intensity) {
@@ -617,12 +681,56 @@ class ChatVoiceModeController extends Notifier<ChatVoiceModeSnapshot> {
     });
   }
 
+  void _handleTranscriptEvent(VoiceTranscriptEvent event, int token) {
+    if (token != _token || state.isMuted) return;
+
+    _currentTranscript = event.text;
+    if (state.isActive && state.phase != ChatVoiceModePhase.paused) {
+      state = state.copyWith(transcript: event.text);
+    }
+
+    if (event.isFinal) {
+      unawaited(_handleFinalTranscript(event.text, token));
+    }
+  }
+
+  Future<void> _handleFinalTranscript(String text, int token) async {
+    if (token != _token ||
+        state.isMuted ||
+        state.phase == ChatVoiceModePhase.paused ||
+        _sendingTranscript) {
+      return;
+    }
+
+    final transcript = text.trim();
+    if (transcript.isEmpty) {
+      return;
+    }
+
+    _sendingTranscript = true;
+    try {
+      _emptyTranscriptRestarts = 0;
+      if (_awaitingAssistant ||
+          state.phase == ChatVoiceModePhase.sending ||
+          state.phase == ChatVoiceModePhase.speaking) {
+        await _interruptAssistantForBargeIn(token);
+      }
+      if (token != _token || state.isMuted) return;
+      await _sendTranscript(transcript, token);
+    } finally {
+      _sendingTranscript = false;
+    }
+  }
+
   Future<void> _handleListeningDone(int token) async {
     if (token != _token || state.phase != ChatVoiceModePhase.listening) {
       return;
     }
 
-    final transcript = _currentTranscript.trim();
+    final input = ref.read(voiceInputServiceProvider);
+    final transcript = input.lastCompletedTranscriptSendable
+        ? _currentTranscript.trim()
+        : '';
     if (transcript.isEmpty) {
       await _restartAfterEmptyTranscript(token);
       return;
@@ -656,8 +764,16 @@ class ChatVoiceModeController extends Notifier<ChatVoiceModeSnapshot> {
   Future<void> _sendTranscript(String transcript, int token) async {
     if (token != _token) return;
 
-    await _cancelListening();
-    await _audioSessionCoordinator?.configureForSpeaking();
+    final input = ref.read(voiceInputServiceProvider);
+    final keepListening = input.isUsingNativeLocalStt;
+    if (!keepListening) {
+      await _cancelListening();
+    }
+    if (keepListening && Platform.isIOS) {
+      await _audioSessionCoordinator?.configureForBargeInSpeaking();
+    } else {
+      await _audioSessionCoordinator?.configureForSpeaking();
+    }
     final tts = ref.read(textToSpeechServiceProvider);
     _assistantMessageIdsBeforeTurn = _currentAssistantMessageIds();
     ref.read(streamingContentProvider.notifier).set(null);
@@ -668,11 +784,14 @@ class ChatVoiceModeController extends Notifier<ChatVoiceModeSnapshot> {
     _awaitingAssistant = true;
     _lastFedAssistantText = '';
     _activeAssistantMessageId = null;
+    _assistantSpeechChunks = const <String>[];
+    _activeAssistantSpeechChunkIndex = -1;
 
     state = state.copyWith(
       phase: ChatVoiceModePhase.sending,
       transcript: transcript,
       assistantPreview: '',
+      clearSpokenResponse: true,
       intensity: 0,
       clearErrorMessage: true,
     );
@@ -702,6 +821,35 @@ class ChatVoiceModeController extends Notifier<ChatVoiceModeSnapshot> {
     }
   }
 
+  Future<void> _interruptAssistantForBargeIn(int token) async {
+    if (token != _token) return;
+
+    DebugLogger.info('barge-in', scope: 'chat/voice_mode');
+    final tts = ref.read(textToSpeechServiceProvider);
+    await tts.stopStreamingTts();
+    await tts.stop();
+
+    try {
+      ref.read(stopGenerationProvider)();
+    } catch (error, stackTrace) {
+      DebugLogger.warning(
+        'barge-in-stop-generation-failed',
+        scope: 'chat/voice_mode',
+        data: {'error': error, 'stackTrace': stackTrace},
+      );
+    }
+
+    _awaitingAssistant = false;
+    _assistantFinalized = true;
+    _streamingTtsStarted = false;
+    _activeAssistantMessageId = null;
+    _lastFedAssistantText = '';
+    _assistantSpeechChunks = const <String>[];
+    _activeAssistantSpeechChunkIndex = -1;
+    _assistantMessageIdsBeforeTurn = <String>{};
+    state = state.copyWith(clearSpokenResponse: true);
+  }
+
   void _handleAssistantContentChanged([List<ChatMessage>? messages]) {
     if (!_awaitingAssistant || !_streamingTtsStarted || _assistantFinalized) {
       return;
@@ -712,6 +860,7 @@ class ChatVoiceModeController extends Notifier<ChatVoiceModeSnapshot> {
       return;
     }
 
+    _syncAssistantSpeechChunks(text);
     state = state.copyWith(assistantPreview: text);
     if (state.phase == ChatVoiceModePhase.paused) {
       _pendingPausedAssistantText = text;
@@ -750,6 +899,7 @@ class ChatVoiceModeController extends Notifier<ChatVoiceModeSnapshot> {
     }
 
     final finalText = _visibleAssistantText() ?? '';
+    _syncAssistantSpeechChunks(finalText);
     state = state.copyWith(assistantPreview: finalText);
 
     if (state.phase == ChatVoiceModePhase.paused) {
@@ -836,6 +986,8 @@ class ChatVoiceModeController extends Notifier<ChatVoiceModeSnapshot> {
     _streamingTtsStarted = false;
     _activeAssistantMessageId = null;
     _lastFedAssistantText = '';
+    _assistantSpeechChunks = const <String>[];
+    _activeAssistantSpeechChunkIndex = -1;
     _assistantMessageIdsBeforeTurn = <String>{};
 
     if (!state.isActive ||
@@ -915,6 +1067,7 @@ class ChatVoiceModeController extends Notifier<ChatVoiceModeSnapshot> {
       phase: ChatVoiceModePhase.error,
       errorMessage: message,
       clearActiveCallId: true,
+      clearSpokenResponse: true,
       intensity: 0,
     );
   }
@@ -923,6 +1076,7 @@ class ChatVoiceModeController extends Notifier<ChatVoiceModeSnapshot> {
     state = state.copyWith(
       phase: ChatVoiceModePhase.error,
       errorMessage: message,
+      clearSpokenResponse: true,
       intensity: 0,
     );
   }
@@ -940,6 +1094,7 @@ class ChatVoiceModeController extends Notifier<ChatVoiceModeSnapshot> {
       phase: ChatVoiceModePhase.ended,
       transcript: '',
       assistantPreview: '',
+      clearSpokenResponse: true,
       intensity: 0,
       elapsed: Duration.zero,
       clearStartedAt: true,
@@ -985,6 +1140,62 @@ class ChatVoiceModeController extends Notifier<ChatVoiceModeSnapshot> {
     _assistantFinalizationDeferred = false;
     _pendingPausedAssistantText = null;
     _pendingPausedAssistantFinalText = null;
+    _sendingTranscript = false;
+    _assistantSpeechChunks = const <String>[];
+    _activeAssistantSpeechChunkIndex = -1;
+  }
+
+  void _syncAssistantSpeechChunks(String text) {
+    _assistantSpeechChunks = ref
+        .read(textToSpeechServiceProvider)
+        .splitTextForSpeech(text);
+
+    final index = _activeAssistantSpeechChunkIndex;
+    if (index >= 0 && index < _assistantSpeechChunks.length) {
+      final chunk = _assistantSpeechChunks[index];
+      if (chunk != state.spokenResponse) {
+        state = state.copyWith(
+          spokenResponse: chunk,
+          clearSpokenProgress: true,
+        );
+      }
+    }
+  }
+
+  void _handleTtsChunkStarted(int chunkIndex) {
+    if (!_awaitingAssistant || !_streamingTtsStarted) {
+      return;
+    }
+
+    _activeAssistantSpeechChunkIndex = chunkIndex;
+    if (chunkIndex < 0) {
+      state = state.copyWith(clearSpokenResponse: true);
+      return;
+    }
+
+    if (chunkIndex >= _assistantSpeechChunks.length) {
+      _syncAssistantSpeechChunks(state.assistantPreview);
+    }
+
+    if (chunkIndex >= _assistantSpeechChunks.length) {
+      state = state.copyWith(clearSpokenResponse: true);
+      return;
+    }
+
+    state = state.copyWith(
+      spokenResponse: _assistantSpeechChunks[chunkIndex],
+      clearSpokenProgress: true,
+    );
+  }
+
+  void _handleTtsWordProgress(int start, int end) {
+    if (!_awaitingAssistant ||
+        !_streamingTtsStarted ||
+        state.spokenResponse.trim().isEmpty) {
+      return;
+    }
+
+    state = state.copyWith(spokenWordStart: start, spokenWordEnd: end);
   }
 
   void _startElapsedTimer(int token) {

--- a/lib/features/chat/voice_mode/chat_voice_mode_controller.dart
+++ b/lib/features/chat/voice_mode/chat_voice_mode_controller.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:collection';
 import 'dart:io' show Platform;
 
 import 'package:flutter/foundation.dart';
@@ -206,7 +207,7 @@ class ChatVoiceModeController extends Notifier<ChatVoiceModeSnapshot> {
   bool _assistantFinalizationDeferred = false;
   String? _pendingPausedAssistantText;
   String? _pendingPausedAssistantFinalText;
-  String? _pendingFinalTranscript;
+  final Queue<String> _pendingFinalTranscripts = Queue<String>();
   String? _lastSubmittedTranscript;
   bool _stoppingFromCallKit = false;
   bool _sendingTranscript = false;
@@ -709,7 +710,7 @@ class ChatVoiceModeController extends Notifier<ChatVoiceModeSnapshot> {
     }
 
     if (_sendingTranscript) {
-      _pendingFinalTranscript = transcript;
+      _enqueuePendingFinalTranscript(transcript);
       return;
     }
 
@@ -779,13 +780,26 @@ class ChatVoiceModeController extends Notifier<ChatVoiceModeSnapshot> {
     }
   }
 
-  String? _takePendingFinalTranscript() {
-    final pending = _pendingFinalTranscript?.trim();
-    _pendingFinalTranscript = null;
-    if (pending == null || pending.isEmpty) {
-      return null;
+  void _enqueuePendingFinalTranscript(String transcript) {
+    final pending = transcript.trim();
+    if (pending.isEmpty || pending == _lastSubmittedTranscript) {
+      return;
     }
-    return pending;
+    if (_pendingFinalTranscripts.isNotEmpty &&
+        _pendingFinalTranscripts.last == pending) {
+      return;
+    }
+    _pendingFinalTranscripts.addLast(pending);
+  }
+
+  String? _takePendingFinalTranscript() {
+    while (_pendingFinalTranscripts.isNotEmpty) {
+      final pending = _pendingFinalTranscripts.removeFirst().trim();
+      if (pending.isNotEmpty && pending != _lastSubmittedTranscript) {
+        return pending;
+      }
+    }
+    return null;
   }
 
   Future<void> _restartAfterEmptyTranscript(int token) async {
@@ -1032,7 +1046,7 @@ class ChatVoiceModeController extends Notifier<ChatVoiceModeSnapshot> {
 
     _awaitingAssistant = false;
     _streamingTtsStarted = false;
-    _pendingFinalTranscript = null;
+    _pendingFinalTranscripts.clear();
     _lastSubmittedTranscript = null;
     _activeAssistantMessageId = null;
     _lastFedAssistantText = '';
@@ -1190,7 +1204,7 @@ class ChatVoiceModeController extends Notifier<ChatVoiceModeSnapshot> {
     _assistantFinalizationDeferred = false;
     _pendingPausedAssistantText = null;
     _pendingPausedAssistantFinalText = null;
-    _pendingFinalTranscript = null;
+    _pendingFinalTranscripts.clear();
     _lastSubmittedTranscript = null;
     _sendingTranscript = false;
     _assistantSpeechChunks = const <String>[];

--- a/lib/features/chat/voice_mode/chat_voice_mode_overlay.dart
+++ b/lib/features/chat/voice_mode/chat_voice_mode_overlay.dart
@@ -176,50 +176,55 @@ class _CollapsedVoicePill extends ConsumerWidget {
     return Align(
       key: const ValueKey('voice-overlay-collapsed'),
       alignment: Alignment.center,
-      child: DecoratedBox(
-        decoration: BoxDecoration(
-          color: theme.cardBackground.withValues(alpha: 0.96),
-          borderRadius: BorderRadius.circular(28),
-          border: Border.all(color: theme.cardBorder),
-          boxShadow: ConduitShadows.messageBubble(context),
-        ),
-        child: Padding(
-          padding: const EdgeInsets.fromLTRB(12, 8, 8, 8),
-          child: Row(
-            mainAxisSize: MainAxisSize.min,
-            children: [
-              _StatusDot(snapshot: snapshot, compact: true),
-              const SizedBox(width: Spacing.sm),
-              ConstrainedBox(
-                constraints: const BoxConstraints(maxWidth: 180),
-                child: Text(
-                  _phaseLabel(l10n, snapshot),
-                  style: AppTypography.labelStyle.copyWith(
-                    color: theme.textPrimary,
-                    fontWeight: FontWeight.w700,
+      child: ConstrainedBox(
+        constraints: const BoxConstraints(minHeight: 52),
+        child: DecoratedBox(
+          decoration: BoxDecoration(
+            color: theme.cardBackground.withValues(alpha: 0.96),
+            borderRadius: BorderRadius.circular(28),
+            border: Border.all(color: theme.cardBorder),
+            boxShadow: ConduitShadows.messageBubble(context),
+          ),
+          child: Padding(
+            padding: const EdgeInsets.fromLTRB(16, 10, 10, 10),
+            child: Row(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                _StatusDot(snapshot: snapshot, compact: true),
+                const SizedBox(width: Spacing.sm),
+                ConstrainedBox(
+                  constraints: const BoxConstraints(maxWidth: 220),
+                  child: Text(
+                    _phaseLabel(l10n, snapshot),
+                    style: AppTypography.labelStyle.copyWith(
+                      color: theme.textPrimary,
+                      fontWeight: FontWeight.w700,
+                    ),
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
                   ),
-                  maxLines: 1,
-                  overflow: TextOverflow.ellipsis,
                 ),
-              ),
-              _AdaptiveVoiceAction(
-                tooltip: 'Expand',
-                onPressed: controller.expand,
-                icon: Platform.isIOS
-                    ? CupertinoIcons.chevron_up
-                    : Icons.keyboard_arrow_up_rounded,
-                compact: true,
-              ),
-              _AdaptiveVoiceAction(
-                tooltip: l10n.voiceCallEnd,
-                onPressed: controller.stop,
-                icon: Platform.isIOS
-                    ? CupertinoIcons.phone_down_fill
-                    : Icons.call_end_rounded,
-                destructive: true,
-                compact: true,
-              ),
-            ],
+                const SizedBox(width: Spacing.sm),
+                _AdaptiveVoiceAction(
+                  tooltip: 'Expand',
+                  onPressed: controller.expand,
+                  icon: Platform.isIOS
+                      ? CupertinoIcons.chevron_up
+                      : Icons.keyboard_arrow_up_rounded,
+                  compact: true,
+                ),
+                const SizedBox(width: Spacing.xxs),
+                _AdaptiveVoiceAction(
+                  tooltip: l10n.voiceCallEnd,
+                  onPressed: controller.stop,
+                  icon: Platform.isIOS
+                      ? CupertinoIcons.phone_down_fill
+                      : Icons.call_end_rounded,
+                  destructive: true,
+                  compact: true,
+                ),
+              ],
+            ),
           ),
         ),
       ),
@@ -259,11 +264,16 @@ class _VoiceText extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final text = switch (snapshot.phase) {
-      ChatVoiceModePhase.speaking ||
-      ChatVoiceModePhase.sending => snapshot.assistantPreview,
-      _ => snapshot.transcript,
-    };
+    if (snapshot.phase == ChatVoiceModePhase.speaking ||
+        snapshot.phase == ChatVoiceModePhase.sending) {
+      final spoken = snapshot.spokenResponse.trim();
+      if (spoken.isEmpty) {
+        return const SizedBox(height: 36);
+      }
+      return _KaraokeResponseBar(snapshot: snapshot);
+    }
+
+    final text = snapshot.transcript;
     if (text.trim().isEmpty) {
       return const SizedBox(height: 20);
     }
@@ -275,6 +285,97 @@ class _VoiceText extends StatelessWidget {
       ),
       maxLines: 3,
       overflow: TextOverflow.ellipsis,
+    );
+  }
+}
+
+class _KaraokeResponseBar extends StatelessWidget {
+  const _KaraokeResponseBar({required this.snapshot});
+
+  final ChatVoiceModeSnapshot snapshot;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = context.conduitTheme;
+    final text = snapshot.spokenResponse.trim();
+    final baseStyle = AppTypography.bodyMediumStyle.copyWith(
+      color: theme.textPrimary.withValues(alpha: Alpha.strong),
+      fontWeight: FontWeight.w500,
+      height: 1.25,
+    );
+    final highlightStyle = baseStyle.copyWith(
+      color: theme.buttonPrimaryText,
+      backgroundColor: theme.buttonPrimary,
+      fontWeight: FontWeight.w800,
+    );
+
+    return Semantics(
+      label: text,
+      child: DecoratedBox(
+        decoration: BoxDecoration(
+          color: theme.surfaceContainerHighest.withValues(alpha: 0.78),
+          borderRadius: BorderRadius.circular(8),
+          border: Border.all(
+            color: theme.cardBorder.withValues(alpha: 0.75),
+            width: BorderWidth.thin,
+          ),
+        ),
+        child: Padding(
+          padding: const EdgeInsets.symmetric(
+            horizontal: Spacing.sm,
+            vertical: Spacing.xs,
+          ),
+          child: AnimatedSwitcher(
+            duration: const Duration(milliseconds: 160),
+            switchInCurve: Curves.easeOutCubic,
+            switchOutCurve: Curves.easeOutCubic,
+            child: RichText(
+              key: ValueKey<String>(text),
+              text: _karaokeTextSpan(
+                text: text,
+                baseStyle: baseStyle,
+                highlightStyle: highlightStyle,
+                start: snapshot.spokenWordStart,
+                end: snapshot.spokenWordEnd,
+              ),
+              maxLines: 2,
+              overflow: TextOverflow.ellipsis,
+              textScaler: MediaQuery.textScalerOf(context),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  TextSpan _karaokeTextSpan({
+    required String text,
+    required TextStyle baseStyle,
+    required TextStyle highlightStyle,
+    required int? start,
+    required int? end,
+  }) {
+    if (start == null ||
+        end == null ||
+        start < 0 ||
+        end <= start ||
+        start >= text.length) {
+      return TextSpan(text: text, style: baseStyle);
+    }
+
+    final safeStart = start.clamp(0, text.length);
+    final safeEnd = end.clamp(safeStart, text.length);
+    return TextSpan(
+      children: [
+        if (safeStart > 0)
+          TextSpan(text: text.substring(0, safeStart), style: baseStyle),
+        TextSpan(
+          text: text.substring(safeStart, safeEnd),
+          style: highlightStyle,
+        ),
+        if (safeEnd < text.length)
+          TextSpan(text: text.substring(safeEnd), style: baseStyle),
+      ],
     );
   }
 }

--- a/lib/features/chat/voice_mode/chat_voice_mode_overlay.dart
+++ b/lib/features/chat/voice_mode/chat_voice_mode_overlay.dart
@@ -297,7 +297,15 @@ class _KaraokeResponseBar extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final theme = context.conduitTheme;
-    final text = snapshot.spokenResponse.trim();
+    final rawText = snapshot.spokenResponse;
+    final text = rawText.trim();
+    final leadingTrim = rawText.length - rawText.trimLeft().length;
+    final adjustedStart = snapshot.spokenWordStart == null
+        ? null
+        : snapshot.spokenWordStart! - leadingTrim;
+    final adjustedEnd = snapshot.spokenWordEnd == null
+        ? null
+        : snapshot.spokenWordEnd! - leadingTrim;
     final baseStyle = AppTypography.bodyMediumStyle.copyWith(
       color: theme.textPrimary.withValues(alpha: Alpha.strong),
       fontWeight: FontWeight.w500,
@@ -335,8 +343,8 @@ class _KaraokeResponseBar extends StatelessWidget {
                 text: text,
                 baseStyle: baseStyle,
                 highlightStyle: highlightStyle,
-                start: snapshot.spokenWordStart,
-                end: snapshot.spokenWordEnd,
+                start: adjustedStart,
+                end: adjustedEnd,
               ),
               maxLines: 2,
               overflow: TextOverflow.ellipsis,
@@ -363,8 +371,8 @@ class _KaraokeResponseBar extends StatelessWidget {
       return TextSpan(text: text, style: baseStyle);
     }
 
-    final safeStart = start.clamp(0, text.length);
-    final safeEnd = end.clamp(safeStart, text.length);
+    final safeStart = start.clamp(0, text.length).toInt();
+    final safeEnd = end.clamp(safeStart, text.length).toInt();
     return TextSpan(
       children: [
         if (safeStart > 0)

--- a/lib/features/chat/widgets/assistant_message_widget.dart
+++ b/lib/features/chat/widgets/assistant_message_widget.dart
@@ -62,6 +62,7 @@ class AssistantMessageWidget extends ConsumerStatefulWidget {
   final String? modelIconUrl;
   final List<String?> versionModelNames;
   final List<String?> versionModelIconUrls;
+  final bool suppressStreamingHaptics;
   final VoidCallback? onCopy;
   final VoidCallback? onRegenerate;
   final VoidCallback onDelete;
@@ -78,6 +79,7 @@ class AssistantMessageWidget extends ConsumerStatefulWidget {
     this.modelIconUrl,
     this.versionModelNames = const <String?>[],
     this.versionModelIconUrls = const <String?>[],
+    this.suppressStreamingHaptics = false,
     this.onCopy,
     this.onRegenerate,
     required this.onDelete,
@@ -858,7 +860,7 @@ class _AssistantMessageWidgetState extends ConsumerState<AssistantMessageWidget>
 
   /// Fires a single haptic impulse if streaming haptics are enabled.
   void _streamingHaptic(HapticType type) {
-    final enabled = ref.read(streamingHapticsEnabledProvider);
+    final enabled = _streamingHapticsAllowed;
     PlatformService.hapticFeedbackWithSettings(
       type: type,
       hapticEnabled: enabled,
@@ -870,18 +872,21 @@ class _AssistantMessageWidgetState extends ConsumerState<AssistantMessageWidget>
   /// Each tap is spaced 150ms apart so the user perceives three
   /// separate impulses rather than a single buzz.
   void _tripleHaptic() {
-    final enabled = ref.read(streamingHapticsEnabledProvider);
-    if (!enabled) return;
+    if (!_streamingHapticsAllowed) return;
     PlatformService.hapticFeedback(type: HapticType.medium);
     Future.delayed(const Duration(milliseconds: 150), () {
-      if (!mounted) return;
+      if (!mounted || !_streamingHapticsAllowed) return;
       PlatformService.hapticFeedback(type: HapticType.medium);
     });
     Future.delayed(const Duration(milliseconds: 300), () {
-      if (!mounted) return;
+      if (!mounted || !_streamingHapticsAllowed) return;
       PlatformService.hapticFeedback(type: HapticType.medium);
     });
   }
+
+  bool get _streamingHapticsAllowed =>
+      ref.read(streamingHapticsEnabledProvider) &&
+      !widget.suppressStreamingHaptics;
 
   /// Subscribes to [streamingContentProvider] only while this message is
   /// actively streaming. Uses [ref.listenManual] for explicit lifecycle

--- a/lib/features/chat/widgets/modern_chat_input.dart
+++ b/lib/features/chat/widgets/modern_chat_input.dart
@@ -2000,7 +2000,6 @@ class _ModernChatInputState extends ConsumerState<ModernChatInput>
       orElse: () => false,
     );
     final selectedToolIds = ref.watch(selectedToolIdsProvider);
-    final selectedTerminalId = ref.watch(selectedTerminalIdProvider);
     final selectedFilterIds = ref.watch(selectedFilterIdsProvider);
 
     // Get filters from the selected model for quick pills
@@ -2009,10 +2008,6 @@ class _ModernChatInputState extends ConsumerState<ModernChatInput>
         (model) => model?.filters ?? const <ToggleFilter>[],
       ),
     );
-    final terminalModelSupported = ref.watch(
-      selectedModelProvider.select(modelSupportsTerminal),
-    );
-    final terminalActive = selectedTerminalId != null && terminalModelSupported;
     final nativeAttachmentActions = _nativeKeyboardAttachmentActions(
       l10n: l10n,
       webSearchAvailable: webSearchAvailable,
@@ -2041,7 +2036,7 @@ class _ModernChatInputState extends ConsumerState<ModernChatInput>
     _controller.mentionBackground = mentionColor.withValues(alpha: 0.12);
 
     final bool hasComposerFocus = _focusNode.hasFocus;
-    final bool isActive = hasComposerFocus || _hasText;
+    final bool isActive = hasComposerFocus || _hasText || _isRecording;
     final Color placeholderColor = context.conduitTheme.textSecondary
         .withValues(alpha: 0.5);
     final Color placeholderBase = placeholderColor;
@@ -2245,16 +2240,14 @@ class _ModernChatInputState extends ConsumerState<ModernChatInput>
           ),
           child: Row(
             children: [
-              _buildOverflowButton(
-                tooltip: l10n.more,
-                webSearchActive: webSearchEnabled,
-                imageGenerationActive: imageGenEnabled,
-                toolsActive: selectedToolIds.isNotEmpty,
-                terminalActive: terminalActive,
-                filtersActive: selectedFilterIds.isNotEmpty,
-                dense: true,
-                nativeActions: nativeAttachmentActions,
-              ),
+              if (_isRecording)
+                _buildDictationStopButton(size: 36.0)
+              else
+                _buildOverflowButton(
+                  tooltip: l10n.more,
+                  dense: true,
+                  nativeActions: nativeAttachmentActions,
+                ),
               const SizedBox(width: Spacing.xs),
               Expanded(
                 child: ClipRect(
@@ -2272,7 +2265,10 @@ class _ModernChatInputState extends ConsumerState<ModernChatInput>
                 const SizedBox(width: Spacing.xs),
                 _buildCreateDraftNoteButton(isLoading: isCreatingDraftNote),
               ],
-              if (!_hasText && voiceAvailable && !isGenerating) ...[
+              if (!_isRecording &&
+                  !_hasText &&
+                  voiceAvailable &&
+                  !isGenerating) ...[
                 const SizedBox(width: Spacing.xs),
                 _buildInlineMicAction(voiceAvailable),
               ],
@@ -2333,7 +2329,10 @@ class _ModernChatInputState extends ConsumerState<ModernChatInput>
                     ),
                   ),
                 ),
-                if (!_hasText && voiceAvailable && !isGenerating) ...[
+                if (!_isRecording &&
+                    !_hasText &&
+                    voiceAvailable &&
+                    !isGenerating) ...[
                   const SizedBox(width: Spacing.xs),
                   Platform.isAndroid
                       ? Transform.translate(
@@ -2382,6 +2381,7 @@ class _ModernChatInputState extends ConsumerState<ModernChatInput>
         key: const ValueKey('compact-composer-shell'),
         borderRadius: shellRadius,
         useSmoothRectangleBorder: _isMultiline,
+        isRecording: _isRecording,
         child: textFieldContent,
       );
 
@@ -2405,15 +2405,13 @@ class _ModernChatInputState extends ConsumerState<ModernChatInput>
             Row(
               crossAxisAlignment: CrossAxisAlignment.end,
               children: [
-                _buildOverflowButton(
-                  tooltip: l10n.more,
-                  webSearchActive: webSearchEnabled,
-                  imageGenerationActive: imageGenEnabled,
-                  toolsActive: selectedToolIds.isNotEmpty,
-                  terminalActive: terminalActive,
-                  filtersActive: selectedFilterIds.isNotEmpty,
-                  nativeActions: nativeAttachmentActions,
-                ),
+                if (_isRecording)
+                  _buildDictationStopButton()
+                else
+                  _buildOverflowButton(
+                    tooltip: l10n.more,
+                    nativeActions: nativeAttachmentActions,
+                  ),
                 const SizedBox(width: Spacing.sm),
                 Expanded(
                   child: _wrapIosSurfaceShadow(
@@ -2450,7 +2448,11 @@ class _ModernChatInputState extends ConsumerState<ModernChatInput>
     );
 
     final Widget shell = _wrapIosSurfaceShadow(
-      _buildComposerShell(borderRadius: shellRadius, child: shellContent),
+      _buildComposerShell(
+        borderRadius: shellRadius,
+        isRecording: _isRecording,
+        child: shellContent,
+      ),
       borderRadius: shellRadius,
     );
 
@@ -2593,6 +2595,10 @@ class _ModernChatInputState extends ConsumerState<ModernChatInput>
                   ? FontWeight.w500
                   : FontWeight.w400;
               final TextStyle baseChatStyle = AppTypography.chatMessageStyle;
+              final inputPlaceholder = _isRecording
+                  ? AppLocalizations.of(context)!.recordingAudio
+                  : widget.placeholder ??
+                        AppLocalizations.of(context)!.messageHintText;
 
               // IMPORTANT: Always use TextInputAction.newline for multiline
               // chat input. Using TextInputAction.send causes issues with
@@ -2604,9 +2610,7 @@ class _ModernChatInputState extends ConsumerState<ModernChatInput>
                 return CupertinoTextField(
                   controller: _controller,
                   focusNode: _focusNode,
-                  placeholder:
-                      widget.placeholder ??
-                      AppLocalizations.of(context)!.messageHintText,
+                  placeholder: inputPlaceholder,
                   placeholderStyle: baseChatStyle.copyWith(
                     color: animatedPlaceholder,
                     fontWeight: recordingWeight,
@@ -2676,11 +2680,7 @@ class _ModernChatInputState extends ConsumerState<ModernChatInput>
                   fontWeight: recordingWeight,
                 ),
                 decoration: context.conduitInputStyles
-                    .borderless(
-                      hint:
-                          widget.placeholder ??
-                          AppLocalizations.of(context)!.messageHintText,
-                    )
+                    .borderless(hint: inputPlaceholder)
                     .copyWith(
                       hintStyle: baseChatStyle.copyWith(
                         color: animatedPlaceholder,
@@ -2721,11 +2721,6 @@ class _ModernChatInputState extends ConsumerState<ModernChatInput>
 
   Widget _buildOverflowButton({
     required String tooltip,
-    required bool webSearchActive,
-    required bool imageGenerationActive,
-    required bool toolsActive,
-    required bool terminalActive,
-    required bool filtersActive,
     bool dense = false,
     List<IosKeyboardAttachmentActionConfig> nativeActions = const [],
   }) {
@@ -2738,48 +2733,19 @@ class _ModernChatInputState extends ConsumerState<ModernChatInput>
 
     final bool enabled = widget.enabled && !_isRecording;
 
-    Color? activeColor;
     final bool nativePanelVisible =
         !kIsWeb && Platform.isIOS && _isNativeAttachmentPanelVisible;
-
-    // Native attachment panel uses an X to dismiss; keep it neutral like the idle
-    // + control, not the same primary-filled treatment as feature/tool "active" states.
-    if (webSearchActive ||
-        imageGenerationActive ||
-        toolsActive ||
-        terminalActive ||
-        filtersActive) {
-      activeColor = context.conduitTheme.buttonPrimary;
-    }
-
-    final bool isActive = activeColor != null;
     final theme = context.conduitTheme;
 
     final Color iconColor = !enabled
         ? theme.textPrimary.withValues(alpha: Alpha.disabled)
         : nativePanelVisible
         ? theme.textPrimary.withValues(alpha: Alpha.strong)
-        : isActive
-        ? theme.buttonPrimaryText
         : theme.textPrimary.withValues(alpha: Alpha.strong);
 
     final IconData overflowIcon;
     if (nativePanelVisible) {
       overflowIcon = CupertinoIcons.xmark;
-    } else if (webSearchActive) {
-      overflowIcon = Platform.isIOS ? CupertinoIcons.search : Icons.search;
-    } else if (imageGenerationActive) {
-      overflowIcon = Platform.isIOS ? CupertinoIcons.photo : Icons.image;
-    } else if (toolsActive) {
-      overflowIcon = Platform.isIOS ? CupertinoIcons.wrench : Icons.build;
-    } else if (terminalActive) {
-      overflowIcon = Platform.isIOS
-          ? CupertinoIcons.chevron_left_slash_chevron_right
-          : Icons.terminal_rounded;
-    } else if (filtersActive) {
-      overflowIcon = Platform.isIOS
-          ? CupertinoIcons.sparkles
-          : Icons.auto_awesome;
     } else {
       overflowIcon = Platform.isIOS ? CupertinoIcons.add : Icons.add;
     }
@@ -2793,8 +2759,8 @@ class _ModernChatInputState extends ConsumerState<ModernChatInput>
               }
             : null,
         size: buttonSize,
-        isProminent: isActive && !nativePanelVisible,
-        androidShowBackground: !isActive,
+        isProminent: false,
+        androidShowBackground: true,
         color: nativePanelVisible ? theme.surfaceContainerHighest : null,
         child: Icon(overflowIcon, size: IconSize.large, color: iconColor),
       ),
@@ -2816,16 +2782,74 @@ class _ModernChatInputState extends ConsumerState<ModernChatInput>
     );
   }
 
-  Widget _buildInlineMicAction(bool voiceAvailable, {double? size}) {
-    final bool enabledMic = widget.enabled && voiceAvailable;
-    final icon = Icon(
-      Platform.isIOS ? CupertinoIcons.mic : Icons.mic,
-      size: IconSize.large,
-      color: _isRecording
-          ? context.conduitTheme.buttonPrimary
-          : context.conduitTheme.textSecondary.withValues(
-              alpha: enabledMic ? Alpha.strong : Alpha.disabled,
+  Widget _buildDictationStopButton({double size = TouchTarget.minimum}) {
+    final theme = context.conduitTheme;
+    final iconSize = size <= 36.0 ? IconSize.medium : IconSize.large;
+    final background = theme.surfaceContainerHighest.withValues(alpha: 0.96);
+    final border = theme.cardBorder.withValues(alpha: 0.75);
+
+    return AdaptiveTooltip(
+      message: AppLocalizations.of(context)!.stopRecording,
+      child: GestureDetector(
+        key: const ValueKey('composer-dictation-stop-button'),
+        behavior: HitTestBehavior.opaque,
+        onTap: widget.enabled
+            ? () {
+                ConduitHaptics.selectionClick();
+                unawaited(_stopVoice());
+              }
+            : null,
+        child: AnimatedContainer(
+          duration: const Duration(milliseconds: 160),
+          curve: Curves.easeOutCubic,
+          width: size,
+          height: size,
+          decoration: BoxDecoration(
+            color: background,
+            shape: BoxShape.circle,
+            border: Border.all(color: border, width: BorderWidth.thin),
+          ),
+          child: Center(
+            child: Icon(
+              Platform.isIOS ? CupertinoIcons.stop_fill : Icons.stop_rounded,
+              size: iconSize,
+              color: theme.textPrimary.withValues(alpha: Alpha.strong),
             ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildInlineMicAction(bool voiceAvailable, {double? size}) {
+    final bool enabledMic = widget.enabled && (voiceAvailable || _isRecording);
+    final theme = context.conduitTheme;
+    final bool active = _isRecording;
+    final double buttonSize = size ?? 36.0;
+    final IconData iconData = active
+        ? (Platform.isIOS ? CupertinoIcons.stop_fill : Icons.stop_rounded)
+        : (Platform.isIOS ? CupertinoIcons.mic : Icons.mic);
+    final Color iconColor = active
+        ? theme.buttonPrimaryText
+        : theme.textSecondary.withValues(
+            alpha: enabledMic ? Alpha.strong : Alpha.disabled,
+          );
+    final icon = AnimatedSwitcher(
+      duration: const Duration(milliseconds: 160),
+      switchInCurve: Curves.easeOutCubic,
+      switchOutCurve: Curves.easeOutCubic,
+      transitionBuilder: (child, animation) {
+        return FadeTransition(
+          opacity: animation,
+          child: ScaleTransition(scale: animation, child: child),
+        );
+      },
+      child: Icon(
+        iconData,
+        key: ValueKey<IconData>(iconData),
+        size: IconSize.large,
+        color: iconColor,
+      ),
     );
     final onPressed = enabledMic
         ? () {
@@ -2834,20 +2858,20 @@ class _ModernChatInputState extends ConsumerState<ModernChatInput>
           }
         : null;
 
-    if (size != null) {
-      return _buildComposerIconButton(
-        onPressed: onPressed,
-        size: size,
-        child: icon,
-      );
-    }
-
-    return GestureDetector(
-      behavior: HitTestBehavior.opaque,
-      onTap: onPressed,
-      child: Padding(
-        padding: const EdgeInsets.symmetric(horizontal: Spacing.xs),
-        child: icon,
+    return AdaptiveTooltip(
+      message: active
+          ? AppLocalizations.of(context)!.stopRecording
+          : AppLocalizations.of(context)!.startDictation,
+      child: GestureDetector(
+        key: ValueKey<String>(
+          active ? 'composer-dictation-stop' : 'composer-dictation-start',
+        ),
+        behavior: HitTestBehavior.opaque,
+        onTap: onPressed,
+        child: SizedBox.square(
+          dimension: buttonSize,
+          child: Center(child: icon),
+        ),
       ),
     );
   }
@@ -2922,11 +2946,17 @@ class _ModernChatInputState extends ConsumerState<ModernChatInput>
       );
     }
 
-    // If there's text, render SEND variant; otherwise render VOICE CALL variant
-    if (hasText) {
+    // If there's text, render SEND variant. During active dictation, keep the
+    // send affordance visible even before text arrives so the layout stays
+    // stable around the middle text field.
+    if (hasText || _isRecording) {
       final onPressed = enabled
           ? () {
-              _sendMessage();
+              if (_isRecording) {
+                unawaited(_stopVoiceAndSend());
+              } else {
+                _sendMessage();
+              }
             }
           : null;
       final sendChild = hasUploadsInProgress
@@ -2964,7 +2994,7 @@ class _ModernChatInputState extends ConsumerState<ModernChatInput>
     // VOICE CALL variant when no text is present and voice is available.
     // Otherwise fall back to a muted send button.
     if (widget.onVoiceCall != null) {
-      final bool enabledVoiceCall = widget.enabled;
+      final bool enabledVoiceCall = widget.enabled && !_isRecording;
       return AdaptiveTooltip(
         message: AppLocalizations.of(context)!.voiceCallTitle,
         child: _buildComposerIconButton(
@@ -3145,8 +3175,14 @@ class _ModernChatInputState extends ConsumerState<ModernChatInput>
     required Widget child,
     required BorderRadius borderRadius,
     bool useSmoothRectangleBorder = true,
+    bool isRecording = false,
   }) {
     final theme = context.conduitTheme;
+    final recordingBorderColor = theme.buttonPrimary.withValues(alpha: 0.56);
+    final recordingSurfaceColor = Color.alphaBlend(
+      theme.buttonPrimary.withValues(alpha: 0.045),
+      theme.surfaceContainerHighest,
+    );
 
     if (conduitSupportsNativeGlass()) {
       return Stack(
@@ -3166,17 +3202,41 @@ class _ModernChatInputState extends ConsumerState<ModernChatInput>
               ),
             ),
           ),
+          Positioned.fill(
+            child: IgnorePointer(
+              child: AnimatedContainer(
+                duration: const Duration(milliseconds: 160),
+                curve: Curves.easeOutCubic,
+                decoration: BoxDecoration(
+                  borderRadius: borderRadius,
+                  border: Border.all(
+                    color: isRecording
+                        ? recordingBorderColor
+                        : Colors.transparent,
+                    width: isRecording ? BorderWidth.thin * 1.5 : 0,
+                  ),
+                ),
+              ),
+            ),
+          ),
           child,
         ],
       );
     }
 
-    return Container(
+    return AnimatedContainer(
       key: key,
+      duration: const Duration(milliseconds: 160),
+      curve: Curves.easeOutCubic,
       decoration: BoxDecoration(
-        color: theme.surfaceContainerHighest,
+        color: isRecording
+            ? recordingSurfaceColor
+            : theme.surfaceContainerHighest,
         borderRadius: borderRadius,
-        border: Border.all(color: theme.cardBorder, width: BorderWidth.thin),
+        border: Border.all(
+          color: isRecording ? recordingBorderColor : theme.cardBorder,
+          width: isRecording ? BorderWidth.thin * 1.5 : BorderWidth.thin,
+        ),
       ),
       child: child,
     );
@@ -3410,6 +3470,18 @@ class _ModernChatInputState extends ConsumerState<ModernChatInput>
     if (!mounted) return;
     setState(() => _isRecording = false);
     ConduitHaptics.selectionClick();
+  }
+
+  Future<void> _stopVoiceAndSend() async {
+    if (_controller.text.trim().isEmpty) {
+      await _stopVoice();
+      return;
+    }
+    await _voiceService.stopListening();
+    if (!mounted) return;
+    setState(() => _isRecording = false);
+    ConduitHaptics.lightImpact();
+    _sendMessage();
   }
 
   // When on-device STT is unavailable we rely on server transcription.

--- a/lib/features/chat/widgets/modern_chat_input.dart
+++ b/lib/features/chat/widgets/modern_chat_input.dart
@@ -2795,7 +2795,6 @@ class _ModernChatInputState extends ConsumerState<ModernChatInput>
         behavior: HitTestBehavior.opaque,
         onTap: widget.enabled
             ? () {
-                ConduitHaptics.selectionClick();
                 unawaited(_stopVoice());
               }
             : null,

--- a/lib/features/profile/views/app_customization_page.dart
+++ b/lib/features/profile/views/app_customization_page.dart
@@ -10,6 +10,7 @@ import '../../../core/models/model.dart';
 import '../../../core/services/ios_native_dropdown_bridge.dart';
 import '../../../core/services/native_sheet_bridge.dart';
 import '../../../core/services/settings_service.dart';
+import '../../../core/utils/tts_voice_utils.dart';
 import '../../../shared/theme/theme_extensions.dart';
 import '../../../shared/theme/tweakcn_themes.dart';
 import '../../tools/providers/tools_providers.dart';
@@ -1181,6 +1182,7 @@ class AppCustomizationPage extends ConsumerWidget {
                   final notifier = ref.read(appSettingsProvider.notifier);
                   if (engine == TtsEngine.server) {
                     notifier.setTtsVoice(null);
+                    notifier.setTtsVoiceName(null);
                   }
                   notifier.setTtsEngine(engine);
                 },
@@ -1323,13 +1325,14 @@ class AppCustomizationPage extends ConsumerWidget {
   }
 
   String _ttsVoiceSubtitle(AppLocalizations l10n, AppSettings settings) {
-    final deviceName = _getDisplayVoiceName(
-      settings.ttsVoice,
-      l10n.ttsSystemDefault,
+    final deviceName = formatTtsVoiceDisplayName(
+      settings.ttsVoiceName ?? settings.ttsVoice ?? l10n.ttsSystemDefault,
     );
     final serverVoice =
-        (settings.ttsServerVoiceName ?? settings.ttsServerVoiceId) ?? '';
-    final serverName = _getDisplayVoiceName(serverVoice, l10n.ttsSystemDefault);
+        settings.ttsServerVoiceName ??
+        settings.ttsServerVoiceId ??
+        l10n.ttsSystemDefault;
+    final serverName = formatTtsVoiceDisplayName(serverVoice);
 
     switch (settings.ttsEngine) {
       case TtsEngine.device:
@@ -1458,32 +1461,24 @@ class AppCustomizationPage extends ConsumerWidget {
 
     // Combine: matching voices first, then others
     final voices = [...matchingVoices, ...otherVoices];
-    const systemDefaultId = '__system_default__';
+    final voiceOptions = buildTtsVoiceOptions(l10n, settings.ttsEngine, voices);
+    final selectedOptionId = selectedTtsVoiceOptionId(settings, voices);
     if (Platform.isIOS) {
       try {
         final selectedId = await NativeSheetBridge.instance
             .presentOptionsSelector(
               title: l10n.ttsSelectVoice,
-              selectedOptionId:
-                  ((settings.ttsEngine == TtsEngine.server
-                              ? settings.ttsServerVoiceId
-                              : settings.ttsVoice)
-                          ?.isNotEmpty ??
-                      false)
-                  ? settings.ttsEngine == TtsEngine.server
-                        ? settings.ttsServerVoiceId
-                        : settings.ttsVoice
-                  : systemDefaultId,
+              selectedOptionId: selectedOptionId,
               options: [
                 NativeSheetOptionConfig(
-                  id: systemDefaultId,
+                  id: ttsSystemDefaultVoiceId,
                   label: l10n.ttsSystemDefault,
                 ),
-                for (final voice in voices)
+                for (final option in voiceOptions)
                   NativeSheetOptionConfig(
-                    id: _getVoiceIdentifier(voice, settings.ttsEngine),
-                    label: _formatVoiceName(l10n, voice),
-                    subtitle: _getVoiceSubtitle(voice),
+                    id: option.id,
+                    label: option.label,
+                    subtitle: option.subtitle,
                   ),
               ],
               rethrowErrors: true,
@@ -1492,25 +1487,31 @@ class AppCustomizationPage extends ConsumerWidget {
           return;
         }
         final notifier = ref.read(appSettingsProvider.notifier);
-        if (selectedId == systemDefaultId) {
+        if (selectedId == ttsSystemDefaultVoiceId) {
           if (settings.ttsEngine == TtsEngine.server) {
             notifier.setTtsServerVoiceId(null);
             notifier.setTtsServerVoiceName(null);
           } else {
             notifier.setTtsVoice(null);
+            notifier.setTtsVoiceName(null);
           }
           return;
         }
-        final selectedVoice = voices.firstWhere(
-          (voice) =>
-              _getVoiceIdentifier(voice, settings.ttsEngine) == selectedId,
+        final selectedVoice = findTtsVoiceOption(
+          l10n,
+          settings.ttsEngine,
+          voices,
+          selectedId,
         );
-        final displayName = _formatVoiceName(l10n, selectedVoice);
+        if (selectedVoice == null) {
+          return;
+        }
         if (settings.ttsEngine == TtsEngine.server) {
-          notifier.setTtsServerVoiceId(selectedId);
-          notifier.setTtsServerVoiceName(displayName);
+          notifier.setTtsServerVoiceId(selectedVoice.id);
+          notifier.setTtsServerVoiceName(selectedVoice.label);
         } else {
-          notifier.setTtsVoice(selectedId);
+          notifier.setTtsVoice(selectedVoice.id);
+          notifier.setTtsVoiceName(selectedVoice.label);
         }
         return;
       } catch (_) {
@@ -1520,21 +1521,31 @@ class AppCustomizationPage extends ConsumerWidget {
       }
     }
 
-    final entries = <({String? section, Map<String, dynamic>? voice})>[
-      (section: null, voice: null),
+    final matchingOptions = buildTtsVoiceOptions(
+      l10n,
+      settings.ttsEngine,
+      matchingVoices,
+    );
+    final otherOptions = buildTtsVoiceOptions(
+      l10n,
+      settings.ttsEngine,
+      otherVoices,
+    );
+    final entries = <({String? section, TtsVoiceOptionData? option})>[
+      (section: null, option: null),
       if (matchingVoices.isNotEmpty && otherVoices.isNotEmpty)
         (
           section: l10n.ttsVoicesForLanguage(appLanguageCode.toUpperCase()),
-          voice: null,
+          option: null,
         ),
       if (matchingVoices.isNotEmpty && otherVoices.isNotEmpty)
-        for (final voice in matchingVoices) (section: null, voice: voice),
+        for (final option in matchingOptions) (section: null, option: option),
       if (matchingVoices.isNotEmpty && otherVoices.isNotEmpty)
-        (section: l10n.ttsOtherVoices, voice: null),
+        (section: l10n.ttsOtherVoices, option: null),
       if (matchingVoices.isNotEmpty && otherVoices.isNotEmpty)
-        for (final voice in otherVoices) (section: null, voice: voice),
+        for (final option in otherOptions) (section: null, option: option),
       if (matchingVoices.isEmpty || otherVoices.isEmpty)
-        for (final voice in voices) (section: null, voice: voice),
+        for (final option in voiceOptions) (section: null, option: option),
     ];
 
     if (!context.mounted) {
@@ -1570,14 +1581,11 @@ class AppCustomizationPage extends ConsumerWidget {
               );
             }
 
-            final voice = entry.voice;
-            if (voice == null) {
-              final selected = settings.ttsEngine == TtsEngine.server
-                  ? settings.ttsServerVoiceId == null
-                  : settings.ttsVoice == null;
+            final option = entry.option;
+            if (option == null) {
               return SettingsSelectorTile(
                 title: l10n.ttsSystemDefault,
-                selected: selected,
+                selected: selectedOptionId == ttsSystemDefaultVoiceId,
                 onTap: () {
                   final notifier = ref.read(appSettingsProvider.notifier);
                   if (settings.ttsEngine == TtsEngine.server) {
@@ -1585,30 +1593,25 @@ class AppCustomizationPage extends ConsumerWidget {
                     notifier.setTtsServerVoiceName(null);
                   } else {
                     notifier.setTtsVoice(null);
+                    notifier.setTtsVoiceName(null);
                   }
                   Navigator.of(sheetContext).pop();
                 },
               );
             }
 
-            final voiceId = _getVoiceIdentifier(voice, settings.ttsEngine);
-            final displayName = _formatVoiceName(l10n, voice);
-            final subtitle = _getVoiceSubtitle(voice);
-            final selected = settings.ttsEngine == TtsEngine.server
-                ? settings.ttsServerVoiceId == voiceId
-                : settings.ttsVoice == voiceId;
-
             return SettingsSelectorTile(
-              title: displayName,
-              subtitle: subtitle.isEmpty ? null : subtitle,
-              selected: selected,
+              title: option.label,
+              subtitle: option.subtitle,
+              selected: option.id == selectedOptionId,
               onTap: () {
                 final notifier = ref.read(appSettingsProvider.notifier);
                 if (settings.ttsEngine == TtsEngine.server) {
-                  notifier.setTtsServerVoiceId(voiceId);
-                  notifier.setTtsServerVoiceName(displayName);
+                  notifier.setTtsServerVoiceId(option.id);
+                  notifier.setTtsServerVoiceName(option.label);
                 } else {
-                  notifier.setTtsVoice(voiceId);
+                  notifier.setTtsVoice(option.id);
+                  notifier.setTtsVoiceName(option.label);
                 }
                 Navigator.of(sheetContext).pop();
               },
@@ -1653,169 +1656,6 @@ class AppCustomizationPage extends ConsumerWidget {
         type: AdaptiveSnackBarType.error,
       );
     }
-  }
-
-  String _getDisplayVoiceName(String? voiceName, String defaultLabel) {
-    if (voiceName == null || voiceName.isEmpty) {
-      return defaultLabel;
-    }
-
-    // Format Android-style voice names with # separator
-    if (voiceName.contains('#')) {
-      final parts = voiceName.split('#');
-      if (parts.length > 1) {
-        var friendlyName = parts[1]
-            .replaceAll('-local', '')
-            .replaceAll('-network', '')
-            .replaceAll('_', ' ')
-            .split(' ')
-            .map(
-              (word) =>
-                  word.isEmpty ? '' : word[0].toUpperCase() + word.substring(1),
-            )
-            .join(' ');
-
-        final localeInfo = parts[0].toUpperCase().replaceAll('_', '-');
-        return '$localeInfo - $friendlyName';
-      }
-    }
-
-    // Handle Android-style voice IDs without # (e.g., "es-us-x-sfb-local")
-    if (voiceName.contains('-x-') ||
-        voiceName.endsWith('-local') ||
-        voiceName.endsWith('-network') ||
-        voiceName.endsWith('-language')) {
-      var localePart = '';
-      var qualityPart = '';
-
-      if (voiceName.contains('-x-')) {
-        final xParts = voiceName.split('-x-');
-        localePart = xParts[0];
-        qualityPart = xParts.length > 1 ? xParts[1] : '';
-      } else if (voiceName.contains('-language')) {
-        localePart = voiceName.replaceAll('-language', '');
-      } else {
-        final dashIndex = voiceName.indexOf('-', 3);
-        if (dashIndex > 0) {
-          localePart = voiceName.substring(0, dashIndex);
-        } else {
-          localePart = voiceName;
-        }
-      }
-
-      final formattedLocale = localePart.toUpperCase();
-
-      if (qualityPart.isNotEmpty) {
-        qualityPart = qualityPart
-            .replaceAll('-local', '')
-            .replaceAll('-network', '')
-            .toUpperCase();
-        return '$formattedLocale ($qualityPart)';
-      }
-
-      return formattedLocale;
-    }
-
-    // For iOS or other platforms with proper names, return as-is
-    return voiceName;
-  }
-
-  String _formatVoiceName(AppLocalizations l10n, Map<String, dynamic> voice) {
-    final name = voice['name'] as String? ?? l10n.unknownLabel;
-    final locale = voice['locale'] as String? ?? '';
-
-    // Handle Android-style voice IDs with # separator (e.g., "en-us-x-sfg#male_1-local")
-    if (name.contains('#')) {
-      final parts = name.split('#');
-      if (parts.length > 1) {
-        var friendlyName = parts[1]
-            .replaceAll('-local', '')
-            .replaceAll('-network', '')
-            .replaceAll('_', ' ')
-            .split(' ')
-            .map(
-              (word) =>
-                  word.isEmpty ? '' : word[0].toUpperCase() + word.substring(1),
-            )
-            .join(' ');
-
-        if (locale.isNotEmpty) {
-          final localeUpper = locale.toUpperCase().replaceAll('_', '-');
-          return '$localeUpper - $friendlyName';
-        }
-        return friendlyName;
-      }
-    }
-
-    // Handle Android-style voice IDs without # (e.g., "es-us-x-sfb-local", "ja-jp-x-htm-network")
-    if (name.contains('-x-') ||
-        name.endsWith('-local') ||
-        name.endsWith('-network') ||
-        name.endsWith('-language')) {
-      // Extract the main locale part (first 2-5 chars before -x- or other markers)
-      var localePart = '';
-      var qualityPart = '';
-
-      if (name.contains('-x-')) {
-        final xParts = name.split('-x-');
-        localePart = xParts[0];
-        qualityPart = xParts.length > 1 ? xParts[1] : '';
-      } else if (name.contains('-language')) {
-        localePart = name.replaceAll('-language', '');
-      } else {
-        // Try to extract locale (first 5 chars like "es-us" or "ja-jp")
-        final dashIndex = name.indexOf('-', 3);
-        if (dashIndex > 0) {
-          localePart = name.substring(0, dashIndex);
-        } else {
-          localePart = name;
-        }
-      }
-
-      // Format the locale part
-      final formattedLocale = localePart.toUpperCase();
-
-      // Format quality indicators
-      if (qualityPart.isNotEmpty) {
-        qualityPart = qualityPart
-            .replaceAll('-local', '')
-            .replaceAll('-network', '')
-            .toUpperCase();
-        return '$formattedLocale ($qualityPart)';
-      }
-
-      return formattedLocale;
-    }
-
-    // For iOS or other platforms with proper names, return as-is
-    return name;
-  }
-
-  String _getVoiceIdentifier(Map<String, dynamic> voice, TtsEngine engine) {
-    final id = voice['id'] as String?;
-    final name = voice['name'] as String?;
-    final identifier = voice['identifier'] as String?;
-
-    return switch (engine) {
-      TtsEngine.server => id ?? name ?? identifier ?? 'unknown',
-      TtsEngine.device => name ?? identifier ?? id ?? 'unknown',
-    };
-  }
-
-  String _getVoiceSubtitle(Map<String, dynamic> voice) {
-    final locale = voice['locale'] as String? ?? '';
-    final name = voice['name'] as String? ?? '';
-
-    // If name contains technical info, show the locale part
-    if (name.contains('#')) {
-      final parts = name.split('#');
-      if (parts.isNotEmpty) {
-        final localeInfo = parts[0].toUpperCase().replaceAll('_', '-');
-        return localeInfo;
-      }
-    }
-
-    return locale.isNotEmpty ? locale : '';
   }
 
   String _resolveLanguageLabel(BuildContext context, String code) {

--- a/lib/features/profile/views/app_customization_page.dart
+++ b/lib/features/profile/views/app_customization_page.dart
@@ -1178,13 +1178,9 @@ class AppCustomizationPage extends ConsumerWidget {
               const SizedBox(height: Spacing.sm),
               AdaptiveSegmentedSelector<TtsEngine>(
                 value: settings.ttsEngine,
-                onChanged: (engine) {
+                onChanged: (engine) async {
                   final notifier = ref.read(appSettingsProvider.notifier);
-                  if (engine == TtsEngine.server) {
-                    notifier.setTtsVoice(null);
-                    notifier.setTtsVoiceName(null);
-                  }
-                  notifier.setTtsEngine(engine);
+                  await notifier.setTtsEngineSelection(engine);
                 },
                 options: [
                   (
@@ -1489,11 +1485,9 @@ class AppCustomizationPage extends ConsumerWidget {
         final notifier = ref.read(appSettingsProvider.notifier);
         if (selectedId == ttsSystemDefaultVoiceId) {
           if (settings.ttsEngine == TtsEngine.server) {
-            notifier.setTtsServerVoiceId(null);
-            notifier.setTtsServerVoiceName(null);
+            await notifier.setTtsServerVoiceSelection(null, null);
           } else {
-            notifier.setTtsVoice(null);
-            notifier.setTtsVoiceName(null);
+            await notifier.setTtsDeviceVoiceSelection(null, null);
           }
           return;
         }
@@ -1507,11 +1501,15 @@ class AppCustomizationPage extends ConsumerWidget {
           return;
         }
         if (settings.ttsEngine == TtsEngine.server) {
-          notifier.setTtsServerVoiceId(selectedVoice.id);
-          notifier.setTtsServerVoiceName(selectedVoice.label);
+          await notifier.setTtsServerVoiceSelection(
+            selectedVoice.id,
+            selectedVoice.label,
+          );
         } else {
-          notifier.setTtsVoice(selectedVoice.id);
-          notifier.setTtsVoiceName(selectedVoice.label);
+          await notifier.setTtsDeviceVoiceSelection(
+            selectedVoice.id,
+            selectedVoice.label,
+          );
         }
         return;
       } catch (_) {
@@ -1586,15 +1584,14 @@ class AppCustomizationPage extends ConsumerWidget {
               return SettingsSelectorTile(
                 title: l10n.ttsSystemDefault,
                 selected: selectedOptionId == ttsSystemDefaultVoiceId,
-                onTap: () {
+                onTap: () async {
                   final notifier = ref.read(appSettingsProvider.notifier);
                   if (settings.ttsEngine == TtsEngine.server) {
-                    notifier.setTtsServerVoiceId(null);
-                    notifier.setTtsServerVoiceName(null);
+                    await notifier.setTtsServerVoiceSelection(null, null);
                   } else {
-                    notifier.setTtsVoice(null);
-                    notifier.setTtsVoiceName(null);
+                    await notifier.setTtsDeviceVoiceSelection(null, null);
                   }
+                  if (!sheetContext.mounted) return;
                   Navigator.of(sheetContext).pop();
                 },
               );
@@ -1604,15 +1601,20 @@ class AppCustomizationPage extends ConsumerWidget {
               title: option.label,
               subtitle: option.subtitle,
               selected: option.id == selectedOptionId,
-              onTap: () {
+              onTap: () async {
                 final notifier = ref.read(appSettingsProvider.notifier);
                 if (settings.ttsEngine == TtsEngine.server) {
-                  notifier.setTtsServerVoiceId(option.id);
-                  notifier.setTtsServerVoiceName(option.label);
+                  await notifier.setTtsServerVoiceSelection(
+                    option.id,
+                    option.label,
+                  );
                 } else {
-                  notifier.setTtsVoice(option.id);
-                  notifier.setTtsVoiceName(option.label);
+                  await notifier.setTtsDeviceVoiceSelection(
+                    option.id,
+                    option.label,
+                  );
                 }
+                if (!sheetContext.mounted) return;
                 Navigator.of(sheetContext).pop();
               },
             );

--- a/lib/features/profile/views/audio_settings_page.dart
+++ b/lib/features/profile/views/audio_settings_page.dart
@@ -7,6 +7,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../../core/services/native_sheet_bridge.dart';
 import '../../../core/services/settings_service.dart';
+import '../../../core/utils/tts_voice_utils.dart';
 import '../../../l10n/app_localizations.dart';
 import '../../../shared/theme/theme_extensions.dart';
 import '../../../shared/utils/ui_utils.dart';
@@ -218,6 +219,7 @@ class AudioSettingsPage extends ConsumerWidget {
                   final notifier = ref.read(appSettingsProvider.notifier);
                   if (engine == TtsEngine.server) {
                     notifier.setTtsVoice(null);
+                    notifier.setTtsVoiceName(null);
                   }
                   notifier.setTtsEngine(engine);
                 },
@@ -334,11 +336,15 @@ class AudioSettingsPage extends ConsumerWidget {
 
   String _voiceSubtitle(AppLocalizations l10n, AppSettings settings) {
     if (settings.ttsEngine == TtsEngine.server) {
-      return settings.ttsServerVoiceName ??
+      final voice =
+          settings.ttsServerVoiceName ??
           settings.ttsServerVoiceId ??
           l10n.ttsSystemDefault;
+      return formatTtsVoiceDisplayName(voice);
     }
-    return settings.ttsVoice ?? l10n.ttsSystemDefault;
+    final voice =
+        settings.ttsVoiceName ?? settings.ttsVoice ?? l10n.ttsSystemDefault;
+    return formatTtsVoiceDisplayName(voice);
   }
 
   Future<void> _showVoicePickerSheet(
@@ -360,28 +366,24 @@ class AudioSettingsPage extends ConsumerWidget {
     }
 
     final notifier = ref.read(appSettingsProvider.notifier);
-    const systemDefaultId = '__system_default__';
+    final voiceOptions = buildTtsVoiceOptions(l10n, settings.ttsEngine, voices);
+    final selectedOptionId = selectedTtsVoiceOptionId(settings, voices);
     if (Platform.isIOS) {
       try {
         final selectedId = await NativeSheetBridge.instance
             .presentOptionsSelector(
               title: l10n.ttsSelectVoice,
-              selectedOptionId: _isSystemDefaultSelected(settings)
-                  ? systemDefaultId
-                  : settings.ttsEngine == TtsEngine.server
-                  ? settings.ttsServerVoiceId
-                  : settings.ttsVoice,
+              selectedOptionId: selectedOptionId,
               options: [
                 NativeSheetOptionConfig(
-                  id: systemDefaultId,
+                  id: ttsSystemDefaultVoiceId,
                   label: l10n.ttsSystemDefault,
                 ),
-                for (final voice in voices)
+                for (final option in voiceOptions)
                   NativeSheetOptionConfig(
-                    id: _voiceId(settings.ttsEngine, voice),
-                    label: (voice['name'] ?? voice['id'] ?? l10n.unknownLabel)
-                        .toString(),
-                    subtitle: (voice['locale'] as String?)?.trim(),
+                    id: option.id,
+                    label: option.label,
+                    subtitle: option.subtitle,
                   ),
               ],
               rethrowErrors: true,
@@ -389,26 +391,31 @@ class AudioSettingsPage extends ConsumerWidget {
         if (selectedId == null) {
           return;
         }
-        if (selectedId == systemDefaultId) {
+        if (selectedId == ttsSystemDefaultVoiceId) {
           if (settings.ttsEngine == TtsEngine.server) {
             notifier.setTtsServerVoiceId(null);
             notifier.setTtsServerVoiceName(null);
           } else {
             notifier.setTtsVoice(null);
+            notifier.setTtsVoiceName(null);
           }
           return;
         }
-        final selectedVoice = voices.cast<Map<String, dynamic>>().firstWhere(
-          (voice) => _voiceId(settings.ttsEngine, voice) == selectedId,
+        final selectedVoice = findTtsVoiceOption(
+          l10n,
+          settings.ttsEngine,
+          voices,
+          selectedId,
         );
-        final selectedName =
-            (selectedVoice['name'] ?? selectedVoice['id'] ?? l10n.unknownLabel)
-                .toString();
+        if (selectedVoice == null) {
+          return;
+        }
         if (settings.ttsEngine == TtsEngine.server) {
-          notifier.setTtsServerVoiceId(selectedId);
-          notifier.setTtsServerVoiceName(selectedName);
+          notifier.setTtsServerVoiceId(selectedVoice.id);
+          notifier.setTtsServerVoiceName(selectedVoice.label);
         } else {
-          notifier.setTtsVoice(selectedId);
+          notifier.setTtsVoice(selectedVoice.id);
+          notifier.setTtsVoiceName(selectedVoice.label);
         }
         return;
       } catch (_) {}
@@ -422,7 +429,7 @@ class AudioSettingsPage extends ConsumerWidget {
       builder: (sheetContext) {
         return SettingsSelectorSheet(
           title: l10n.ttsSelectVoice,
-          itemCount: voices.length + 1,
+          itemCount: voiceOptions.length + 1,
           initialChildSize: 0.68,
           minChildSize: 0.42,
           maxChildSize: 0.9,
@@ -430,34 +437,32 @@ class AudioSettingsPage extends ConsumerWidget {
             if (index == 0) {
               return SettingsSelectorTile(
                 title: l10n.ttsSystemDefault,
-                selected: _isSystemDefaultSelected(settings),
+                selected: selectedOptionId == ttsSystemDefaultVoiceId,
                 onTap: () {
                   if (settings.ttsEngine == TtsEngine.server) {
                     notifier.setTtsServerVoiceId(null);
                     notifier.setTtsServerVoiceName(null);
                   } else {
                     notifier.setTtsVoice(null);
+                    notifier.setTtsVoiceName(null);
                   }
                   Navigator.of(sheetContext).pop();
                 },
               );
             }
 
-            final voice = voices[index - 1];
-            final name = (voice['name'] ?? voice['id'] ?? l10n.unknownLabel)
-                .toString();
-            final locale = (voice['locale'] as String?)?.trim() ?? '';
+            final option = voiceOptions[index - 1];
             return SettingsSelectorTile(
-              title: name,
-              subtitle: locale.isEmpty ? null : locale,
-              selected: _isSelectedVoice(settings, voice),
+              title: option.label,
+              subtitle: option.subtitle,
+              selected: option.id == selectedOptionId,
               onTap: () {
-                final id = _voiceId(settings.ttsEngine, voice);
                 if (settings.ttsEngine == TtsEngine.server) {
-                  notifier.setTtsServerVoiceId(id);
-                  notifier.setTtsServerVoiceName(name);
+                  notifier.setTtsServerVoiceId(option.id);
+                  notifier.setTtsServerVoiceName(option.label);
                 } else {
-                  notifier.setTtsVoice(id);
+                  notifier.setTtsVoice(option.id);
+                  notifier.setTtsVoiceName(option.label);
                 }
                 Navigator.of(sheetContext).pop();
               },
@@ -466,29 +471,6 @@ class AudioSettingsPage extends ConsumerWidget {
         );
       },
     );
-  }
-
-  bool _isSystemDefaultSelected(AppSettings settings) {
-    return settings.ttsEngine == TtsEngine.server
-        ? settings.ttsServerVoiceId == null
-        : settings.ttsVoice == null;
-  }
-
-  bool _isSelectedVoice(AppSettings settings, Map<String, dynamic> voice) {
-    final id = _voiceId(settings.ttsEngine, voice);
-    return settings.ttsEngine == TtsEngine.server
-        ? settings.ttsServerVoiceId == id
-        : settings.ttsVoice == id;
-  }
-
-  String _voiceId(TtsEngine engine, Map<String, dynamic> voice) {
-    final id = voice['id']?.toString();
-    final name = voice['name']?.toString();
-    final identifier = voice['identifier']?.toString();
-    return switch (engine) {
-      TtsEngine.server => id ?? name ?? identifier ?? 'unknown',
-      TtsEngine.device => name ?? identifier ?? id ?? 'unknown',
-    };
   }
 
   Future<void> _previewTtsVoice(BuildContext context, WidgetRef ref) async {

--- a/lib/features/profile/views/audio_settings_page.dart
+++ b/lib/features/profile/views/audio_settings_page.dart
@@ -215,13 +215,9 @@ class AudioSettingsPage extends ConsumerWidget {
             children: [
               AdaptiveSegmentedSelector<TtsEngine>(
                 value: settings.ttsEngine,
-                onChanged: (engine) {
+                onChanged: (engine) async {
                   final notifier = ref.read(appSettingsProvider.notifier);
-                  if (engine == TtsEngine.server) {
-                    notifier.setTtsVoice(null);
-                    notifier.setTtsVoiceName(null);
-                  }
-                  notifier.setTtsEngine(engine);
+                  await notifier.setTtsEngineSelection(engine);
                 },
                 options: [
                   (
@@ -393,11 +389,9 @@ class AudioSettingsPage extends ConsumerWidget {
         }
         if (selectedId == ttsSystemDefaultVoiceId) {
           if (settings.ttsEngine == TtsEngine.server) {
-            notifier.setTtsServerVoiceId(null);
-            notifier.setTtsServerVoiceName(null);
+            await notifier.setTtsServerVoiceSelection(null, null);
           } else {
-            notifier.setTtsVoice(null);
-            notifier.setTtsVoiceName(null);
+            await notifier.setTtsDeviceVoiceSelection(null, null);
           }
           return;
         }
@@ -411,11 +405,15 @@ class AudioSettingsPage extends ConsumerWidget {
           return;
         }
         if (settings.ttsEngine == TtsEngine.server) {
-          notifier.setTtsServerVoiceId(selectedVoice.id);
-          notifier.setTtsServerVoiceName(selectedVoice.label);
+          await notifier.setTtsServerVoiceSelection(
+            selectedVoice.id,
+            selectedVoice.label,
+          );
         } else {
-          notifier.setTtsVoice(selectedVoice.id);
-          notifier.setTtsVoiceName(selectedVoice.label);
+          await notifier.setTtsDeviceVoiceSelection(
+            selectedVoice.id,
+            selectedVoice.label,
+          );
         }
         return;
       } catch (_) {}
@@ -438,14 +436,13 @@ class AudioSettingsPage extends ConsumerWidget {
               return SettingsSelectorTile(
                 title: l10n.ttsSystemDefault,
                 selected: selectedOptionId == ttsSystemDefaultVoiceId,
-                onTap: () {
+                onTap: () async {
                   if (settings.ttsEngine == TtsEngine.server) {
-                    notifier.setTtsServerVoiceId(null);
-                    notifier.setTtsServerVoiceName(null);
+                    await notifier.setTtsServerVoiceSelection(null, null);
                   } else {
-                    notifier.setTtsVoice(null);
-                    notifier.setTtsVoiceName(null);
+                    await notifier.setTtsDeviceVoiceSelection(null, null);
                   }
+                  if (!sheetContext.mounted) return;
                   Navigator.of(sheetContext).pop();
                 },
               );
@@ -456,14 +453,19 @@ class AudioSettingsPage extends ConsumerWidget {
               title: option.label,
               subtitle: option.subtitle,
               selected: option.id == selectedOptionId,
-              onTap: () {
+              onTap: () async {
                 if (settings.ttsEngine == TtsEngine.server) {
-                  notifier.setTtsServerVoiceId(option.id);
-                  notifier.setTtsServerVoiceName(option.label);
+                  await notifier.setTtsServerVoiceSelection(
+                    option.id,
+                    option.label,
+                  );
                 } else {
-                  notifier.setTtsVoice(option.id);
-                  notifier.setTtsVoiceName(option.label);
+                  await notifier.setTtsDeviceVoiceSelection(
+                    option.id,
+                    option.label,
+                  );
                 }
+                if (!sheetContext.mounted) return;
                 Navigator.of(sheetContext).pop();
               },
             );

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -1429,11 +1429,11 @@
   "@sttServerUnavailableWarning": {
     "description": "Warning shown when the user selects server speech recognition but no server is available."
   },
-  "sttSilenceDuration": "Silence Duration",
+  "sttSilenceDuration": "Server STT silence duration",
   "@sttSilenceDuration": {
     "description": "Label for the silence duration setting in server speech-to-text."
   },
-  "sttSilenceDurationDescription": "Time to wait after silence before auto-stopping recording",
+  "sttSilenceDurationDescription": "Used by server transcription and legacy fallback only. Native on-device STT sends recognizer final results instead.",
   "@sttSilenceDurationDescription": {
     "description": "Description for the silence duration slider in server speech-to-text settings."
   },

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -23,6 +23,7 @@ import 'core/services/carplay_service.dart';
 import 'core/services/settings_service.dart';
 import 'core/sync/request_completion_runner_provider.dart';
 import 'core/utils/tts_voice_utils.dart';
+import 'core/utils/current_localizations.dart';
 import 'features/auth/providers/unified_auth_providers.dart';
 import 'features/chat/services/request_completion_runner.dart';
 import 'features/chat/providers/text_to_speech_provider.dart';
@@ -289,7 +290,7 @@ class _ConduitAppState extends ConsumerState<ConduitApp> {
     } catch (error, stackTrace) {
       DebugLogger.error(
         'native-edit-profile-commit-failed',
-        scope: 'native-sheet',
+        scope: 'native/sheet',
         error: error,
         stackTrace: stackTrace,
       );
@@ -482,7 +483,7 @@ class _ConduitAppState extends ConsumerState<ConduitApp> {
             } else {
               DebugLogger.validation(
                 'Ignoring invalid native STT language code',
-                scope: 'native-sheet',
+                scope: 'native/sheet',
                 data: {'value': value},
               );
               await _refreshNativeVoiceDetail();
@@ -491,12 +492,10 @@ class _ConduitAppState extends ConsumerState<ConduitApp> {
         case 'tts-engine':
           final notifier = ref.read(appSettingsProvider.notifier);
           if (value == TtsEngine.server.name) {
-            await notifier.setTtsVoice(null);
-            await notifier.setTtsVoiceName(null);
-            await notifier.setTtsEngine(TtsEngine.server);
+            await notifier.setTtsEngineSelection(TtsEngine.server);
             await _refreshNativeVoiceDetail();
           } else if (value == TtsEngine.device.name) {
-            await notifier.setTtsEngine(TtsEngine.device);
+            await notifier.setTtsEngineSelection(TtsEngine.device);
             await _refreshNativeVoiceDetail();
           }
         case 'theme-light':
@@ -618,7 +617,7 @@ class _ConduitAppState extends ConsumerState<ConduitApp> {
     } catch (error, stackTrace) {
       DebugLogger.error(
         'native-sheet-control-failed',
-        scope: 'native-sheet',
+        scope: 'native/sheet',
         error: error,
         stackTrace: stackTrace,
       );
@@ -686,11 +685,9 @@ class _ConduitAppState extends ConsumerState<ConduitApp> {
 
     if (voiceKey == ttsSystemDefaultVoiceId) {
       if (settings.ttsEngine == TtsEngine.server) {
-        await notifier.setTtsServerVoiceId(null);
-        await notifier.setTtsServerVoiceName(null);
+        await notifier.setTtsServerVoiceSelection(null, null);
       } else {
-        await notifier.setTtsVoice(null);
-        await notifier.setTtsVoiceName(null);
+        await notifier.setTtsDeviceVoiceSelection(null, null);
       }
       await _refreshNativeVoiceDetail();
       return;
@@ -698,7 +695,7 @@ class _ConduitAppState extends ConsumerState<ConduitApp> {
 
     var selectedId = voiceKey;
     var displayName = fallbackDisplayName ?? voiceKey;
-    final l10n = AppLocalizations.of(context)!;
+    final l10n = currentAppLocalizations();
     try {
       final ttsService = ref.read(textToSpeechServiceProvider);
       await ttsService.updateSettings(engine: settings.ttsEngine);
@@ -716,17 +713,15 @@ class _ConduitAppState extends ConsumerState<ConduitApp> {
     } catch (error, stackTrace) {
       DebugLogger.warning(
         'native-tts-voice-selection-lookup-failed',
-        scope: 'native-sheet',
+        scope: 'native/sheet',
         data: {'error': error, 'stackTrace': stackTrace},
       );
     }
 
     if (settings.ttsEngine == TtsEngine.server) {
-      await notifier.setTtsServerVoiceId(selectedId);
-      await notifier.setTtsServerVoiceName(displayName);
+      await notifier.setTtsServerVoiceSelection(selectedId, displayName);
     } else {
-      await notifier.setTtsVoice(selectedId);
-      await notifier.setTtsVoiceName(displayName);
+      await notifier.setTtsDeviceVoiceSelection(selectedId, displayName);
     }
     await _refreshNativeVoiceDetail();
   }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -339,7 +339,9 @@ class _ConduitAppState extends ConsumerState<ConduitApp> {
       }
 
       if (event.id == 'tts-voice-picker' && value is String) {
-        await _handleNativeTtsVoiceSelection(value);
+        await _handleNativeTtsVoiceSelection(
+          value == '__default__' ? ttsSystemDefaultVoiceId : value,
+        );
         return;
       }
 

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -22,6 +22,7 @@ import 'core/services/performance_profiler.dart';
 import 'core/services/carplay_service.dart';
 import 'core/services/settings_service.dart';
 import 'core/sync/request_completion_runner_provider.dart';
+import 'core/utils/tts_voice_utils.dart';
 import 'features/auth/providers/unified_auth_providers.dart';
 import 'features/chat/services/request_completion_runner.dart';
 import 'features/chat/providers/text_to_speech_provider.dart';
@@ -336,6 +337,11 @@ class _ConduitAppState extends ConsumerState<ConduitApp> {
         return;
       }
 
+      if (event.id == 'tts-voice-picker' && value is String) {
+        await _handleNativeTtsVoiceSelection(value);
+        return;
+      }
+
       if (event.id.startsWith('memory-save:')) {
         final encoded = event.id.substring('memory-save:'.length);
         final memoryId = Uri.decodeComponent(encoded);
@@ -486,6 +492,7 @@ class _ConduitAppState extends ConsumerState<ConduitApp> {
           final notifier = ref.read(appSettingsProvider.notifier);
           if (value == TtsEngine.server.name) {
             await notifier.setTtsVoice(null);
+            await notifier.setTtsVoiceName(null);
             await notifier.setTtsEngine(TtsEngine.server);
             await _refreshNativeVoiceDetail();
           } else if (value == TtsEngine.device.name) {
@@ -661,28 +668,67 @@ class _ConduitAppState extends ConsumerState<ConduitApp> {
   ) async {
     final encoded = event.id.substring('tts-voice-pick:'.length);
     final voiceKey = Uri.decodeComponent(encoded);
+    final fallbackDisplayName = event.value is String
+        ? event.value as String
+        : null;
+    await _handleNativeTtsVoiceSelection(
+      voiceKey == '__default__' ? ttsSystemDefaultVoiceId : voiceKey,
+      fallbackDisplayName: fallbackDisplayName,
+    );
+  }
+
+  Future<void> _handleNativeTtsVoiceSelection(
+    String voiceKey, {
+    String? fallbackDisplayName,
+  }) async {
     final settings = ref.read(appSettingsProvider);
     final notifier = ref.read(appSettingsProvider.notifier);
 
-    if (voiceKey == '__default__') {
+    if (voiceKey == ttsSystemDefaultVoiceId) {
       if (settings.ttsEngine == TtsEngine.server) {
         await notifier.setTtsServerVoiceId(null);
         await notifier.setTtsServerVoiceName(null);
       } else {
         await notifier.setTtsVoice(null);
+        await notifier.setTtsVoiceName(null);
       }
+      await _refreshNativeVoiceDetail();
       return;
     }
 
-    final displayName = event.value is String
-        ? event.value as String
-        : voiceKey;
+    var selectedId = voiceKey;
+    var displayName = fallbackDisplayName ?? voiceKey;
+    final l10n = AppLocalizations.of(context)!;
+    try {
+      final ttsService = ref.read(textToSpeechServiceProvider);
+      await ttsService.updateSettings(engine: settings.ttsEngine);
+      final voices = await ttsService.getAvailableVoices();
+      final selected = findTtsVoiceOption(
+        l10n,
+        settings.ttsEngine,
+        voices,
+        voiceKey,
+      );
+      if (selected != null) {
+        selectedId = selected.id;
+        displayName = selected.label;
+      }
+    } catch (error, stackTrace) {
+      DebugLogger.warning(
+        'native-tts-voice-selection-lookup-failed',
+        scope: 'native-sheet',
+        data: {'error': error, 'stackTrace': stackTrace},
+      );
+    }
+
     if (settings.ttsEngine == TtsEngine.server) {
-      await notifier.setTtsServerVoiceId(voiceKey);
+      await notifier.setTtsServerVoiceId(selectedId);
       await notifier.setTtsServerVoiceName(displayName);
     } else {
-      await notifier.setTtsVoice(voiceKey);
+      await notifier.setTtsVoice(selectedId);
+      await notifier.setTtsVoiceName(displayName);
     }
+    await _refreshNativeVoiceDetail();
   }
 
   void _initializeAppState() {

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -789,14 +789,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "5.2.7"
-  flutter_tts:
-    dependency: "direct main"
-    description:
-      name: flutter_tts
-      sha256: ce5eb209b40e95f2f4a1397116c87ab2fcdff32257d04ed7a764e75894c03775
-      url: "https://pub.dev"
-    source: hosted
-    version: "4.2.5"
   flutter_web_plugins:
     dependency: transitive
     description: flutter
@@ -1908,30 +1900,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.10.2"
-  speech_to_text:
-    dependency: "direct main"
-    description:
-      name: speech_to_text
-      sha256: "75587f7400f485fdf166beacd471549d98fe5d58e634f708916bb65dec05d6a4"
-      url: "https://pub.dev"
-    source: hosted
-    version: "7.4.0"
-  speech_to_text_platform_interface:
-    dependency: transitive
-    description:
-      name: speech_to_text_platform_interface
-      sha256: a7e16e02853853ed7534ac2bde9a1c4f39c8879970a7974ac6ff832d4bdaa4b0
-      url: "https://pub.dev"
-    source: hosted
-    version: "2.4.0"
-  speech_to_text_windows:
-    dependency: transitive
-    description:
-      name: speech_to_text_windows
-      sha256: "2d1d10565b23262386b453b33656299608dc7a66784453735d6c1318f13f44d7"
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.0.1"
   sqflite:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -46,9 +46,7 @@ dependencies:
   
   # Platform Features
   vad: ^0.0.8
-  speech_to_text: ^7.4.0
   record: ^6.2.0
-  flutter_tts: ^4.2.5
   audio_session: ^0.2.2
   permission_handler: ^12.0.1
   image_picker: ^1.2.0

--- a/test/core/services/settings_service_test.dart
+++ b/test/core/services/settings_service_test.dart
@@ -76,6 +76,10 @@ void main() {
         check(settings.ttsVoice).isNull();
       });
 
+      test('ttsVoiceName defaults to null', () {
+        check(settings.ttsVoiceName).isNull();
+      });
+
       test('ttsSpeechRate defaults to 0.5', () {
         check(settings.ttsSpeechRate).equals(0.5);
       });
@@ -178,6 +182,7 @@ void main() {
           voiceLocaleId: 'en_US',
           sttLanguageCode: 'pl',
           ttsVoice: 'voice1',
+          ttsVoiceName: 'Voice One',
           ttsServerVoiceId: 'server-voice-1',
           ttsServerVoiceName: 'Server Voice',
         );
@@ -186,6 +191,7 @@ void main() {
         check(modified.voiceLocaleId).equals('en_US');
         check(modified.sttLanguageCode).equals('pl');
         check(modified.ttsVoice).equals('voice1');
+        check(modified.ttsVoiceName).equals('Voice One');
         check(modified.ttsServerVoiceId).equals('server-voice-1');
         check(modified.ttsServerVoiceName).equals('Server Voice');
       });
@@ -196,6 +202,7 @@ void main() {
           voiceLocaleId: 'en_US',
           sttLanguageCode: 'pl',
           ttsVoice: 'voice1',
+          ttsVoiceName: 'Voice One',
           ttsServerVoiceId: 'server-voice-1',
           ttsServerVoiceName: 'Server Voice',
         );
@@ -205,6 +212,7 @@ void main() {
           voiceLocaleId: null,
           sttLanguageCode: null,
           ttsVoice: null,
+          ttsVoiceName: null,
           ttsServerVoiceId: null,
           ttsServerVoiceName: null,
         );
@@ -213,6 +221,7 @@ void main() {
         check(cleared.voiceLocaleId).isNull();
         check(cleared.sttLanguageCode).isNull();
         check(cleared.ttsVoice).isNull();
+        check(cleared.ttsVoiceName).isNull();
         check(cleared.ttsServerVoiceId).isNull();
         check(cleared.ttsServerVoiceName).isNull();
       });
@@ -281,6 +290,12 @@ void main() {
 
       test('different sttLanguageCode yields inequality', () {
         final a = const AppSettings().copyWith(sttLanguageCode: 'pl');
+        const b = AppSettings();
+        check(a).not((it) => it.equals(b));
+      });
+
+      test('different ttsVoiceName yields inequality', () {
+        final a = const AppSettings().copyWith(ttsVoiceName: 'Voice One');
         const b = AppSettings();
         check(a).not((it) => it.equals(b));
       });

--- a/test/core/utils/tts_voice_utils_test.dart
+++ b/test/core/utils/tts_voice_utils_test.dart
@@ -1,0 +1,77 @@
+import 'package:checks/checks.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:conduit/core/services/settings_service.dart';
+import 'package:conduit/core/utils/tts_voice_utils.dart';
+import 'package:conduit/l10n/app_localizations_en.dart';
+
+void main() {
+  final l10n = AppLocalizationsEn();
+
+  group('TTS voice utils', () {
+    test('device voice ids prefer native identifiers', () {
+      final voice = {
+        'id': 'com.apple.voice.compact.en-US.Samantha',
+        'identifier': 'com.apple.voice.enhanced.en-US.Samantha',
+        'name': 'Samantha',
+      };
+
+      check(
+        ttsVoiceIdFor(TtsEngine.device, voice),
+      ).equals('com.apple.voice.enhanced.en-US.Samantha');
+    });
+
+    test('selected option resolves legacy saved names to native ids', () {
+      final voices = [
+        {
+          'id': 'com.apple.voice.compact.en-US.Samantha',
+          'identifier': 'com.apple.voice.enhanced.en-US.Samantha',
+          'name': 'Samantha',
+          'locale': 'en-US',
+        },
+      ];
+      final settings = const AppSettings().copyWith(ttsVoice: 'Samantha');
+
+      check(
+        selectedTtsVoiceOptionId(settings, voices),
+      ).equals('com.apple.voice.enhanced.en-US.Samantha');
+      check(ttsVoiceMatchesSettings(settings, voices.single)).isTrue();
+    });
+
+    test('builds display labels and subtitles consistently', () {
+      final options = buildTtsVoiceOptions(l10n, TtsEngine.device, [
+        {
+          'identifier': 'com.apple.voice.enhanced.en-US.Samantha',
+          'name': 'Samantha',
+          'displayName': 'Samantha',
+          'locale': 'en-US',
+          'qualityName': 'Enhanced',
+        },
+      ]);
+
+      check(options).length.equals(1);
+      check(options.single.label).equals('Samantha');
+      check(options.single.subtitle).equals('en-US · Enhanced');
+    });
+
+    test('includes native iOS voice metadata in subtitles', () {
+      final options = buildTtsVoiceOptions(l10n, TtsEngine.device, [
+        {
+          'identifier': 'com.apple.voice.personal.en-US.Example',
+          'name': 'Example',
+          'displayName': 'Example (Personal Voice)',
+          'locale': 'en-US',
+          'languageName': 'English (United States)',
+          'qualityName': 'Premium',
+          'isPersonalVoice': true,
+        },
+      ]);
+
+      check(options).length.equals(1);
+      check(options.single.label).equals('Example (Personal Voice)');
+      check(
+        options.single.subtitle,
+      ).equals('English (United States) · Premium · Personal Voice');
+    });
+  });
+}

--- a/test/features/chat/providers/chat_transport_parity_test.dart
+++ b/test/features/chat/providers/chat_transport_parity_test.dart
@@ -79,6 +79,7 @@ class _StubAdapter implements HttpClientAdapter {
   final Map<String, dynamic>? pollResponse;
   final cancelledIds = <String>[];
   final stoppedTaskIds = <String>[];
+  final stoppedChatIds = <String>[];
 
   @override
   Future<ResponseBody> fetch(
@@ -90,6 +91,25 @@ class _StubAdapter implements HttpClientAdapter {
     if (options.method == 'POST' && options.path.contains('/api/tasks/stop/')) {
       final taskId = options.path.split('/').last;
       stoppedTaskIds.add(taskId);
+      return ResponseBody(
+        Stream.value(utf8.encode('{"status": true}')),
+        200,
+        headers: {
+          'content-type': ['application/json'],
+        },
+      );
+    }
+
+    if (options.method == 'POST' &&
+        options.path.contains('/api/tasks/chat/') &&
+        options.path.endsWith('/stop')) {
+      const prefix = '/api/tasks/chat/';
+      const suffix = '/stop';
+      final start = options.path.indexOf(prefix) + prefix.length;
+      final end = options.path.length - suffix.length;
+      stoppedChatIds.add(
+        Uri.decodeComponent(options.path.substring(start, end)),
+      );
       return ResponseBody(
         Stream.value(utf8.encode('{"status": true}')),
         200,
@@ -691,21 +711,31 @@ void main() {
 
       await pumpMicrotasks();
 
-      registrar.emitChatEvent('chat:completion', {
-        'choices': [
-          {
-            'delta': {'content': 'He'},
-          },
-        ],
-      }, conversationId: 'conv-1', messageId: 'server-msg-1');
+      registrar.emitChatEvent(
+        'chat:completion',
+        {
+          'choices': [
+            {
+              'delta': {'content': 'He'},
+            },
+          ],
+        },
+        conversationId: 'conv-1',
+        messageId: 'server-msg-1',
+      );
       await pumpMicrotasks();
-      registrar.emitChatEvent('chat:completion', {
-        'choices': [
-          {
-            'delta': {'content': 'llo'},
-          },
-        ],
-      }, conversationId: 'conv-1', messageId: 'server-msg-1');
+      registrar.emitChatEvent(
+        'chat:completion',
+        {
+          'choices': [
+            {
+              'delta': {'content': 'llo'},
+            },
+          ],
+        },
+        conversationId: 'conv-1',
+        messageId: 'server-msg-1',
+      );
       await pumpMicrotasks();
 
       check(log.appendedChunks).deepEquals(['He', 'llo']);
@@ -741,13 +771,18 @@ void main() {
 
       await pumpMicrotasks();
 
-      registrar.emitChatEvent('chat:completion', {
-        'choices': [
-          {
-            'delta': {'content': 'tial'},
-          },
-        ],
-      }, conversationId: 'conv-1', messageId: 'server-msg-1');
+      registrar.emitChatEvent(
+        'chat:completion',
+        {
+          'choices': [
+            {
+              'delta': {'content': 'tial'},
+            },
+          ],
+        },
+        conversationId: 'conv-1',
+        messageId: 'server-msg-1',
+      );
       await pumpMicrotasks();
 
       // Only the new delta is appended; the already-visible 'Par' prefix is
@@ -1004,6 +1039,38 @@ void main() {
 
       check(adapter.stoppedTaskIds).deepEquals(['task-abc']);
     });
+
+    test(
+      'stop cancels taskSocket by chat when conversation metadata exists',
+      () async {
+        final api = _buildFakeApi();
+        final adapter = api.dio.httpClientAdapter as _StubAdapter;
+
+        final message = ChatMessage(
+          id: 'msg-task-chat',
+          role: 'assistant',
+          content: 'partial...',
+          timestamp: DateTime.now(),
+          isStreaming: true,
+          metadata: const {
+            'transport': 'taskSocket',
+            'taskId': 'task-abc',
+            'taskConversationId': 'conv/with/slash',
+          },
+        );
+
+        stopActiveTransport(message, api);
+
+        await pumpMicrotasks();
+        await pumpMicrotasks();
+        await pumpMicrotasks();
+        await pumpMicrotasks();
+        await pumpMicrotasks();
+
+        check(adapter.stoppedChatIds).deepEquals(['conv/with/slash']);
+        check(adapter.stoppedTaskIds).isEmpty();
+      },
+    );
 
     // -------------------------------------------------------------------
     // 5. Stop cancels both abort handle and task id for mixed initiation

--- a/test/features/chat/services/voice_input_service_test.dart
+++ b/test/features/chat/services/voice_input_service_test.dart
@@ -3,6 +3,7 @@ import 'package:conduit/features/chat/services/voice_input_service.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter/widgets.dart';
+import 'package:vad/vad.dart';
 
 void main() {
   group('VoiceInputService.silenceDurationToVadFrames', () {
@@ -43,6 +44,62 @@ void main() {
       );
 
       check(language).equals('pl');
+    });
+  });
+
+  group('VoiceInputService.androidServerVadRecordConfig', () {
+    test('uses speech recognition routing outside voice calls', () {
+      final config = VoiceInputService.androidServerVadRecordConfigForTesting(
+        voiceCallSession: false,
+      );
+
+      check(config.audioSource).equals(AndroidAudioSource.voiceRecognition);
+      check(config.audioManagerMode).equals(AudioManagerMode.modeNormal);
+      check(config.manageBluetooth).isTrue();
+    });
+
+    test('uses communication routing during voice calls', () {
+      final config = VoiceInputService.androidServerVadRecordConfigForTesting(
+        voiceCallSession: true,
+      );
+
+      check(config.audioSource).equals(AndroidAudioSource.voiceCommunication);
+      check(
+        config.audioManagerMode,
+      ).equals(AudioManagerMode.modeInCommunication);
+      check(config.manageBluetooth).isTrue();
+    });
+  });
+
+  group('VoiceInputService.shouldSettleNativeDictation', () {
+    test('settles cumulative native dictation on final result', () {
+      check(
+        VoiceInputService.shouldSettleNativeDictationForTesting(
+          isFinal: true,
+          nativeAccumulateResults: true,
+          usingServerStt: false,
+        ),
+      ).isTrue();
+    });
+
+    test('keeps voice-call native STT continuous after final chunks', () {
+      check(
+        VoiceInputService.shouldSettleNativeDictationForTesting(
+          isFinal: true,
+          nativeAccumulateResults: false,
+          usingServerStt: false,
+        ),
+      ).isFalse();
+    });
+
+    test('does not settle server STT through the native final path', () {
+      check(
+        VoiceInputService.shouldSettleNativeDictationForTesting(
+          isFinal: true,
+          nativeAccumulateResults: true,
+          usingServerStt: true,
+        ),
+      ).isFalse();
     });
   });
 

--- a/test/features/chat/voice_mode/chat_voice_mode_controller_test.dart
+++ b/test/features/chat/voice_mode/chat_voice_mode_controller_test.dart
@@ -131,6 +131,238 @@ void main() {
   );
 
   test(
+    'does not send partial-only transcript when listening completes',
+    () async {
+      final input = _FakeVoiceInputService();
+      final tts = _FakeTextToSpeechService();
+      final audioSession = _FakeChatVoiceAudioSessionCoordinator();
+      final container = ProviderContainer(
+        overrides: [
+          authNavigationStateProvider.overrideWithValue(
+            AuthNavigationState.authenticated,
+          ),
+          selectedModelProvider.overrideWithValue(_model),
+          appSettingsProvider.overrideWithValue(const AppSettings()),
+          reviewerModeProvider.overrideWithValue(true),
+          voiceInputServiceProvider.overrideWithValue(input),
+          textToSpeechServiceProvider.overrideWithValue(tts),
+          callKitServiceProvider.overrideWithValue(
+            _UnavailableCallKitService(),
+          ),
+          chatVoiceModeBackgroundCoordinatorProvider.overrideWithValue(
+            _FakeChatVoiceBackgroundCoordinator(),
+          ),
+          chatVoiceAudioSessionCoordinatorProvider.overrideWithValue(
+            audioSession,
+          ),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      final controller = container.read(
+        chatVoiceModeControllerProvider.notifier,
+      );
+
+      await controller.start(startNewConversation: false);
+      await input.completeCurrent('partial transcript', finalResult: false);
+      await _until(() => input.beginCalls == 2);
+
+      expect(container.read(chatMessagesProvider), isEmpty);
+      expect(tts.startedStreaming, isFalse);
+      expect(
+        container.read(chatVoiceModeControllerProvider).phase,
+        ChatVoiceModePhase.listening,
+      );
+    },
+  );
+
+  test(
+    'native continuous STT sends finals without restarting the recognizer',
+    () async {
+      final input = _FakeVoiceInputService()..nativeLocalStt = true;
+      final tts = _FakeTextToSpeechService();
+      final audioSession = _FakeChatVoiceAudioSessionCoordinator();
+      final container = ProviderContainer(
+        overrides: [
+          authNavigationStateProvider.overrideWithValue(
+            AuthNavigationState.authenticated,
+          ),
+          selectedModelProvider.overrideWithValue(_model),
+          appSettingsProvider.overrideWithValue(const AppSettings()),
+          reviewerModeProvider.overrideWithValue(true),
+          voiceInputServiceProvider.overrideWithValue(input),
+          textToSpeechServiceProvider.overrideWithValue(tts),
+          callKitServiceProvider.overrideWithValue(
+            _UnavailableCallKitService(),
+          ),
+          chatVoiceModeBackgroundCoordinatorProvider.overrideWithValue(
+            _FakeChatVoiceBackgroundCoordinator(),
+          ),
+          chatVoiceAudioSessionCoordinatorProvider.overrideWithValue(
+            audioSession,
+          ),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      final controller = container.read(
+        chatVoiceModeControllerProvider.notifier,
+      );
+
+      await controller.start(startNewConversation: false);
+      input.stopCalls = 0;
+      await input.completeCurrent('continuous final', close: false);
+      await _until(() => tts.finishedTexts.isNotEmpty);
+      await _until(
+        () =>
+            container.read(chatVoiceModeControllerProvider).phase ==
+            ChatVoiceModePhase.listening,
+      );
+
+      expect(
+        container.read(chatMessagesProvider).first.content,
+        'continuous final',
+      );
+      expect(input.beginCalls, 1);
+      expect(input.stopCalls, 0);
+      expect(input.isListening, isTrue);
+      await controller.stop();
+    },
+  );
+
+  test(
+    'barge-in stops assistant playback and sends the next final transcript',
+    () async {
+      final input = _FakeVoiceInputService()..nativeLocalStt = true;
+      final tts = _FakeTextToSpeechService()..holdCompletion = true;
+      final audioSession = _FakeChatVoiceAudioSessionCoordinator();
+      var stopGenerationCalls = 0;
+      final container = ProviderContainer(
+        overrides: [
+          authNavigationStateProvider.overrideWithValue(
+            AuthNavigationState.authenticated,
+          ),
+          selectedModelProvider.overrideWithValue(_model),
+          appSettingsProvider.overrideWithValue(const AppSettings()),
+          reviewerModeProvider.overrideWithValue(true),
+          voiceInputServiceProvider.overrideWithValue(input),
+          textToSpeechServiceProvider.overrideWithValue(tts),
+          stopGenerationProvider.overrideWithValue(() {
+            stopGenerationCalls += 1;
+          }),
+          callKitServiceProvider.overrideWithValue(
+            _UnavailableCallKitService(),
+          ),
+          chatVoiceModeBackgroundCoordinatorProvider.overrideWithValue(
+            _FakeChatVoiceBackgroundCoordinator(),
+          ),
+          chatVoiceAudioSessionCoordinatorProvider.overrideWithValue(
+            audioSession,
+          ),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      final controller = container.read(
+        chatVoiceModeControllerProvider.notifier,
+      );
+
+      await controller.start(startNewConversation: false);
+      await input.completeCurrent('first assistant turn', close: false);
+      await _until(
+        () =>
+            container.read(chatVoiceModeControllerProvider).phase ==
+            ChatVoiceModePhase.speaking,
+      );
+
+      await input.completeCurrent('second barge in turn', close: false);
+      await _until(() => stopGenerationCalls == 1);
+      await _until(
+        () =>
+            container
+                .read(chatMessagesProvider)
+                .where((message) => message.role == 'user')
+                .length ==
+            2,
+      );
+
+      final userMessages = container
+          .read(chatMessagesProvider)
+          .where((message) => message.role == 'user')
+          .map((message) => message.content)
+          .toList();
+      expect(userMessages, <String>[
+        'first assistant turn',
+        'second barge in turn',
+      ]);
+      await _until(() => tts.finishedTexts.length == 2);
+      expect(tts.stopStreamingCalls, 1);
+      expect(tts.stopCalls, 1);
+      expect(input.beginCalls, 1);
+      await controller.stop();
+    },
+  );
+
+  test('tracks the spoken assistant chunk and word progress', () async {
+    final input = _FakeVoiceInputService();
+    final tts = _FakeTextToSpeechService()..holdCompletion = true;
+    final audioSession = _FakeChatVoiceAudioSessionCoordinator();
+    final container = ProviderContainer(
+      overrides: [
+        authNavigationStateProvider.overrideWithValue(
+          AuthNavigationState.authenticated,
+        ),
+        selectedModelProvider.overrideWithValue(_model),
+        appSettingsProvider.overrideWithValue(const AppSettings()),
+        reviewerModeProvider.overrideWithValue(true),
+        voiceInputServiceProvider.overrideWithValue(input),
+        textToSpeechServiceProvider.overrideWithValue(tts),
+        callKitServiceProvider.overrideWithValue(_UnavailableCallKitService()),
+        chatVoiceModeBackgroundCoordinatorProvider.overrideWithValue(
+          _FakeChatVoiceBackgroundCoordinator(),
+        ),
+        chatVoiceAudioSessionCoordinatorProvider.overrideWithValue(
+          audioSession,
+        ),
+      ],
+    );
+    addTearDown(container.dispose);
+
+    final controller = container.read(chatVoiceModeControllerProvider.notifier);
+
+    await controller.start(startNewConversation: false);
+    await input.completeCurrent('show karaoke progress');
+    await _until(() => tts.fedTexts.isNotEmpty);
+
+    tts.emitChunkStarted(0);
+    await _until(
+      () => container
+          .read(chatVoiceModeControllerProvider)
+          .spokenResponse
+          .trim()
+          .isNotEmpty,
+    );
+
+    final spoken = container
+        .read(chatVoiceModeControllerProvider)
+        .spokenResponse;
+    final word = RegExp(r'\S+').firstMatch(spoken)!;
+    tts.emitWordProgress(word.start, word.end);
+    await _until(
+      () =>
+          container.read(chatVoiceModeControllerProvider).spokenWordStart ==
+          word.start,
+    );
+
+    final snapshot = container.read(chatVoiceModeControllerProvider);
+    expect(snapshot.phase, ChatVoiceModePhase.speaking);
+    expect(snapshot.spokenResponse, spoken);
+    expect(snapshot.spokenWordEnd, word.end);
+
+    await controller.stop();
+  });
+
+  test(
     'holds a voice background lease and uses managed audio during CallKit session',
     () async {
       final input = _FakeVoiceInputService()
@@ -255,8 +487,12 @@ class _FakeVoiceInputService extends VoiceInputService {
   bool localSttAvailable = true;
   bool serverSttAvailable = false;
   SttPreference sttPreference = SttPreference.deviceOnly;
+  bool completedTranscriptSendable = false;
+  bool nativeLocalStt = false;
+  bool listening = false;
+  int stopCalls = 0;
   final managedAudioFlags = <bool>[];
-  StreamController<String>? _textController;
+  StreamController<VoiceTranscriptEvent>? _transcriptController;
   StreamController<int>? _intensityController;
 
   @override
@@ -275,32 +511,61 @@ class _FakeVoiceInputService extends VoiceInputService {
   bool get prefersDeviceOnly => sttPreference == SttPreference.deviceOnly;
 
   @override
+  bool get lastCompletedTranscriptSendable => completedTranscriptSendable;
+
+  @override
+  bool get isUsingNativeLocalStt => nativeLocalStt;
+
+  @override
+  bool get isListening => listening;
+
+  @override
   Future<bool> initialize({bool forceLocalStt = false}) async => true;
 
   @override
-  Future<Stream<String>> beginListening({
+  Future<Stream<VoiceTranscriptEvent>> beginListeningEvents({
     bool iosAudioSessionManagedExternally = false,
   }) async {
     beginCalls += 1;
+    listening = true;
+    completedTranscriptSendable = false;
     managedAudioFlags.add(iosAudioSessionManagedExternally);
-    _textController = StreamController<String>.broadcast();
+    _transcriptController = StreamController<VoiceTranscriptEvent>.broadcast();
     _intensityController = StreamController<int>.broadcast();
-    return _textController!.stream;
+    return _transcriptController!.stream;
   }
 
   @override
   Stream<int> get intensityStream =>
       _intensityController?.stream ?? const Stream<int>.empty();
 
-  Future<void> completeCurrent(String transcript) async {
-    final controller = _textController;
+  Future<void> completeCurrent(
+    String transcript, {
+    bool finalResult = true,
+    bool close = true,
+  }) async {
+    final controller = _transcriptController;
     if (controller == null) return;
-    controller.add(transcript);
-    await controller.close();
+    controller.add(
+      VoiceTranscriptEvent(text: transcript, isFinal: finalResult),
+    );
+    completedTranscriptSendable = finalResult;
+    if (close) {
+      listening = false;
+      await controller.close();
+    }
   }
 
   @override
-  Future<void> stopListening() async {}
+  Future<void> stopListening() async {
+    stopCalls += 1;
+    listening = false;
+    final controller = _transcriptController;
+    _transcriptController = null;
+    if (controller != null && !controller.isClosed) {
+      await controller.close();
+    }
+  }
 }
 
 class _FakeTextToSpeechService extends TextToSpeechService {
@@ -310,12 +575,24 @@ class _FakeTextToSpeechService extends TextToSpeechService {
   final fedTexts = <String>[];
   final finishedTexts = <String?>[];
   bool startedStreaming = false;
+  bool holdCompletion = false;
   int pauseCalls = 0;
   int resumeCalls = 0;
+  int stopStreamingCalls = 0;
+  int stopCalls = 0;
   bool _didStart = false;
 
   @override
   Stream<TtsEvent> get events => _events.stream;
+
+  @override
+  List<String> splitTextForSpeech(String text) {
+    return text
+        .split(RegExp(r'(?<=[.!?])\s+|\n+'))
+        .map((chunk) => chunk.trim())
+        .where((chunk) => chunk.isNotEmpty)
+        .toList(growable: false);
+  }
 
   @override
   Future<bool> initialize({
@@ -347,11 +624,16 @@ class _FakeTextToSpeechService extends TextToSpeechService {
   @override
   Future<void> finishStreamingTts({String? finalText}) async {
     finishedTexts.add(finalText);
+    if (holdCompletion) {
+      return;
+    }
     _events.add(const TtsCompleted());
   }
 
   @override
-  Future<void> stopStreamingTts() async {}
+  Future<void> stopStreamingTts() async {
+    stopStreamingCalls += 1;
+  }
 
   @override
   Future<void> pause() async {
@@ -366,7 +648,17 @@ class _FakeTextToSpeechService extends TextToSpeechService {
   }
 
   @override
-  Future<void> stop() async {}
+  Future<void> stop() async {
+    stopCalls += 1;
+  }
+
+  void emitChunkStarted(int index) {
+    _events.add(TtsChunkStarted(index));
+  }
+
+  void emitWordProgress(int start, int end) {
+    _events.add(TtsWordProgress(start, end));
+  }
 }
 
 class _UnavailableCallKitService extends CallKitService {

--- a/test/features/chat/voice_mode/chat_voice_mode_controller_test.dart
+++ b/test/features/chat/voice_mode/chat_voice_mode_controller_test.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 
+import 'package:checks/checks.dart';
 import 'package:conduit/core/models/model.dart';
 import 'package:conduit/core/providers/app_providers.dart';
 import 'package:conduit/core/services/callkit_service.dart';
@@ -167,12 +168,11 @@ void main() {
       await input.completeCurrent('partial transcript', finalResult: false);
       await _until(() => input.beginCalls == 2);
 
-      expect(container.read(chatMessagesProvider), isEmpty);
-      expect(tts.startedStreaming, isFalse);
-      expect(
+      check(container.read(chatMessagesProvider)).isEmpty();
+      check(tts.startedStreaming).isFalse();
+      check(
         container.read(chatVoiceModeControllerProvider).phase,
-        ChatVoiceModePhase.listening,
-      );
+      ).equals(ChatVoiceModePhase.listening);
     },
   );
 
@@ -219,13 +219,76 @@ void main() {
             ChatVoiceModePhase.listening,
       );
 
-      expect(
+      check(
         container.read(chatMessagesProvider).first.content,
-        'continuous final',
+      ).equals('continuous final');
+      check(input.beginCalls).equals(1);
+      check(input.stopCalls).equals(0);
+      check(input.isListening).isTrue();
+      await controller.stop();
+    },
+  );
+
+  test(
+    'queues a final transcript that arrives while the previous final is sending',
+    () async {
+      final input = _FakeVoiceInputService()..nativeLocalStt = true;
+      final tts = _FakeTextToSpeechService()..holdCompletion = true;
+      final audioSession = _FakeChatVoiceAudioSessionCoordinator();
+      var stopGenerationCalls = 0;
+      final container = ProviderContainer(
+        overrides: [
+          authNavigationStateProvider.overrideWithValue(
+            AuthNavigationState.authenticated,
+          ),
+          selectedModelProvider.overrideWithValue(_model),
+          appSettingsProvider.overrideWithValue(const AppSettings()),
+          reviewerModeProvider.overrideWithValue(true),
+          voiceInputServiceProvider.overrideWithValue(input),
+          textToSpeechServiceProvider.overrideWithValue(tts),
+          stopGenerationProvider.overrideWithValue(() {
+            stopGenerationCalls += 1;
+          }),
+          callKitServiceProvider.overrideWithValue(
+            _UnavailableCallKitService(),
+          ),
+          chatVoiceModeBackgroundCoordinatorProvider.overrideWithValue(
+            _FakeChatVoiceBackgroundCoordinator(),
+          ),
+          chatVoiceAudioSessionCoordinatorProvider.overrideWithValue(
+            audioSession,
+          ),
+        ],
       );
-      expect(input.beginCalls, 1);
-      expect(input.stopCalls, 0);
-      expect(input.isListening, isTrue);
+      addTearDown(container.dispose);
+
+      final controller = container.read(
+        chatVoiceModeControllerProvider.notifier,
+      );
+
+      await controller.start(startNewConversation: false);
+      await input.completeCurrent('first queued final', close: false);
+      await input.completeCurrent('second queued final', close: false);
+      await _until(
+        () =>
+            container
+                .read(chatMessagesProvider)
+                .where((message) => message.role == 'user')
+                .length ==
+            2,
+      );
+
+      final userMessages = container
+          .read(chatMessagesProvider)
+          .where((message) => message.role == 'user')
+          .map((message) => message.content)
+          .toList();
+      check(
+        userMessages,
+      ).deepEquals(<String>['first queued final', 'second queued final']);
+      await _until(() => tts.finishedTexts.length == 2);
+      check(stopGenerationCalls).equals(1);
+      check(input.beginCalls).equals(1);
       await controller.stop();
     },
   );
@@ -291,14 +354,13 @@ void main() {
           .where((message) => message.role == 'user')
           .map((message) => message.content)
           .toList();
-      expect(userMessages, <String>[
-        'first assistant turn',
-        'second barge in turn',
-      ]);
+      check(
+        userMessages,
+      ).deepEquals(<String>['first assistant turn', 'second barge in turn']);
       await _until(() => tts.finishedTexts.length == 2);
-      expect(tts.stopStreamingCalls, 1);
-      expect(tts.stopCalls, 1);
-      expect(input.beginCalls, 1);
+      check(tts.stopStreamingCalls).equals(1);
+      check(tts.stopCalls).equals(1);
+      check(input.beginCalls).equals(1);
       await controller.stop();
     },
   );
@@ -355,9 +417,9 @@ void main() {
     );
 
     final snapshot = container.read(chatVoiceModeControllerProvider);
-    expect(snapshot.phase, ChatVoiceModePhase.speaking);
-    expect(snapshot.spokenResponse, spoken);
-    expect(snapshot.spokenWordEnd, word.end);
+    check(snapshot.phase).equals(ChatVoiceModePhase.speaking);
+    check(snapshot.spokenResponse).equals(spoken);
+    check(snapshot.spokenWordEnd).equals(word.end);
 
     await controller.stop();
   });

--- a/test/features/chat/voice_mode/chat_voice_mode_controller_test.dart
+++ b/test/features/chat/voice_mode/chat_voice_mode_controller_test.dart
@@ -230,7 +230,7 @@ void main() {
   );
 
   test(
-    'queues a final transcript that arrives while the previous final is sending',
+    'queues final transcripts that arrive while the previous final is sending',
     () async {
       final input = _FakeVoiceInputService()..nativeLocalStt = true;
       final tts = _FakeTextToSpeechService()..holdCompletion = true;
@@ -269,13 +269,14 @@ void main() {
       await controller.start(startNewConversation: false);
       await input.completeCurrent('first queued final', close: false);
       await input.completeCurrent('second queued final', close: false);
+      await input.completeCurrent('third queued final', close: false);
       await _until(
         () =>
             container
                 .read(chatMessagesProvider)
                 .where((message) => message.role == 'user')
                 .length ==
-            2,
+            3,
       );
 
       final userMessages = container
@@ -283,11 +284,13 @@ void main() {
           .where((message) => message.role == 'user')
           .map((message) => message.content)
           .toList();
-      check(
-        userMessages,
-      ).deepEquals(<String>['first queued final', 'second queued final']);
-      await _until(() => tts.finishedTexts.length == 2);
-      check(stopGenerationCalls).equals(1);
+      check(userMessages).deepEquals(<String>[
+        'first queued final',
+        'second queued final',
+        'third queued final',
+      ]);
+      await _until(() => tts.finishedTexts.length == 3);
+      check(stopGenerationCalls).equals(2);
       check(input.beginCalls).equals(1);
       await controller.stop();
     },

--- a/test/shared/widgets/markdown/renderer/streaming_markdown_widget_test.dart
+++ b/test/shared/widgets/markdown/renderer/streaming_markdown_widget_test.dart
@@ -38,6 +38,10 @@ Iterable<_RecordedPlatformCall> _mediumImpactCalls(
       call.arguments == 'HapticFeedbackType.mediumImpact',
 );
 
+Iterable<_RecordedPlatformCall> _hapticFeedbackCalls(
+  List<_RecordedPlatformCall> calls,
+) => calls.where((call) => call.method == 'HapticFeedback.vibrate');
+
 /// Returns `true` if [text] contains any unpaired UTF-16 surrogate, which would
 /// render as a tofu/replacement glyph (the regression the fade-split snap
 /// guards against).
@@ -287,6 +291,7 @@ void main() {
     required ChatMessage message,
     required bool isStreaming,
     bool disableAnimations = false,
+    bool suppressStreamingHaptics = false,
   }) {
     return UncontrolledProviderScope(
       container: container,
@@ -301,6 +306,7 @@ void main() {
               message: message,
               isStreaming: isStreaming,
               showFollowUps: false,
+              suppressStreamingHaptics: suppressStreamingHaptics,
               onDelete: () {},
             ),
           ),
@@ -1456,6 +1462,69 @@ Tail keeps growing
         await tester.pump();
 
         expect(_mediumImpactCalls(platformCalls), isEmpty);
+      } finally {
+        messenger.setMockMethodCallHandler(SystemChannels.platform, null);
+        container.dispose();
+        debugDefaultTargetPlatformOverride = null;
+      }
+    },
+  );
+
+  testWidgets(
+    'assistant streaming haptics stay silent when suppressed by voice mode',
+    (tester) async {
+      debugDefaultTargetPlatformOverride = TargetPlatform.android;
+
+      final container = ProviderContainer(
+        overrides: [
+          appSettingsProvider.overrideWithValue(const AppSettings()),
+          textToSpeechControllerProvider.overrideWith(
+            _TestTextToSpeechController.new,
+          ),
+        ],
+      );
+      final messenger =
+          TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger;
+      final platformCalls = <_RecordedPlatformCall>[];
+      messenger.setMockMethodCallHandler(SystemChannels.platform, (call) async {
+        platformCalls.add(_RecordedPlatformCall(call.method, call.arguments));
+        return null;
+      });
+
+      final message = ChatMessage(
+        id: 'voice-streaming-message',
+        role: 'assistant',
+        content: '',
+        timestamp: DateTime(2026),
+      );
+
+      try {
+        await tester.pumpWidget(
+          buildAssistantHarness(
+            container: container,
+            message: message,
+            isStreaming: true,
+            disableAnimations: true,
+            suppressStreamingHaptics: true,
+          ),
+        );
+
+        container.read(streamingContentProvider.notifier).set('Hello');
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 350));
+
+        await tester.pumpWidget(
+          buildAssistantHarness(
+            container: container,
+            message: message.copyWith(content: 'Hello'),
+            isStreaming: false,
+            disableAnimations: true,
+            suppressStreamingHaptics: true,
+          ),
+        );
+        await tester.pump();
+
+        expect(_hapticFeedbackCalls(platformCalls), isEmpty);
       } finally {
         messenger.setMockMethodCallHandler(SystemChannels.platform, null);
         container.dispose();

--- a/test/shared/widgets/markdown/renderer/streaming_markdown_widget_test.dart
+++ b/test/shared/widgets/markdown/renderer/streaming_markdown_widget_test.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 
+import 'package:checks/checks.dart';
 import 'package:conduit/l10n/app_localizations.dart';
 import 'package:conduit/core/services/worker_manager.dart';
 import 'package:conduit/core/models/chat_message.dart';
@@ -670,11 +671,7 @@ graph TD
 
       final afterFade = baseRenders;
       await tester.pump(const Duration(milliseconds: 400));
-      expect(
-        baseRenders,
-        afterFade,
-        reason: 'settling adds no base render',
-      );
+      expect(baseRenders, afterFade, reason: 'settling adds no base render');
     },
   );
 
@@ -778,7 +775,9 @@ graph TD
       isTrue,
       reason: 'every span settles to full opacity',
     );
-    final settledDocs = settledLeaves.singleWhere((span) => span.text == 'docs');
+    final settledDocs = settledLeaves.singleWhere(
+      (span) => span.text == 'docs',
+    );
     expect(
       settledDocs.recognizer,
       isNotNull,
@@ -818,10 +817,7 @@ graph TD
 
     await tester.pump(const Duration(milliseconds: 360));
     final settled = _textSpanLeaves(tailText().textSpan!).toList();
-    expect(
-      settled.every((span) => (span.style?.color?.a ?? 1) == 1),
-      isTrue,
-    );
+    expect(settled.every((span) => (span.style?.color?.a ?? 1) == 1), isTrue);
   });
 
   testWidgets('surrogate-pair boundary never splits mid-emoji while fading', (
@@ -866,14 +862,8 @@ graph TD
 
     await tester.pump(const Duration(milliseconds: 360));
     final settled = _textSpanLeaves(renderedText().textSpan!).toList();
-    expect(
-      settled.map((span) => span.text ?? '').join(),
-      'Hi \u{1F600} there',
-    );
-    expect(
-      settled.every((span) => (span.style?.color?.a ?? 1) == 1),
-      isTrue,
-    );
+    expect(settled.map((span) => span.text ?? '').join(), 'Hi \u{1F600} there');
+    expect(settled.every((span) => (span.style?.color?.a ?? 1) == 1), isTrue);
   });
 
   testWidgets('renders OpenWebUI mentions without placeholder leakage', (
@@ -1524,7 +1514,7 @@ Tail keeps growing
         );
         await tester.pump();
 
-        expect(_hapticFeedbackCalls(platformCalls), isEmpty);
+        check(_hapticFeedbackCalls(platformCalls)).isEmpty();
       } finally {
         messenger.setMockMethodCallHandler(SystemChannels.platform, null);
         container.dispose();


### PR DESCRIPTION
## Summary
- Replace Flutter STT/TTS package usage with native speech bridges: Android ML Kit GenAI/Android speech recognition plus Android TTS, and iOS SpeechAnalyzer on iOS 26+ with SFSpeechRecognizer fallback plus AVSpeechSynthesizer voice selection.
- Improve voice-call behavior with continuous final-result auto-send, partial transcript streaming, barge-in/audio session coordination, streaming TTS startup, Android Auto/iOS routing handling, and removed silence/haptic streaming call config.
- Polish chat voice UX with manual dictation stop, centered composer controls, stable plus icon state, karaoke-style spoken response highlighting, and a roomier collapsed voice pill.

## Tests
- `flutter analyze`
- `flutter test`
- `flutter test test/features/chat/voice_mode/chat_voice_mode_controller_test.dart test/features/chat/voice_mode/chat_voice_mode_overlay_test.dart`
- Final spacing follow-up: `git diff --check -- lib/features/chat/voice_mode/chat_voice_mode_overlay.dart` and `flutter test test/features/chat/voice_mode/chat_voice_mode_overlay_test.dart`


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Replace plugin-based STT/TTS with native platform bridges and add barge-in voice UI
> - Removes `speech_to_text` and `flutter_tts` Flutter plugins, replacing them with native Android/iOS bridges (`NativeSttBridge`, `NativeTtsBridge`) communicating over Flutter method/event channels.
> - `TtsManager` now drives all device TTS through the native bridge, including voice enumeration, playback controls, and lifecycle events.
> - `VoiceInputService` migrates local STT to the native bridge, exposing a `VoiceTranscriptEvent` stream with partial and final results and a 900ms settle timer.
> - `ChatVoiceModeController` gains barge-in support: when the user speaks while the assistant is responding, TTS is interrupted and generation is stopped before the new transcript is submitted. It also tracks word-level TTS progress for karaoke-style highlighting.
> - The voice mode overlay shows the assistant's currently spoken text with live word highlighting via a new `_KaraokeResponseBar` widget.
> - Audio session routing is improved on both platforms: Android forces in-communication mode with Bluetooth SCO, iOS requests Bluetooth HFP input via a new `VoiceAudioRouteBridge`.
> - `AppSettings` gains `ttsVoiceName` to persist friendly TTS voice display names alongside raw identifiers; selection helpers (`setTtsDeviceVoiceSelection`, `setTtsServerVoiceSelection`, `setTtsEngineSelection`) are added to the notifier.
> - Risk: Behavioral change — device TTS and STT now depend entirely on native bridge availability; the app will not fall back to the removed plugins if a native bridge fails to initialize.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3975e4a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added native speech-to-text and text-to-speech on Android/iOS with streamed transcription plus TTS lifecycle/progress events.
  * Added voice selection improvements, including saving preferred TTS device voice name and a unified voice picker experience.
  * Added karaoke-style spoken-word highlighting and spoken-response tracking during voice mode.
  * Added iOS Personal Voice permission and improved Bluetooth/audio routing for voice interactions.
* **Bug Fixes**
  * Improved chat stop behavior by stopping conversation-scoped background tasks.
  * Improved Bluetooth hands-free and iOS audio routing; assistant streaming haptics are suppressed during voice mode.
* **Documentation**
  * Updated STT silence-duration text to clarify server transcription vs on-device results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds native voice input and output support with voice-mode UI updates. The main changes are:

- Native Android and iOS speech-to-text bridges.
- Native Android and iOS text-to-speech bridges with voice selection.
- Continuous voice-mode transcript handling and barge-in behavior.
- Audio session and Bluetooth routing coordination for voice calls.
- Karaoke-style spoken response highlighting in the voice overlay.
- Settings updates for saved TTS voice names and engine choices.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

No blocking issues were identified in the reviewed changes.

The changes are broad and native-platform-heavy, but the review did not identify concrete correctness, security, or merge-safety problems.
</details>


<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Stopped at a series of test-harness runs for stop-tasks-by-chat and noted that the test command exits with code 127 due to Flutter not being installed, with the harness file removed afterward.
- Inspected the voice-controller test run and observed the same exit code 127 from the base and head checkouts, indicating Flutter is still unavailable and the partial transcript logic could not be executed.
- Reviewed the karaoke-highlight test harness and confirmed the test attempts fail with Flutter not found, preventing a real widget capture and validation of the capture flow.
- Checked the tts-voice-name-persistence test path and noted the head contains persistence code, but the Flutter test command exits with 127, leaving the persistence validation inconclusive.

<a href="https://app.greptile.com/trex/runs/12139630/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=1"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=1" height="32"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `lib/features/profile/views/audio_settings_page.dart`, line 218-224 ([link](https://github.com/cogwheel0/conduit/blob/6daac9b3b819cd43668c36a3dc4fde7f20fd613f/lib/features/profile/views/audio_settings_page.dart#L218-L224)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Races settings saves**

   Switching the TTS engine fires multiple async settings writes without awaiting them. Because each setter updates state and persists independently, the voice-clear writes and engine write can complete in different orders, leaving storage or listeners with an inconsistent engine/voice combination after the user changes engines.
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (5): Last reviewed commit: ["Stop stale SFSpeech sessions on error"](https://github.com/cogwheel0/conduit/commit/3975e4a4ca1c5c77d9bcacbfe049a73f959aa4d3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39516557)</sub>

<!-- /greptile_comment -->