### PR TITLE
fix(streaming): render Open WebUI structured output for live and reloaded messages

### DIFF
--- a/lib/core/services/conversation_parsing.dart
+++ b/lib/core/services/conversation_parsing.dart
@@ -7,6 +7,7 @@ import '../models/conversation.dart';
 import '../utils/embed_utils.dart';
 import '../utils/message_tree_utils.dart' as message_tree;
 import '../utils/openwebui_source_parser.dart';
+import 'openwebui_stream_parser.dart';
 
 /// Utilities for converting OpenWebUI conversation payloads into JSON maps
 /// that match the app's `Conversation` / `ChatMessage` schemas. All helpers
@@ -513,6 +514,19 @@ Map<String, dynamic> _parseOpenWebUIMessageToJson(
     }
   }
 
+  // Responses-API models persist only the structured `output` list (the
+  // `content` string stays empty on the server). Serialize it client-side so
+  // reloaded assistant messages render their text, reasoning, and tools.
+  final outputItems = _normalizeOutputItems(
+    msgData['output'] ?? historyMsg?['output'],
+  );
+  if (contentString.trim().isEmpty && outputItems.isNotEmpty) {
+    final fromOutput = serializeOpenWebUIOutput(outputItems);
+    if (fromOutput.isNotEmpty) {
+      contentString = fromOutput;
+    }
+  }
+
   // Extract error field from OpenWebUI - preserve it separately for round-trip
   final errorData = _extractErrorData(msgData, historyMsg);
 
@@ -608,6 +622,7 @@ Map<String, dynamic> _parseOpenWebUIMessageToJson(
     'sources': _parseSourcesField(sourcesRaw),
     'usage': usage,
     'versions': const <Map<String, dynamic>>[],
+    if (outputItems.isNotEmpty) 'output': outputItems,
     'error': ?errorData,
   };
 }
@@ -1006,6 +1021,34 @@ String _jsonStringify(dynamic value) {
   } catch (_) {
     return value.toString();
   }
