### PR TITLE
Fix streaming body strobing between content and loading skeleton (#540)

### DIFF
--- a/lib/shared/widgets/markdown/markdown_document_controller.dart
+++ b/lib/shared/widgets/markdown/markdown_document_controller.dart
@@ -204,6 +204,22 @@ class MarkdownDocumentController {
     _invalidatePendingAsyncDocument();
   }
 
+  /// Immediately drops the rendered document (without re-resolving) so a stale
+  /// scope's content stops painting on the very next frame. Used when a scope
+  /// change's recompile is deferred: merely arming a pending clear would let the
+  /// old document paint for one frame under the new scope before the deferred
+  /// refresh lands (#541). The deferred refresh then compiles the new content.
+  void clearDocument() {
+    // Always cancel any in-flight/queued async resolve first, so a stale compile
+    // started under the previous scope can't land after the clear — even when
+    // there is no rendered document to drop yet.
+    _invalidatePendingAsyncDocument();
+    if (_compiledDocument == null) {
+      return;
+    }
+    _setState(_compiledPreparedContent, null);
+  }
+
   void dispose() {
     _disposed = true;
     _queuedRequest = null;

--- a/lib/shared/widgets/markdown/markdown_document_controller.dart
+++ b/lib/shared/widgets/markdown/markdown_document_controller.dart
@@ -139,7 +139,10 @@ class MarkdownDocumentController {
     unawaited(_refreshCompiledDocument(request));
   }
 
-  void resolveStreamingPrepared(String preparedContent) {
+  void resolveStreamingPrepared(
+    String preparedContent, {
+    bool clearDocumentWhenAsync = false,
+  }) {
     final preparedChanged =
         _requestedPreparedContent != preparedContent ||
         _requestedResolveMode != _MarkdownResolveMode.streamingIncremental;
@@ -179,6 +182,10 @@ class MarkdownDocumentController {
       );
       _setState(preparedContent, syncDocument);
       return;
+    }
+
+    if (clearDocumentWhenAsync && preparedChanged) {
+      _setState(_compiledPreparedContent, null);
     }
 
     final request = _MarkdownResolveRequest(

--- a/lib/shared/widgets/markdown/streaming_markdown_widget.dart
+++ b/lib/shared/widgets/markdown/streaming_markdown_widget.dart
@@ -129,6 +129,10 @@ class _StreamingMarkdownWidgetState
   bool _snapshotInFlight = false;
   bool _streamingRefreshFrameScheduled = false;
   String? _pendingStreamingContent;
+  // Set when a scope change (new message/version) arrives on the deferred
+  // streaming path, so the first async refresh clears the previous scope's
+  // stale document instead of showing it under the new scope (issue #541).
+  bool _pendingClearStaleDocument = false;
   String? _selectedText;
   int _snapshotGeneration = 0;
   bool _isAppForeground = true;
@@ -208,10 +212,19 @@ class _StreamingMarkdownWidgetState
         widget.debugOnStreamingRefreshFrame?.call();
       }
       _invalidatePendingAsyncSnapshot();
-      _applyPreparedSnapshotIfNeeded(preparedContent);
+      _applyPreparedSnapshotIfNeeded(
+        preparedContent,
+        clearStaleDocument: scopeChanged,
+      );
       return;
     }
 
+    // Deferred streaming path: the body needs an async compile, so a scope
+    // change must clear the previous scope's document when that refresh lands
+    // (the sync paths above replace the document directly and don't need it).
+    if (scopeChanged) {
+      _pendingClearStaleDocument = true;
+    }
     _markPendingStreamingContent(widget.content);
     _scheduleStreamingRefresh();
   }
@@ -262,6 +275,10 @@ class _StreamingMarkdownWidgetState
     _debugStreamingDelayTimer?.cancel();
     _debugStreamingDelayTimer = null;
     _pendingStreamingContent = null;
+    // The sync/non-streaming callers that invalidate the async pipeline handle
+    // their own scope-change clear, so drop any pending deferred clear to keep
+    // it from leaking onto a later, unrelated refresh.
+    _pendingClearStaleDocument = false;
     _snapshotGeneration += 1;
     _documentController.invalidatePending();
   }
@@ -313,6 +330,11 @@ class _StreamingMarkdownWidgetState
 
     _snapshotInFlight = true;
     final generation = _snapshotGeneration;