+}
+
+/// Normalizes a raw `output` payload (as persisted by Open WebUI for
+/// Responses-API models) into a typed list suitable for serialization.
+///
+/// Newer Open WebUI servers stream `chat:completion` deltas carrying only
+/// the structured `output` list (no pre-serialized `content` string) and
+/// persist messages the same way. When a message is reloaded from the server,
+/// its `content` field is empty for such models, so the structured `output`
+/// must be serialized client-side to render the assistant text, reasoning,
+/// and tool-call blocks.
+List<Map<String, dynamic>> _normalizeOutputItems(dynamic raw) {
+  if (raw is! List) return const [];
+  final items = <Map<String, dynamic>>[];
+  for (final item in raw) {
+    if (item is Map) {
+      items.add(Map<String, dynamic>.from(item));
+    }
+  }
+  return List<Map<String, dynamic>>.unmodifiable(items);
+}
+
+/// Returns serialized visible content for `output` items, or an empty string
+/// when `output` is absent/empty. Mirrors upstream `serialize_output`.
+String _contentFromOutput(dynamic raw) {
+  final items = _normalizeOutputItems(raw);
+  if (items.isEmpty) return '';
+  return serializeOpenWebUIOutput(items);
 }
 
 String _escapeHtmlAttr(String value) {

--- a/lib/core/services/openwebui_stream_parser.dart
+++ b/lib/core/services/openwebui_stream_parser.dart
@@ -1,6 +1,9 @@
 import 'dart:async';
 import 'dart:convert';
 
+/// Reusable HTML escaper for attribute and body text in serialized output.
+const HtmlEscape _outputHtmlEscape = HtmlEscape();
+
 /// Base class for all stream update types emitted by the OpenWebUI SSE parser.
 sealed class OpenWebUIStreamUpdate {
   const OpenWebUIStreamUpdate();
@@ -204,6 +207,189 @@ Iterable<OpenWebUIStreamUpdate> parseOpenWebUIParsedPayload(
   }
 }
 
+/// Serializes OpenWebUI OR-aligned output items into a visible HTML string.
+///
+/// Mirrors the upstream `serialize_output` contract that Open WebUI used to
+/// emit as the `content` field on `chat:completion` socket deltas. Newer
+/// servers emit only the structured `output` list (no `content` string), so
+/// callers must serialize it client-side to render assistant text, reasoning,
+/// and tool-call blocks.
+///
+/// Supported item types:
+/// - `message`: concatenates `content[].text` for `text`/`output_text` parts.
+/// - `reasoning`: renders a `<details type="reasoning">` block matching the
+///   shape produced by `streaming_helper._buildStreamingReasoningDetails` so
+///   existing reasoning parsers keep working.
+/// - `function_call`: renders a `<details type="tool_calls">` block, paired
+///   with any matching `function_call_output` by `call_id`.
+/// - `function_call_output`: skipped (consumed inline with its call).
+/// - `code_interpreter`: renders a `<details type="code_interpreter">` block.
+String serializeOpenWebUIOutput(List<Map<String, dynamic>> output) {
+  if (output.isEmpty) return '';
+
+  // First pass: index function_call_output items by call_id for pairing.
+  final toolOutputs = <String, Map<String, dynamic>>{};
+  for (final item in output) {
+    if (item['type']?.toString() == 'function_call_output') {
+      final callId = item['call_id']?.toString();
+      if (callId != null && callId.isNotEmpty) {
+        toolOutputs[callId] = item;
+      }
+    }
+  }
+
+  final parts = <String>[];
+  for (var index = 0; index < output.length; index++) {
+    final item = output[index];
+    final itemType = item['type']?.toString() ?? '';
+
+    if (itemType == 'message') {
+      final content = item['content'];
+      if (content is List) {
+        for (final part in content) {
+          if (part is Map) {
+            final partType = part['type']?.toString();
+            if (partType == 'text' || partType == 'output_text') {
+              final text = part['text']?.toString().trim() ?? '';
+              if (text.isNotEmpty) {
+                parts.add(text);
+              }
+            }
+          }
+        }
+      }
+    } else if (itemType == 'reasoning') {
+      final sourceList = item['summary'] is List
+          ? item['summary'] as List
+          : (item['content'] is List ? item['content'] as List : const []);
+      final reasoningParts = <String>[];
+      for (final part in sourceList) {
+        if (part is Map) {
+          final text = part['text']?.toString();
+          if (text != null && text.isNotEmpty) {
+            reasoningParts.add(text);
+          }
+        }
+      }
+      final reasoningContent = reasoningParts.join().trim();
+      if (reasoningContent.isNotEmpty) {
+        final duration = item['duration']?.toString();
+        final status = item['status']?.toString();
+        final isLastItem = index == output.length - 1;
+        final done = status == 'completed' || duration != null || !isLastItem;
+        final escapedDisplay = _outputHtmlEscape.convert(
+          LineSplitter.split(reasoningContent)
+              .map((line) => line.startsWith('>') ? line : '> $line')
+              .join('\n'),
+        );
+        if (done) {
+          final dur = duration ?? '0';
+          parts.add(
+            '<details type="reasoning" done="true" duration="$dur">\n'
+            '<summary>Thought for $dur seconds</summary>\n'
+            '$escapedDisplay\n'
+            '</details>',
+          );
+        } else {
+          parts.add(
+            '<details type="reasoning" done="false">\n'
+            '<summary>Thinking…</summary>\n'
+            '$escapedDisplay\n'
+            '</details>',
+          );
+        }
+      }
+    } else if (itemType == 'function_call') {
+      final callId = item['call_id']?.toString() ?? '';
+      final name = item['name']?.toString() ?? '';
+      final arguments = item['arguments'] ?? '';
+      final escapedArgs = _outputHtmlEscape.convert(jsonEncode(arguments));
+      final resultItem = toolOutputs[callId];
+      if (resultItem != null) {
+        final resultParts = <String>[];
+        final resultOutput = resultItem['output'];
+        if (resultOutput is List) {
+          for (final out in resultOutput) {
+            if (out is Map) {
+              final text = out['text'];
+              if (text != null) {
+                resultParts.add(
+                  text is String ? text : text.toString(),
+                );
+              }
+            }
+          }
+        } else if (resultOutput is String) {
+          resultParts.add(resultOutput);
+        }
+        final resultText = resultParts.join();
+        final escapedResult = _outputHtmlEscape.convert(
+          jsonEncode(resultText),
+        );
+        final files = resultItem['files'];
+        final escapedFiles =
+            files == null ? '' : _outputHtmlEscape.convert(jsonEncode(files));
+        final embeds = resultItem['embeds'];
+        final escapedEmbeds =
+            embeds == null ? '' : _outputHtmlEscape.convert(jsonEncode(embeds));
+        parts.add(
+          '<details type="tool_calls" done="true" id="$callId" name="$name" arguments="$escapedArgs" files="$escapedFiles" embeds="$escapedEmbeds">\n'
+          '<summary>Tool Executed</summary>\n'
+          '$escapedResult\n'
+          '</details>',
+        );
+      } else {
+        parts.add(
+          '<details type="tool_calls" done="false" id="$callId" name="$name" arguments="$escapedArgs">\n'
+          '<summary>Executing...</summary>\n'
+          '</details>',
+        );
+      }
+    } else if (itemType == 'function_call_output') {
+      // Consumed inline with its function_call above.
+      continue;
+    } else if (itemType == 'code_interpreter') {
+      final status = item['status']?.toString() ?? 'in_progress';
+      final duration = item['duration']?.toString();
+      final isLastItem = index == output.length - 1;
+      final done = status == 'completed' ||
+          status == 'failed' ||
+          status == 'incomplete' ||
+          duration != null ||
+          !isLastItem;
+      final code = item['code']?.toString() ?? '';
+      final lang = item['language']?.toString() ?? '';
+      final display = code.isEmpty ? '' : '```$lang\n$code\n```';
+      final ciOutput = item['output'];
+      String outputAttr = '';
+      if (ciOutput != null) {
+        final outputJson = ciOutput is Map
+            ? jsonEncode(ciOutput)
+            : jsonEncode({'result': ciOutput.toString()});
+        outputAttr = ' output="${_outputHtmlEscape.convert(outputJson)}"';
+      }
+      if (done) {
+        final dur = duration ?? '0';
+        parts.add(
+          '<details type="code_interpreter" done="true" duration="$dur"$outputAttr>\n'
+          '<summary>Analyzed</summary>\n'
+          '$display\n'
+          '</details>',
+        );
+      } else {
+        parts.add(
+          '<details type="code_interpreter" done="false"$outputAttr>\n'
+          '<summary>Analyzing…</summary>\n'
+          '$display\n'
+          '</details>',
+        );
+      }
+    }
+  }
+
+  return parts.join('\n').trim();
+}
+
 /// Incrementally scans decoded SSE text and emits complete `data:` payloads.
 final class _OpenWebUISseScanner {
   final StringBuffer _lineBuffer = StringBuffer();
@@ -304,10 +490,10 @@ OpenWebUIEventUpdate? _eventUpdateFromMap(Map<dynamic, dynamic> raw) {
   final data = raw.containsKey('data')
       ? raw['data']
       : raw.entries
-            .where((entry) => entry.key?.toString() != 'type')
-            .fold<Map<String, dynamic>>(<String, dynamic>{}, (map, entry) {
-              map[entry.key.toString()] = entry.value;
-              return map;
-            });
+          .where((entry) => entry.key?.toString() != 'type')
+          .fold<Map<String, dynamic>>(<String, dynamic>{}, (map, entry) {
+          map[entry.key.toString()] = entry.value;
+          return map;
+        });
   return OpenWebUIEventUpdate(type: type, data: data);
 }

--- a/lib/core/services/streaming_helper.dart
+++ b/lib/core/services/streaming_helper.dart
@@ -37,7 +37,8 @@ int debugTaskSocketStableNonTerminalRecoveryLimit = 3;
 @visibleForTesting
 List<Map<String, dynamic>> debugCollectImageReferencesFromContent(
   String content,
-) => _collectImageReferencesWorker(content);
+) =>
+    _collectImageReferencesWorker(content);
 
 const Set<String> _explicitImageFileTypes = {'image'};
 
@@ -244,8 +245,7 @@ List<Map<String, dynamic>> _extractExplicitImageFiles(dynamic raw) {
   }
 
   final type = map['type']?.toString().toLowerCase().trim();
-  final contentType =
-      (map['content_type'] ??
+  final contentType = (map['content_type'] ??
               map['contentType'] ??
               map['mime_type'] ??
               map['mimeType'])
@@ -253,8 +253,7 @@ List<Map<String, dynamic>> _extractExplicitImageFiles(dynamic raw) {
           .toLowerCase()
           .trim() ??
       '';
-  final isImage =
-      (type != null && _explicitImageFileTypes.contains(type)) ||
+  final isImage = (type != null && _explicitImageFileTypes.contains(type)) ||
       contentType.startsWith('image/');
   if (!isImage) {
     return results;
@@ -263,18 +262,17 @@ List<Map<String, dynamic>> _extractExplicitImageFiles(dynamic raw) {
   final url = map['url']?.toString();
   final content = map['content']?.toString();
   final rawBase64 = (map['b64_json'] ?? map['b64'])?.toString();
-  final base64MimeType = contentType.startsWith('image/')
-      ? contentType
-      : 'image/png';
+  final base64MimeType =
+      contentType.startsWith('image/') ? contentType : 'image/png';
   final imageUrl = url?.isNotEmpty == true
       ? url
       : content?.startsWith('data:image/') == true
-      ? content
-      : rawBase64?.isNotEmpty == true
-      ? rawBase64!.startsWith('data:image/')
-            ? rawBase64
-            : 'data:$base64MimeType;base64,$rawBase64'
-      : null;
+          ? content
+          : rawBase64?.isNotEmpty == true
+              ? rawBase64!.startsWith('data:image/')
+                  ? rawBase64
+                  : 'data:$base64MimeType;base64,$rawBase64'
+              : null;
 
   if (imageUrl != null && imageUrl.isNotEmpty) {
     results.add({'type': 'image', 'url': imageUrl});
@@ -345,8 +343,7 @@ Future<void> _handleReconnectRecovery({
     required bool isDone,
     required String source,
     String? errorContent,
-  })
-  applyServerContent,
+  }) applyServerContent,
   required void Function() syncImages,
 }) async {
   try {
@@ -408,18 +405,17 @@ ActiveChatStream attachUnifiedChunkedStreaming({
   required void Function(String) bufferLastMessageContent,
   required void Function(String) replaceLastMessageContent,
   required void Function(ChatMessage Function(ChatMessage))
-  updateLastMessageWith,
+      updateLastMessageWith,
   required void Function(String messageId, ChatStatusUpdate update)
-  appendStatusUpdate,
+      appendStatusUpdate,
   required void Function(String messageId, ChatCodeExecution execution)
-  upsertCodeExecution,
+      upsertCodeExecution,
   required void Function(String messageId, ChatSourceReference reference)
-  appendSourceReference,
+      appendSourceReference,
   required void Function(
     String messageId,
     ChatMessage Function(ChatMessage current),
-  )
-  updateMessageById,
+  ) updateMessageById,
   void Function(String newTitle)? onChatTitleUpdated,
   void Function()? onChatTagsUpdated,
 
@@ -469,7 +465,7 @@ ActiveChatStream attachUnifiedChunkedStreaming({
   String? boundRemoteMessageId;
   StreamingResponseController? streamController;
   late void Function(String reason, {String? incomingMessageId})
-  retireObsoleteStream;
+      retireObsoleteStream;
 
   bool isTerminalFinishReason(String? finishReason) {
     return finishReason == 'stop' ||
@@ -483,14 +479,13 @@ ActiveChatStream attachUnifiedChunkedStreaming({
   if (Platform.isIOS || Platform.isAndroid) {
     // Fire-and-forget: background execution is best-effort and shouldn't block streaming
     BackgroundStreamingHandler.instance
-        .startBackgroundExecution([streamId])
-        .catchError((Object e) {
-          DebugLogger.error(
-            'background-start-failed',
-            scope: 'streaming/helper',
-            error: e,
-          );
-        });
+        .startBackgroundExecution([streamId]).catchError((Object e) {
+      DebugLogger.error(
+        'background-start-failed',
+        scope: 'streaming/helper',
+        error: e,
+      );
+    });
   }
 
   String? currentAssistantTargetId() {
@@ -530,9 +525,8 @@ ActiveChatStream attachUnifiedChunkedStreaming({
 
     return (
       previous: targetIndex > 0 ? messages[targetIndex - 1] : null,
-      next: targetIndex + 1 < messages.length
-          ? messages[targetIndex + 1]
-          : null,
+      next:
+          targetIndex + 1 < messages.length ? messages[targetIndex + 1] : null,
     );
   }
 
@@ -663,10 +657,10 @@ ActiveChatStream attachUnifiedChunkedStreaming({
       DebugLogger.log(
         boundMessageId == null
             ? 'Ignoring $eventType for wrong message: '
-                  '$incomingMessageId (expected $assistantMessageId)'
+                '$incomingMessageId (expected $assistantMessageId)'
             : 'Ignoring $eventType for unexpected message: '
-                  '$incomingMessageId '
-                  '(expected $assistantMessageId or $boundMessageId)',
+                '$incomingMessageId '
+                '(expected $assistantMessageId or $boundMessageId)',
         scope: 'streaming/helper',
       );
       return null;
@@ -699,14 +693,13 @@ ActiveChatStream attachUnifiedChunkedStreaming({
     backgroundExecutionStopped = true;
     if (Platform.isIOS || Platform.isAndroid) {
       BackgroundStreamingHandler.instance
-          .stopBackgroundExecution([streamId])
-          .catchError((Object e) {
-            DebugLogger.error(
-              'background-stop-failed',
-              scope: 'streaming/helper',
-              error: e,
-            );
-          });
+          .stopBackgroundExecution([streamId]).catchError((Object e) {
+        DebugLogger.error(
+          'background-stop-failed',
+          scope: 'streaming/helper',
+          error: e,
+        );
+      });
     }
   }
 
@@ -822,7 +815,7 @@ ActiveChatStream attachUnifiedChunkedStreaming({
   final socketSubscriptions = <VoidCallback>[];
   final hasSocketSignals = socketService != null;
   late final void Function({required String source})
-  scheduleTerminalCompletionRecovery;
+      scheduleTerminalCompletionRecovery;
 
   void resetTerminalCompletionRecoveryStability() {
     stableNonTerminalTerminalRecoveryCount = 0;
@@ -833,8 +826,7 @@ ActiveChatStream attachUnifiedChunkedStreaming({
     if (chunk.isEmpty) return;
 
     if (inReasoningBlock) {
-      renderedStreamingContent =
-          _prependReasoningDetails(
+      renderedStreamingContent = _prependReasoningDetails(
             reasoningPrefix,
             _buildStreamingReasoningDetails(reasoningContent, done: true),
           ) +
@@ -883,8 +875,7 @@ ActiveChatStream attachUnifiedChunkedStreaming({
 
   void handleToolCallStatus(String name) {
     if (name.isEmpty) return;
-    final status =
-        '\n<details type="tool_calls" done="false" '
+    final status = '\n<details type="tool_calls" done="false" '
         'name="$name"><summary>Executing...</summary>\n</details>\n';
     appendVisibleAssistantChunk(status, updateImages: false);
   }
@@ -899,9 +890,8 @@ ActiveChatStream attachUnifiedChunkedStreaming({
         continue;
       }
       final fn = call['function'];
-      final name = (fn is Map && fn['name'] is String)
-          ? fn['name'] as String
-          : null;
+      final name =
+          (fn is Map && fn['name'] is String) ? fn['name'] as String : null;
       if (name is String && name.isNotEmpty) {
         final exists = renderedStreamingContent.contains('name="$name"');
         if (!exists) {
@@ -927,8 +917,7 @@ ActiveChatStream attachUnifiedChunkedStreaming({
   late final bool Function({
     required String targetId,
     required _AssistantServerPatch Function(ChatMessage current) buildPatch,
-  })
-  applyAssistantServerPatch;
+  }) applyAssistantServerPatch;
 
   void applyParsedOpenWebUIUpdate(
     OpenWebUIStreamUpdate update, {
@@ -1089,7 +1078,7 @@ ActiveChatStream attachUnifiedChunkedStreaming({
   }
 
   ({ChatMessage message, String comparisonContent})
-  readLocalMessageComparisonSnapshot(ChatMessage localMessage) {
+      readLocalMessageComparisonSnapshot(ChatMessage localMessage) {
     if (localMessage.role != 'assistant' ||
         localMessage.id != assistantMessageId) {
       return (message: localMessage, comparisonContent: localMessage.content);
@@ -1097,8 +1086,7 @@ ActiveChatStream attachUnifiedChunkedStreaming({
 
     flushStreamingBuffer();
 
-    final refreshedMessage =
-        getMessages()
+    final refreshedMessage = getMessages()
             .where((message) => message.id == localMessage.id)
             .firstOrNull ??
         localMessage;
@@ -1216,17 +1204,14 @@ ActiveChatStream attachUnifiedChunkedStreaming({
         continue;
       }
       if (assistantOrdinal == targetOrdinal) {
-        final previous = index > 0
-            ? _asStringMap(rawMessages[index - 1])
-            : null;
+        final previous =
+            index > 0 ? _asStringMap(rawMessages[index - 1]) : null;
         final next = index + 1 < rawMessages.length
             ? _asStringMap(rawMessages[index + 1])
             : null;
-        final previousMatches =
-            !usePreviousContext ||
+        final previousMatches = !usePreviousContext ||
             serverMessageMatchesLocalContext(previous, neighbors.previous!);
-        final nextMatches =
-            !useNextContext ||
+        final nextMatches = !useNextContext ||
             serverMessageMatchesLocalContext(next, neighbors.next!);
         if (previousMatches && nextMatches) {
           return message;
@@ -1265,14 +1250,12 @@ ActiveChatStream attachUnifiedChunkedStreaming({
       if (assistantOrdinal == targetOrdinal) {
         final previous = index > 0 ? messages[index - 1] : null;
         final next = index + 1 < messages.length ? messages[index + 1] : null;
-        final previousMatches =
-            !usePreviousContext ||
+        final previousMatches = !usePreviousContext ||
             conversationMessageMatchesLocalContext(
               previous,
               neighbors.previous!,
             );
-        final nextMatches =
-            !useNextContext ||
+        final nextMatches = !useNextContext ||
             conversationMessageMatchesLocalContext(next, neighbors.next!);
         if (previousMatches && nextMatches) {
           return message;
@@ -1315,11 +1298,9 @@ ActiveChatStream attachUnifiedChunkedStreaming({
           break;
         }
       }
-      serverMsg ??=
-          findServerMessageInList(chatObj?['messages']) ??
+      serverMsg ??= findServerMessageInList(chatObj?['messages']) ??
           findServerMessageInList(data?['messages']);
-      serverMsg ??=
-          findServerAssistantByReverseOrdinal(chatObj?['messages']) ??
+      serverMsg ??= findServerAssistantByReverseOrdinal(chatObj?['messages']) ??
           findServerAssistantByReverseOrdinal(data?['messages']);
       if (serverMsg == null) return null;
       bindRecoveredRemoteMessageId(
@@ -1337,8 +1318,7 @@ ActiveChatStream attachUnifiedChunkedStreaming({
       final errorContent = extractServerErrorContent(serverMsg['error']);
 
       // Check completion status
-      final isDone =
-          serverMsg['done'] == true ||
+      final isDone = serverMsg['done'] == true ||
           errorContent != null ||
           (serverMsg['isStreaming'] != true && content.isNotEmpty);
 
@@ -1371,76 +1351,74 @@ ActiveChatStream attachUnifiedChunkedStreaming({
     }
   }
 
-  applyAssistantServerPatch =
-      ({
-        required String targetId,
-        required _AssistantServerPatch Function(ChatMessage current) buildPatch,
-      }) {
-        var applied = false;
-        updateMessageById(targetId, (current) {
-          final patch = buildPatch(current);
-          final nextContent = patch.content ?? current.content;
-          final nextFollowUps = patch.followUps == null
-              ? current.followUps
-              : List<String>.from(patch.followUps!);
-          final nextStatusHistory = patch.statusHistory == null
-              ? current.statusHistory
-              : List<ChatStatusUpdate>.from(patch.statusHistory!);
-          final nextSources = patch.sources == null
-              ? current.sources
-              : List<ChatSourceReference>.from(patch.sources!);
-          final nextUsage = patch.usage == null
-              ? current.usage
-              : Map<String, dynamic>.from(patch.usage!);
-          final nextOutput = patch.output == null
-              ? current.output
-              : _copyJsonMapList(patch.output!);
-          final nextFiles = patch.files == null
-              ? current.files
-              : _copyJsonMapList(patch.files!);
-          final nextEmbeds = patch.embeds == null
-              ? current.embeds
-              : _copyJsonMapList(patch.embeds!);
-          final nextMetadata = patch.metadata == null
-              ? current.metadata
-              : patch.mergeMetadata
+  applyAssistantServerPatch = ({
+    required String targetId,
+    required _AssistantServerPatch Function(ChatMessage current) buildPatch,
+  }) {
+    var applied = false;
+    updateMessageById(targetId, (current) {
+      final patch = buildPatch(current);
+      final nextContent = patch.content ?? current.content;
+      final nextFollowUps = patch.followUps == null
+          ? current.followUps
+          : List<String>.from(patch.followUps!);
+      final nextStatusHistory = patch.statusHistory == null
+          ? current.statusHistory
+          : List<ChatStatusUpdate>.from(patch.statusHistory!);
+      final nextSources = patch.sources == null
+          ? current.sources
+          : List<ChatSourceReference>.from(patch.sources!);
+      final nextUsage = patch.usage == null
+          ? current.usage
+          : Map<String, dynamic>.from(patch.usage!);
+      final nextOutput = patch.output == null
+          ? current.output
+          : _copyJsonMapList(patch.output!);
+      final nextFiles =
+          patch.files == null ? current.files : _copyJsonMapList(patch.files!);
+      final nextEmbeds = patch.embeds == null
+          ? current.embeds
+          : _copyJsonMapList(patch.embeds!);
+      final nextMetadata = patch.metadata == null
+          ? current.metadata
+          : patch.mergeMetadata
               ? <String, dynamic>{...?current.metadata, ...patch.metadata!}
               : Map<String, dynamic>.from(patch.metadata!);
-          final nextIsStreaming = patch.isStreaming ?? current.isStreaming;
-          final nextError = patch.error ?? current.error;
-          if (current.content == nextContent &&
-              listEquals(current.followUps, nextFollowUps) &&
-              _statusHistoriesEquivalent(
-                current.statusHistory,
-                nextStatusHistory,
-              ) &&
-              listEquals(current.sources, nextSources) &&
-              _deepEquals(current.usage, nextUsage) &&
-              _deepEquals(current.output, nextOutput) &&
-              _deepEquals(current.files, nextFiles) &&
-              _deepEquals(current.embeds, nextEmbeds) &&
-              _deepEquals(current.metadata, nextMetadata) &&
-              current.isStreaming == nextIsStreaming &&
-              current.error == nextError) {
-            return current;
-          }
-          applied = true;
-          return current.copyWith(
-            content: nextContent,
-            followUps: nextFollowUps,
-            statusHistory: nextStatusHistory,
-            sources: nextSources,
-            usage: nextUsage,
-            output: nextOutput,
-            files: nextFiles,
-            embeds: nextEmbeds,
-            metadata: nextMetadata,
-            isStreaming: nextIsStreaming,
-            error: nextError,
-          );
-        });
-        return applied;
-      };
+      final nextIsStreaming = patch.isStreaming ?? current.isStreaming;
+      final nextError = patch.error ?? current.error;
+      if (current.content == nextContent &&
+          listEquals(current.followUps, nextFollowUps) &&
+          _statusHistoriesEquivalent(
+            current.statusHistory,
+            nextStatusHistory,
+          ) &&
+          listEquals(current.sources, nextSources) &&
+          _deepEquals(current.usage, nextUsage) &&
+          _deepEquals(current.output, nextOutput) &&
+          _deepEquals(current.files, nextFiles) &&
+          _deepEquals(current.embeds, nextEmbeds) &&
+          _deepEquals(current.metadata, nextMetadata) &&
+          current.isStreaming == nextIsStreaming &&
+          current.error == nextError) {
+        return current;
+      }
+      applied = true;
+      return current.copyWith(
+        content: nextContent,
+        followUps: nextFollowUps,
+        statusHistory: nextStatusHistory,
+        sources: nextSources,
+        usage: nextUsage,
+        output: nextOutput,
+        files: nextFiles,
+        embeds: nextEmbeds,
+        metadata: nextMetadata,
+        isStreaming: nextIsStreaming,
+        error: nextError,
+      );
+    });
+    return applied;
+  };
 
   // Helper to apply server content if it's better than local.
   // Returns true if content was applied, so caller can trigger image sync.
@@ -1500,8 +1478,7 @@ ActiveChatStream attachUnifiedChunkedStreaming({
       );
     }
 
-    applied =
-        applyAssistantServerPatch(
+    applied = applyAssistantServerPatch(
           targetId: assistantMessageId,
           buildPatch: (_) => _AssistantServerPatch(
             content: shouldAdoptContent && !isVisibleTarget ? content : null,
@@ -1509,8 +1486,8 @@ ActiveChatStream attachUnifiedChunkedStreaming({
             error: errorContent == null
                 ? null
                 : errorContent.isNotEmpty
-                ? ChatMessageError(content: errorContent)
-                : const ChatMessageError(content: null),
+                    ? ChatMessageError(content: errorContent)
+                    : const ChatMessageError(content: null),
           ),
         ) ||
         applied;
@@ -1609,14 +1586,14 @@ ActiveChatStream attachUnifiedChunkedStreaming({
           final nextStatusHistory = assistant.statusHistory.isNotEmpty
               ? assistant.statusHistory
               : current.isStreaming
-              ? current.statusHistory
-              : current.statusHistory
-                    .where((status) => status.done != false)
-                    .toList(growable: false);
+                  ? current.statusHistory
+                  : current.statusHistory
+                      .where((status) => status.done != false)
+                      .toList(growable: false);
           final nextSources =
               assistant.sources.isNotEmpty || !current.isStreaming
-              ? assistant.sources
-              : current.sources;
+                  ? assistant.sources
+                  : current.sources;
           return _AssistantServerPatch(
             followUps: nextFollowUps,
             statusHistory: nextStatusHistory,
@@ -1653,14 +1630,12 @@ ActiveChatStream attachUnifiedChunkedStreaming({
       return true;
     }
 
-    final hasNonTextTerminalArtifacts =
-        (last.files?.isNotEmpty ?? false) ||
+    final hasNonTextTerminalArtifacts = (last.files?.isNotEmpty ?? false) ||
         (last.output?.isNotEmpty ?? false) ||
         (last.embeds?.isNotEmpty ?? false) ||
         last.codeExecutions.isNotEmpty ||
         last.sources.isNotEmpty;
-    final hasTerminalState =
-        last.error != null ||
+    final hasTerminalState = last.error != null ||
         (allowContentOnlyTerminal &&
             (comparisonSnapshot.comparisonContent.trim().isNotEmpty ||
                 hasNonTextTerminalArtifacts));
@@ -1712,29 +1687,30 @@ ActiveChatStream attachUnifiedChunkedStreaming({
           final messages = getMessages();
           final stabilitySignature =
               messages.isEmpty || messages.last.role != 'assistant'
-              ? [
-                  result.content,
-                  result.followUps.join('\u001f'),
-                  result.errorContent ?? '',
-                ].join('\u0001')
-              : () {
-                  final comparisonSnapshot = readLocalMessageComparisonSnapshot(
-                    messages.last,
-                  );
-                  final last = comparisonSnapshot.message;
-                  return [
-                    result.content,
-                    result.followUps.join('\u001f'),
-                    result.errorContent ?? '',
-                    comparisonSnapshot.comparisonContent.trim(),
-                    last.error?.content?.trim() ?? '',
-                    last.followUps.join('\u001f'),
-                    '${last.files?.length ?? 0}/${last.output?.length ?? 0}/'
-                        '${last.embeds?.length ?? 0}/${last.codeExecutions.length}/'
-                        '${last.sources.length}',
-                    last.usage?.toString() ?? '',
-                  ].join('\u0001');
-                }();
+                  ? [
+                      result.content,
+                      result.followUps.join('\u001f'),
+                      result.errorContent ?? '',
+                    ].join('\u0001')
+                  : () {
+                      final comparisonSnapshot =
+                          readLocalMessageComparisonSnapshot(
+                        messages.last,
+                      );
+                      final last = comparisonSnapshot.message;
+                      return [
+                        result.content,
+                        result.followUps.join('\u001f'),
+                        result.errorContent ?? '',
+                        comparisonSnapshot.comparisonContent.trim(),
+                        last.error?.content?.trim() ?? '',
+                        last.followUps.join('\u001f'),
+                        '${last.files?.length ?? 0}/${last.output?.length ?? 0}/'
+                            '${last.embeds?.length ?? 0}/${last.codeExecutions.length}/'
+                            '${last.sources.length}',
+                        last.usage?.toString() ?? '',
+                      ].join('\u0001');
+                    }();
           if (stabilitySignature ==
               stableNonTerminalTerminalRecoverySignature) {
             stableNonTerminalTerminalRecoveryCount += 1;
@@ -1744,7 +1720,7 @@ ActiveChatStream attachUnifiedChunkedStreaming({
           }
           allowStableNonTerminalLocalFallback =
               stableNonTerminalTerminalRecoveryCount >=
-              debugTaskSocketStableNonTerminalRecoveryLimit;
+                  debugTaskSocketStableNonTerminalRecoveryLimit;
         } else {
           resetTerminalCompletionRecoveryStability();
         }
@@ -1759,23 +1735,23 @@ ActiveChatStream attachUnifiedChunkedStreaming({
       final messages = getMessages();
       final stabilitySignature =
           messages.isEmpty || messages.last.role != 'assistant'
-          ? 'poll-missing'
-          : () {
-              final comparisonSnapshot = readLocalMessageComparisonSnapshot(
-                messages.last,
-              );
-              final last = comparisonSnapshot.message;
-              return [
-                'poll-missing',
-                comparisonSnapshot.comparisonContent.trim(),
-                last.error?.content?.trim() ?? '',
-                last.followUps.join('\u001f'),
-                '${last.files?.length ?? 0}/${last.output?.length ?? 0}/'
-                    '${last.embeds?.length ?? 0}/${last.codeExecutions.length}/'
-                    '${last.sources.length}',
-                last.usage?.toString() ?? '',
-              ].join('\u0001');
-            }();
+              ? 'poll-missing'
+              : () {
+                  final comparisonSnapshot = readLocalMessageComparisonSnapshot(
+                    messages.last,
+                  );
+                  final last = comparisonSnapshot.message;
+                  return [
+                    'poll-missing',
+                    comparisonSnapshot.comparisonContent.trim(),
+                    last.error?.content?.trim() ?? '',
+                    last.followUps.join('\u001f'),
+                    '${last.files?.length ?? 0}/${last.output?.length ?? 0}/'
+                        '${last.embeds?.length ?? 0}/${last.codeExecutions.length}/'
+                        '${last.sources.length}',
+                    last.usage?.toString() ?? '',
+                  ].join('\u0001');
+                }();
       if (stabilitySignature == stableNonTerminalTerminalRecoverySignature) {
         stableNonTerminalTerminalRecoveryCount += 1;
       } else {
@@ -1784,13 +1760,12 @@ ActiveChatStream attachUnifiedChunkedStreaming({
       }
       allowStableNonTerminalLocalFallback =
           stableNonTerminalTerminalRecoveryCount >=
-          debugTaskSocketStableNonTerminalRecoveryLimit;
+              debugTaskSocketStableNonTerminalRecoveryLimit;
     } else if (pollFailedOrMissing) {
       resetTerminalCompletionRecoveryStability();
     }
 
-    final shouldAllowLocalContentFallback =
-        allowContentOnlyTerminal &&
+    final shouldAllowLocalContentFallback = allowContentOnlyTerminal &&
         (allowLocalContentFallbackAfterPollFailedOrMissing ||
             snapshotIndicatedDone ||
             allowLocalContentFallbackAfterNonTerminalSnapshot ||
@@ -1978,53 +1953,52 @@ ActiveChatStream attachUnifiedChunkedStreaming({
     unawaited(
       workerManager
           .schedule<String, List<Map<String, dynamic>>>(
-            _collectImageReferencesWorker,
-            content,
-            debugLabel: 'stream_collect_images',
-          )
+        _collectImageReferencesWorker,
+        content,
+        debugLabel: 'stream_collect_images',
+      )
           .then((collected) {
-            if (isObsoleteStream) {
-              return;
-            }
-            if (requestId != imageCollectionRequestId) {
-              return;
-            }
+        if (isObsoleteStream) {
+          return;
+        }
+        if (requestId != imageCollectionRequestId) {
+          return;
+        }
 
-            final currentMessages = getMessages();
-            if (currentMessages.isEmpty) {
-              return;
-            }
-            final last = currentMessages.last;
-            if (last.id != targetMessageId || last.role != 'assistant') {
-              return;
-            }
+        final currentMessages = getMessages();
+        if (currentMessages.isEmpty) {
+          return;
+        }
+        final last = currentMessages.last;
+        if (last.id != targetMessageId || last.role != 'assistant') {
+          return;
+        }
 
-            lastProcessedImageSignature = signature;
+        lastProcessedImageSignature = signature;
 
-            if (collected.isEmpty) {
-              return;
-            }
+        if (collected.isEmpty) {
+          return;
+        }
 
-            final existing = last.files ?? <Map<String, dynamic>>[];
-            final seen = <String>{
-              for (final f in existing)
-                if (f['url'] is String) (f['url'] as String) else '',
-            }..removeWhere((e) => e.isEmpty);
+        final existing = last.files ?? <Map<String, dynamic>>[];
+        final seen = <String>{
+          for (final f in existing)
+            if (f['url'] is String) (f['url'] as String) else '',
+        }..removeWhere((e) => e.isEmpty);
 
-            final merged = <Map<String, dynamic>>[...existing];
-            for (final f in collected) {
-              final url = f['url'] as String?;
-              if (url != null && url.isNotEmpty && !seen.contains(url)) {
-                merged.add({'type': 'image', 'url': url});
-                seen.add(url);
-              }
-            }
+        final merged = <Map<String, dynamic>>[...existing];
+        for (final f in collected) {
+          final url = f['url'] as String?;
+          if (url != null && url.isNotEmpty && !seen.contains(url)) {
+            merged.add({'type': 'image', 'url': url});
+            seen.add(url);
+          }
+        }
 
-            if (merged.length != existing.length) {
-              updateLastMessageWith((m) => m.copyWith(files: merged));
-            }
-          })
-          .catchError((_) {}),
+        if (merged.length != existing.length) {
+          updateLastMessageWith((m) => m.copyWith(files: merged));
+        }
+      }).catchError((_) {}),
     );
   }
 
@@ -2166,13 +2140,13 @@ ActiveChatStream attachUnifiedChunkedStreaming({
       ensureChatCompletedSynced()
           .then((_) => refreshConversationSnapshot())
           .catchError((Object error, StackTrace stackTrace) {
-            DebugLogger.error(
-              'post-completion-refresh-failed',
-              error: error,
-              stackTrace: stackTrace,
-              scope: 'chat/streaming',
-            );
-          }),
+        DebugLogger.error(
+          'post-completion-refresh-failed',
+          error: error,
+          stackTrace: stackTrace,
+          scope: 'chat/streaming',
+        );
+      }),
     );
   }
 
@@ -2192,7 +2166,7 @@ ActiveChatStream attachUnifiedChunkedStreaming({
           last.action != null && last.action == withTimestamp.action;
       final sameDescription =
           (withTimestamp.description?.isNotEmpty ?? false) &&
-          withTimestamp.description == last.description;
+              withTimestamp.description == last.description;
       if (sameAction && sameDescription) {
         final history = [...existing];
         history[history.length - 1] = withTimestamp;
@@ -2373,8 +2347,7 @@ ActiveChatStream attachUnifiedChunkedStreaming({
       final comparisonSnapshot = readLocalMessageComparisonSnapshot(msgs.last);
       final last = comparisonSnapshot.message;
       final lastContent = comparisonSnapshot.comparisonContent.trim();
-      final hasNonTextArtifacts =
-          (last.files?.isNotEmpty ?? false) ||
+      final hasNonTextArtifacts = (last.files?.isNotEmpty ?? false) ||
           (last.output?.isNotEmpty ?? false) ||
           (last.embeds?.isNotEmpty ?? false) ||
           last.codeExecutions.isNotEmpty ||
@@ -2573,15 +2546,15 @@ ActiveChatStream attachUnifiedChunkedStreaming({
           final normalizedSources = _normalizeSourcesPayload(rawSources);
           final parsedSources =
               normalizedSources == null || normalizedSources.isEmpty
-              ? const <ChatSourceReference>[]
-              : parseOpenWebUISourceList(normalizedSources);
+                  ? const <ChatSourceReference>[]
+                  : parseOpenWebUISourceList(normalizedSources);
           final metadataPatch =
               selectedModelId != null && selectedModelId.isNotEmpty
-              ? <String, dynamic>{
-                  'selectedModelId': selectedModelId,
-                  'arena': true,
-                }
-              : null;
+                  ? <String, dynamic>{
+                      'selectedModelId': selectedModelId,
+                      'arena': true,
+                    }
+                  : null;
           if (completionTargetId != null &&
               (normalizedOutputItems.isNotEmpty ||
                   metadataPatch != null ||
@@ -2633,9 +2606,8 @@ ActiveChatStream attachUnifiedChunkedStreaming({
             if (choices is List && choices.isNotEmpty) {
               final choice = choices.first;
               final delta = choice is Map ? choice['delta'] : null;
-              final finishReason = choice is Map
-                  ? choice['finish_reason']?.toString()
-                  : null;
+              final finishReason =
+                  choice is Map ? choice['finish_reason']?.toString() : null;
               if (isTerminalFinishReason(finishReason)) {
                 terminalFinishReason = finishReason;
               }
@@ -2670,14 +2642,25 @@ ActiveChatStream attachUnifiedChunkedStreaming({
             if (raw.isNotEmpty) {
               replaceVisibleAssistantContent(raw);
             }
+          } else if (completionTargetId != null &&
+              normalizedOutputItems.isNotEmpty &&
+              !payload.containsKey('choices')) {
+            // Newer Open WebUI servers emit the structured `output` list instead
+            // of a pre-serialized `content` string on `chat:completion` deltas.
+            // Serialize it client-side so assistant text, reasoning, and tool
+            // blocks render. These are full snapshots (not incremental
+            // deltas), so replace rather than append.
+            final serialized = serializeOpenWebUIOutput(normalizedOutputItems);
+            if (serialized.isNotEmpty) {
+              replaceVisibleAssistantContent(serialized);
+            }
           }
           if (terminalFinishReason != null && !hasFinished) {
             flushStreamingBuffer();
             final msgs = getMessages();
             if (msgs.isNotEmpty && msgs.last.role == 'assistant') {
               final last = msgs.last;
-              final hasTerminalContent =
-                  last.content.trim().isNotEmpty ||
+              final hasTerminalContent = last.content.trim().isNotEmpty ||
                   last.error != null ||
                   (last.files?.isNotEmpty ?? false) ||
                   last.codeExecutions.isNotEmpty ||
@@ -2787,12 +2770,10 @@ ActiveChatStream attachUnifiedChunkedStreaming({
             // entire local chat history back here because the local buffer may
             // still be incomplete for large persisted conversations.
           } else {
-            final isForeignSession =
-                incomingSessionId != null &&
+            final isForeignSession = incomingSessionId != null &&
                 incomingSessionId.isNotEmpty &&
                 !matchesCurrentStreamSession(incomingSessionId);
-            final isUnexpectedMessage =
-                messageId != null &&
+            final isUnexpectedMessage = messageId != null &&
                 messageId.isNotEmpty &&
                 messageId != assistantMessageId &&
                 messageId != boundRemoteMessageId;
@@ -3413,21 +3394,19 @@ ActiveChatStream attachUnifiedChunkedStreaming({
 
       // If there's a byteStream from the HTTP response, forward it.
       if (session.byteStream != null) {
-        httpSubscription = session.byteStream!
-            .transform(utf8.decoder)
-            .listen(
-              (data) => pc.add(data),
-              onDone: () {
-                DebugLogger.stream(
-                  'taskSocket HTTP stream completed '
-                  '- WebSocket handles content delivery',
-                );
-                if (!pc.isClosed) {
-                  pc.close();
-                }
-              },
-              onError: pc.addError,
+        httpSubscription = session.byteStream!.transform(utf8.decoder).listen(
+          (data) => pc.add(data),
+          onDone: () {
+            DebugLogger.stream(
+              'taskSocket HTTP stream completed '
+              '- WebSocket handles content delivery',
             );
+            if (!pc.isClosed) {
+              pc.close();
+            }
+          },
+          onError: pc.addError,
+        );
       } else {
         // No byte stream to forward — close the controller immediately so
         // the StreamingResponseController treats the HTTP side as complete.
@@ -3513,8 +3492,7 @@ ActiveChatStream attachUnifiedChunkedStreaming({
           );
 
           final errorText = error.toString();
-          final isRecoverable =
-              error is! FormatException &&
+          final isRecoverable = error is! FormatException &&
               (errorText.contains('SocketException') ||
                   errorText.contains('TimeoutException') ||
                   errorText.contains('HandshakeException'));
@@ -3594,17 +3572,17 @@ ActiveChatStream attachUnifiedChunkedStreaming({
           final selectedModelId = payload['selected_model_id']?.toString();
           final metadataPatch =
               selectedModelId != null && selectedModelId.isNotEmpty
-              ? <String, dynamic>{
-                  'selectedModelId': selectedModelId,
-                  'arena': true,
-                }
-              : null;
+                  ? <String, dynamic>{
+                      'selectedModelId': selectedModelId,
+                      'arena': true,
+                    }
+                  : null;
           final rawSources = payload['sources'] ?? payload['citations'];
           final normalizedSources = _normalizeSourcesPayload(rawSources);
           final parsedSources =
               normalizedSources == null || normalizedSources.isEmpty
-              ? const <ChatSourceReference>[]
-              : parseOpenWebUISourceList(normalizedSources);
+                  ? const <ChatSourceReference>[]
+                  : parseOpenWebUISourceList(normalizedSources);
           if (usagePatch != null ||
               normalizedOutputItems.isNotEmpty ||
               metadataPatch != null ||
@@ -3874,9 +3852,8 @@ Future<String?> _showInputDialog(Map<String, dynamic> data) async {
             AdaptiveTextField(
               controller: controller,
               autofocus: true,
-              placeholder: placeholder.isNotEmpty
-                  ? placeholder
-                  : 'Enter a value',
+              placeholder:
+                  placeholder.isNotEmpty ? placeholder : 'Enter a value',
               onSubmitted: (value) {
                 Navigator.of(
                   dialogCtx,

--- a/test/core/services/conversation_parsing_test.dart
+++ b/test/core/services/conversation_parsing_test.dart
@@ -639,6 +639,48 @@ void main() {
         check(content).contains('<details type="reasoning" done="true"');
         check(content).contains('Final answer');
       });
+
+      test(
+        'derives content from output on the history-backed reload path',
+        () {
+          // Reloaded conversations source messages from
+          // `chat.history.messages` (a Map keyed by id) following the
+          // `currentId` parent chain. Responses-API models persist `output`
+          // with an empty `content` there too, so the fallback must fire on
+          // this path (the actual leave-and-return scenario).
+          final result = parseFullConversation({
+            'id': 'conv-1',
+            'title': 'Reloaded',
+            'chat': {
+              'history': {
+                'currentId': 'msg-1',
+                'messages': {
+                  'msg-1': {
+                    'id': 'msg-1',
+                    'role': 'assistant',
+                    'content': '',
+                    'output': [
+                      {
+                        'type': 'message',
+                        'role': 'assistant',
+                        'content': [
+                          {'type': 'output_text', 'text': 'Reloaded output'},
+                        ],
+                      },
+                    ],
+                    'timestamp': 1700000000,
+                  },
+                },
+              },
+            },
+          });
+
+          final messages = result['messages'] as List<Map<String, dynamic>>;
+          check(messages).has((it) => it.length, 'length').equals(1);
+          check(messages.first['content']).equals('Reloaded output');
+          check(messages.first['output']).isNotNull();
+        },
+      );
     });
 
     group('empty or missing data', () {

--- a/test/core/services/conversation_parsing_test.dart
+++ b/test/core/services/conversation_parsing_test.dart
@@ -549,6 +549,98 @@ void main() {
       });
     });
 
+    group('Responses API output fallback', () {
+      test('derives content from output when content is empty', () {
+        final result = parseFullConversation({
+          'chat': {
+            'messages': [
+              {
+                'id': 'msg-1',
+                'role': 'assistant',
+                'content': '',
+                'output': [
+                  {
+                    'type': 'message',
+                    'role': 'assistant',
+                    'content': [
+                      {'type': 'output_text', 'text': 'Hello from output'},
+                    ],
+                  },
+                ],
+                'timestamp': 1700000000,
+              },
+            ],
+          },
+        });
+
+        final messages = result['messages'] as List<Map<String, dynamic>>;
+        check(messages.first['content']).equals('Hello from output');
+        check(messages.first['output']).isNotNull();
+      });
+
+      test('keeps existing content when populated', () {
+        final result = parseFullConversation({
+          'chat': {
+            'messages': [
+              {
+                'id': 'msg-1',
+                'role': 'assistant',
+                'content': 'Existing content',
+                'output': [
+                  {
+                    'type': 'message',
+                    'content': [
+                      {'type': 'output_text', 'text': 'should not win'},
+                    ],
+                  },
+                ],
+                'timestamp': 1700000000,
+              },
+            ],
+          },
+        });
+
+        final messages = result['messages'] as List<Map<String, dynamic>>;
+        check(messages.first['content']).equals('Existing content');
+      });
+
+      test('derives reasoning and message text from output', () {
+        final result = parseFullConversation({
+          'chat': {
+            'messages': [
+              {
+                'id': 'msg-1',
+                'role': 'assistant',
+                'content': '',
+                'output': [
+                  {
+                    'type': 'reasoning',
+                    'summary': [
+                      {'type': 'summary_text', 'text': 'Thinking hard'},
+                    ],
+                    'duration': 2,
+                    'status': 'completed',
+                  },
+                  {
+                    'type': 'message',
+                    'content': [
+                      {'type': 'output_text', 'text': 'Final answer'},
+                    ],
+                  },
+                ],
+                'timestamp': 1700000000,
+              },
+            ],
+          },
+        });
+
+        final messages = result['messages'] as List<Map<String, dynamic>>;
+        final content = messages.first['content'] as String;
+        check(content).contains('<details type="reasoning" done="true"');
+        check(content).contains('Final answer');
+      });
+    });
+
     group('empty or missing data', () {
       test('empty chatData returns minimal structure', () {
         final result = parseFullConversation({});

--- a/test/core/services/openwebui_stream_parser_test.dart
+++ b/test/core/services/openwebui_stream_parser_test.dart
@@ -69,9 +69,9 @@ void main() {
         Stream<List<int>>.fromIterable([
           utf8.encode(
             'data: ${jsonEncode({
-              'type': 'error',
-              'error': {'message': 'boom'},
-            })}\n\n',
+                  'type': 'error',
+                  'error': {'message': 'boom'},
+                })}\n\n',
           ),
         ]),
       ).toList();
@@ -111,14 +111,11 @@ void main() {
           .isA<OpenWebUIEventUpdate>()
           .has((u) => u.type, 'type')
           .equals('citation');
-      check(updates[0])
-          .isA<OpenWebUIEventUpdate>()
-          .has((u) {
-            final data = u.data as Map<String, dynamic>;
-            final source = data['source'] as Map<String, dynamic>;
-            return source['name'];
-          }, 'source.name')
-          .equals('Example Title');
+      check(updates[0]).isA<OpenWebUIEventUpdate>().has((u) {
+        final data = u.data as Map<String, dynamic>;
+        final source = data['source'] as Map<String, dynamic>;
+        return source['name'];
+      }, 'source.name').equals('Example Title');
       check(
         updates[1],
       ).isA<OpenWebUIEventUpdate>().has((u) => u.type, 'type').equals('status');
@@ -128,13 +125,17 @@ void main() {
       final updates = await parseOpenWebUIStream(
         Stream<List<int>>.fromIterable([
           utf8.encode(
-            'data: ${jsonEncode({'type': 'status', 'description': 'Searching', 'done': false})}\n\n',
+            'data: ${jsonEncode({
+                  'type': 'status',
+                  'description': 'Searching',
+                  'done': false
+                })}\n\n',
           ),
           utf8.encode(
             'data: ${jsonEncode({
-              'type': 'citation',
-              'source': {'name': 'Example Title'},
-            })}\n\n',
+                  'type': 'citation',
+                  'source': {'name': 'Example Title'},
+                })}\n\n',
           ),
         ]),
       ).toList();
@@ -147,14 +148,11 @@ void main() {
             'description',
           )
           .equals('Searching');
-      check(updates[1])
-          .isA<OpenWebUIEventUpdate>()
-          .has((u) {
-            final data = u.data as Map<String, dynamic>;
-            final source = data['source'] as Map<String, dynamic>;
-            return source['name'];
-          }, 'source.name')
-          .equals('Example Title');
+      check(updates[1]).isA<OpenWebUIEventUpdate>().has((u) {
+        final data = u.data as Map<String, dynamic>;
+        final source = data['source'] as Map<String, dynamic>;
+        return source['name'];
+      }, 'source.name').equals('Example Title');
     });
 
     test(
@@ -367,6 +365,84 @@ void main() {
           .isA<OpenWebUIContentDelta>()
           .has((u) => u.content, 'content')
           .equals('say');
+    });
+  });
+
+  group('serializeOpenWebUIOutput', () {
+    test('renders message output_text as visible content', () {
+      final result = serializeOpenWebUIOutput([
+        {
+          'type': 'message',
+          'role': 'assistant',
+          'content': [
+            {'type': 'output_text', 'text': 'Hello world'},
+          ],
+        },
+      ]);
+      check(result).equals('Hello world');
+    });
+
+    test('renders reasoning as a done details block', () {
+      final result = serializeOpenWebUIOutput([
+        {
+          'type': 'reasoning',
+          'summary': [
+            {'type': 'summary_text', 'text': 'Because 2+2=4'},
+          ],
+          'duration': 3,
+          'status': 'completed',
+        },
+        {
+          'type': 'message',
+          'content': [
+            {'type': 'output_text', 'text': '4'},
+          ],
+        },
+      ]);
+      check(result)
+          .contains('<details type="reasoning" done="true" duration="3">');
+      check(result).contains('Thought for 3 seconds');
+      check(result).contains('&gt; Because 2+2=4');
+      check(result).endsWith('4');
+    });
+
+    test('pairs function_call with function_call_output by call_id', () {
+      final result = serializeOpenWebUIOutput([
+        {
+          'type': 'function_call',
+          'call_id': 'call_1',
+          'name': 'get_weather',
+          'arguments': '{"city":"Tampa"}',
+        },
+        {
+          'type': 'function_call_output',
+          'call_id': 'call_1',
+          'output': [
+            {'text': 'Sunny, 90F'},
+          ],
+        },
+      ]);
+      check(result).contains('<details type="tool_calls" done="true"');
+      check(result).contains('name="get_weather"');
+      check(result).contains('Tool Executed');
+      check(result).contains('Sunny, 90F');
+    });
+
+    test('renders pending function_call without output', () {
+      final result = serializeOpenWebUIOutput([
+        {
+          'type': 'function_call',
+          'call_id': 'call_2',
+          'name': 'search',
+          'arguments': '{}',
+        },
+      ]);
+      check(result).contains('<details type="tool_calls" done="false"');
+      check(result).contains('Executing...');
+    });
+
+    test('returns empty string for empty output', () {
+      check(serializeOpenWebUIOutput(const [])).equals('');
     });
   });
 }

--- a/test/core/services/streaming_helper_transport_test.dart
+++ b/test/core/services/streaming_helper_transport_test.dart
@@ -822,6 +822,9 @@ void main() {
         check(log.messageByIdMutationCount).equals(1);
         check(log.sourceReferences).isEmpty();
         check(lastMessage.output).has((it) => it?.length, 'length').equals(1);
+        // Newer Open WebUI servers emit `output` without a `content` string;
+        // the helper must serialize the output so the assistant text renders.
+        check(lastMessage.content).equals('Structured output');
         check(lastMessage.metadata).isNotNull();
         check(lastMessage.metadata!['selectedModelId']).equals('gpt-4o');
         check(lastMessage.metadata!['arena']).equals(true);


### PR DESCRIPTION
## Summary

Recent Open WebUI server update changed `chat:completion` socket deltas from `{content: serialize_output(...)}` (a pre-serialized HTML string) to `{output: full_output()}` (a structured list of items with no `content` field). Conduit stored `output` to message metadata but never serialized it to visible text, so:

1. **Live streaming** responses stopped appearing in chat.
2. **Leave and return** to a chat showed blank agent messages (server persists the same output-only shape).

## Changes

- **`lib/core/services/openwebui_stream_parser.dart`** — added `serializeOpenWebUIOutput(List<Map<String, dynamic>> output)`, mirroring upstream `serialize_output`: message text, reasoning `<details>` blocks (matching Conduit's existing `_buildStreamingReasoningDetails` shape so reasoning parsers keep working), `function_call`/`function_call_output` pairing by `call_id`, and `code_interpreter` blocks.
- **`lib/core/services/streaming_helper.dart`** — in the `chat:completion` socket handler, when the payload has `output` but no `content`/`choices`, `replaceVisibleAssistantContent` with the serialized output. Replace (not append) because new deltas are full snapshots, same semantics as the old `content` path.
- **`lib/core/services/conversation_parsing.dart`** — in `_parseOpenWebUIMessageToJson` (server→ChatMessage hydration on reload), derive `content` from the persisted `output` list when `content` is empty (Responses-API models store only `output` server-side) and preserve `output` on the returned map for parity with the live streaming path.

## Root cause reference

Diffing the vendored `openwebui-src` submodule (HEAD `02dc3e68`, 2026-06-01) against upstream `dev` showed `backend/open_webui/utils/middleware.py` now emits `chat:completion` deltas as `{output: full_output()}` and only sets `assistant_message['content']` for legacy Chat Completions deltas (line 2937), not Responses-API models. The server's `content = serialize_output(output)` rederive only fires on explicit `update_chat_by_id`, not on the streaming-completion save path.

## Tests

- `flutter test test/core/services/openwebui_stream_parser_test.dart` — 22 pass (5 new serializer tests)
- `flutter test test/core/services/streaming_helper_transport_test.dart` — 56 pass (updated `batches output` test asserts `content == 'Structured output'`)
- `flutter test test/core/services/conversation_parsing_test.dart` — 38 pass (3 new reload-from-output tests)
- `flutter analyze` (changed files) — no issues
- Verified on Pixel 10 Pro XL against an updated Open WebUI server: live streaming and leave-and-return reload both render.

## Checklist

- [x] `flutter pub get` + `dart run build_runner build`
- [x] `flutter test` (targeted suites, 428+ tests green)
- [x] `flutter analyze` (changed files, 0 issues)
- [x] No raw `print` calls (uses existing `DebugLogger` conventions)
- [x] Tests use `package:checks` / `flutter_test` per AGENTS.md

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Render Open WebUI structured `output` in assistant messages during streaming and reload
> - Adds `serializeOpenWebUIOutput` in [`openwebui_stream_parser.dart`](https://github.com/cogwheel0/conduit/pull/539/files#diff-d4d4ad50ccdefe56dc2118bdba22065a69eda416e3736fc22c650c26c8d4d4e6) to convert Responses-API structured `output` items (text, reasoning, tool calls, code interpreter) into an HTML string.
> - Updates [`streaming_helper.dart`](https://github.com/cogwheel0/conduit/pull/539/files#diff-798cd51b9c90e33f1996e46793ed52481d6afe68244655a6660e89a28ff823dc) to call `serializeOpenWebUIOutput` during live streaming when OpenWebUI sends `output` snapshots without a `content` field.
> - Updates [`conversation_parsing.dart`](https://github.com/cogwheel0/conduit/pull/539/files#diff-e4db13e41feb6c15316d833b71d038f0182d0987e989f879f595072bc7ff3a08) to derive visible content from `output` when `contentString` is empty, so reloaded messages also render correctly.
> - Adds test coverage in the `conversation_parsing`, `openwebui_stream_parser`, and `streaming_helper` test suites for the new serialization and fallback paths.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 62d292c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved support for Open WebUI Responses/API messages by rendering structured assistant output as visible text, including reasoning, tool calls, and final answers.
  * Added richer handling for streamed assistant updates so structured output can appear correctly even when plain text content is missing.

* **Bug Fixes**
  * Fixed cases where assistant messages could appear blank despite containing valid structured output.
  * Preserved existing visible message content when it is already present.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR renders Open WebUI structured output in chat. The main changes are:

- Adds serialization for message, reasoning, tool call, and code-interpreter output items.
- Uses serialized output for live `chat:completion` updates without plain `content`.
- Rebuilds visible content from persisted `output` when reloading empty assistant messages.
- Adds targeted tests for streaming, reload, and serializer behavior.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The changes are focused on Open WebUI structured-output rendering and are covered by targeted parser, streaming, and reload tests.

No code issues were identified in the reviewed changes, and the implementation includes tests for the key live-streaming and persisted-message scenarios described by the patch.
</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran the OpenWebUI serializer test; the before-run log showed base could not resolve serializeOpenWebUIOutput and exit code 254, and the after-run log showed exit code 0 with serialized content for all four scenarios, including reasoning details, paired tool\_calls, and code\_interpreter blocks.
- Attempted the Flutter/Dart-based tests for the base and head states, but the environment lacked a Flutter runtime, so commands exited with code 127 and no visible assistant content.
- Attempted the reload-output tests for base and head paths; both ran into the same environment blocker and exited with code 127.

<a href="https://app.greptile.com/trex/runs/12732245/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=1"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=1" height="32"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (2): Last reviewed commit: ["test(parsing): cover history-backed relo..."](https://github.com/cogwheel0/conduit/commit/62d292cbf45e57fc8848f5b31fc223a761c23218) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40720438)</sub>

<!-- /greptile_comment -->