+    // Consume any pending scope-change clear so only this first refresh after the
+    // scope change discards the previous scope's document; later refreshes (same
+    // scope, growing content) must keep it (issue #540).
+    final clearStaleDocument = _pendingClearStaleDocument;
+    _pendingClearStaleDocument = false;
     try {
       final compiler = ref.read(markdownCompileServiceProvider);
       if (compiler.shouldPrepareSynchronously(
@@ -323,7 +345,10 @@ class _StreamingMarkdownWidgetState
           content,
           streaming: true,
         );
-        _applyPreparedSnapshotIfNeeded(synchronousPrepared);
+        _applyPreparedSnapshotIfNeeded(
+          synchronousPrepared,
+          clearStaleDocument: clearStaleDocument,
+        );
         return;
       }
       final preparedContent = await compiler.prepareContent(
@@ -333,13 +358,17 @@ class _StreamingMarkdownWidgetState
       if (!mounted || generation != _snapshotGeneration) {
         return;
       }
-      _applyPreparedSnapshotIfNeeded(preparedContent);
+      _applyPreparedSnapshotIfNeeded(
+        preparedContent,
+        clearStaleDocument: clearStaleDocument,
+      );
     } catch (_) {
       if (!mounted || generation != _snapshotGeneration) {
         return;
       }
       _applyPreparedSnapshotIfNeeded(
         prepareMarkdownContent(content, streaming: true),
+        clearStaleDocument: clearStaleDocument,
       );
     } finally {
       _snapshotInFlight = false;
@@ -484,7 +513,10 @@ class _StreamingMarkdownWidgetState
     bool clearStaleDocument = false,
   }) {
     if (widget.isStreaming) {
-      _documentController.resolveStreamingPrepared(snapshot.normalizedContent);
+      _documentController.resolveStreamingPrepared(
+        snapshot.normalizedContent,
+        clearDocumentWhenAsync: clearStaleDocument,
+      );
       return;
     }
     _documentController.resolvePrepared(

--- a/lib/shared/widgets/markdown/streaming_markdown_widget.dart
+++ b/lib/shared/widgets/markdown/streaming_markdown_widget.dart
@@ -168,11 +168,12 @@ class _StreamingMarkdownWidgetState
   @override
   void didUpdateWidget(covariant StreamingMarkdownWidget oldWidget) {
     super.didUpdateWidget(oldWidget);
+    final scopeChanged = widget.stateScopeId != oldWidget.stateScopeId;
     if (!identical(widget.sources, oldWidget.sources) ||
         widget.onSourceTap != oldWidget.onSourceTap ||
         widget.onTapLink != oldWidget.onTapLink ||
         widget.imageBuilderOverride != oldWidget.imageBuilderOverride ||
-        widget.stateScopeId != oldWidget.stateScopeId) {
+        scopeChanged) {
       setState(() {});
     }
     if (widget.content == oldWidget.content &&
@@ -184,6 +185,11 @@ class _StreamingMarkdownWidgetState
       _invalidatePendingAsyncSnapshot();
       _applyPreparedSnapshotIfNeeded(
         prepareMarkdownContent(widget.content, streaming: false),
+        // A scope change means a new message/version, not a continuation of the
+        // current content. Clear the stale document so the previous scope's
+        // content isn't shown while the new body compiles (the skeleton covers
+        // the gap instead). Same-scope growth keeps its document (issue #540).
+        clearStaleDocument: scopeChanged,
       );
       return;
     }
@@ -346,22 +352,34 @@ class _StreamingMarkdownWidgetState
     }
   }
 
-  void _applySnapshot(_MarkdownRenderSnapshot nextSnapshot) {
+  void _applySnapshot(
+    _MarkdownRenderSnapshot nextSnapshot, {
+    bool clearStaleDocument = false,
+  }) {
     final changed = _snapshot != nextSnapshot;
     if (!changed) {
       if (_compiledDocument == null ||
           _compiledPreparedContent != nextSnapshot.normalizedContent) {
-        _resolveCompiledDocument(nextSnapshot);
+        _resolveCompiledDocument(
+          nextSnapshot,
+          clearStaleDocument: clearStaleDocument,
+        );
       }
       return;
     }
     if (!mounted) {
       _snapshot = nextSnapshot;
-      _resolveCompiledDocument(nextSnapshot);
+      _resolveCompiledDocument(
+        nextSnapshot,
+        clearStaleDocument: clearStaleDocument,
+      );
       return;
     }
     setState(() => _snapshot = nextSnapshot);
-    _resolveCompiledDocument(nextSnapshot);
+    _resolveCompiledDocument(
+      nextSnapshot,
+      clearStaleDocument: clearStaleDocument,
+    );
   }
 
   /// Adapts the legacy [imageBuilderOverride] callback
@@ -458,12 +476,18 @@ class _StreamingMarkdownWidgetState
     );
   }
 
-  void _resolveCompiledDocument(_MarkdownRenderSnapshot snapshot) {
+  void _resolveCompiledDocument(
+    _MarkdownRenderSnapshot snapshot, {
+    bool clearStaleDocument = false,
+  }) {
     if (widget.isStreaming) {
       _documentController.resolveStreamingPrepared(snapshot.normalizedContent);
       return;
     }
-    _documentController.resolvePrepared(snapshot.normalizedContent);
+    _documentController.resolvePrepared(
+      snapshot.normalizedContent,
+      clearDocumentWhenAsync: clearStaleDocument,
+    );
   }
 
   bool _needsPreparedSnapshotUpdate(String preparedContent) {
@@ -474,11 +498,17 @@ class _StreamingMarkdownWidgetState
         _compiledPreparedContent != preparedContent;
   }
 
-  void _applyPreparedSnapshotIfNeeded(String preparedContent) {
+  void _applyPreparedSnapshotIfNeeded(
+    String preparedContent, {
+    bool clearStaleDocument = false,
+  }) {
     if (!_needsPreparedSnapshotUpdate(preparedContent)) {
       return;
     }
-    _applySnapshot(_MarkdownRenderSnapshot.full(preparedContent));
+    _applySnapshot(
+      _MarkdownRenderSnapshot.full(preparedContent),
+      clearStaleDocument: clearStaleDocument,
+    );
   }
 
   bool get _canActivelyRefreshStreamingMarkdown =>

--- a/lib/shared/widgets/markdown/streaming_markdown_widget.dart
+++ b/lib/shared/widgets/markdown/streaming_markdown_widget.dart
@@ -129,10 +129,6 @@ class _StreamingMarkdownWidgetState
   bool _snapshotInFlight = false;
   bool _streamingRefreshFrameScheduled = false;
   String? _pendingStreamingContent;
-  // Set when a scope change (new message/version) arrives on the deferred
-  // streaming path, so the first async refresh clears the previous scope's
-  // stale document instead of showing it under the new scope (issue #541).
-  bool _pendingClearStaleDocument = false;
   String? _selectedText;
   int _snapshotGeneration = 0;
   bool _isAppForeground = true;
@@ -219,11 +215,14 @@ class _StreamingMarkdownWidgetState
       return;
     }
 
-    // Deferred streaming path: the body needs an async compile, so a scope
-    // change must clear the previous scope's document when that refresh lands
-    // (the sync paths above replace the document directly and don't need it).
+    // Deferred streaming path: the body needs an async compile, so the new
+    // document won't be ready this frame. On a scope change, clear the previous
+    // scope's document now — deferring the clear to the scheduled refresh would
+    // let the old document paint for one frame under the new scope (#541). The
+    // scheduled refresh below then compiles the new content. (The sync paths
+    // above clear/replace the document synchronously and don't need this.)
     if (scopeChanged) {
-      _pendingClearStaleDocument = true;
+      _documentController.clearDocument();
     }
     _markPendingStreamingContent(widget.content);
     _scheduleStreamingRefresh();
@@ -275,10 +274,6 @@ class _StreamingMarkdownWidgetState
     _debugStreamingDelayTimer?.cancel();
     _debugStreamingDelayTimer = null;
     _pendingStreamingContent = null;
-    // The sync/non-streaming callers that invalidate the async pipeline handle
-    // their own scope-change clear, so drop any pending deferred clear to keep
-    // it from leaking onto a later, unrelated refresh.
-    _pendingClearStaleDocument = false;
     _snapshotGeneration += 1;
     _documentController.invalidatePending();
   }
@@ -330,11 +325,6 @@ class _StreamingMarkdownWidgetState
 
     _snapshotInFlight = true;
     final generation = _snapshotGeneration;
-    // Consume any pending scope-change clear so only this first refresh after the
-    // scope change discards the previous scope's document; later refreshes (same
-    // scope, growing content) must keep it (issue #540).
-    final clearStaleDocument = _pendingClearStaleDocument;
-    _pendingClearStaleDocument = false;
     try {
       final compiler = ref.read(markdownCompileServiceProvider);
       if (compiler.shouldPrepareSynchronously(
@@ -345,10 +335,7 @@ class _StreamingMarkdownWidgetState
           content,
           streaming: true,
         );
-        _applyPreparedSnapshotIfNeeded(
-          synchronousPrepared,
-          clearStaleDocument: clearStaleDocument,
-        );
+        _applyPreparedSnapshotIfNeeded(synchronousPrepared);
         return;
       }
       final preparedContent = await compiler.prepareContent(
@@ -358,17 +345,13 @@ class _StreamingMarkdownWidgetState
       if (!mounted || generation != _snapshotGeneration) {
         return;
       }
-      _applyPreparedSnapshotIfNeeded(
-        preparedContent,
-        clearStaleDocument: clearStaleDocument,
-      );
+      _applyPreparedSnapshotIfNeeded(preparedContent);
     } catch (_) {
       if (!mounted || generation != _snapshotGeneration) {
         return;
       }
       _applyPreparedSnapshotIfNeeded(
         prepareMarkdownContent(content, streaming: true),
-        clearStaleDocument: clearStaleDocument,
       );
     } finally {
       _snapshotInFlight = false;

--- a/lib/shared/widgets/markdown/streaming_markdown_widget.dart
+++ b/lib/shared/widgets/markdown/streaming_markdown_widget.dart
@@ -125,7 +125,6 @@ class _StreamingMarkdownWidgetState
   late final MarkdownDocumentController _documentController;
   final GlobalKey _markdownContentKey = GlobalKey();
   _MarkdownRenderSnapshot _snapshot = const _MarkdownRenderSnapshot.empty();
-  bool _preserveStaleCompiledDocumentUntilFreshFinal = false;
   Timer? _debugStreamingDelayTimer;
   bool _snapshotInFlight = false;
   bool _streamingRefreshFrameScheduled = false;
@@ -169,12 +168,6 @@ class _StreamingMarkdownWidgetState
   @override
   void didUpdateWidget(covariant StreamingMarkdownWidget oldWidget) {
     super.didUpdateWidget(oldWidget);
-    if (oldWidget.isStreaming && !widget.isStreaming) {
-      _preserveStaleCompiledDocumentUntilFreshFinal = true;
-    } else if (widget.isStreaming ||
-        widget.stateScopeId != oldWidget.stateScopeId) {
-      _preserveStaleCompiledDocumentUntilFreshFinal = false;
-    }
     if (!identical(widget.sources, oldWidget.sources) ||
         widget.onSourceTap != oldWidget.onSourceTap ||
         widget.onTapLink != oldWidget.onTapLink ||
@@ -407,11 +400,12 @@ class _StreamingMarkdownWidgetState
     if (compiledDocument == null) {
       return const SizedBox.shrink();
     }
-    if (!widget.isStreaming &&
-        !hasFreshCompiledDocument &&
-        !_preserveStaleCompiledDocumentUntilFreshFinal) {
-      return const SizedBox.shrink();
-    }
+    // Once a compiled document exists, always render it — even when it is stale
+    // (a newer snapshot is still compiling). Replacing already-rendered content
+    // with a placeholder/blank causes the streaming body to flash whenever the
+    // turn phase flips to non-streaming mid-response (issue #540). The stale
+    // document is valid markdown and is superseded by `_applyCompiledDocumentState`
+    // within a frame once the fresh compile lands.
 
     final result = KeyedSubtree(
       key: _markdownContentKey,
@@ -534,8 +528,11 @@ class _StreamingMarkdownWidgetState
     if (hasFreshCompiledDocument) {
       return false;
     }
-    if (_preserveStaleCompiledDocumentUntilFreshFinal &&
-        compiledDocument != null) {
+    // The loading skeleton is strictly a first-paint state: it may only appear
+    // when no compiled document exists yet. Once any valid document has been
+    // rendered, a stale-but-valid document is kept on screen during async
+    // recompiles instead of regressing to the skeleton (issue #540).
+    if (compiledDocument != null) {
       return false;
     }
     return true;
@@ -545,19 +542,12 @@ class _StreamingMarkdownWidgetState
     String compiledPreparedContent,
     CompiledMarkdownDocument? document,
   ) {
-    final hasFreshCompiledDocument =
-        compiledPreparedContent == _snapshot.normalizedContent;
     if (!mounted) {
-      if (hasFreshCompiledDocument) {
-        _preserveStaleCompiledDocumentUntilFreshFinal = false;
-      }
       return;
     }
-    setState(() {
-      if (hasFreshCompiledDocument) {
-        _preserveStaleCompiledDocumentUntilFreshFinal = false;
-      }
-    });
+    // Rebuild so the freshly compiled document (or a cleared document) is
+    // reflected. Any stale document already on screen is superseded here.
+    setState(() {});
   }
 }
 

--- a/lib/shared/widgets/markdown/streaming_markdown_widget.dart
+++ b/lib/shared/widgets/markdown/streaming_markdown_widget.dart
@@ -430,10 +430,13 @@ class _StreamingMarkdownWidgetState
       child: _buildMarkdownWithCitations(compiledDocument),
     );
 
-    // Only wrap in SelectionArea when not streaming to
-    // avoid concurrent modification errors in Flutter's
-    // selection system during rapid updates.
-    if (widget.isStreaming) {
+    // Only wrap in SelectionArea when not streaming AND the rendered document is
+    // fresh for the current content. A stale-but-valid document shown during
+    // ongoing updates (the responseDone-gap growing-content path that #540's fix
+    // now keeps on screen) must not be made selectable: SelectionArea over
+    // rapidly-changing content triggers concurrent-modification errors in
+    // Flutter's selection system. It becomes selectable once the compile settles.
+    if (widget.isStreaming || !hasFreshCompiledDocument) {
       return result;
     }
 

--- a/test/shared/widgets/markdown/renderer/streaming_markdown_widget_test.dart
+++ b/test/shared/widgets/markdown/renderer/streaming_markdown_widget_test.dart
@@ -2641,6 +2641,76 @@ Tail keeps growing
     },
   );
 
+  testWidgets(
+    'clears stale content when the scope changes to a new message/version',
+    (tester) async {
+      // #540 follow-up: a scope change (new message/version) must NOT keep the
+      // previous scope's rendered content on screen while the new body compiles;
+      // the skeleton covers the gap instead (same-scope growth keeps content).
+      const firstVersion = 'First version answer.';
+      const secondVersion = 'Second version answer.';
+      final compiler = _SelectiveDelayedMarkdownCompileService(
+        delayedPreparedContent: prepareMarkdownContent(
+          secondVersion,
+          streaming: false,
+        ),
+      );
+      addTearDown(compiler.dispose);
+      final skeletonFinder = find.byType(MarkdownLoadingSkeleton);
+
+      Widget buildScopedHarness(String content, String scope) {
+        return ProviderScope(
+          overrides: [
+            markdownCompileServiceProvider.overrideWithValue(compiler),
+          ],
+          child: MaterialApp(
+            theme: AppTheme.light(TweakcnThemes.t3Chat),
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
+            home: Scaffold(
+              body: SingleChildScrollView(
+                child: StreamingMarkdownWidget(
+                  content: content,
+                  isStreaming: false,
+                  stateScopeId: scope,
+                ),
+              ),
+            ),
+          ),
+        );
+      }
+
+      await tester.pumpWidget(
+        buildScopedHarness(firstVersion, 'msg|version:0'),
+      );
+      await tester.pump();
+      expect(
+        find.textContaining('First version', findRichText: true),
+        findsOneWidget,
+      );
+
+      // Switch to a different version: scope + content change, compile delayed.
+      await tester.pumpWidget(
+        buildScopedHarness(secondVersion, 'msg|version:1'),
+      );
+      await tester.pump();
+      expect(
+        find.textContaining('First version', findRichText: true),
+        findsNothing,
+      );
+      expect(skeletonFinder, findsOneWidget);
+
+      compiler.release();
+      await tester.pump();
+      await tester.pump();
+      expect(
+        find.textContaining('Second version', findRichText: true),
+        findsOneWidget,
+      );
+      expect(skeletonFinder, findsNothing);
+    },
+  );
+
   testWidgets('defers tool call embeds until the details view opens', (
     tester,
   ) async {

--- a/test/shared/widgets/markdown/renderer/streaming_markdown_widget_test.dart
+++ b/test/shared/widgets/markdown/renderer/streaming_markdown_widget_test.dart
@@ -197,6 +197,53 @@ class _PrepareCountingMarkdownCompileService extends MarkdownCompileService {
   }
 }
 
+// Forces the deferred streaming path (async prepare) AND delays the compile of
+// one target prepared content, so a streaming scope change exercises the
+// `_pendingClearStaleDocument` flag and the streaming async-clear branch.
+class _DeferredStreamingCompileService extends MarkdownCompileService {
+  _DeferredStreamingCompileService({required this.delayedPreparedContent})
+    : super(workerManager: WorkerManager());
+
+  final String delayedPreparedContent;
+  final Completer<void> _release = Completer<void>();
+
+  void release() {
+    if (!_release.isCompleted) {
+      _release.complete();
+    }
+  }
+
+  @override
+  bool shouldPrepareSynchronously(String content, {bool widgetTest = false}) =>
+      false;
+
+  @override
+  Future<String> prepareContent(
+    String content, {
+    required bool streaming,
+    bool allowSynchronous = false,
+    bool widgetTest = false,
+  }) async => prepareMarkdownContent(content, streaming: streaming);
+
+  @override
+  bool shouldCompileSynchronously(
+    String preparedContent, {
+    bool widgetTest = false,
+  }) => preparedContent != delayedPreparedContent;
+
+  @override
+  Future<CompiledMarkdownDocument> compilePrepared(
+    String preparedContent, {
+    bool allowSynchronous = false,
+    bool widgetTest = false,
+  }) async {
+    if (preparedContent == delayedPreparedContent) {
+      await _release.future;
+    }
+    return compilePreparedSynchronously(preparedContent);
+  }
+}
+
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
@@ -2715,6 +2762,86 @@ Tail keeps growing
         findsOneWidget,
       );
       expect(skeletonFinder, findsNothing);
+    },
+  );
+
+  testWidgets(
+    'clears stale content when the scope changes while streaming',
+    (tester) async {
+      // #541 follow-up: the scope-change clear must also run on the deferred
+      // streaming path (e.g. switching from an old version back to the live,
+      // streaming current). The previous scope's document must not flash under
+      // the new scope while the streaming body compiles.
+      const oldVersion = 'Old version body.';
+      const liveResponse = 'Live streaming response.';
+      final compiler = _DeferredStreamingCompileService(
+        delayedPreparedContent: prepareMarkdownContent(
+          liveResponse,
+          streaming: true,
+        ),
+      );
+      addTearDown(compiler.dispose);
+      final skeletonFinder = find.byType(MarkdownLoadingSkeleton);
+
+      Widget buildScopedHarness(
+        String content,
+        String scope,
+        bool streaming,
+      ) {
+        return ProviderScope(
+          overrides: [
+            markdownCompileServiceProvider.overrideWithValue(compiler),
+          ],
+          child: MaterialApp(
+            theme: AppTheme.light(TweakcnThemes.t3Chat),
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
+            home: Scaffold(
+              body: SingleChildScrollView(
+                child: StreamingMarkdownWidget(
+                  content: content,
+                  isStreaming: streaming,
+                  stateScopeId: scope,
+                ),
+              ),
+            ),
+          ),
+        );
+      }
+
+      await tester.pumpWidget(
+        buildScopedHarness(oldVersion, 'msg|version:0', false),
+      );
+      await tester.pump();
+      expect(
+        find.textContaining('Old version', findRichText: true),
+        findsOneWidget,
+      );
+
+      // Switch to the live, still-streaming current version: scope + content
+      // change with the new body needing an async compile.
+      await tester.pumpWidget(
+        buildScopedHarness(liveResponse, 'msg|current', true),
+      );
+      // Fire the scheduled streaming refresh frame, then let the async prepare
+      // resolve so the stale document is cleared before the compile lands.
+      await tester.pump();
+      await tester.pump();
+      expect(
+        find.textContaining('Old version', findRichText: true),
+        findsNothing,
+      );
+      // Streaming never shows the skeleton; the gap is blank until the compile
+      // settles.
+      expect(skeletonFinder, findsNothing);
+
+      compiler.release();
+      await tester.pump();
+      await tester.pump();
+      expect(
+        find.textContaining('Live streaming response', findRichText: true),
+        findsOneWidget,
+      );
     },
   );
 

--- a/test/shared/widgets/markdown/renderer/streaming_markdown_widget_test.dart
+++ b/test/shared/widgets/markdown/renderer/streaming_markdown_widget_test.dart
@@ -2799,6 +2799,11 @@ Tail keeps growing
             home: Scaffold(
               body: SingleChildScrollView(
                 child: StreamingMarkdownWidget(
+                  // Shared key: the second pump must reuse this State so the
+                  // switch goes through didUpdateWidget's scope-change clear,
+                  // not a remount (which would hide the old content for the
+                  // wrong reason).
+                  key: const ValueKey('streaming-markdown-under-test'),
                   content: content,
                   isStreaming: streaming,
                   stateScopeId: scope,
@@ -2823,10 +2828,10 @@ Tail keeps growing
       await tester.pumpWidget(
         buildScopedHarness(liveResponse, 'msg|current', true),
       );
-      // Fire the scheduled streaming refresh frame, then let the async prepare
-      // resolve so the stale document is cleared before the compile lands.
-      await tester.pump();
-      await tester.pump();
+      // The very first frame after the switch — before the scheduled streaming
+      // refresh runs — must already be clear of the old scope. A deferred clear
+      // would let the old document paint for this one frame under the new scope,
+      // which is exactly the flash this guards against (#541).
       expect(
         find.textContaining('Old version', findRichText: true),
         findsNothing,
@@ -2834,6 +2839,23 @@ Tail keeps growing
       // Streaming never shows the skeleton; the gap is blank until the compile
       // settles.
       expect(skeletonFinder, findsNothing);
+
+      // Let the scheduled streaming refresh frame fire and the async prepare
+      // resolve; the old scope must stay gone throughout.
+      await tester.pump();
+      await tester.pump();
+      expect(
+        find.textContaining('Old version', findRichText: true),
+        findsNothing,
+      );
+      expect(skeletonFinder, findsNothing);
+      // The compile is still blocked, so the new body must NOT have appeared
+      // yet — this proves the gap is a genuine async wait, not a synchronous
+      // swap that would mask whether the clear happened at the right time.
+      expect(
+        find.textContaining('Live streaming response', findRichText: true),
+        findsNothing,
+      );
 
       compiler.release();
       await tester.pump();

--- a/test/shared/widgets/markdown/renderer/streaming_markdown_widget_test.dart
+++ b/test/shared/widgets/markdown/renderer/streaming_markdown_widget_test.dart
@@ -2609,7 +2609,8 @@ Tail keeps growing
         );
       }
 
-      // Frame 1: first settled content compiles immediately and renders.
+      // Frame 1: first settled content compiles immediately and renders. A
+      // fresh non-streaming document is selectable.
       await tester.pumpWidget(buildSelectiveHarness(firstContent));
       await tester.pump();
       expect(skeletonFinder, findsNothing);
@@ -2617,9 +2618,12 @@ Tail keeps growing
         find.textContaining('Settled answer paragraph', findRichText: true),
         findsOneWidget,
       );
+      expect(find.byType(SelectionArea), findsOneWidget);
 
       // Frame 2: content grows while still non-streaming; the grown content's
-      // compile is delayed. The previously-rendered body must stay visible.
+      // compile is delayed. The previously-rendered body must stay visible, but
+      // the stale document must NOT be wrapped in SelectionArea (that would
+      // re-enable the concurrent-modification crash during ongoing updates).
       await tester.pumpWidget(buildSelectiveHarness(grownContent));
       await tester.pump();
 
@@ -2628,6 +2632,7 @@ Tail keeps growing
         find.textContaining('Settled answer paragraph', findRichText: true),
         findsOneWidget,
       );
+      expect(find.byType(SelectionArea), findsNothing);
 
       compiler.release();
       await tester.pump();
@@ -2638,6 +2643,8 @@ Tail keeps growing
         find.textContaining('Follow-up sentence', findRichText: true),
         findsOneWidget,
       );
+      // Once the compile settles, the document becomes selectable again.
+      expect(find.byType(SelectionArea), findsOneWidget);
     },
   );
 

--- a/test/shared/widgets/markdown/renderer/streaming_markdown_widget_test.dart
+++ b/test/shared/widgets/markdown/renderer/streaming_markdown_widget_test.dart
@@ -2568,6 +2568,79 @@ Tail keeps growing
     },
   );
 
+  testWidgets(
+    'keeps rendered content visible when non-streaming content grows mid-response',
+    (tester) async {
+      // Reproduces issue #540: during the responseDone gap the turn phase
+      // latches to completed (isStreaming:false to the body) while answer tokens
+      // keep arriving. Each non-streaming content growth must NOT regress the
+      // already-rendered body to a loading skeleton (the ~13Hz strobe).
+      const firstContent = 'Settled answer paragraph.';
+      const grownContent = 'Settled answer paragraph.\n\nFollow-up sentence.';
+      final compiler = _SelectiveDelayedMarkdownCompileService(
+        delayedPreparedContent: prepareMarkdownContent(
+          grownContent,
+          streaming: false,
+        ),
+      );
+      addTearDown(compiler.dispose);
+      final skeletonFinder = find.byType(MarkdownLoadingSkeleton);
+
+      Widget buildSelectiveHarness(String content) {
+        return ProviderScope(
+          overrides: [
+            markdownCompileServiceProvider.overrideWithValue(compiler),
+          ],
+          child: MaterialApp(
+            theme: AppTheme.light(TweakcnThemes.t3Chat),
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
+            home: Scaffold(
+              body: SingleChildScrollView(
+                child: StreamingMarkdownWidget(
+                  content: content,
+                  // The body already treats the turn as settled (responseDone
+                  // gap), so isStreaming is false for both frames.
+                  isStreaming: false,
+                ),
+              ),
+            ),
+          ),
+        );
+      }
+
+      // Frame 1: first settled content compiles immediately and renders.
+      await tester.pumpWidget(buildSelectiveHarness(firstContent));
+      await tester.pump();
+      expect(skeletonFinder, findsNothing);
+      expect(
+        find.textContaining('Settled answer paragraph', findRichText: true),
+        findsOneWidget,
+      );
+
+      // Frame 2: content grows while still non-streaming; the grown content's
+      // compile is delayed. The previously-rendered body must stay visible.
+      await tester.pumpWidget(buildSelectiveHarness(grownContent));
+      await tester.pump();
+
+      expect(skeletonFinder, findsNothing);
+      expect(
+        find.textContaining('Settled answer paragraph', findRichText: true),
+        findsOneWidget,
+      );
+
+      compiler.release();
+      await tester.pump();
+      await tester.pump();
+
+      expect(skeletonFinder, findsNothing);
+      expect(
+        find.textContaining('Follow-up sentence', findRichText: true),
+        findsOneWidget,
+      );
+    },
+  );
+
   testWidgets('defers tool call embeds until the details view opens', (
     tester,
   ) async {


### PR DESCRIPTION
## Hotfix for #540 — photosensitivity/seizure hazard

Targeted, isolated fix cherry-picked to `main` (also fixed on the chat-streaming-timeline-polish branch).

### Symptom
During an assistant response, the message body **flashes at ~13Hz** between the rendered markdown and the `MarkdownLoadingSkeleton`. Confirmed frame-by-frame from the reporter's recording: the body alternates rendered-text ↔ gray skeleton bars while the completed action row / "5 Sources" are visible at the same time.

### Root cause
`StreamingMarkdownWidget` allowed the loading skeleton (and a second `SizedBox.shrink()` blank path) to **replace already-rendered content**. On a multi-phase response (reasoning + tool call) the turn phase latches to *completed* mid-response (the responseDone gap), so the body is treated as non-streaming while answer tokens keep arriving. Each non-streaming content growth leaves the compiled markdown stale-but-valid during its async recompile, and the gate regressed to the skeleton — then back to text on the next update.

### Fix
Make the skeleton/blank strictly a **first-paint** state: once any compiled document exists it is always rendered (a stale doc lags ≤1 frame and is superseded within a frame). Immune to any `isStreaming` flicker, so no provider/responseDone change is needed. Removed the now-dead `_preserveStaleCompiledDocumentUntilFreshFinal` field.

### Verification
- Added a deterministic regression test (delayed compile service) reproducing the non-streaming content-growth stale window — **fails before** (`Found 1 MarkdownLoadingSkeleton` over rendered content), **passes after**.
- `flutter analyze` clean; full suite passes; existing first-paint-skeleton and streaming stale-protection tests still pass.

Fixes #540

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix streaming body strobing between rendered content and loading skeleton
> - Previously, the widget would toggle between a stale compiled document and a loading skeleton during async recompiles, causing a visible strobe effect.
> - The loading skeleton in `_shouldShowLoadingSkeleton` now only appears before the first compiled document exists; subsequent recompiles keep the existing document visible.
> - On scope changes, `clearDocument()` is called immediately to discard stale content before scheduling a new compile, while same-scope content growth preserves the existing document during recompilation.
> - Text selection via `SelectionArea` is now gated on the compiled document being fresh for the current content, not just present.
> - The removed `_preserveStaleCompiledDocumentUntilFreshFinal` flag is replaced by the new `clearDocumentWhenAsync` parameter on `resolveStreamingPrepared` and `resolvePrepared`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ea89c98.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved markdown rendering during streaming and scope/message changes by clearing stale compiled content at the right time.
  * Loading skeletons now appear only as an initial first-paint state and are suppressed when existing compiled content is available.
  * Selection behavior was refined to avoid wrapping selection around stale-but-visible content, while still supporting fresh/streaming updates.
* **Tests**
  * Added regression coverage for delayed markdown compilation, including mid-response growth and scope changes (non-streaming and streaming), verifying skeleton/stale-content and selection behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes streaming markdown flashes during assistant responses. The main changes are:

- Keeps stale compiled markdown visible during same-message async recompiles.
- Clears compiled markdown when the message or version scope changes.
- Adds an immediate clear for deferred streaming scope changes.
- Updates tests for non-streaming growth and streaming scope switches.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The changes are targeted to markdown rendering state transitions and covered by regression tests for the streaming and scope-change paths.

No blocking issues were identified in the changed files, and the added tests exercise the reported stale-content and loading-skeleton behavior.
</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- The runner executed a Flutter command that failed due to a missing Flutter binary, inspected logs showing exit code 127 before and after the attempt, and included a generated validation harness artifact to enable reproducible testing in Flutter-enabled environments.

<a href="https://app.greptile.com/trex/runs/12747666/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=1"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=1" height="32"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (5): Last reviewed commit: ["Clear the stale streaming document immed..."](https://github.com/cogwheel0/conduit/commit/ea89c98f8dda5525a31951df8421751f757daf1e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40744850)</sub>

<!-- /greptile_comment -->