### PR TITLE
Add Open WebUI 0.10 compatibility

### DIFF
--- a/lib/core/models/backend_config.dart
+++ b/lib/core/models/backend_config.dart
@@ -297,11 +297,23 @@ class BackendConfig {
     final vad = json['vad_enabled'];
     if (vad is bool) vadEnabled = vad;
 
+    final audio = _coerceJsonMap(json['audio']);
+    final audioTts = _coerceJsonMap(audio?['tts']);
+    final audioStt = _coerceJsonMap(audio?['stt']);
+    final nestedTtsEngine = _normalizeString(audioTts?['engine']);
+    final nestedTtsVoice = _normalizeString(audioTts?['voice']);
+    final nestedTtsSplitOn = _normalizeString(audioTts?['split_on']);
+    final nestedSttEngine = _normalizeString(audioStt?['engine']);
+    ttsProvider ??= nestedTtsEngine;
+    ttsVoice ??= nestedTtsVoice;
+    ttsSplitOn ??= nestedTtsSplitOn;
+    sttProvider ??= nestedSttEngine;
+
     // Parse OAuth providers from top-level oauth.providers
-    final oauth = json['oauth'];
-    if (oauth is Map<String, dynamic>) {
-      final providers = oauth['providers'];
-      if (providers is Map<String, dynamic>) {
+    final oauth = _coerceJsonMap(json['oauth']);
+    if (oauth != null) {
+      final providers = _coerceJsonMap(oauth['providers']);
+      if (providers != null) {
         oauthProviders = OAuthProviders.fromJson(providers);
       }
     }
@@ -381,6 +393,13 @@ class BackendConfig {
       if (nestedLoginForm is bool) enableLoginForm = nestedLoginForm;
     }
 
+    if (nestedTtsEngine != null) {
+      enableAudioOutput ??= true;
+    }
+    if (nestedSttEngine != null) {
+      enableAudioInput ??= true;
+    }
+
     return BackendConfig(
       enableWebsocket: enableWebsocket,
       enableWebSearch: enableWebSearch,
@@ -400,4 +419,22 @@ class BackendConfig {
       enableLoginForm: enableLoginForm,
     );
   }
+}
+
+Map<String, dynamic>? _coerceJsonMap(dynamic value) {
+  if (value is Map<String, dynamic>) {
+    return value;
+  }
+  if (value is Map) {
+    return value.map((key, entryValue) => MapEntry(key.toString(), entryValue));
+  }
+  return null;
+}
+
+String? _normalizeString(dynamic value) {
+  if (value is! String) {
+    return null;
+  }
+  final trimmed = value.trim();
+  return trimmed.isEmpty ? null : trimmed;
 }

--- a/lib/core/models/server_about_info.dart
+++ b/lib/core/models/server_about_info.dart
@@ -56,6 +56,8 @@ class ServerAboutInfo {
     final audio = _coerceJsonMap(config['audio']) ?? const {};
     final audioTts = _coerceJsonMap(audio['tts']) ?? const {};
     final audioStt = _coerceJsonMap(audio['stt']) ?? const {};
+    final sttEngine = _normalizeString(audioStt['engine']);
+    final ttsEngine = _normalizeString(audioTts['engine']);
 
     return ServerAboutInfo(
       name: (config['name'] ?? 'Open WebUI').toString(),
@@ -77,10 +79,12 @@ class ServerAboutInfo {
         features['enable_password_change_form'],
       ),
       enableApiKeys: _coerceBool(features['enable_api_keys']),
-      enableAudioInput: _coerceBool(features['enable_audio_input']),
-      enableAudioOutput: _coerceBool(features['enable_audio_output']),
-      sttEngine: _normalizeString(audioStt['engine']),
-      ttsEngine: _normalizeString(audioTts['engine']),
+      enableAudioInput:
+          _coerceBool(features['enable_audio_input']) ?? sttEngine != null,
+      enableAudioOutput:
+          _coerceBool(features['enable_audio_output']) ?? ttsEngine != null,
+      sttEngine: sttEngine,
+      ttsEngine: ttsEngine,
     );
   }
 }
@@ -139,12 +143,20 @@ int? _coerceInt(dynamic value) {
 }
 
 List<String> _coerceStringList(dynamic value) {
-  if (value is! List) {
-    return const <String>[];
+  if (value is String) {
+    return List<String>.unmodifiable(
+      value
+          .split(',')
+          .map((entry) => entry.trim())
+          .where((entry) => entry.isNotEmpty),
+    );
   }
-  return List<String>.unmodifiable(
-    value
-        .map((entry) => entry.toString().trim())
-        .where((entry) => entry.isNotEmpty),
-  );
+  if (value is List) {
+    return List<String>.unmodifiable(
+      value
+          .map((entry) => entry.toString().trim())
+          .where((entry) => entry.isNotEmpty),
+    );
+  }
+  return const <String>[];
 }

--- a/lib/core/services/api_service.dart
+++ b/lib/core/services/api_service.dart
@@ -3729,6 +3729,7 @@ class ApiService {
         final uploadData = uploadResponse.data as Map<String, dynamic>;
         final fileId = _fileIdFromUploadResponse(uploadData);
         if (fileId == null) {
+          await _deleteUploadedFileFromUploadResponseBestEffort(uploadData);
           throw StateError(
             'Upload succeeded but did not return a file id to attach',
           );
@@ -3790,6 +3791,15 @@ class ApiService {
     }
   }
 
+  Future<void> _deleteUploadedFileFromUploadResponseBestEffort(
+    Map<String, dynamic> data,
+  ) async {
+    final ids = _fileIdsFromUploadResponse(data);
+    for (final id in ids) {
+      await _deleteUploadedFileBestEffort(id);
+    }
+  }
+
   bool _shouldFallbackToLegacyKnowledgeFileAdd(DioException error) {
     final statusCode = error.response?.statusCode;
     return statusCode == 404 ||
@@ -3799,16 +3809,52 @@ class ApiService {
   }
 
   String? _fileIdFromUploadResponse(Map<String, dynamic> data) {
+    final ids = _fileIdsFromUploadResponse(data);
+    return ids.isEmpty ? null : ids.first;
+  }
+
+  List<String> _fileIdsFromUploadResponse(Map<String, dynamic> data) {
+    final ids = <String>{};
+    void collect(dynamic value, {String? key}) {
+      if (value is Map) {
+        for (final entry in value.entries) {
+          collect(entry.value, key: entry.key.toString());
+        }
+        return;
+      }
+      if (value is List) {
+        for (final item in value) {
+          collect(item);
+        }
+        return;
+      }
+      final normalizedKey = key?.replaceAll(RegExp(r'[_-]'), '').toLowerCase();
+      if (normalizedKey == 'id' ||
+          normalizedKey == 'fileid' ||
+          normalizedKey == 'uuid' ||
+          normalizedKey == 'identifier') {
+        final id = _normalizeDynamicString(value);
+        if (id != null) {
+          ids.add(id);
+        }
+      }
+    }
+
     final id = _normalizeDynamicString(
       data['id'] ?? data['file_id'] ?? data['fileId'] ?? data['uuid'],
     );
     if (id != null) {
-      return id;
+      ids.add(id);
     }
     final file = _coerceJsonMap(data['file']) ?? _coerceJsonMap(data['data']);
-    return _normalizeDynamicString(
+    final nestedId = _normalizeDynamicString(
       file?['id'] ?? file?['file_id'] ?? file?['fileId'] ?? file?['uuid'],
     );
+    if (nestedId != null) {
+      ids.add(nestedId);
+    }
+    collect(data);
+    return ids.toList(growable: false);
   }
 
   Future<Map<String, dynamic>?> processWebpage({

--- a/lib/core/services/api_service.dart
+++ b/lib/core/services/api_service.dart
@@ -3401,6 +3401,7 @@ class ApiService {
     var page = 1;
     int? total;
     const maxPages = 100;
+    var useLegacyItemsFallback = false;
 
     try {
       while (true) {
@@ -3415,11 +3416,15 @@ class ApiService {
         }
 
         final responseMap = _coerceJsonMap(data);
-        final pageItems = responseMap?['items'] is List
-            ? responseMap!['items'] as List
+        if (responseMap == null) {
+          useLegacyItemsFallback = true;
+          break;
+        }
+        final pageItems = responseMap['items'] is List
+            ? responseMap['items'] as List
             : const <dynamic>[];
         rawItems.addAll(pageItems);
-        final rawTotal = responseMap?['total'];
+        final rawTotal = responseMap['total'];
         if (rawTotal is int) {
           total = rawTotal;
         } else if (rawTotal is num) {
@@ -3442,6 +3447,11 @@ class ApiService {
       if (!_shouldFallbackToLegacyKnowledgeApi(error)) {
         rethrow;
       }
+      useLegacyItemsFallback = true;
+    }
+
+    if (useLegacyItemsFallback) {
+      rawItems.clear();
       final response = await _dio.get(
         '/api/v1/knowledge/$knowledgeBaseId/items',
       );
@@ -3815,24 +3825,43 @@ class ApiService {
 
   List<String> _fileIdsFromUploadResponse(Map<String, dynamic> data) {
     final ids = <String>{};
-    void collect(dynamic value, {String? key}) {
+    void collect(dynamic value, {String? key, bool inFileContainer = false}) {
       if (value is Map) {
         for (final entry in value.entries) {
-          collect(entry.value, key: entry.key.toString());
+          final childKey = entry.key.toString();
+          final normalizedChildKey = childKey
+              .replaceAll(RegExp(r'[_-]'), '')
+              .toLowerCase();
+          final childIsFileContainer =
+              inFileContainer ||
+              const {
+                'file',
+                'data',
+                'upload',
+                'item',
+                'result',
+                'document',
+              }.contains(normalizedChildKey);
+          collect(
+            entry.value,
+            key: childKey,
+            inFileContainer: childIsFileContainer,
+          );
         }
         return;
       }
       if (value is List) {
         for (final item in value) {
-          collect(item);
+          collect(item, inFileContainer: inFileContainer);
         }
         return;
       }
       final normalizedKey = key?.replaceAll(RegExp(r'[_-]'), '').toLowerCase();
-      if (normalizedKey == 'id' ||
-          normalizedKey == 'fileid' ||
-          normalizedKey == 'uuid' ||
-          normalizedKey == 'identifier') {
+      if (normalizedKey == 'fileid' ||
+          (inFileContainer &&
+              (normalizedKey == 'id' ||
+                  normalizedKey == 'uuid' ||
+                  normalizedKey == 'identifier'))) {
         final id = _normalizeDynamicString(value);
         if (id != null) {
           ids.add(id);

--- a/lib/core/services/api_service.dart
+++ b/lib/core/services/api_service.dart
@@ -1905,6 +1905,7 @@ class ApiService {
               'modelIdx': 0,
               'done': true,
               if (ver.files != null) 'files': _sanitizeFilesForWebUI(ver.files),
+              if (ver.output != null) 'output': ver.output,
               if (_sanitizeEmbedsForWebUI(ver.embeds) != null)
                 'embeds': _sanitizeEmbedsForWebUI(ver.embeds),
               // Mirror follow-ups, code executions, sources, and errors for versions

--- a/lib/core/services/api_service.dart
+++ b/lib/core/services/api_service.dart
@@ -618,22 +618,12 @@ class ApiService {
   Future<BackendConfig> _enrichBackendConfigWithAudioConfig(
     BackendConfig config,
   ) async {
-    try {
-      final audioConfig = await _loadServerAudioConfig();
-      return config.copyWith(
-        ttsVoice: audioConfig.voice ?? config.ttsVoice,
-        ttsSplitOn: audioConfig.splitOn,
-        ttsVoices: audioConfig.voices,
-      );
-    } catch (e, stackTrace) {
-      DebugLogger.error(
-        'backend-config-audio-defaults',
-        scope: 'api/config',
-        error: e,
-        stackTrace: stackTrace,
-      );
-      return config;
-    }
+    final audioConfig = await _loadServerAudioConfig();
+    return config.copyWith(
+      ttsVoice: audioConfig.voice,
+      ttsSplitOn: audioConfig.splitOn,
+      ttsVoices: audioConfig.voices.isEmpty ? null : audioConfig.voices,
+    );
   }
 
   Future<ServerAboutInfo> getServerAboutInfo() async {
@@ -938,7 +928,7 @@ class ApiService {
     try {
       final response = await _dio.get('/api/config');
       final config = _coerceResponseMap(response.data);
-      final defaultModels = _coerceStringList(config?['default_models']);
+      final defaultModels = _coerceConfigStringList(config?['default_models']);
       if (defaultModels.isNotEmpty) {
         final defaultModel = defaultModels.first;
         DebugLogger.log(
@@ -2006,6 +1996,14 @@ class ApiService {
     return trimmed;
   }
 
+  String? _normalizeDynamicString(dynamic value) {
+    final trimmed = value?.toString().trim();
+    if (trimmed == null || trimmed.isEmpty) {
+      return null;
+    }
+    return trimmed;
+  }
+
   List<String> _coerceStringList(dynamic value) {
     if (value is! List) {
       return <String>[];
@@ -2015,6 +2013,17 @@ class ApiService {
         .map((item) => item?.toString().trim() ?? '')
         .where((item) => item.isNotEmpty)
         .toList(growable: true);
+  }
+
+  List<String> _coerceConfigStringList(dynamic value) {
+    if (value is String) {
+      return value
+          .split(',')
+          .map((item) => item.trim())
+          .where((item) => item.isNotEmpty)
+          .toList(growable: true);
+    }
+    return _coerceStringList(value);
   }
 
   List<Map<String, dynamic>> _buildHistoryChainMessages(
@@ -2031,39 +2040,46 @@ class ApiService {
         .toList(growable: false);
   }
 
-  Set<String> _collectMessageDescendantIds(
-    Map<String, Map<String, dynamic>> messagesMap,
-    String messageId,
-  ) {
-    return message_tree.collectDescendantIds(messageId, {
-      for (final entry in messagesMap.entries)
-        entry.key: message_tree.rawMessageChildrenIds(entry.value),
-    });
-  }
-
-  String? _latestRemainingMessageId(
-    Map<String, Map<String, dynamic>> messagesMap,
-  ) {
-    return message_tree.latestRemainingMessageId<Map<String, dynamic>>(
-      messagesMap,
-      timestampOf: (message) {
-        final timestamp = message['timestamp'];
-        return timestamp is num ? timestamp : null;
-      },
-    );
-  }
-
   /// Deletes one message from the current server-side chat history.
-  ///
-  /// This edits the latest raw chat payload from the server instead of replaying
-  /// a local message list, preserving any server-only history fields and
-  /// messages that may have arrived since the local state last synced.
   Future<void> deleteConversationMessage(
     String conversationId,
     String messageId,
   ) async {
     _traceApi('Deleting message $messageId from chat $conversationId');
+    try {
+      await _dio.delete('/api/v1/chats/$conversationId/messages/$messageId');
+    } on DioException catch (error) {
+      if (!_shouldFallbackToLegacyMessageDelete(error)) {
+        rethrow;
+      }
+      DebugLogger.log(
+        'delete-message-legacy-fallback',
+        scope: 'api/conversation',
+        data: {
+          'chatId': conversationId,
+          'messageId': messageId,
+          'status': error.response?.statusCode,
+        },
+      );
+      await _deleteConversationMessageByHistoryRewrite(
+        conversationId,
+        messageId,
+      );
+    }
+  }
 
+  bool _shouldFallbackToLegacyMessageDelete(DioException error) {
+    final statusCode = error.response?.statusCode;
+    return statusCode == 404 || statusCode == 405;
+  }
+
+  /// Legacy fallback for older Open WebUI servers that predate the per-message
+  /// DELETE endpoint. It edits the latest raw chat payload instead of replaying
+  /// a local message list, preserving server-only history fields.
+  Future<void> _deleteConversationMessageByHistoryRewrite(
+    String conversationId,
+    String messageId,
+  ) async {
     final response = await _dio.get('/api/v1/chats/$conversationId');
     final rawConversation = _coerceJsonMap(response.data);
     final rawChat = _coerceJsonMap(rawConversation?['chat']);
@@ -2089,21 +2105,15 @@ class ApiService {
       return;
     }
 
-    final removedIds = _collectMessageDescendantIds(messagesMap, messageId);
-    messagesMap.removeWhere((id, _) => removedIds.contains(id));
-
-    for (final entry in messagesMap.entries) {
-      final message = entry.value;
-      final children = _coerceStringList(
-        message['childrenIds'],
-      ).where((id) => !removedIds.contains(id)).toList(growable: false);
-      message['childrenIds'] = children;
+    final deleteResult = message_tree.deleteOpenWebUiMessageFromRawHistory(
+      messagesMap,
+      messageId,
+    );
+    if (deleteResult == null) {
+      return;
     }
 
-    final currentId = history['currentId']?.toString();
-    final nextCurrentId = currentId != null && !removedIds.contains(currentId)
-        ? currentId
-        : _latestRemainingMessageId(messagesMap);
+    final nextCurrentId = deleteResult.currentId;
 
     history['messages'] = messagesMap;
     if (nextCurrentId == null || nextCurrentId.isEmpty) {
@@ -2257,13 +2267,64 @@ class ApiService {
   // Pin/Unpin conversation
   Future<void> pinConversation(String id, bool pinned) async {
     _traceApi('${pinned ? 'Pinning' : 'Unpinning'} conversation: $id');
-    await _dio.post('/api/v1/chats/$id/pin', data: {'pinned': pinned});
+    await _setConversationToggle(
+      id: id,
+      field: 'pinned',
+      endpoint: '/api/v1/chats/$id/pin',
+      desired: pinned,
+    );
   }
 
   // Archive/Unarchive conversation
   Future<void> archiveConversation(String id, bool archived) async {
     _traceApi('${archived ? 'Archiving' : 'Unarchiving'} conversation: $id');
-    await _dio.post('/api/v1/chats/$id/archive', data: {'archived': archived});
+    await _setConversationToggle(
+      id: id,
+      field: 'archived',
+      endpoint: '/api/v1/chats/$id/archive',
+      desired: archived,
+    );
+  }
+
+  Future<void> _setConversationToggle({
+    required String id,
+    required String field,
+    required String endpoint,
+    required bool desired,
+  }) async {
+    final current = await _fetchConversationBooleanField(id, field);
+    if (current == desired) {
+      return;
+    }
+
+    final response = await _dio.post(endpoint);
+    final data = _coerceResponseMap(response.data);
+    final actual = data?[field];
+    if (actual is bool && actual != desired) {
+      DebugLogger.warning(
+        'toggle-mismatch',
+        scope: 'api/conversation',
+        data: {'id': id, 'field': field, 'desired': desired, 'actual': actual},
+      );
+    }
+  }
+
+  Future<bool?> _fetchConversationBooleanField(String id, String field) async {
+    try {
+      final response = await _dio.get('/api/v1/chats/$id');
+      final data = _coerceResponseMap(response.data);
+      final value = data?[field];
+      return value is bool ? value : null;
+    } catch (e, stackTrace) {
+      DebugLogger.error(
+        'toggle-state-fetch-failed',
+        scope: 'api/conversation',
+        error: e,
+        stackTrace: stackTrace,
+        data: {'id': id, 'field': field},
+      );
+      return null;
+    }
   }
 
   // Share conversation
@@ -2301,6 +2362,7 @@ class ApiService {
     _traceApi('Cloning conversation: $id');
     final response = await _dio.post(
       '/api/v1/chats/$id/clone',
+      data: const <String, dynamic>{},
       options: Options(responseType: ResponseType.bytes),
     );
     return _parseConversationPayload(
@@ -2436,12 +2498,69 @@ class ApiService {
   // Suggestions
   Future<List<String>> getSuggestions() async {
     _traceApi('Fetching conversation suggestions');
-    final response = await _dio.get('/api/v1/configs/suggestions');
-    final data = response.data;
-    if (data is List) {
-      return data.cast<String>();
+    final data = await _loadPromptSuggestionConfig();
+    final suggestions = data?['default_prompt_suggestions'];
+    if (suggestions is List) {
+      return suggestions
+          .map(_promptSuggestionToString)
+          .whereType<String>()
+          .toList(growable: false);
+    }
+    return _loadLegacyPromptSuggestions();
+  }
+
+  Future<Map<String, dynamic>?> _loadPromptSuggestionConfig() async {
+    try {
+      final response = await _dio.get('/api/config');
+      return _coerceResponseMap(response.data);
+    } on DioException {
+      return null;
+    }
+  }
+
+  Future<List<String>> _loadLegacyPromptSuggestions() async {
+    try {
+      final response = await _dio.get('/api/v1/configs/suggestions');
+      final data = response.data;
+      final suggestions = data is List
+          ? data
+          : _coerceResponseMap(data)?['suggestions'] ??
+                _coerceResponseMap(data)?['default_prompt_suggestions'];
+      if (suggestions is List) {
+        return suggestions
+            .map(_promptSuggestionToString)
+            .whereType<String>()
+            .toList(growable: false);
+      }
+    } on DioException {
+      return const [];
     }
     return [];
+  }
+
+  String? _promptSuggestionToString(dynamic value) {
+    if (value is String) {
+      final trimmed = value.trim();
+      return trimmed.isEmpty ? null : trimmed;
+    }
+    final suggestion = _coerceJsonMap(value);
+    if (suggestion == null) {
+      return null;
+    }
+    final content = suggestion['content']?.toString().trim();
+    if (content != null && content.isNotEmpty) {
+      return content;
+    }
+    final title = suggestion['title'];
+    if (title is List) {
+      final parts = title
+          .map((part) => part?.toString().trim() ?? '')
+          .where((part) => part.isNotEmpty)
+          .toList(growable: false);
+      return parts.isEmpty ? null : parts.join(' ');
+    }
+    final fallback = title?.toString().trim();
+    return fallback == null || fallback.isEmpty ? null : fallback;
   }
 
   Future<Conversation> _parseConversationPayload(
@@ -2746,14 +2865,24 @@ class ApiService {
     final response = await _dio.get('/api/v1/chats/$conversationId/tags');
     final data = response.data;
     if (data is List) {
-      return data.cast<String>();
+      return data.map(_tagNameFromEntry).whereType<String>().toList();
     }
     return [];
   }
 
   Future<void> addTagToConversation(String conversationId, String tag) async {
     _traceApi('Adding tag "$tag" to conversation: $conversationId');
-    await _dio.post('/api/v1/chats/$conversationId/tags', data: {'tag': tag});
+    try {
+      await _dio.post(
+        '/api/v1/chats/$conversationId/tags',
+        data: {'name': tag},
+      );
+    } on DioException catch (error) {
+      if (!_shouldFallbackToLegacyTagApi(error)) {
+        rethrow;
+      }
+      await _dio.post('/api/v1/chats/$conversationId/tags', data: {'tag': tag});
+    }
   }
 
   Future<void> removeTagFromConversation(
@@ -2761,29 +2890,80 @@ class ApiService {
     String tag,
   ) async {
     _traceApi('Removing tag "$tag" from conversation: $conversationId');
-    await _dio.delete('/api/v1/chats/$conversationId/tags/$tag');
+    try {
+      await _dio.delete(
+        '/api/v1/chats/$conversationId/tags',
+        data: {'name': tag},
+      );
+    } on DioException catch (error) {
+      if (!_shouldFallbackToLegacyTagApi(error)) {
+        rethrow;
+      }
+      await _dio.delete(
+        '/api/v1/chats/$conversationId/tags/${Uri.encodeComponent(tag)}',
+      );
+    }
   }
 
   Future<List<String>> getAllTags() async {
     _traceApi('Fetching all available tags');
-    final response = await _dio.get('/api/v1/chats/tags');
+    Response<dynamic> response;
+    try {
+      response = await _dio.get('/api/v1/chats/all/tags');
+    } on DioException catch (error) {
+      if (!_shouldFallbackToLegacyTagApi(error)) {
+        rethrow;
+      }
+      response = await _dio.get('/api/v1/chats/tags');
+    }
     final data = response.data;
     if (data is List) {
-      return data.cast<String>();
+      return data.map(_tagNameFromEntry).whereType<String>().toList();
     }
     return [];
   }
 
   Future<List<Conversation>> getConversationsByTag(String tag) async {
     _traceApi('Fetching conversations with tag: $tag');
-    final response = await _dio.get(
-      '/api/v1/chats/tags/$tag',
-      options: Options(responseType: ResponseType.bytes),
-    );
+    Response<dynamic> response;
+    try {
+      response = await _dio.post(
+        '/api/v1/chats/tags',
+        data: {'name': tag},
+        options: Options(responseType: ResponseType.bytes),
+      );
+    } on DioException catch (error) {
+      if (!_shouldFallbackToLegacyTagApi(error)) {
+        rethrow;
+      }
+      response = await _dio.get(
+        '/api/v1/chats/tags/${Uri.encodeComponent(tag)}',
+        options: Options(responseType: ResponseType.bytes),
+      );
+    }
     return _parseConversationSummaryPayload(
       regular: response.data,
       debugLabel: 'parse_tag_$tag',
     );
+  }
+
+  bool _shouldFallbackToLegacyTagApi(DioException error) {
+    final statusCode = error.response?.statusCode;
+    return statusCode == 400 ||
+        statusCode == 404 ||
+        statusCode == 405 ||
+        statusCode == 422;
+  }
+
+  String? _tagNameFromEntry(dynamic value) {
+    if (value is String) {
+      final trimmed = value.trim();
+      return trimmed.isEmpty ? null : trimmed;
+    }
+    final tag = _coerceJsonMap(value);
+    final name = tag?['name'] ?? tag?['id'];
+    final normalized = name?.toString().trim();
+    return normalized == null || normalized.isEmpty ? null : normalized;
   }
 
   // Files
@@ -3086,10 +3266,21 @@ class ApiService {
     String? description,
   }) async {
     _traceApi('Creating knowledge base: $name');
-    final response = await _dio.post(
-      '/api/v1/knowledge/',
-      data: {'name': name, 'description': ?description},
-    );
+    Response<dynamic> response;
+    try {
+      response = await _dio.post(
+        '/api/v1/knowledge/create',
+        data: {'name': name, 'description': description ?? ''},
+      );
+    } on DioException catch (error) {
+      if (!_shouldFallbackToLegacyKnowledgeApi(error)) {
+        rethrow;
+      }
+      response = await _dio.post(
+        '/api/v1/knowledge/',
+        data: {'name': name, 'description': ?description},
+      );
+    }
     return response.data as Map<String, dynamic>;
   }
 
@@ -3099,31 +3290,136 @@ class ApiService {
     String? description,
   }) async {
     _traceApi('Updating knowledge base: $id');
-    await _dio.put(
-      '/api/v1/knowledge/$id',
-      data: {'name': ?name, 'description': ?description},
-    );
+    var nextName = name;
+    var nextDescription = description;
+    if (nextName == null || nextDescription == null) {
+      final current = _coerceResponseMap(
+        (await _dio.get('/api/v1/knowledge/$id')).data,
+      );
+      nextName ??= current?['name']?.toString();
+      nextDescription ??= current?['description']?.toString();
+    }
+    try {
+      await _dio.post(
+        '/api/v1/knowledge/$id/update',
+        data: {'name': nextName ?? '', 'description': nextDescription ?? ''},
+      );
+    } on DioException catch (error) {
+      if (!_shouldFallbackToLegacyKnowledgeApi(error)) {
+        rethrow;
+      }
+      await _dio.put(
+        '/api/v1/knowledge/$id',
+        data: {'name': ?name, 'description': ?description},
+      );
+    }
   }
 
   Future<void> deleteKnowledgeBase(String id) async {
     _traceApi('Deleting knowledge base: $id');
-    await _dio.delete('/api/v1/knowledge/$id');
+    try {
+      await _dio.delete('/api/v1/knowledge/$id/delete');
+    } on DioException catch (error) {
+      if (!_shouldFallbackToLegacyKnowledgeApi(error)) {
+        rethrow;
+      }
+      await _dio.delete('/api/v1/knowledge/$id');
+    }
   }
 
   Future<List<KnowledgeBaseItem>> getKnowledgeBaseItems(
     String knowledgeBaseId,
   ) async {
     _traceApi('Fetching knowledge base items: $knowledgeBaseId');
-    final response = await _dio.get('/api/v1/knowledge/$knowledgeBaseId/items');
-    final data = response.data;
-    if (data is List) {
+    final rawItems = <dynamic>[];
+    var page = 1;
+    int? total;
+
+    try {
+      while (true) {
+        final response = await _dio.get(
+          '/api/v1/knowledge/$knowledgeBaseId/files',
+          queryParameters: {'page': page},
+        );
+        final data = response.data;
+        if (data is List) {
+          rawItems.addAll(data);
+          break;
+        }
+
+        final responseMap = _coerceJsonMap(data);
+        final pageItems = responseMap?['items'] is List
+            ? responseMap!['items'] as List
+            : const <dynamic>[];
+        rawItems.addAll(pageItems);
+        final rawTotal = responseMap?['total'];
+        if (rawTotal is int) {
+          total = rawTotal;
+        } else if (rawTotal is num) {
+          total = rawTotal.toInt();
+        }
+
+        if (pageItems.isEmpty || (total != null && rawItems.length >= total)) {
+          break;
+        }
+        page += 1;
+      }
+    } on DioException catch (error) {
+      if (!_shouldFallbackToLegacyKnowledgeApi(error)) {
+        rethrow;
+      }
+      final response = await _dio.get(
+        '/api/v1/knowledge/$knowledgeBaseId/items',
+      );
+      final data = response.data;
+      if (data is List) {
+        rawItems
+          ..clear()
+          ..addAll(data);
+      }
+    }
+
+    if (rawItems.isNotEmpty) {
       final normalized = await _normalizeList(
-        data,
+        rawItems,
         debugLabel: 'parse_kb_items',
       );
-      return normalized.map(KnowledgeBaseItem.fromJson).toList(growable: false);
+      return normalized.map(_knowledgeEntryToItem).toList(growable: false);
     }
     return const [];
+  }
+
+  KnowledgeBaseItem _knowledgeEntryToItem(Map<String, dynamic> file) {
+    if (file.containsKey('title') || file.containsKey('content')) {
+      return KnowledgeBaseItem.fromJson(file);
+    }
+    final meta = _coerceJsonMap(file['meta']) ?? const <String, dynamic>{};
+    final filename =
+        _normalizeDynamicString(file['filename']) ??
+        _normalizeDynamicString(file['name']) ??
+        _normalizeDynamicString(meta['name']) ??
+        'Unknown';
+    final content =
+        file['content']?.toString() ?? file['text']?.toString() ?? '';
+    return KnowledgeBaseItem.fromJson({
+      'id': file['id'],
+      'content': content,
+      'title': filename,
+      'created_at': file['created_at'] ?? file['createdAt'],
+      'updated_at':
+          file['updated_at'] ?? file['updatedAt'] ?? file['created_at'],
+      'metadata': {
+        ...meta,
+        'filename': filename,
+        if (file['hash'] != null) 'hash': file['hash'],
+        if (file['content_hash'] != null) 'content_hash': file['content_hash'],
+      },
+    });
+  }
+
+  bool _shouldFallbackToLegacyKnowledgeApi(DioException error) {
+    final statusCode = error.response?.statusCode;
+    return statusCode == 404 || statusCode == 405;
   }
 
   Future<Map<String, dynamic>> addKnowledgeBaseItem(
@@ -3309,15 +3605,43 @@ class ApiService {
     _traceApi('Adding file to knowledge base: $knowledgeBaseId ($filename)');
     try {
       final mimeType = _getMimeType(filename);
+      FormData formData() => FormData.fromMap({
+        'file': MultipartFile.fromBytes(
+          content,
+          filename: filename,
+          contentType: mimeType != null ? MediaType.parse(mimeType) : null,
+        ),
+      });
+      try {
+        final uploadResponse = await _dio.post(
+          '/api/v1/files/',
+          queryParameters: const {
+            'process': true,
+            'process_in_background': false,
+          },
+          data: formData(),
+        );
+        final uploadData = uploadResponse.data as Map<String, dynamic>;
+        final fileId = _fileIdFromUploadResponse(uploadData);
+        if (fileId != null) {
+          try {
+            await _attachUploadedFileToKnowledgeBase(knowledgeBaseId, fileId);
+            return uploadData;
+          } on DioException catch (error) {
+            if (!_shouldFallbackToLegacyKnowledgeFileAdd(error)) {
+              rethrow;
+            }
+            await _deleteUploadedFileBestEffort(fileId);
+          }
+        }
+      } on DioException catch (error) {
+        if (!_shouldFallbackToLegacyKnowledgeApi(error)) {
+          rethrow;
+        }
+      }
       final response = await _dio.post(
         '/api/v1/knowledge/$knowledgeBaseId/file/add',
-        data: FormData.fromMap({
-          'file': MultipartFile.fromBytes(
-            content,
-            filename: filename,
-            contentType: mimeType != null ? MediaType.parse(mimeType) : null,
-          ),
-        }),
+        data: formData(),
       );
       return response.data as Map<String, dynamic>;
     } on DioException catch (e) {
@@ -3334,6 +3658,42 @@ class ApiService {
       }
       rethrow;
     }
+  }
+
+  Future<void> _attachUploadedFileToKnowledgeBase(
+    String knowledgeBaseId,
+    String fileId,
+  ) async {
+    await _dio.post(
+      '/api/v1/knowledge/$knowledgeBaseId/file/add',
+      data: {'file_id': fileId},
+    );
+  }
+
+  Future<void> _deleteUploadedFileBestEffort(String fileId) async {
+    try {
+      await _dio.delete('/api/v1/files/$fileId');
+    } catch (e, stackTrace) {
+      DebugLogger.warning(
+        'knowledge-upload-orphan-cleanup-failed',
+        scope: 'api/knowledge',
+        data: {'fileId': fileId, 'error': e, 'stackTrace': stackTrace},
+      );
+    }
+  }
+
+  bool _shouldFallbackToLegacyKnowledgeFileAdd(DioException error) {
+    final statusCode = error.response?.statusCode;
+    return statusCode == 404 || statusCode == 405 || statusCode == 422;
+  }
+
+  String? _fileIdFromUploadResponse(Map<String, dynamic> data) {
+    final id = _normalizeDynamicString(data['id'] ?? data['file_id']);
+    if (id != null) {
+      return id;
+    }
+    final file = _coerceJsonMap(data['file']) ?? _coerceJsonMap(data['data']);
+    return _normalizeDynamicString(file?['id'] ?? file?['file_id']);
   }
 
   Future<Map<String, dynamic>?> processWebpage({
@@ -3550,7 +3910,7 @@ class ApiService {
       'model': model,
       'messages': formattedMessages,
       'chat_id': chatId,
-      'session_id': ?sessionId,
+      'session_id': sessionId,
       'id': messageId,
     };
 
@@ -3653,29 +4013,46 @@ class ApiService {
   }
 
   // Audio
-  Future<({String? voice, String splitOn, List<BackendTtsVoice> voices})>
+  Future<({String? voice, String? splitOn, List<BackendTtsVoice> voices})>
   _loadServerAudioConfig() async {
-    _traceApi('Fetching server TTS defaults');
-    final response = await _dio.get('/api/v1/audio/config');
-    final data = response.data;
-    final voices = await _loadServerTtsVoicesFromAudioEndpoint();
-    if (data is Map<String, dynamic>) {
-      final ttsConfig = data['tts'];
-      if (ttsConfig is Map<String, dynamic>) {
-        final rawVoice = ttsConfig['VOICE'] ?? ttsConfig['voice'];
-        final rawSplitOn = ttsConfig['SPLIT_ON'] ?? ttsConfig['split_on'];
+    String? voice;
+    String? splitOn;
 
-        final voice = rawVoice is String && rawVoice.trim().isNotEmpty
-            ? rawVoice.trim()
-            : null;
-        final splitOn = rawSplitOn is String && rawSplitOn.trim().isNotEmpty
-            ? rawSplitOn.trim()
-            : 'punctuation';
-
-        return (voice: voice, splitOn: splitOn, voices: voices);
-      }
+    try {
+      _traceApi('Fetching server TTS defaults');
+      final response = await _dio.get('/api/v1/audio/config');
+      final data = response.data;
+      final config = _coerceJsonMap(data);
+      final ttsConfig = _coerceJsonMap(config?['tts']);
+      final rawVoice = ttsConfig?['VOICE'] ?? ttsConfig?['voice'];
+      final rawSplitOn = ttsConfig?['SPLIT_ON'] ?? ttsConfig?['split_on'];
+      voice = _normalizeDynamicString(rawVoice);
+      splitOn = _normalizeDynamicString(rawSplitOn) ?? 'punctuation';
+    } catch (e, stackTrace) {
+      DebugLogger.error(
+        'backend-config-audio-defaults',
+        scope: 'api/config',
+        error: e,
+        stackTrace: stackTrace,
+      );
     }
-    return (voice: null, splitOn: 'punctuation', voices: voices);
+
+    final voices = await _loadServerTtsVoicesOrEmpty();
+    return (voice: voice, splitOn: splitOn, voices: voices);
+  }
+
+  Future<List<BackendTtsVoice>> _loadServerTtsVoicesOrEmpty() async {
+    try {
+      return await _loadServerTtsVoicesFromAudioEndpoint();
+    } catch (e, stackTrace) {
+      DebugLogger.error(
+        'backend-config-audio-voices',
+        scope: 'api/config',
+        error: e,
+        stackTrace: stackTrace,
+      );
+      return const [];
+    }
   }
 
   Future<List<BackendTtsVoice>> _loadServerTtsVoicesFromAudioEndpoint() async {

--- a/lib/core/services/api_service.dart
+++ b/lib/core/services/api_service.dart
@@ -3474,12 +3474,20 @@ class ApiService {
         _normalizeDynamicString(meta['filename']) ??
         _normalizeDynamicString(meta['name']) ??
         'Unknown';
+    String? nonBlankContent(dynamic value) {
+      final text = value?.toString();
+      if (text == null || text.trim().isEmpty) {
+        return null;
+      }
+      return text;
+    }
+
     final dataMap = _coerceJsonMap(file['data']);
     final content =
-        file['content']?.toString() ??
-        file['text']?.toString() ??
-        dataMap?['content']?.toString() ??
-        dataMap?['text']?.toString() ??
+        nonBlankContent(file['content']) ??
+        nonBlankContent(file['text']) ??
+        nonBlankContent(dataMap?['content']) ??
+        nonBlankContent(dataMap?['text']) ??
         '';
     return KnowledgeBaseItem.fromJson({
       'id': file['id'],
@@ -3720,15 +3728,18 @@ class ApiService {
         );
         final uploadData = uploadResponse.data as Map<String, dynamic>;
         final fileId = _fileIdFromUploadResponse(uploadData);
-        if (fileId != null) {
-          try {
-            await _attachUploadedFileToKnowledgeBase(knowledgeBaseId, fileId);
-            return uploadData;
-          } on DioException catch (error) {
-            await _deleteUploadedFileBestEffort(fileId);
-            if (!_shouldFallbackToLegacyKnowledgeFileAdd(error)) {
-              rethrow;
-            }
+        if (fileId == null) {
+          throw StateError(
+            'Upload succeeded but did not return a file id to attach',
+          );
+        }
+        try {
+          await _attachUploadedFileToKnowledgeBase(knowledgeBaseId, fileId);
+          return uploadData;
+        } on DioException catch (error) {
+          await _deleteUploadedFileBestEffort(fileId);
+          if (!_shouldFallbackToLegacyKnowledgeFileAdd(error)) {
+            rethrow;
           }
         }
       } on DioException catch (error) {
@@ -3781,10 +3792,10 @@ class ApiService {
 
   bool _shouldFallbackToLegacyKnowledgeFileAdd(DioException error) {
     final statusCode = error.response?.statusCode;
-    return statusCode == 400 ||
-        statusCode == 404 ||
+    return statusCode == 404 ||
         statusCode == 405 ||
-        statusCode == 422;
+        statusCode == 422 ||
+        (statusCode == 400 && _looksLikeLegacyShapeError(error.response?.data));
   }
 
   String? _fileIdFromUploadResponse(Map<String, dynamic> data) {

--- a/lib/core/services/api_service.dart
+++ b/lib/core/services/api_service.dart
@@ -2332,6 +2332,9 @@ class ApiService {
           if (pinned is bool) {
             return pinned;
           }
+          if (pinned == null) {
+            return false;
+          }
         } on DioException {
           // Older servers may not expose the dedicated pinned-status endpoint;
           // fall through to the full chat payload below.
@@ -2340,6 +2343,9 @@ class ApiService {
       final response = await _dio.get('/api/v1/chats/$id');
       final data = _coerceResponseMap(response.data);
       final value = data?[field];
+      if (value == null && (data?.containsKey(field) ?? false)) {
+        return false;
+      }
       return value is bool ? value : null;
     } catch (e, stackTrace) {
       DebugLogger.error(

--- a/lib/core/services/api_service.dart
+++ b/lib/core/services/api_service.dart
@@ -2296,11 +2296,24 @@ class ApiService {
     if (current == desired) {
       return;
     }
+    if (current == null) {
+      throw StateError(
+        'Cannot set $field for chat $id because the current state is unknown',
+      );
+    }
 
-    final response = await _dio.post(endpoint);
-    final data = _coerceResponseMap(response.data);
-    final actual = data?[field];
-    if (actual is bool && actual != desired) {
+    for (var attempt = 0; attempt < 2; attempt += 1) {
+      final response = await _dio.post(endpoint);
+      final data = _coerceResponseMap(response.data);
+      final actual = data?[field] is bool
+          ? data![field] as bool
+          : await _fetchConversationBooleanField(id, field);
+      if (actual == desired) {
+        return;
+      }
+      if (attempt == 0) {
+        continue;
+      }
       DebugLogger.warning(
         'toggle-mismatch',
         scope: 'api/conversation',
@@ -2311,6 +2324,18 @@ class ApiService {
 
   Future<bool?> _fetchConversationBooleanField(String id, String field) async {
     try {
+      if (field == 'pinned') {
+        try {
+          final pinnedResponse = await _dio.get('/api/v1/chats/$id/pinned');
+          final pinned = pinnedResponse.data;
+          if (pinned is bool) {
+            return pinned;
+          }
+        } on DioException {
+          // Older servers may not expose the dedicated pinned-status endpoint;
+          // fall through to the full chat payload below.
+        }
+      }
       final response = await _dio.get('/api/v1/chats/$id');
       final data = _coerceResponseMap(response.data);
       final value = data?[field];
@@ -2925,26 +2950,40 @@ class ApiService {
 
   Future<List<Conversation>> getConversationsByTag(String tag) async {
     _traceApi('Fetching conversations with tag: $tag');
-    Response<dynamic> response;
     try {
-      response = await _dio.post(
-        '/api/v1/chats/tags',
-        data: {'name': tag},
-        options: Options(responseType: ResponseType.bytes),
-      );
+      const pageSize = 50;
+      final conversations = <Conversation>[];
+      var skip = 0;
+      while (true) {
+        final response = await _dio.post(
+          '/api/v1/chats/tags',
+          data: {'name': tag, 'skip': skip, 'limit': pageSize},
+          options: Options(responseType: ResponseType.bytes),
+        );
+        final page = await _parseConversationSummaryPayload(
+          regular: response.data,
+          debugLabel: 'parse_tag_${tag}_skip_$skip',
+        );
+        conversations.addAll(page);
+        if (page.length < pageSize) {
+          break;
+        }
+        skip += pageSize;
+      }
+      return conversations;
     } on DioException catch (error) {
       if (!_shouldFallbackToLegacyTagApi(error)) {
         rethrow;
       }
-      response = await _dio.get(
+      final response = await _dio.get(
         '/api/v1/chats/tags/${Uri.encodeComponent(tag)}',
         options: Options(responseType: ResponseType.bytes),
       );
+      return _parseConversationSummaryPayload(
+        regular: response.data,
+        debugLabel: 'parse_tag_$tag',
+      );
     }
-    return _parseConversationSummaryPayload(
-      regular: response.data,
-      debugLabel: 'parse_tag_$tag',
-    );
   }
 
   bool _shouldFallbackToLegacyTagApi(DioException error) {
@@ -3339,7 +3378,7 @@ class ApiService {
       while (true) {
         final response = await _dio.get(
           '/api/v1/knowledge/$knowledgeBaseId/files',
-          queryParameters: {'page': page},
+          queryParameters: {'page': page, 'include_content': true},
         );
         final data = response.data;
         if (data is List) {
@@ -3390,7 +3429,7 @@ class ApiService {
   }
 
   KnowledgeBaseItem _knowledgeEntryToItem(Map<String, dynamic> file) {
-    if (file.containsKey('title') || file.containsKey('content')) {
+    if (file.containsKey('title')) {
       return KnowledgeBaseItem.fromJson(file);
     }
     final meta = _coerceJsonMap(file['meta']) ?? const <String, dynamic>{};
@@ -3419,7 +3458,10 @@ class ApiService {
 
   bool _shouldFallbackToLegacyKnowledgeApi(DioException error) {
     final statusCode = error.response?.statusCode;
-    return statusCode == 404 || statusCode == 405;
+    return statusCode == 400 ||
+        statusCode == 404 ||
+        statusCode == 405 ||
+        statusCode == 422;
   }
 
   Future<Map<String, dynamic>> addKnowledgeBaseItem(
@@ -3628,10 +3670,10 @@ class ApiService {
             await _attachUploadedFileToKnowledgeBase(knowledgeBaseId, fileId);
             return uploadData;
           } on DioException catch (error) {
+            await _deleteUploadedFileBestEffort(fileId);
             if (!_shouldFallbackToLegacyKnowledgeFileAdd(error)) {
               rethrow;
             }
-            await _deleteUploadedFileBestEffort(fileId);
           }
         }
       } on DioException catch (error) {
@@ -3684,7 +3726,10 @@ class ApiService {
 
   bool _shouldFallbackToLegacyKnowledgeFileAdd(DioException error) {
     final statusCode = error.response?.statusCode;
-    return statusCode == 404 || statusCode == 405 || statusCode == 422;
+    return statusCode == 400 ||
+        statusCode == 404 ||
+        statusCode == 405 ||
+        statusCode == 422;
   }
 
   String? _fileIdFromUploadResponse(Map<String, dynamic> data) {
@@ -3910,8 +3955,8 @@ class ApiService {
       'model': model,
       'messages': formattedMessages,
       'chat_id': chatId,
-      'session_id': sessionId,
       'id': messageId,
+      'session_id': ?sessionId,
     };
 
     // Include filter_ids if provided (for outlet filters)

--- a/lib/core/services/api_service.dart
+++ b/lib/core/services/api_service.dart
@@ -3332,11 +3332,22 @@ class ApiService {
     var nextName = name;
     var nextDescription = description;
     if (nextName == null || nextDescription == null) {
-      final current = _coerceResponseMap(
-        (await _dio.get('/api/v1/knowledge/$id')).data,
-      );
-      nextName ??= current?['name']?.toString();
-      nextDescription ??= current?['description']?.toString();
+      try {
+        final current = _coerceResponseMap(
+          (await _dio.get('/api/v1/knowledge/$id')).data,
+        );
+        nextName ??= current?['name']?.toString();
+        nextDescription ??= current?['description']?.toString();
+      } on DioException catch (error) {
+        if (!_shouldFallbackToLegacyKnowledgeApi(error)) {
+          rethrow;
+        }
+        await _dio.put(
+          '/api/v1/knowledge/$id',
+          data: {'name': ?name, 'description': ?description},
+        );
+        return;
+      }
     }
     try {
       await _dio.post(
@@ -3373,6 +3384,7 @@ class ApiService {
     final rawItems = <dynamic>[];
     var page = 1;
     int? total;
+    const maxPages = 100;
 
     try {
       while (true) {
@@ -3402,6 +3414,13 @@ class ApiService {
           break;
         }
         page += 1;
+        if (page > maxPages) {
+          _traceApi(
+            'Warning: Hit max knowledge item page limit '
+            '($maxPages) for $knowledgeBaseId',
+          );
+          break;
+        }
       }
     } on DioException catch (error) {
       if (!_shouldFallbackToLegacyKnowledgeApi(error)) {

--- a/lib/core/services/api_service.dart
+++ b/lib/core/services/api_service.dart
@@ -2303,18 +2303,12 @@ class ApiService {
       );
     }
 
-    for (var attempt = 0; attempt < 2; attempt += 1) {
-      final response = await _dio.post(endpoint);
-      final data = _coerceResponseMap(response.data);
-      final actual = data?[field] is bool
-          ? data![field] as bool
-          : await _fetchConversationBooleanField(id, field);
-      if (actual == desired) {
-        return;
-      }
-      if (attempt == 0) {
-        continue;
-      }
+    final response = await _dio.post(endpoint);
+    final data = _coerceResponseMap(response.data);
+    final actual = data?[field] is bool
+        ? data![field] as bool
+        : await _fetchConversationBooleanField(id, field);
+    if (actual is bool && actual != desired) {
       DebugLogger.warning(
         'toggle-mismatch',
         scope: 'api/conversation',
@@ -2959,8 +2953,10 @@ class ApiService {
     _traceApi('Fetching conversations with tag: $tag');
     try {
       const pageSize = 50;
+      const maxPages = 100;
       final conversations = <Conversation>[];
       var skip = 0;
+      var pageCount = 0;
       while (true) {
         final response = await _dio.post(
           '/api/v1/chats/tags',
@@ -2976,6 +2972,11 @@ class ApiService {
           break;
         }
         skip += pageSize;
+        pageCount += 1;
+        if (pageCount >= maxPages) {
+          _traceApi('Warning: Hit max tag page limit ($maxPages) for $tag');
+          break;
+        }
       }
       return conversations;
     } on DioException catch (error) {
@@ -3484,10 +3485,24 @@ class ApiService {
 
   bool _shouldFallbackToLegacyKnowledgeApi(DioException error) {
     final statusCode = error.response?.statusCode;
-    return statusCode == 400 ||
-        statusCode == 404 ||
+    return statusCode == 404 ||
         statusCode == 405 ||
-        statusCode == 422;
+        statusCode == 422 ||
+        (statusCode == 400 && _looksLikeLegacyShapeError(error.response?.data));
+  }
+
+  bool _looksLikeLegacyShapeError(dynamic data) {
+    final detail = data is Map
+        ? data['detail']?.toString()
+        : data is String
+        ? data
+        : null;
+    final normalized = detail?.toLowerCase() ?? '';
+    return normalized.contains('invalid body') ||
+        normalized.contains('field required') ||
+        normalized.contains('extra') ||
+        normalized.contains('schema') ||
+        normalized.contains('validation');
   }
 
   Future<Map<String, dynamic>> addKnowledgeBaseItem(

--- a/lib/core/services/api_service.dart
+++ b/lib/core/services/api_service.dart
@@ -3387,7 +3387,7 @@ class ApiService {
       }
       await _dio.put(
         '/api/v1/knowledge/$id',
-        data: {'name': ?name, 'description': ?description},
+        data: {'name': ?nextName, 'description': ?nextDescription},
       );
     }
   }
@@ -3848,18 +3848,7 @@ class ApiService {
       'document',
       'documents',
     };
-    const nonFileContainerKeys = {
-      'user',
-      'users',
-      'owner',
-      'owners',
-      'collection',
-      'collections',
-      'workspace',
-      'organization',
-      'metadata',
-      'meta',
-    };
+    const filePayloadWrapperKeys = {'data', 'item', 'result'};
     void collect(dynamic value, {String? key, bool inFileContainer = false}) {
       if (value is Map) {
         for (final entry in value.entries) {
@@ -3867,10 +3856,13 @@ class ApiService {
           final normalizedChildKey = childKey
               .replaceAll(RegExp(r'[_-]'), '')
               .toLowerCase();
+          final valueIsNestedContainer =
+              entry.value is Map || entry.value is List;
           final childIsFileContainer =
               fileContainerKeys.contains(normalizedChildKey) ||
               (inFileContainer &&
-                  !nonFileContainerKeys.contains(normalizedChildKey));
+                  (!valueIsNestedContainer ||
+                      filePayloadWrapperKeys.contains(normalizedChildKey)));
           collect(
             entry.value,
             key: childKey,

--- a/lib/core/services/api_service.dart
+++ b/lib/core/services/api_service.dart
@@ -2308,7 +2308,12 @@ class ApiService {
     final actual = data?[field] is bool
         ? data![field] as bool
         : await _fetchConversationBooleanField(id, field);
-    if (actual is bool && actual != desired) {
+    if (actual == null) {
+      throw StateError(
+        'Cannot confirm $field for chat $id after toggling to $desired',
+      );
+    }
+    if (actual != desired) {
       DebugLogger.warning(
         'toggle-mismatch',
         scope: 'api/conversation',
@@ -3836,11 +3841,12 @@ class ApiService {
               inFileContainer ||
               const {
                 'file',
-                'data',
+                'files',
                 'upload',
-                'item',
-                'result',
+                'uploadedfile',
+                'uploadedfiles',
                 'document',
+                'documents',
               }.contains(normalizedChildKey);
           collect(
             entry.value,

--- a/lib/core/services/api_service.dart
+++ b/lib/core/services/api_service.dart
@@ -3788,12 +3788,16 @@ class ApiService {
   }
 
   String? _fileIdFromUploadResponse(Map<String, dynamic> data) {
-    final id = _normalizeDynamicString(data['id'] ?? data['file_id']);
+    final id = _normalizeDynamicString(
+      data['id'] ?? data['file_id'] ?? data['fileId'] ?? data['uuid'],
+    );
     if (id != null) {
       return id;
     }
     final file = _coerceJsonMap(data['file']) ?? _coerceJsonMap(data['data']);
-    return _normalizeDynamicString(file?['id'] ?? file?['file_id']);
+    return _normalizeDynamicString(
+      file?['id'] ?? file?['file_id'] ?? file?['fileId'] ?? file?['uuid'],
+    );
   }
 
   Future<Map<String, dynamic>?> processWebpage({

--- a/lib/core/services/api_service.dart
+++ b/lib/core/services/api_service.dart
@@ -2340,7 +2340,15 @@ class ApiService {
       if (value == null && (data?.containsKey(field) ?? false)) {
         return false;
       }
-      return value is bool ? value : null;
+      if (value is bool) {
+        return value;
+      }
+      final wrappedChat = _coerceJsonMap(data?['chat']);
+      final wrappedValue = wrappedChat?[field];
+      if (wrappedValue == null && (wrappedChat?.containsKey(field) ?? false)) {
+        return false;
+      }
+      return wrappedValue is bool ? wrappedValue : null;
     } catch (e, stackTrace) {
       DebugLogger.error(
         'toggle-state-fetch-failed',
@@ -3463,6 +3471,7 @@ class ApiService {
     final filename =
         _normalizeDynamicString(file['filename']) ??
         _normalizeDynamicString(file['name']) ??
+        _normalizeDynamicString(meta['filename']) ??
         _normalizeDynamicString(meta['name']) ??
         'Unknown';
     final content =

--- a/lib/core/services/api_service.dart
+++ b/lib/core/services/api_service.dart
@@ -621,7 +621,7 @@ class ApiService {
     final audioConfig = await _loadServerAudioConfig();
     return config.copyWith(
       ttsVoice: audioConfig.voice ?? config.ttsVoice,
-      ttsSplitOn: audioConfig.splitOn ?? config.ttsSplitOn,
+      ttsSplitOn: audioConfig.splitOn ?? config.ttsSplitOn ?? 'punctuation',
       ttsVoices: audioConfig.voices.isEmpty
           ? config.ttsVoices
           : audioConfig.voices,
@@ -3848,6 +3848,18 @@ class ApiService {
       'document',
       'documents',
     };
+    const nonFileContainerKeys = {
+      'user',
+      'users',
+      'owner',
+      'owners',
+      'collection',
+      'collections',
+      'workspace',
+      'organization',
+      'metadata',
+      'meta',
+    };
     void collect(dynamic value, {String? key, bool inFileContainer = false}) {
       if (value is Map) {
         for (final entry in value.entries) {
@@ -3857,7 +3869,8 @@ class ApiService {
               .toLowerCase();
           final childIsFileContainer =
               fileContainerKeys.contains(normalizedChildKey) ||
-              (inFileContainer && entry.value is! Map);
+              (inFileContainer &&
+                  !nonFileContainerKeys.contains(normalizedChildKey));
           collect(
             entry.value,
             key: childKey,
@@ -4233,7 +4246,7 @@ class ApiService {
       final rawVoice = ttsConfig?['VOICE'] ?? ttsConfig?['voice'];
       final rawSplitOn = ttsConfig?['SPLIT_ON'] ?? ttsConfig?['split_on'];
       voice = _normalizeDynamicString(rawVoice);
-      splitOn = _normalizeDynamicString(rawSplitOn) ?? 'punctuation';
+      splitOn = _normalizeDynamicString(rawSplitOn);
     } catch (e, stackTrace) {
       DebugLogger.error(
         'backend-config-audio-defaults',

--- a/lib/core/services/api_service.dart
+++ b/lib/core/services/api_service.dart
@@ -3474,8 +3474,13 @@ class ApiService {
         _normalizeDynamicString(meta['filename']) ??
         _normalizeDynamicString(meta['name']) ??
         'Unknown';
+    final dataMap = _coerceJsonMap(file['data']);
     final content =
-        file['content']?.toString() ?? file['text']?.toString() ?? '';
+        file['content']?.toString() ??
+        file['text']?.toString() ??
+        dataMap?['content']?.toString() ??
+        dataMap?['text']?.toString() ??
+        '';
     return KnowledgeBaseItem.fromJson({
       'id': file['id'],
       'content': content,

--- a/lib/core/services/api_service.dart
+++ b/lib/core/services/api_service.dart
@@ -620,9 +620,11 @@ class ApiService {
   ) async {
     final audioConfig = await _loadServerAudioConfig();
     return config.copyWith(
-      ttsVoice: audioConfig.voice,
-      ttsSplitOn: audioConfig.splitOn,
-      ttsVoices: audioConfig.voices.isEmpty ? null : audioConfig.voices,
+      ttsVoice: audioConfig.voice ?? config.ttsVoice,
+      ttsSplitOn: audioConfig.splitOn ?? config.ttsSplitOn,
+      ttsVoices: audioConfig.voices.isEmpty
+          ? config.ttsVoices
+          : audioConfig.voices,
     );
   }
 
@@ -2319,6 +2321,10 @@ class ApiService {
         scope: 'api/conversation',
         data: {'id': id, 'field': field, 'desired': desired, 'actual': actual},
       );
+      throw StateError(
+        'Cannot confirm $field for chat $id after toggling to $desired '
+        '(actual: $actual)',
+      );
     }
   }
 
@@ -3389,7 +3395,10 @@ class ApiService {
   Future<void> deleteKnowledgeBase(String id) async {
     _traceApi('Deleting knowledge base: $id');
     try {
-      await _dio.delete('/api/v1/knowledge/$id/delete');
+      final response = await _dio.delete('/api/v1/knowledge/$id/delete');
+      if (response.data is bool && response.data == false) {
+        throw StateError('Failed to delete knowledge base: $id');
+      }
     } on DioException catch (error) {
       if (!_shouldFallbackToLegacyKnowledgeApi(error)) {
         rethrow;
@@ -3830,6 +3839,15 @@ class ApiService {
 
   List<String> _fileIdsFromUploadResponse(Map<String, dynamic> data) {
     final ids = <String>{};
+    const fileContainerKeys = {
+      'file',
+      'files',
+      'upload',
+      'uploadedfile',
+      'uploadedfiles',
+      'document',
+      'documents',
+    };
     void collect(dynamic value, {String? key, bool inFileContainer = false}) {
       if (value is Map) {
         for (final entry in value.entries) {
@@ -3838,16 +3856,8 @@ class ApiService {
               .replaceAll(RegExp(r'[_-]'), '')
               .toLowerCase();
           final childIsFileContainer =
-              inFileContainer ||
-              const {
-                'file',
-                'files',
-                'upload',
-                'uploadedfile',
-                'uploadedfiles',
-                'document',
-                'documents',
-              }.contains(normalizedChildKey);
+              fileContainerKeys.contains(normalizedChildKey) ||
+              (inFileContainer && entry.value is! Map);
           collect(
             entry.value,
             key: childKey,

--- a/lib/core/services/conversation_parsing.dart
+++ b/lib/core/services/conversation_parsing.dart
@@ -909,9 +909,10 @@ String _stripRenderedSemanticDetails(String content) {
   if (!content.contains('<details')) {
     return content;
   }
-  return content
-      .replaceAll(RegExp(r'<details[\s\S]*?</details>\s*'), '')
-      .trim();
+  final semanticDetailsPattern = RegExp(
+    r'''<details\b(?=[^>]*\btype\s*=\s*["'](?:reasoning|tool_calls|code_interpreter|openai_builtin_tool)["'])[\s\S]*?</details>\s*''',
+  );
+  return content.replaceAll(semanticDetailsPattern, '').trim();
 }
 
 String _stringOr(dynamic value, String fallback) {

--- a/lib/core/services/conversation_parsing.dart
+++ b/lib/core/services/conversation_parsing.dart
@@ -880,9 +880,8 @@ String _mergeContentWithStructuredOutput(
   List<StructuredOutputBlock> outputBlocks,
 ) {
   final hasDetails = structuredOutputBlocksContainDetails(outputBlocks);
-  final baseContent = hasDetails
-      ? _stripRenderedSemanticDetails(content)
-      : content;
+  final baseContent = _stripRenderedSemanticDetails(content);
+  final strippedSemanticDetails = baseContent != content;
   final outputPlainText = structuredOutputBlocksPlainText(outputBlocks);
   final hasOutputPlainText = outputPlainText.trim().isNotEmpty;
   final outputTextIsAuthoritative =
@@ -900,7 +899,8 @@ String _mergeContentWithStructuredOutput(
       effectiveContent,
     );
   }
-  return outputTextIsAuthoritative
+  return outputTextIsAuthoritative ||
+          (strippedSemanticDetails && hasOutputPlainText)
       ? renderStructuredOutputBlocks(outputBlocks)
       : '';
 }

--- a/lib/core/services/conversation_parsing.dart
+++ b/lib/core/services/conversation_parsing.dart
@@ -7,6 +7,9 @@ import '../models/conversation.dart';
 import '../utils/embed_utils.dart';
 import '../utils/message_tree_utils.dart' as message_tree;
 import '../utils/openwebui_source_parser.dart';
+import 'semantic_message_builder.dart';
+import 'structured_output.dart';
+import 'structured_output_renderer.dart';
 
 /// Utilities for converting OpenWebUI conversation payloads into JSON maps
 /// that match the app's `Conversation` / `ChatMessage` schemas. All helpers
@@ -279,6 +282,21 @@ Map<String, dynamic>? _parseSiblingAsVersion(
     }
   }
 
+  final outputItems = _normalizeOutputItems(
+    msgData['output'] ?? historyMsg?['output'],
+  );
+  if (outputItems.isNotEmpty) {
+    final outputBlocks = parseOpenWebUIStructuredOutput(outputItems);
+    final outputContent = contentString.trim().isEmpty
+        ? renderStructuredOutputBlocks(outputBlocks)
+        : structuredOutputBlocksContainDetails(outputBlocks)
+        ? renderStructuredOutputBlocksWithContent(outputBlocks, contentString)
+        : '';
+    if (outputContent.isNotEmpty) {
+      contentString = outputContent;
+    }
+  }
+
   // Extract files
   final effectiveFiles = msgData['files'] ?? historyMsg?['files'];
   List<Map<String, dynamic>>? files;
@@ -331,6 +349,7 @@ Map<String, dynamic>? _parseSiblingAsVersion(
     'followUps': _coerceStringList(followUpsRaw),
     'codeExecutions': _parseCodeExecutionsField(codeExecRaw),
     if (rawUsage.isNotEmpty) 'usage': rawUsage,
+    if (outputItems.isNotEmpty) 'output': outputItems,
     'error': ?errorData,
   };
 }
@@ -513,6 +532,21 @@ Map<String, dynamic> _parseOpenWebUIMessageToJson(
     }
   }
 
+  final outputItems = _normalizeOutputItems(
+    msgData['output'] ?? historyMsg?['output'],
+  );
+  if (outputItems.isNotEmpty) {
+    final outputBlocks = parseOpenWebUIStructuredOutput(outputItems);
+    final outputContent = contentString.trim().isEmpty
+        ? renderStructuredOutputBlocks(outputBlocks)
+        : structuredOutputBlocksContainDetails(outputBlocks)
+        ? renderStructuredOutputBlocksWithContent(outputBlocks, contentString)
+        : '';
+    if (outputContent.isNotEmpty) {
+      contentString = outputContent;
+    }
+  }
+
   // Extract error field from OpenWebUI - preserve it separately for round-trip
   final errorData = _extractErrorData(msgData, historyMsg);
 
@@ -608,6 +642,7 @@ Map<String, dynamic> _parseOpenWebUIMessageToJson(
     'sources': _parseSourcesField(sourcesRaw),
     'usage': usage,
     'versions': const <Map<String, dynamic>>[],
+    if (outputItems.isNotEmpty) 'output': outputItems,
     'error': ?errorData,
   };
 }
@@ -824,6 +859,17 @@ dynamic _coerceJsonValue(dynamic value) {
   return value;
 }
 
+List<Map<String, dynamic>> _normalizeOutputItems(dynamic raw) {
+  if (raw is! List) return const [];
+  final items = <Map<String, dynamic>>[];
+  for (final item in raw) {
+    if (item is Map) {
+      items.add(_coerceJsonMap(item));
+    }
+  }
+  return List<Map<String, dynamic>>.unmodifiable(items);
+}
+
 String _stringOr(dynamic value, String fallback) {
   if (value is String && value.isNotEmpty) {
     return value;
@@ -846,7 +892,13 @@ bool? _safeBool(dynamic value) {
 }
 
 String _synthesizeToolDetailsFromToolCalls(List<Map> calls) {
-  final buffer = StringBuffer();
+  return renderSemanticMessageBlocks(
+    _semanticToolBlocksFromToolCalls(calls),
+  ).trim();
+}
+
+List<SemanticMessageBlock> _semanticToolBlocksFromToolCalls(List<Map> calls) {
+  final blocks = <SemanticMessageBlock>[];
   for (final rawCall in calls) {
     final call = Map<String, dynamic>.from(rawCall);
     final function = call['function'];
@@ -856,34 +908,39 @@ String _synthesizeToolDetailsFromToolCalls(List<Map> calls) {
     final id =
         (call['id']?.toString() ??
         'call_${DateTime.now().millisecondsSinceEpoch}');
-    final done = call['done']?.toString() ?? 'true';
+    final done = _safeBool(call['done']) ?? true;
     final argsRaw = function is Map ? function['arguments'] : call['arguments'];
     final resRaw =
         call['result'] ??
         call['output'] ??
         (function is Map ? function['result'] : null);
-    final attrs = StringBuffer()
-      ..write('type="tool_calls"')
-      ..write(' done="${_escapeHtmlAttr(done)}"')
-      ..write(' id="${_escapeHtmlAttr(id)}"')
-      ..write(' name="${_escapeHtmlAttr(name)}"')
-      ..write(' arguments="${_escapeHtmlAttr(_jsonStringify(argsRaw))}"');
-    final resultStr = _jsonStringify(resRaw);
-    if (resultStr.isNotEmpty) {
-      attrs.write(' result="${_escapeHtmlAttr(resultStr)}"');
-    }
-    buffer.writeln(
-      '<details ${attrs.toString()}><summary>Tool Executed</summary></details>',
+    blocks.add(
+      SemanticDetailsBlock.toolCall(
+        id: id,
+        name: name,
+        arguments: argsRaw,
+        done: done,
+        result: resRaw,
+      ),
     );
   }
-  return buffer.toString().trim();
+  return blocks;
 }
 
 String _synthesizeToolDetailsFromToolCallsWithResults(
   List<Map> calls,
   List<Map> results,
 ) {
-  final buffer = StringBuffer();
+  return renderSemanticMessageBlocks(
+    _semanticToolBlocksFromToolCallsWithResults(calls, results),
+  ).trim();
+}
+
+List<SemanticMessageBlock> _semanticToolBlocksFromToolCallsWithResults(
+  List<Map> calls,
+  List<Map> results,
+) {
+  final blocks = <SemanticMessageBlock>[];
   final resultsMap = <String, Map<String, dynamic>>{};
   for (final rawResult in results) {
     final result = Map<String, dynamic>.from(rawResult);
@@ -908,36 +965,24 @@ String _synthesizeToolDetailsFromToolCallsWithResults(
     final filesRaw = resultEntry != null ? resultEntry['files'] : null;
     final embedsRaw = resultEntry != null ? resultEntry['embeds'] : null;
 
-    final attrs = StringBuffer()
-      ..write('type="tool_calls"')
-      ..write(
-        ' done="${_escapeHtmlAttr(resultEntry != null ? 'true' : 'false')}"',
-      )
-      ..write(' id="${_escapeHtmlAttr(id)}"')
-      ..write(' name="${_escapeHtmlAttr(name)}"')
-      ..write(' arguments="${_escapeHtmlAttr(_jsonStringify(argsRaw))}"');
-    final resultStr = _jsonStringify(resRaw);
-    if (resultStr.isNotEmpty) {
-      attrs.write(' result="${_escapeHtmlAttr(resultStr)}"');
-    }
-    final filesStr = _jsonStringify(filesRaw);
-    if (filesStr.isNotEmpty) {
-      attrs.write(' files="${_escapeHtmlAttr(filesStr)}"');
-    }
-    final embedsStr = _jsonStringify(embedsRaw);
-    if (embedsStr.isNotEmpty) {
-      attrs.write(' embeds="${_escapeHtmlAttr(embedsStr)}"');
-    }
-    buffer.writeln(
-      '<details ${attrs.toString()}><summary>${resultEntry != null ? 'Tool Executed' : 'Executing...'}</summary></details>',
+    blocks.add(
+      SemanticDetailsBlock.toolCall(
+        id: id,
+        name: name,
+        arguments: argsRaw,
+        done: resultEntry != null,
+        result: resRaw,
+        files: filesRaw,
+        embeds: embedsRaw,
+      ),
     );
   }
 
-  return buffer.toString().trim();
+  return blocks;
 }
 
 String _synthesizeToolDetailsFromContentArray(List<dynamic> content) {
-  final buffer = StringBuffer();
+  final blocks = <SemanticMessageBlock>[];
   for (final item in content) {
     if (item is! Map) continue;
     final type = item['type']?.toString();
@@ -960,13 +1005,9 @@ String _synthesizeToolDetailsFromContentArray(List<dynamic> content) {
           }
         }
       }
-      final synthesized = _synthesizeToolDetailsFromToolCallsWithResults(
-        calls,
-        results,
+      blocks.addAll(
+        _semanticToolBlocksFromToolCallsWithResults(calls, results),
       );
-      if (synthesized.isNotEmpty) {
-        buffer.writeln(synthesized);
-      }
       continue;
     }
 
@@ -975,46 +1016,21 @@ String _synthesizeToolDetailsFromContentArray(List<dynamic> content) {
       final id =
           (item['id']?.toString() ??
           'call_${DateTime.now().millisecondsSinceEpoch}');
-      final argsStr = _jsonStringify(item['arguments'] ?? item['args']);
+      final argsRaw = item['arguments'] ?? item['args'];
       final resStr = item['result'] ?? item['output'] ?? item['response'];
-      final embedsStr = _jsonStringify(item['embeds']);
-      final attrs = StringBuffer()
-        ..write('type="tool_calls"')
-        ..write(' done="${_escapeHtmlAttr(resStr != null ? 'true' : 'false')}"')
-        ..write(' id="${_escapeHtmlAttr(id)}"')
-        ..write(' name="${_escapeHtmlAttr(name)}"')
-        ..write(' arguments="${_escapeHtmlAttr(argsStr)}"');
-      final result = _jsonStringify(resStr);
-      if (result.isNotEmpty) {
-        attrs.write(' result="${_escapeHtmlAttr(result)}"');
-      }
-      if (embedsStr.isNotEmpty) {
-        attrs.write(' embeds="${_escapeHtmlAttr(embedsStr)}"');
-      }
-      buffer.writeln(
-        '<details ${attrs.toString()}><summary>${resStr != null ? 'Tool Executed' : 'Executing...'}</summary></details>',
+      blocks.add(
+        SemanticDetailsBlock.toolCall(
+          id: id,
+          name: name,
+          arguments: argsRaw,
+          done: resStr != null,
+          result: resStr,
+          embeds: item['embeds'],
+        ),
       );
     }
   }
-  return buffer.toString().trim();
-}
-
-String _jsonStringify(dynamic value) {
-  if (value == null) return '';
-  try {
-    return jsonEncode(value);
-  } catch (_) {
-    return value.toString();
-  }
-}
-
-String _escapeHtmlAttr(String value) {
-  return value
-      .replaceAll('&', '&amp;')
-      .replaceAll('"', '&quot;')
-      .replaceAll("'", '&#39;')
-      .replaceAll('<', '&lt;')
-      .replaceAll('>', '&gt;');
+  return renderSemanticMessageBlocks(blocks).trim();
 }
 
 Conversation parseFullConversationModel(Object? payload) {

--- a/lib/core/services/conversation_parsing.dart
+++ b/lib/core/services/conversation_parsing.dart
@@ -282,9 +282,7 @@ Map<String, dynamic>? _parseSiblingAsVersion(
     }
   }
 
-  final outputItems = _normalizeOutputItems(
-    msgData['output'] ?? historyMsg?['output'],
-  );
+  final outputItems = _effectiveOutputItems(msgData, historyMsg);
   if (outputItems.isNotEmpty) {
     final outputBlocks = parseOpenWebUIStructuredOutput(outputItems);
     final outputContent = contentString.trim().isEmpty
@@ -532,9 +530,7 @@ Map<String, dynamic> _parseOpenWebUIMessageToJson(
     }
   }
 
-  final outputItems = _normalizeOutputItems(
-    msgData['output'] ?? historyMsg?['output'],
-  );
+  final outputItems = _effectiveOutputItems(msgData, historyMsg);
   if (outputItems.isNotEmpty) {
     final outputBlocks = parseOpenWebUIStructuredOutput(outputItems);
     final outputContent = contentString.trim().isEmpty
@@ -868,6 +864,17 @@ List<Map<String, dynamic>> _normalizeOutputItems(dynamic raw) {
     }
   }
   return List<Map<String, dynamic>>.unmodifiable(items);
+}
+
+List<Map<String, dynamic>> _effectiveOutputItems(
+  Map<String, dynamic> msgData,
+  Map<String, dynamic>? historyMsg,
+) {
+  final directItems = _normalizeOutputItems(msgData['output']);
+  if (directItems.isNotEmpty || historyMsg == null) {
+    return directItems;
+  }
+  return _normalizeOutputItems(historyMsg['output']);
 }
 
 String _stringOr(dynamic value, String fallback) {

--- a/lib/core/services/conversation_parsing.dart
+++ b/lib/core/services/conversation_parsing.dart
@@ -285,11 +285,10 @@ Map<String, dynamic>? _parseSiblingAsVersion(
   final outputItems = _effectiveOutputItems(msgData, historyMsg);
   if (outputItems.isNotEmpty) {
     final outputBlocks = parseOpenWebUIStructuredOutput(outputItems);
-    final outputContent = contentString.trim().isEmpty
-        ? renderStructuredOutputBlocks(outputBlocks)
-        : structuredOutputBlocksContainDetails(outputBlocks)
-        ? renderStructuredOutputBlocksWithContent(outputBlocks, contentString)
-        : '';
+    final outputContent = _mergeContentWithStructuredOutput(
+      contentString,
+      outputBlocks,
+    );
     if (outputContent.isNotEmpty) {
       contentString = outputContent;
     }
@@ -533,11 +532,10 @@ Map<String, dynamic> _parseOpenWebUIMessageToJson(
   final outputItems = _effectiveOutputItems(msgData, historyMsg);
   if (outputItems.isNotEmpty) {
     final outputBlocks = parseOpenWebUIStructuredOutput(outputItems);
-    final outputContent = contentString.trim().isEmpty
-        ? renderStructuredOutputBlocks(outputBlocks)
-        : structuredOutputBlocksContainDetails(outputBlocks)
-        ? renderStructuredOutputBlocksWithContent(outputBlocks, contentString)
-        : '';
+    final outputContent = _mergeContentWithStructuredOutput(
+      contentString,
+      outputBlocks,
+    );
     if (outputContent.isNotEmpty) {
       contentString = outputContent;
     }
@@ -875,6 +873,32 @@ List<Map<String, dynamic>> _effectiveOutputItems(
     return directItems;
   }
   return _normalizeOutputItems(historyMsg['output']);
+}
+
+String _mergeContentWithStructuredOutput(
+  String content,
+  List<StructuredOutputBlock> outputBlocks,
+) {
+  final outputPlainText = structuredOutputBlocksPlainText(outputBlocks);
+  final hasOutputPlainText = outputPlainText.trim().isNotEmpty;
+  final outputTextIsAuthoritative =
+      hasOutputPlainText && outputPlainText.length > content.length;
+  final effectiveContent = outputTextIsAuthoritative
+      ? outputPlainText
+      : content;
+
+  if (effectiveContent.trim().isEmpty) {
+    return renderStructuredOutputBlocks(outputBlocks);
+  }
+  if (structuredOutputBlocksContainDetails(outputBlocks)) {
+    return renderStructuredOutputBlocksWithContent(
+      outputBlocks,
+      effectiveContent,
+    );
+  }
+  return outputTextIsAuthoritative
+      ? renderStructuredOutputBlocks(outputBlocks)
+      : '';
 }
 
 String _stringOr(dynamic value, String fallback) {

--- a/lib/core/services/conversation_parsing.dart
+++ b/lib/core/services/conversation_parsing.dart
@@ -899,10 +899,13 @@ String _mergeContentWithStructuredOutput(
       effectiveContent,
     );
   }
-  return outputTextIsAuthoritative ||
-          (strippedSemanticDetails && hasOutputPlainText)
-      ? renderStructuredOutputBlocks(outputBlocks)
-      : '';
+  if (outputTextIsAuthoritative) {
+    return renderStructuredOutputBlocks(outputBlocks);
+  }
+  if (strippedSemanticDetails) {
+    return renderSemanticMessageBlocks([SemanticTextBlock(baseContent)]);
+  }
+  return '';
 }
 
 String _stripRenderedSemanticDetails(String content) {

--- a/lib/core/services/conversation_parsing.dart
+++ b/lib/core/services/conversation_parsing.dart
@@ -879,18 +879,22 @@ String _mergeContentWithStructuredOutput(
   String content,
   List<StructuredOutputBlock> outputBlocks,
 ) {
+  final hasDetails = structuredOutputBlocksContainDetails(outputBlocks);
+  final baseContent = hasDetails
+      ? _stripRenderedSemanticDetails(content)
+      : content;
   final outputPlainText = structuredOutputBlocksPlainText(outputBlocks);
   final hasOutputPlainText = outputPlainText.trim().isNotEmpty;
   final outputTextIsAuthoritative =
-      hasOutputPlainText && outputPlainText.length > content.length;
+      hasOutputPlainText && outputPlainText.length > baseContent.length;
   final effectiveContent = outputTextIsAuthoritative
       ? outputPlainText
-      : content;
+      : baseContent;
 
   if (effectiveContent.trim().isEmpty) {
     return renderStructuredOutputBlocks(outputBlocks);
   }
-  if (structuredOutputBlocksContainDetails(outputBlocks)) {
+  if (hasDetails) {
     return renderStructuredOutputBlocksWithContent(
       outputBlocks,
       effectiveContent,
@@ -899,6 +903,15 @@ String _mergeContentWithStructuredOutput(
   return outputTextIsAuthoritative
       ? renderStructuredOutputBlocks(outputBlocks)
       : '';
+}
+
+String _stripRenderedSemanticDetails(String content) {
+  if (!content.contains('<details')) {
+    return content;
+  }
+  return content
+      .replaceAll(RegExp(r'<details[\s\S]*?</details>\s*'), '')
+      .trim();
 }
 
 String _stringOr(dynamic value, String fallback) {

--- a/lib/core/services/conversation_parsing.dart
+++ b/lib/core/services/conversation_parsing.dart
@@ -903,6 +903,9 @@ String _mergeContentWithStructuredOutput(
     return renderStructuredOutputBlocks(outputBlocks);
   }
   if (strippedSemanticDetails) {
+    if (hasOutputPlainText && !baseContent.contains(outputPlainText)) {
+      return renderStructuredOutputBlocks(outputBlocks);
+    }
     return renderSemanticMessageBlocks([SemanticTextBlock(baseContent)]);
   }
   return '';

--- a/lib/core/services/openwebui_stream_parser.dart
+++ b/lib/core/services/openwebui_stream_parser.dart
@@ -1,6 +1,8 @@
 import 'dart:async';
 import 'dart:convert';
 
+import 'structured_output.dart';
+
 /// Base class for all stream update types emitted by the OpenWebUI SSE parser.
 sealed class OpenWebUIStreamUpdate {
   const OpenWebUIStreamUpdate();
@@ -30,10 +32,14 @@ final class OpenWebUIReasoningDelta extends OpenWebUIStreamUpdate {
 /// The `output` array contains OR-aligned items such as message, reasoning,
 /// code_interpreter, function_call, and function_call_output.
 final class OpenWebUIOutputUpdate extends OpenWebUIStreamUpdate {
-  const OpenWebUIOutputUpdate(this.output);
+  OpenWebUIOutputUpdate(this.output)
+    : blocks = parseOpenWebUIStructuredOutput(output);
 
-  /// List of output item maps.
+  /// Raw output item maps from the server, preserved for message storage.
   final List<dynamic> output;
+
+  /// Typed blocks parsed from [output].
+  final List<StructuredOutputBlock> blocks;
 }
 
 /// Token usage statistics from a completion chunk.
@@ -166,41 +172,39 @@ Iterable<OpenWebUIStreamUpdate> parseOpenWebUIParsedPayload(
   }
   if (parsed['sources'] != null) {
     yield OpenWebUISourcesUpdate(parsed['sources'] as List<dynamic>);
-    return;
   }
   if (parsed['selected_model_id'] != null) {
     yield OpenWebUISelectedModelUpdate(parsed['selected_model_id'].toString());
-    return;
   }
   if (parsed['usage'] is Map<String, dynamic>) {
     yield OpenWebUIUsageUpdate(parsed['usage'] as Map<String, dynamic>);
-    return;
-  }
-
-  // Structured output items from the backend middleware.
-  final output = parsed['output'];
-  if (output is List && output.isNotEmpty) {
-    yield OpenWebUIOutputUpdate(output);
   }
 
   final choices = parsed['choices'];
-  if (choices is! List || choices.isEmpty) return;
+  if (choices is List && choices.isNotEmpty) {
+    final firstChoice = choices.first;
+    if (firstChoice is Map<String, dynamic>) {
+      final delta = firstChoice['delta'];
+      if (delta is Map<String, dynamic>) {
+        // Reasoning/thinking content (chain-of-thought tokens).
+        final reasoning = delta['reasoning_content']?.toString() ?? '';
+        if (reasoning.isNotEmpty) {
+          yield OpenWebUIReasoningDelta(reasoning);
+        }
 
-  final firstChoice = choices.first;
-  if (firstChoice is! Map<String, dynamic>) return;
-
-  final delta = firstChoice['delta'];
-  if (delta is! Map<String, dynamic>) return;
-
-  // Reasoning/thinking content (chain-of-thought tokens).
-  final reasoning = delta['reasoning_content']?.toString() ?? '';
-  if (reasoning.isNotEmpty) {
-    yield OpenWebUIReasoningDelta(reasoning);
+        final content = delta['content']?.toString() ?? '';
+        if (content.isNotEmpty) {
+          yield OpenWebUIContentDelta(content);
+        }
+      }
+    }
   }
 
-  final content = delta['content']?.toString() ?? '';
-  if (content.isNotEmpty) {
-    yield OpenWebUIContentDelta(content);
+  // Structured output snapshots are applied after deltas from the same frame so
+  // the renderer can merge details with the plain text instead of duplicating it.
+  final output = parsed['output'];
+  if (output is List && output.isNotEmpty) {
+    yield OpenWebUIOutputUpdate(output);
   }
 }
 

--- a/lib/core/services/semantic_message_builder.dart
+++ b/lib/core/services/semantic_message_builder.dart
@@ -80,7 +80,7 @@ final class SemanticDetailsBlock extends SemanticMessageBlock {
     Object? output,
   }) {
     final bodyParts = <String>[
-      if (code.isNotEmpty) '```$language\n$code\n```',
+      if (code.isNotEmpty) _markdownCodeFence(code, language),
       if (output != null) _formatBodyValue(output),
     ].where((part) => part.trim().isNotEmpty).toList(growable: false);
     return SemanticDetailsBlock._(
@@ -169,6 +169,18 @@ String _formatBodyValue(Object value) {
   } catch (_) {
     return value.toString();
   }
+}
+
+String _markdownCodeFence(String code, String language) {
+  final longestFence = RegExp(r'`+').allMatches(code).fold<int>(0, (
+    max,
+    match,
+  ) {
+    final length = match.group(0)?.length ?? 0;
+    return length > max ? length : max;
+  });
+  final fence = '`' * (longestFence >= 3 ? longestFence + 1 : 3);
+  return '$fence$language\n$code\n$fence';
 }
 
 String _escape(String value) => _semanticHtmlEscape.convert(value);

--- a/lib/core/services/semantic_message_builder.dart
+++ b/lib/core/services/semantic_message_builder.dart
@@ -1,0 +1,174 @@
+import 'dart:convert';
+
+const HtmlEscape _semanticHtmlEscape = HtmlEscape();
+
+/// Semantic assistant-message blocks that can be serialized into the markdown
+/// dialect consumed by Conduit's shared markdown renderer.
+sealed class SemanticMessageBlock {
+  const SemanticMessageBlock();
+}
+
+final class SemanticTextBlock extends SemanticMessageBlock {
+  const SemanticTextBlock(this.text);
+
+  final String text;
+}
+
+final class SemanticDetailsBlock extends SemanticMessageBlock {
+  const SemanticDetailsBlock._({
+    required this.type,
+    required this.summary,
+    required this.done,
+    this.bodyMarkdown = '',
+    this.id,
+    this.name,
+    this.duration,
+    this.arguments,
+    this.result,
+    this.files,
+    this.embeds,
+  });
+
+  factory SemanticDetailsBlock.reasoning({
+    required String text,
+    required bool done,
+    String? duration,
+  }) {
+    final normalized = text.trim();
+    final display = normalized.isEmpty
+        ? ''
+        : LineSplitter.split(
+            normalized,
+          ).map((line) => line.startsWith('>') ? line : '> $line').join('\n');
+    final resolvedDuration = duration ?? '0';
+    return SemanticDetailsBlock._(
+      type: 'reasoning',
+      summary: done ? 'Thought for $resolvedDuration seconds' : 'Thinking…',
+      done: done,
+      duration: done ? resolvedDuration : null,
+      bodyMarkdown: display,
+    );
+  }
+
+  factory SemanticDetailsBlock.toolCall({
+    required String id,
+    required String name,
+    required Object? arguments,
+    required bool done,
+    Object? result,
+    Object? files,
+    Object? embeds,
+  }) {
+    return SemanticDetailsBlock._(
+      type: 'tool_calls',
+      summary: done ? 'Tool Executed' : 'Executing...',
+      done: done,
+      id: id,
+      name: name,
+      arguments: arguments,
+      result: result,
+      files: files,
+      embeds: embeds,
+    );
+  }
+
+  factory SemanticDetailsBlock.codeInterpreter({
+    required String code,
+    required String language,
+    required bool done,
+    String? duration,
+    Object? output,
+  }) {
+    final bodyParts = <String>[
+      if (code.isNotEmpty) '```$language\n$code\n```',
+      if (output != null) _formatBodyValue(output),
+    ].where((part) => part.trim().isNotEmpty).toList(growable: false);
+    return SemanticDetailsBlock._(
+      type: 'code_interpreter',
+      summary: done ? 'Analyzed' : 'Analyzing...',
+      done: done,
+      duration: done ? duration ?? '0' : null,
+      bodyMarkdown: bodyParts.join('\n\n'),
+    );
+  }
+
+  final String type;
+  final String summary;
+  final bool done;
+  final String bodyMarkdown;
+  final String? id;
+  final String? name;
+  final String? duration;
+  final Object? arguments;
+  final Object? result;
+  final Object? files;
+  final Object? embeds;
+}
+
+String renderSemanticMessageBlocks(List<SemanticMessageBlock> blocks) {
+  if (blocks.isEmpty) return '';
+
+  final parts = <String>[];
+  for (final block in blocks) {
+    switch (block) {
+      case SemanticTextBlock(:final text):
+        if (text.trim().isNotEmpty) {
+          parts.add(_escape(text));
+        }
+      case SemanticDetailsBlock():
+        final rendered = _renderDetailsBlock(block);
+        if (rendered.trim().isNotEmpty) {
+          parts.add(rendered);
+        }
+    }
+  }
+
+  return parts.join('\n');
+}
+
+String _renderDetailsBlock(SemanticDetailsBlock block) {
+  final attributes = <String, String>{
+    'type': block.type,
+    'done': block.done ? 'true' : 'false',
+    if (block.id != null) 'id': block.id!,
+    if (block.name != null) 'name': block.name!,
+    if (block.duration != null) 'duration': block.duration!,
+    if (block.arguments != null)
+      'arguments': _jsonAttributeValue(block.arguments),
+    if (block.result != null) 'result': _jsonAttributeValue(block.result),
+    if (block.files != null) 'files': _jsonAttributeValue(block.files),
+    if (block.embeds != null) 'embeds': _jsonAttributeValue(block.embeds),
+  };
+  final attrs = attributes.entries
+      .where((entry) => entry.value.trim().isNotEmpty)
+      .map((entry) => '${entry.key}="${_escape(entry.value)}"')
+      .join(' ');
+  final body = block.bodyMarkdown.trim().isEmpty
+      ? ''
+      : '\n${_escape(block.bodyMarkdown)}';
+  return '<details $attrs>\n'
+      '<summary>${_escape(block.summary)}</summary>'
+      '$body\n'
+      '</details>';
+}
+
+String _jsonAttributeValue(Object? value) {
+  try {
+    return jsonEncode(value);
+  } catch (_) {
+    return value?.toString() ?? '';
+  }
+}
+
+String _formatBodyValue(Object value) {
+  if (value is String) {
+    return value;
+  }
+  try {
+    return const JsonEncoder.withIndent('  ').convert(value);
+  } catch (_) {
+    return value.toString();
+  }
+}
+
+String _escape(String value) => _semanticHtmlEscape.convert(value);

--- a/lib/core/services/streaming_helper.dart
+++ b/lib/core/services/streaming_helper.dart
@@ -21,8 +21,11 @@ import '../utils/debug_logger.dart';
 import '../utils/embed_utils.dart';
 import '../utils/openwebui_source_parser.dart';
 import 'openwebui_stream_parser.dart';
+import 'semantic_message_builder.dart';
 import 'streaming_response_controller.dart';
 import 'api_service.dart';
+import 'structured_output.dart';
+import 'structured_output_renderer.dart';
 import 'worker_manager.dart';
 
 // Keep local verbosity toggle for socket logs
@@ -150,31 +153,19 @@ List<ChatSourceReference> _mergeSourceReferences({
   return List<ChatSourceReference>.unmodifiable(merged);
 }
 
-const HtmlEscape _htmlContentEscape = HtmlEscape();
-
 String _buildStreamingReasoningDetails(
   String reasoningContent, {
   required bool done,
   int duration = 0,
 }) {
-  final normalizedReasoning = reasoningContent.trim();
-  final escapedDisplay = normalizedReasoning.isEmpty
-      ? ''
-      : _htmlContentEscape.convert(
-          LineSplitter.split(
-            normalizedReasoning,
-          ).map((line) => line.startsWith('>') ? line : '> $line').join('\n'),
-        );
-  if (done) {
-    return '<details type="reasoning" done="true" duration="$duration">\n'
-        '<summary>Thought for $duration seconds</summary>\n'
-        '$escapedDisplay\n'
-        '</details>\n';
-  }
-  return '<details type="reasoning" done="false">\n'
-      '<summary>Thinking…</summary>\n'
-      '$escapedDisplay\n'
-      '</details>\n';
+  final rendered = renderSemanticMessageBlocks([
+    SemanticDetailsBlock.reasoning(
+      text: reasoningContent,
+      done: done,
+      duration: '$duration',
+    ),
+  ]);
+  return rendered.isEmpty ? '' : '$rendered\n';
 }
 
 String _prependReasoningDetails(String prefix, String reasoningDetails) {
@@ -727,6 +718,9 @@ ActiveChatStream attachUnifiedChunkedStreaming({
     }
     return messages.last.content;
   })();
+  var plainStreamingContent = renderedStreamingContent;
+  var renderedFromStructuredOutput = false;
+  final seenStreamingToolCallKeys = <String>{};
   var inReasoningBlock = false;
   var reasoningPrefix = '';
   var reasoningContent = '';
@@ -744,26 +738,74 @@ ActiveChatStream attachUnifiedChunkedStreaming({
         (renderedStreamingContent.isEmpty ||
             visibleContent.length >= renderedStreamingContent.length)) {
       renderedStreamingContent = visibleContent;
+      if (!renderedFromStructuredOutput) {
+        plainStreamingContent = visibleContent;
+      }
       return;
     }
     final messages = getMessages();
     if (messages.isEmpty || messages.last.role != 'assistant') {
       renderedStreamingContent = '';
+      plainStreamingContent = '';
       return;
     }
     renderedStreamingContent = messages.last.content;
+    if (!renderedFromStructuredOutput) {
+      plainStreamingContent = messages.last.content;
+    }
   }
 
   void replaceVisibleAssistantContent(
     String content, {
     bool updateImages = true,
+    bool fromStructuredOutput = false,
+    String? plainContent,
   }) {
     resetStreamingReasoning();
     renderedStreamingContent = content;
+    renderedFromStructuredOutput = fromStructuredOutput;
+    if (plainContent != null) {
+      plainStreamingContent = plainContent;
+    } else if (!fromStructuredOutput) {
+      plainStreamingContent = content;
+    } else if (content.isEmpty) {
+      plainStreamingContent = '';
+    }
     replaceLastMessageContent(content);
     if (updateImages) {
       updateImagesFromCurrentContent();
     }
+  }
+
+  void replaceVisibleAssistantStructuredOutput(
+    List<StructuredOutputBlock> blocks,
+  ) {
+    if (blocks.isEmpty) return;
+
+    final hasDetails = structuredOutputBlocksContainDetails(blocks);
+    final renderedSnapshot = renderStructuredOutputBlocks(blocks);
+    final hasPlainContent = plainStreamingContent.trim().isNotEmpty;
+    final shouldRenderFullSnapshot =
+        renderedStreamingContent.trim().isEmpty ||
+        renderedFromStructuredOutput ||
+        !hasPlainContent;
+    final outputContent = hasDetails
+        ? shouldRenderFullSnapshot
+              ? renderedSnapshot
+              : renderStructuredOutputBlocksWithContent(
+                  blocks,
+                  plainStreamingContent,
+                )
+        : renderedSnapshot != plainStreamingContent
+        ? renderedSnapshot
+        : '';
+    if (outputContent.isEmpty) return;
+
+    replaceVisibleAssistantContent(
+      outputContent,
+      fromStructuredOutput: shouldRenderFullSnapshot,
+      plainContent: hasDetails ? plainStreamingContent : outputContent,
+    );
   }
 
   void finalizeStreamingReasoning({
@@ -829,8 +871,13 @@ ActiveChatStream attachUnifiedChunkedStreaming({
     stableNonTerminalTerminalRecoverySignature = null;
   }
 
-  void appendVisibleAssistantChunk(String chunk, {bool updateImages = true}) {
+  void appendVisibleAssistantChunk(
+    String chunk, {
+    bool updateImages = true,
+    bool includeInPlainContent = true,
+  }) {
     if (chunk.isEmpty) return;
+    renderedFromStructuredOutput = false;
 
     if (inReasoningBlock) {
       renderedStreamingContent =
@@ -839,10 +886,16 @@ ActiveChatStream attachUnifiedChunkedStreaming({
             _buildStreamingReasoningDetails(reasoningContent, done: true),
           ) +
           chunk;
+      if (includeInPlainContent) {
+        plainStreamingContent += chunk;
+      }
       replaceLastMessageContent(renderedStreamingContent);
       resetStreamingReasoning();
     } else {
       renderedStreamingContent += chunk;
+      if (includeInPlainContent) {
+        plainStreamingContent += chunk;
+      }
       appendToLastMessage(chunk);
     }
 
@@ -881,12 +934,42 @@ ActiveChatStream attachUnifiedChunkedStreaming({
     }
   }
 
-  void handleToolCallStatus(String name) {
+  String? toolCallNameFromPayload(Map<dynamic, dynamic> call) {
+    final function = call['function'];
+    final rawName = function is Map ? function['name'] : call['name'];
+    final name = rawName?.toString().trim();
+    return name == null || name.isEmpty ? null : name;
+  }
+
+  String? toolCallKeyFromPayload(Map<dynamic, dynamic> call) {
+    final rawId = call['id'] ?? call['call_id'] ?? call['tool_call_id'];
+    final id = rawId?.toString().trim();
+    if (id != null && id.isNotEmpty) {
+      return 'id:$id';
+    }
+    final name = toolCallNameFromPayload(call);
+    return name == null ? null : 'name:$name';
+  }
+
+  void handleToolCallStatus(String name, {String? key}) {
     if (name.isEmpty) return;
-    final status =
-        '\n<details type="tool_calls" done="false" '
-        'name="$name"><summary>Executing...</summary>\n</details>\n';
-    appendVisibleAssistantChunk(status, updateImages: false);
+    final toolCallKey = key?.trim().isNotEmpty == true ? key! : 'name:$name';
+    if (!seenStreamingToolCallKeys.add(toolCallKey)) {
+      return;
+    }
+    final status = renderSemanticMessageBlocks([
+      SemanticDetailsBlock.toolCall(
+        id: '',
+        name: name,
+        arguments: null,
+        done: false,
+      ),
+    ]);
+    appendVisibleAssistantChunk(
+      '\n$status\n',
+      updateImages: false,
+      includeInPlainContent: false,
+    );
   }
 
   void handleStreamingToolCallStatuses(dynamic rawToolCalls) {
@@ -895,18 +978,12 @@ ActiveChatStream attachUnifiedChunkedStreaming({
     }
 
     for (final call in rawToolCalls) {
-      if (call is! Map<String, dynamic>) {
+      if (call is! Map) {
         continue;
       }
-      final fn = call['function'];
-      final name = (fn is Map && fn['name'] is String)
-          ? fn['name'] as String
-          : null;
-      if (name is String && name.isNotEmpty) {
-        final exists = renderedStreamingContent.contains('name="$name"');
-        if (!exists) {
-          handleToolCallStatus(name);
-        }
+      final name = toolCallNameFromPayload(call);
+      if (name != null) {
+        handleToolCallStatus(name, key: toolCallKeyFromPayload(call));
       }
     }
   }
@@ -943,13 +1020,14 @@ ActiveChatStream attachUnifiedChunkedStreaming({
       case OpenWebUIReasoningDelta(:final content):
         applyStreamingReasoningDelta(content);
 
-      case OpenWebUIOutputUpdate(:final output):
+      case OpenWebUIOutputUpdate(:final output, :final blocks):
         final normalizedOutput = _normalizeJsonMapList(output);
         if (normalizedOutput.isNotEmpty) {
           applyAssistantServerPatch(
             targetId: assistantMessageId,
             buildPatch: (_) => _AssistantServerPatch(output: normalizedOutput),
           );
+          replaceVisibleAssistantStructuredOutput(blocks);
         }
 
       case OpenWebUIUsageUpdate(:final usage):
@@ -2384,13 +2462,13 @@ ActiveChatStream attachUnifiedChunkedStreaming({
         scope: 'streaming/helper',
       );
       if (allowEmptyContentRecovery &&
-          lastContent.isEmpty &&
+          (lastContent.isEmpty || renderedFromStructuredOutput) &&
           last.error == null) {
         // Non-text artifacts can arrive before the final persisted answer text.
         // Only keep the UI open when the reply is otherwise blank; when files,
         // citations, or structured output are already present, finish now and
         // backfill any late text/error in the background.
-        final waitingForRecovery = !hasNonTextArtifacts;
+        final waitingForRecovery = lastContent.isEmpty && !hasNonTextArtifacts;
         if (scheduleDelayedDoneRecovery(
           finishAfterRecovery: waitingForRecovery,
         )) {
@@ -2607,25 +2685,7 @@ ActiveChatStream attachUnifiedChunkedStreaming({
           }
           if (payload.containsKey('tool_calls')) {
             if (completionTargetId != null) {
-              final tc = payload['tool_calls'];
-              if (tc is List) {
-                for (final call in tc) {
-                  if (call is Map<String, dynamic>) {
-                    final fn = call['function'];
-                    final name = (fn is Map && fn['name'] is String)
-                        ? fn['name'] as String
-                        : null;
-                    if (name is String && name.isNotEmpty) {
-                      final exists = renderedStreamingContent.contains(
-                        'name="$name"',
-                      );
-                      if (!exists) {
-                        handleToolCallStatus(name);
-                      }
-                    }
-                  }
-                }
-              }
+              handleStreamingToolCallStatuses(payload['tool_calls']);
             }
           }
           if (completionTargetId != null && payload.containsKey('choices')) {
@@ -2641,25 +2701,7 @@ ActiveChatStream attachUnifiedChunkedStreaming({
               }
               if (delta is Map) {
                 if (delta.containsKey('tool_calls')) {
-                  final tc = delta['tool_calls'];
-                  if (tc is List) {
-                    for (final call in tc) {
-                      if (call is Map<String, dynamic>) {
-                        final fn = call['function'];
-                        final name = (fn is Map && fn['name'] is String)
-                            ? fn['name'] as String
-                            : null;
-                        if (name is String && name.isNotEmpty) {
-                          final exists = renderedStreamingContent.contains(
-                            'name="$name"',
-                          );
-                          if (!exists) {
-                            handleToolCallStatus(name);
-                          }
-                        }
-                      }
-                    }
-                  }
+                  handleStreamingToolCallStatuses(delta['tool_calls']);
                 }
                 handleStreamingChoiceDelta(delta);
               }
@@ -2670,6 +2712,12 @@ ActiveChatStream attachUnifiedChunkedStreaming({
             if (raw.isNotEmpty) {
               replaceVisibleAssistantContent(raw);
             }
+          }
+          if (completionTargetId != null && normalizedOutputItems.isNotEmpty) {
+            final outputBlocks = parseOpenWebUIStructuredOutput(
+              normalizedOutputItems,
+            );
+            replaceVisibleAssistantStructuredOutput(outputBlocks);
           }
           if (terminalFinishReason != null && !hasFinished) {
             flushStreamingBuffer();
@@ -3493,11 +3541,9 @@ ActiveChatStream attachUnifiedChunkedStreaming({
               '- waiting for socket done signal',
               scope: 'streaming/helper',
             );
-            if (hasCompletedStreamingUi) {
-              scheduleTerminalCompletionRecovery(
-                source: 'taskSocket HTTP completion recovery',
-              );
-            }
+            scheduleTerminalCompletionRecovery(
+              source: 'taskSocket HTTP completion recovery',
+            );
           }
         },
         onError: (error, stackTrace) async {
@@ -3591,6 +3637,12 @@ ActiveChatStream attachUnifiedChunkedStreaming({
           final normalizedOutputItems = _normalizeJsonMapList(
             payload['output'],
           );
+          if (normalizedOutputItems.isNotEmpty) {
+            final outputBlocks = parseOpenWebUIStructuredOutput(
+              normalizedOutputItems,
+            );
+            replaceVisibleAssistantStructuredOutput(outputBlocks);
+          }
           final selectedModelId = payload['selected_model_id']?.toString();
           final metadataPatch =
               selectedModelId != null && selectedModelId.isNotEmpty

--- a/lib/core/services/streaming_helper.dart
+++ b/lib/core/services/streaming_helper.dart
@@ -714,9 +714,10 @@ ActiveChatStream attachUnifiedChunkedStreaming({
     if (!content.contains('<details')) {
       return content;
     }
-    return content
-        .replaceAll(RegExp(r'<details[\s\S]*?</details>\s*'), '')
-        .trim();
+    final semanticDetailsPattern = RegExp(
+      r'''<details\b(?=[^>]*\btype\s*=\s*["'](?:reasoning|tool_calls|code_interpreter|openai_builtin_tool)["'])[\s\S]*?</details>\s*''',
+    );
+    return content.replaceAll(semanticDetailsPattern, '').trim();
   }
 
   var renderedStreamingContent = (() {
@@ -792,6 +793,15 @@ ActiveChatStream attachUnifiedChunkedStreaming({
     }
   }
 
+  bool containsRenderedSemanticDetails(String content) {
+    if (!content.contains('<details')) {
+      return false;
+    }
+    return RegExp(
+      r'''<details\b(?=[^>]*\btype\s*=\s*["'](?:reasoning|tool_calls|code_interpreter|openai_builtin_tool)["'])''',
+    ).hasMatch(content);
+  }
+
   void replaceVisibleAssistantStructuredOutput(
     List<StructuredOutputBlock> blocks,
   ) {
@@ -806,10 +816,17 @@ ActiveChatStream attachUnifiedChunkedStreaming({
             snapshotPlainText.length > plainStreamingContent.length
         ? snapshotPlainText
         : plainStreamingContent;
+    final fullSnapshotPlainText = snapshotPlainText.trim().isNotEmpty
+        ? snapshotPlainText
+        : replacementPlainText;
     final shouldRenderFullSnapshot =
         renderedStreamingContent.trim().isEmpty ||
         renderedFromStructuredOutput ||
         !hasPlainContent;
+    final visibleHasStaleDetails =
+        !hasDetails &&
+        renderedStreamingContent != renderedSnapshot &&
+        containsRenderedSemanticDetails(renderedStreamingContent);
     final outputContent = hasDetails
         ? shouldRenderFullSnapshot
               ? renderedSnapshot
@@ -818,6 +835,8 @@ ActiveChatStream attachUnifiedChunkedStreaming({
                   replacementPlainText,
                 )
         : renderedSnapshot != plainStreamingContent
+        ? renderedSnapshot
+        : visibleHasStaleDetails
         ? renderedSnapshot
         : '';
     if (outputContent.isEmpty) return;
@@ -830,7 +849,7 @@ ActiveChatStream attachUnifiedChunkedStreaming({
       fromStructuredOutput: shouldRenderFullSnapshot,
       plainContent: hasDetails
           ? shouldRenderFullSnapshot
-                ? snapshotPlainText
+                ? fullSnapshotPlainText
                 : replacementPlainText
           : snapshotPlainText,
     );
@@ -910,7 +929,9 @@ ActiveChatStream attachUnifiedChunkedStreaming({
     bool includeInPlainContent = true,
   }) {
     if (chunk.isEmpty) return;
-    renderedFromStructuredOutput = false;
+    if (includeInPlainContent) {
+      renderedFromStructuredOutput = false;
+    }
 
     if (inReasoningBlock) {
       renderedStreamingContent =

--- a/lib/core/services/streaming_helper.dart
+++ b/lib/core/services/streaming_helper.dart
@@ -807,7 +807,11 @@ ActiveChatStream attachUnifiedChunkedStreaming({
     replaceVisibleAssistantContent(
       outputContent,
       fromStructuredOutput: shouldRenderFullSnapshot,
-      plainContent: hasDetails ? plainStreamingContent : snapshotPlainText,
+      plainContent: hasDetails
+          ? shouldRenderFullSnapshot
+                ? snapshotPlainText
+                : plainStreamingContent
+          : snapshotPlainText,
     );
   }
 

--- a/lib/core/services/streaming_helper.dart
+++ b/lib/core/services/streaming_helper.dart
@@ -840,6 +840,10 @@ ActiveChatStream attachUnifiedChunkedStreaming({
     final strippedVisibleContent = visibleHasStaleDetails
         ? stripRenderedSemanticDetails(renderedStreamingContent)
         : '';
+    final strippedVisibleContentMatchesSnapshot =
+        strippedVisibleContent.isNotEmpty &&
+        (renderedSnapshot.trim().isEmpty ||
+            strippedVisibleContent.contains(renderedSnapshot));
     final outputContent = hasDetails
         ? shouldRenderFullSnapshot
               ? renderedSnapshot
@@ -848,7 +852,7 @@ ActiveChatStream attachUnifiedChunkedStreaming({
                   replacementPlainText,
                 )
         : visibleHasStaleDetails
-        ? strippedVisibleContent.isNotEmpty
+        ? strippedVisibleContentMatchesSnapshot
               ? strippedVisibleContent
               : renderedSnapshot
         : renderedSnapshot != plainStreamingContent

--- a/lib/core/services/streaming_helper.dart
+++ b/lib/core/services/streaming_helper.dart
@@ -453,6 +453,8 @@ ActiveChatStream attachUnifiedChunkedStreaming({
   bool isObsoleteStream = false;
   bool backgroundExecutionStopped = false;
   Timer? terminalCompletionRecoveryTimer;
+  bool terminalRecoveryAllowContentOnlyTerminal = false;
+  bool terminalRecoveryAllowStableNonTerminalLocalFallback = false;
   Future<void>? chatCompletedSyncFuture;
   int stableNonTerminalTerminalRecoveryCount = 0;
   String? stableNonTerminalTerminalRecoverySignature;
@@ -784,6 +786,7 @@ ActiveChatStream attachUnifiedChunkedStreaming({
 
     final hasDetails = structuredOutputBlocksContainDetails(blocks);
     final renderedSnapshot = renderStructuredOutputBlocks(blocks);
+    final snapshotPlainText = structuredOutputBlocksPlainText(blocks);
     final hasPlainContent = plainStreamingContent.trim().isNotEmpty;
     final shouldRenderFullSnapshot =
         renderedStreamingContent.trim().isEmpty ||
@@ -804,7 +807,7 @@ ActiveChatStream attachUnifiedChunkedStreaming({
     replaceVisibleAssistantContent(
       outputContent,
       fromStructuredOutput: shouldRenderFullSnapshot,
-      plainContent: hasDetails ? plainStreamingContent : outputContent,
+      plainContent: hasDetails ? plainStreamingContent : snapshotPlainText,
     );
   }
 
@@ -863,7 +866,11 @@ ActiveChatStream attachUnifiedChunkedStreaming({
   // HTTP subscription is tracked separately and cleaned up in disposeSocketSubscriptions.
   final socketSubscriptions = <VoidCallback>[];
   final hasSocketSignals = socketService != null;
-  late final void Function({required String source})
+  late final void Function({
+    required String source,
+    bool allowContentOnlyTerminal,
+    bool allowStableNonTerminalLocalFallback,
+  })
   scheduleTerminalCompletionRecovery;
 
   void resetTerminalCompletionRecoveryStability() {
@@ -1366,6 +1373,7 @@ ActiveChatStream attachUnifiedChunkedStreaming({
   Future<_ServerMessageSnapshot?> pollServerForMessage({
     int attempt = 0,
     int maxAttempts = 3,
+    bool inferDoneFromMissingStreaming = true,
   }) async {
     if (isObsoleteStream) {
       return null;
@@ -1418,7 +1426,9 @@ ActiveChatStream attachUnifiedChunkedStreaming({
       final isDone =
           serverMsg['done'] == true ||
           errorContent != null ||
-          (serverMsg['isStreaming'] != true && content.isNotEmpty);
+          (inferDoneFromMissingStreaming &&
+              serverMsg['isStreaming'] != true &&
+              content.isNotEmpty);
 
       return (
         content: content,
@@ -1442,6 +1452,7 @@ ActiveChatStream attachUnifiedChunkedStreaming({
         return pollServerForMessage(
           attempt: attempt + 1,
           maxAttempts: maxAttempts,
+          inferDoneFromMissingStreaming: inferDoneFromMissingStreaming,
         );
       }
 
@@ -1716,7 +1727,10 @@ ActiveChatStream attachUnifiedChunkedStreaming({
     }
   }
 
-  bool finishFromLocalState({required bool allowContentOnlyTerminal}) {
+  bool finishFromLocalState({
+    required bool allowContentOnlyTerminal,
+    bool allowAlreadyNonStreamingTerminal = true,
+  }) {
     if (isObsoleteStream) {
       return false;
     }
@@ -1728,7 +1742,7 @@ ActiveChatStream attachUnifiedChunkedStreaming({
     final comparisonSnapshot = readLocalMessageComparisonSnapshot(msgs.last);
     final last = comparisonSnapshot.message;
     if (!last.isStreaming) {
-      return true;
+      return allowAlreadyNonStreamingTerminal;
     }
 
     final hasNonTextTerminalArtifacts =
@@ -1755,6 +1769,7 @@ ActiveChatStream attachUnifiedChunkedStreaming({
     bool allowContentOnlyTerminal = false,
     bool allowLocalContentFallbackAfterPollFailedOrMissing = false,
     bool allowLocalContentFallbackAfterNonTerminalSnapshot = false,
+    bool allowStableNonTerminalLocalFallback = true,
     bool retryWhenSnapshotStillStreaming = false,
   }) async {
     if (isObsoleteStream) {
@@ -1762,9 +1777,11 @@ ActiveChatStream attachUnifiedChunkedStreaming({
     }
     bool pollFailedOrMissing = true;
     bool snapshotIndicatedDone = false;
-    bool allowStableNonTerminalLocalFallback = false;
+    bool allowStableNonTerminalLocalFinish = false;
     try {
-      final result = await pollServerForMessage();
+      final result = await pollServerForMessage(
+        inferDoneFromMissingStreaming: allowStableNonTerminalLocalFallback,
+      );
       if (hasFinished || isObsoleteStream) {
         return;
       }
@@ -1820,9 +1837,10 @@ ActiveChatStream attachUnifiedChunkedStreaming({
             stableNonTerminalTerminalRecoverySignature = stabilitySignature;
             stableNonTerminalTerminalRecoveryCount = 1;
           }
-          allowStableNonTerminalLocalFallback =
+          allowStableNonTerminalLocalFinish =
+              allowStableNonTerminalLocalFallback &&
               stableNonTerminalTerminalRecoveryCount >=
-              debugTaskSocketStableNonTerminalRecoveryLimit;
+                  debugTaskSocketStableNonTerminalRecoveryLimit;
         } else {
           resetTerminalCompletionRecoveryStability();
         }
@@ -1860,9 +1878,10 @@ ActiveChatStream attachUnifiedChunkedStreaming({
         stableNonTerminalTerminalRecoverySignature = stabilitySignature;
         stableNonTerminalTerminalRecoveryCount = 1;
       }
-      allowStableNonTerminalLocalFallback =
+      allowStableNonTerminalLocalFinish =
+          allowStableNonTerminalLocalFallback &&
           stableNonTerminalTerminalRecoveryCount >=
-          debugTaskSocketStableNonTerminalRecoveryLimit;
+              debugTaskSocketStableNonTerminalRecoveryLimit;
     } else if (pollFailedOrMissing) {
       resetTerminalCompletionRecoveryStability();
     }
@@ -1872,9 +1891,11 @@ ActiveChatStream attachUnifiedChunkedStreaming({
         (allowLocalContentFallbackAfterPollFailedOrMissing ||
             snapshotIndicatedDone ||
             allowLocalContentFallbackAfterNonTerminalSnapshot ||
-            allowStableNonTerminalLocalFallback);
+            allowStableNonTerminalLocalFinish);
     if (finishFromLocalState(
       allowContentOnlyTerminal: shouldAllowLocalContentFallback,
+      allowAlreadyNonStreamingTerminal:
+          snapshotIndicatedDone || shouldAllowLocalContentFallback,
     )) {
       Future.microtask(refreshConversationSnapshot);
       return;
@@ -1885,42 +1906,66 @@ ActiveChatStream attachUnifiedChunkedStreaming({
         retryWhenSnapshotStillStreaming &&
         !snapshotIndicatedDone &&
         !shouldAllowLocalContentFallback) {
-      scheduleTerminalCompletionRecovery(source: source);
+      scheduleTerminalCompletionRecovery(
+        source: source,
+        allowContentOnlyTerminal: allowContentOnlyTerminal,
+        allowStableNonTerminalLocalFallback:
+            allowStableNonTerminalLocalFallback,
+      );
     }
   }
 
-  scheduleTerminalCompletionRecovery = ({required String source}) {
-    if (hasFinished || isObsoleteStream) {
-      return;
-    }
-    if (terminalCompletionRecoveryTimer != null) {
-      return;
-    }
-
-    terminalCompletionRecoveryTimer = Timer(
-      debugTaskSocketTerminalRecoveryDelay,
-      () {
-        terminalCompletionRecoveryTimer = null;
+  scheduleTerminalCompletionRecovery =
+      ({
+        required String source,
+        bool allowContentOnlyTerminal = true,
+        bool allowStableNonTerminalLocalFallback = true,
+      }) {
         if (hasFinished || isObsoleteStream) {
           return;
         }
-        if (currentAssistantTargetId() != assistantMessageId) {
+        terminalRecoveryAllowContentOnlyTerminal =
+            terminalRecoveryAllowContentOnlyTerminal ||
+            allowContentOnlyTerminal;
+        terminalRecoveryAllowStableNonTerminalLocalFallback =
+            terminalRecoveryAllowStableNonTerminalLocalFallback ||
+            allowStableNonTerminalLocalFallback;
+        if (terminalCompletionRecoveryTimer != null) {
           return;
         }
-        DebugLogger.log(
-          '$source: recovering after missed done/inactive',
-          scope: 'streaming/helper',
+
+        terminalCompletionRecoveryTimer = Timer(
+          debugTaskSocketTerminalRecoveryDelay,
+          () {
+            terminalCompletionRecoveryTimer = null;
+            if (hasFinished || isObsoleteStream) {
+              return;
+            }
+            if (currentAssistantTargetId() != assistantMessageId) {
+              return;
+            }
+            final recoveryAllowContentOnlyTerminal =
+                terminalRecoveryAllowContentOnlyTerminal;
+            final recoveryAllowStableNonTerminalLocalFallback =
+                terminalRecoveryAllowStableNonTerminalLocalFallback;
+            terminalRecoveryAllowContentOnlyTerminal = false;
+            terminalRecoveryAllowStableNonTerminalLocalFallback = false;
+            DebugLogger.log(
+              '$source: recovering after missed done/inactive',
+              scope: 'streaming/helper',
+            );
+            unawaited(
+              recoverTaskSocketTerminalState(
+                source: source,
+                allowContentOnlyTerminal: recoveryAllowContentOnlyTerminal,
+                allowStableNonTerminalLocalFallback:
+                    recoveryAllowStableNonTerminalLocalFallback,
+                retryWhenSnapshotStillStreaming: true,
+              ),
+            );
+          },
         );
-        unawaited(
-          recoverTaskSocketTerminalState(
-            source: source,
-            allowContentOnlyTerminal: true,
-            retryWhenSnapshotStillStreaming: true,
-          ),
-        );
-      },
-    );
-  };
+      };
 
   if (hasSocketSignals) {
     // Handle socket reconnection - update session IDs and check for missed events
@@ -3543,6 +3588,8 @@ ActiveChatStream attachUnifiedChunkedStreaming({
             );
             scheduleTerminalCompletionRecovery(
               source: 'taskSocket HTTP completion recovery',
+              allowContentOnlyTerminal: false,
+              allowStableNonTerminalLocalFallback: false,
             );
           }
         },

--- a/lib/core/services/streaming_helper.dart
+++ b/lib/core/services/streaming_helper.dart
@@ -710,6 +710,15 @@ ActiveChatStream attachUnifiedChunkedStreaming({
   void Function() syncImages = () {};
   void Function() updateImagesFromCurrentContent = () {};
 
+  String initialPlainStreamingContent(String content) {
+    if (!content.contains('<details')) {
+      return content;
+    }
+    return content
+        .replaceAll(RegExp(r'<details[\s\S]*?</details>\s*'), '')
+        .trim();
+  }
+
   var renderedStreamingContent = (() {
     final visibleContent = getVisibleStreamingContent();
     if (visibleContent != null) {
@@ -721,7 +730,9 @@ ActiveChatStream attachUnifiedChunkedStreaming({
     }
     return messages.last.content;
   })();
-  var plainStreamingContent = renderedStreamingContent;
+  var plainStreamingContent = initialPlainStreamingContent(
+    renderedStreamingContent,
+  );
   var renderedFromStructuredOutput = false;
   final seenStreamingToolCallKeys = <String>{};
   var inReasoningBlock = false;

--- a/lib/core/services/streaming_helper.dart
+++ b/lib/core/services/streaming_helper.dart
@@ -802,6 +802,16 @@ ActiveChatStream attachUnifiedChunkedStreaming({
     ).hasMatch(content);
   }
 
+  String stripRenderedSemanticDetails(String content) {
+    if (!content.contains('<details')) {
+      return content;
+    }
+    final semanticDetailsPattern = RegExp(
+      r'''<details\b(?=[^>]*\btype\s*=\s*["'](?:reasoning|tool_calls|code_interpreter|openai_builtin_tool)["'])[\s\S]*?</details>\s*''',
+    );
+    return content.replaceAll(semanticDetailsPattern, '').trim();
+  }
+
   void replaceVisibleAssistantStructuredOutput(
     List<StructuredOutputBlock> blocks,
   ) {
@@ -827,6 +837,9 @@ ActiveChatStream attachUnifiedChunkedStreaming({
         !hasDetails &&
         renderedStreamingContent != renderedSnapshot &&
         containsRenderedSemanticDetails(renderedStreamingContent);
+    final strippedVisibleContent = visibleHasStaleDetails
+        ? stripRenderedSemanticDetails(renderedStreamingContent)
+        : '';
     final outputContent = hasDetails
         ? shouldRenderFullSnapshot
               ? renderedSnapshot
@@ -834,9 +847,11 @@ ActiveChatStream attachUnifiedChunkedStreaming({
                   blocks,
                   replacementPlainText,
                 )
-        : renderedSnapshot != plainStreamingContent
-        ? renderedSnapshot
         : visibleHasStaleDetails
+        ? strippedVisibleContent.isNotEmpty
+              ? strippedVisibleContent
+              : renderedSnapshot
+        : renderedSnapshot != plainStreamingContent
         ? renderedSnapshot
         : '';
     if (outputContent.isEmpty) return;

--- a/lib/core/services/streaming_helper.dart
+++ b/lib/core/services/streaming_helper.dart
@@ -455,6 +455,7 @@ ActiveChatStream attachUnifiedChunkedStreaming({
   Timer? terminalCompletionRecoveryTimer;
   bool terminalRecoveryAllowContentOnlyTerminal = false;
   bool terminalRecoveryAllowStableNonTerminalLocalFallback = false;
+  bool terminalRecoveryInferDoneFromMissingStreaming = false;
   Future<void>? chatCompletedSyncFuture;
   int stableNonTerminalTerminalRecoveryCount = 0;
   String? stableNonTerminalTerminalRecoverySignature;
@@ -874,6 +875,7 @@ ActiveChatStream attachUnifiedChunkedStreaming({
     required String source,
     bool allowContentOnlyTerminal,
     bool allowStableNonTerminalLocalFallback,
+    bool inferDoneFromMissingStreaming,
   })
   scheduleTerminalCompletionRecovery;
 
@@ -1774,6 +1776,7 @@ ActiveChatStream attachUnifiedChunkedStreaming({
     bool allowLocalContentFallbackAfterPollFailedOrMissing = false,
     bool allowLocalContentFallbackAfterNonTerminalSnapshot = false,
     bool allowStableNonTerminalLocalFallback = true,
+    bool inferDoneFromMissingStreaming = true,
     bool retryWhenSnapshotStillStreaming = false,
   }) async {
     if (isObsoleteStream) {
@@ -1784,7 +1787,7 @@ ActiveChatStream attachUnifiedChunkedStreaming({
     bool allowStableNonTerminalLocalFinish = false;
     try {
       final result = await pollServerForMessage(
-        inferDoneFromMissingStreaming: allowStableNonTerminalLocalFallback,
+        inferDoneFromMissingStreaming: inferDoneFromMissingStreaming,
       );
       if (hasFinished || isObsoleteStream) {
         return;
@@ -1915,6 +1918,7 @@ ActiveChatStream attachUnifiedChunkedStreaming({
         allowContentOnlyTerminal: allowContentOnlyTerminal,
         allowStableNonTerminalLocalFallback:
             allowStableNonTerminalLocalFallback,
+        inferDoneFromMissingStreaming: inferDoneFromMissingStreaming,
       );
     }
   }
@@ -1924,6 +1928,7 @@ ActiveChatStream attachUnifiedChunkedStreaming({
         required String source,
         bool allowContentOnlyTerminal = true,
         bool allowStableNonTerminalLocalFallback = true,
+        bool inferDoneFromMissingStreaming = true,
       }) {
         if (hasFinished || isObsoleteStream) {
           return;
@@ -1934,6 +1939,9 @@ ActiveChatStream attachUnifiedChunkedStreaming({
         terminalRecoveryAllowStableNonTerminalLocalFallback =
             terminalRecoveryAllowStableNonTerminalLocalFallback ||
             allowStableNonTerminalLocalFallback;
+        terminalRecoveryInferDoneFromMissingStreaming =
+            terminalRecoveryInferDoneFromMissingStreaming ||
+            inferDoneFromMissingStreaming;
         if (terminalCompletionRecoveryTimer != null) {
           return;
         }
@@ -1952,8 +1960,11 @@ ActiveChatStream attachUnifiedChunkedStreaming({
                 terminalRecoveryAllowContentOnlyTerminal;
             final recoveryAllowStableNonTerminalLocalFallback =
                 terminalRecoveryAllowStableNonTerminalLocalFallback;
+            final recoveryInferDoneFromMissingStreaming =
+                terminalRecoveryInferDoneFromMissingStreaming;
             terminalRecoveryAllowContentOnlyTerminal = false;
             terminalRecoveryAllowStableNonTerminalLocalFallback = false;
+            terminalRecoveryInferDoneFromMissingStreaming = false;
             DebugLogger.log(
               '$source: recovering after missed done/inactive',
               scope: 'streaming/helper',
@@ -1964,6 +1975,8 @@ ActiveChatStream attachUnifiedChunkedStreaming({
                 allowContentOnlyTerminal: recoveryAllowContentOnlyTerminal,
                 allowStableNonTerminalLocalFallback:
                     recoveryAllowStableNonTerminalLocalFallback,
+                inferDoneFromMissingStreaming:
+                    recoveryInferDoneFromMissingStreaming,
                 retryWhenSnapshotStillStreaming: true,
               ),
             );
@@ -3594,6 +3607,7 @@ ActiveChatStream attachUnifiedChunkedStreaming({
               source: 'taskSocket HTTP completion recovery',
               allowContentOnlyTerminal: false,
               allowStableNonTerminalLocalFallback: false,
+              inferDoneFromMissingStreaming: false,
             );
           }
         },

--- a/lib/core/services/streaming_helper.dart
+++ b/lib/core/services/streaming_helper.dart
@@ -840,8 +840,24 @@ ActiveChatStream attachUnifiedChunkedStreaming({
         ? renderedSnapshot
         : '';
     if (outputContent.isEmpty) return;
-    if (!blocks.any((block) => block is StructuredOutputToolCallBlock)) {
+    final renderedToolCallKeys = blocks
+        .whereType<StructuredOutputToolCallBlock>()
+        .map((block) {
+          final id = block.id.trim();
+          if (id.isNotEmpty) {
+            return 'id:$id';
+          }
+          final name = block.name.trim();
+          return name.isEmpty ? null : 'name:$name';
+        })
+        .nonNulls
+        .toSet();
+    if (renderedToolCallKeys.isEmpty) {
       seenStreamingToolCallKeys.clear();
+    } else {
+      seenStreamingToolCallKeys
+        ..clear()
+        ..addAll(renderedToolCallKeys);
     }
 
     replaceVisibleAssistantContent(

--- a/lib/core/services/streaming_helper.dart
+++ b/lib/core/services/streaming_helper.dart
@@ -782,6 +782,7 @@ ActiveChatStream attachUnifiedChunkedStreaming({
       plainStreamingContent = plainContent;
     } else if (!fromStructuredOutput) {
       plainStreamingContent = content;
+      seenStreamingToolCallKeys.clear();
     } else if (content.isEmpty) {
       plainStreamingContent = '';
     }
@@ -800,6 +801,11 @@ ActiveChatStream attachUnifiedChunkedStreaming({
     final renderedSnapshot = renderStructuredOutputBlocks(blocks);
     final snapshotPlainText = structuredOutputBlocksPlainText(blocks);
     final hasPlainContent = plainStreamingContent.trim().isNotEmpty;
+    final replacementPlainText =
+        snapshotPlainText.trim().isNotEmpty &&
+            snapshotPlainText.length > plainStreamingContent.length
+        ? snapshotPlainText
+        : plainStreamingContent;
     final shouldRenderFullSnapshot =
         renderedStreamingContent.trim().isEmpty ||
         renderedFromStructuredOutput ||
@@ -809,12 +815,15 @@ ActiveChatStream attachUnifiedChunkedStreaming({
               ? renderedSnapshot
               : renderStructuredOutputBlocksWithContent(
                   blocks,
-                  plainStreamingContent,
+                  replacementPlainText,
                 )
         : renderedSnapshot != plainStreamingContent
         ? renderedSnapshot
         : '';
     if (outputContent.isEmpty) return;
+    if (!blocks.any((block) => block is StructuredOutputToolCallBlock)) {
+      seenStreamingToolCallKeys.clear();
+    }
 
     replaceVisibleAssistantContent(
       outputContent,
@@ -822,7 +831,7 @@ ActiveChatStream attachUnifiedChunkedStreaming({
       plainContent: hasDetails
           ? shouldRenderFullSnapshot
                 ? snapshotPlainText
-                : plainStreamingContent
+                : replacementPlainText
           : snapshotPlainText,
     );
   }
@@ -1944,14 +1953,10 @@ ActiveChatStream attachUnifiedChunkedStreaming({
         if (hasFinished || isObsoleteStream) {
           return;
         }
-        terminalRecoveryAllowContentOnlyTerminal =
-            terminalRecoveryAllowContentOnlyTerminal ||
-            allowContentOnlyTerminal;
+        terminalRecoveryAllowContentOnlyTerminal = allowContentOnlyTerminal;
         terminalRecoveryAllowStableNonTerminalLocalFallback =
-            terminalRecoveryAllowStableNonTerminalLocalFallback ||
             allowStableNonTerminalLocalFallback;
         terminalRecoveryInferDoneFromMissingStreaming =
-            terminalRecoveryInferDoneFromMissingStreaming ||
             inferDoneFromMissingStreaming;
         if (terminalCompletionRecoveryTimer != null) {
           return;

--- a/lib/core/services/structured_output.dart
+++ b/lib/core/services/structured_output.dart
@@ -107,7 +107,9 @@ List<StructuredOutputBlock> parseOpenWebUIStructuredOutput(
             id: callId,
             name: item['name']?.toString() ?? '',
             arguments: item['arguments'] ?? '',
-            done: resultItem != null || _isDoneStatus(item['status']),
+            done:
+                resultItem != null ||
+                _isDoneStatus(item['status'], includeCompleted: false),
             result: resultItem?['output'],
             files: resultItem?['files'],
             embeds: resultItem?['embeds'],
@@ -214,9 +216,9 @@ bool _isCodeInterpreterDone(
   return _isDoneStatus(status) || hasDuration || !isLastItem;
 }
 
-bool _isDoneStatus(Object? status) {
+bool _isDoneStatus(Object? status, {bool includeCompleted = true}) {
   final normalized = status?.toString();
-  return normalized == 'completed' ||
+  return (includeCompleted && normalized == 'completed') ||
       normalized == 'failed' ||
       normalized == 'incomplete';
 }

--- a/lib/core/services/structured_output.dart
+++ b/lib/core/services/structured_output.dart
@@ -67,8 +67,10 @@ List<StructuredOutputBlock> parseOpenWebUIStructuredOutput(
 
   final toolOutputs = <String, Map<String, dynamic>>{};
   for (final item in output) {
-    if (item is Map && item['type']?.toString() == 'function_call_output') {
-      final callId = item['call_id']?.toString();
+    if (item is Map &&
+        (item['type']?.toString() == 'function_call_output' ||
+            item['type']?.toString() == 'custom_tool_call_output')) {
+      final callId = item['call_id']?.toString() ?? item['id']?.toString();
       if (callId != null && callId.isNotEmpty) {
         toolOutputs[callId] = _coerceJsonMap(item);
       }
@@ -100,22 +102,27 @@ List<StructuredOutputBlock> parseOpenWebUIStructuredOutput(
           );
         }
       case 'function_call':
-        final callId = item['call_id']?.toString() ?? '';
+      case 'custom_tool_call':
+        final callId =
+            item['call_id']?.toString() ?? item['id']?.toString() ?? '';
         final resultItem = toolOutputs[callId];
         blocks.add(
           StructuredOutputToolCallBlock(
             id: callId,
-            name: item['name']?.toString() ?? '',
-            arguments: item['arguments'] ?? '',
+            name:
+                item['name']?.toString() ??
+                (itemType == 'custom_tool_call' ? 'Custom Tool' : ''),
+            arguments: item['arguments'] ?? item['input'] ?? '',
             done:
                 resultItem != null ||
                 _isDoneStatus(item['status'], includeCompleted: false),
-            result: resultItem?['output'],
+            result: resultItem?['output'] ?? resultItem?['content'],
             files: resultItem?['files'],
             embeds: resultItem?['embeds'],
           ),
         );
       case 'function_call_output':
+      case 'custom_tool_call_output':
         continue;
       case 'web_search_call':
       case 'file_search_call':

--- a/lib/core/services/structured_output.dart
+++ b/lib/core/services/structured_output.dart
@@ -161,7 +161,8 @@ String _messageTextFromOutputItem(Map<String, dynamic> item) {
   for (final part in content) {
     if (part is! Map) continue;
     final partType = part['type']?.toString();
-    if (partType == 'text' || partType == 'output_text') {
+    if (part.containsKey('text') &&
+        (partType == null || partType == 'text' || partType == 'output_text')) {
       final text = part['text']?.toString() ?? '';
       if (text.isNotEmpty) {
         messageParts.add(text);

--- a/lib/core/services/structured_output.dart
+++ b/lib/core/services/structured_output.dart
@@ -1,0 +1,293 @@
+/// Typed representation of Open WebUI structured `output` items.
+///
+/// These blocks keep protocol parsing separate from UI string rendering. Raw
+/// `output` maps can still be stored on messages for round-trip compatibility.
+sealed class StructuredOutputBlock {
+  const StructuredOutputBlock();
+}
+
+final class StructuredOutputTextBlock extends StructuredOutputBlock {
+  const StructuredOutputTextBlock({required this.text});
+
+  final String text;
+}
+
+final class StructuredOutputReasoningBlock extends StructuredOutputBlock {
+  const StructuredOutputReasoningBlock({
+    required this.text,
+    required this.done,
+    this.duration,
+  });
+
+  final String text;
+  final bool done;
+  final String? duration;
+}
+
+final class StructuredOutputToolCallBlock extends StructuredOutputBlock {
+  const StructuredOutputToolCallBlock({
+    required this.id,
+    required this.name,
+    required this.arguments,
+    required this.done,
+    this.result,
+    this.files,
+    this.embeds,
+  });
+
+  final String id;
+  final String name;
+  final Object? arguments;
+  final bool done;
+  final Object? result;
+  final Object? files;
+  final Object? embeds;
+}
+
+final class StructuredOutputCodeInterpreterBlock extends StructuredOutputBlock {
+  const StructuredOutputCodeInterpreterBlock({
+    required this.code,
+    required this.language,
+    required this.done,
+    this.duration,
+    this.output,
+  });
+
+  final String code;
+  final String language;
+  final bool done;
+  final String? duration;
+  final Object? output;
+}
+
+List<StructuredOutputBlock> parseOpenWebUIStructuredOutput(
+  List<dynamic> output,
+) {
+  if (output.isEmpty) return const [];
+
+  final toolOutputs = <String, Map<String, dynamic>>{};
+  for (final item in output) {
+    if (item is Map && item['type']?.toString() == 'function_call_output') {
+      final callId = item['call_id']?.toString();
+      if (callId != null && callId.isNotEmpty) {
+        toolOutputs[callId] = _coerceJsonMap(item);
+      }
+    }
+  }
+
+  final blocks = <StructuredOutputBlock>[];
+  for (var index = 0; index < output.length; index++) {
+    final rawItem = output[index];
+    if (rawItem is! Map) continue;
+
+    final item = _coerceJsonMap(rawItem);
+    final itemType = item['type']?.toString() ?? '';
+    switch (itemType) {
+      case 'message':
+        final text = _messageTextFromOutputItem(item);
+        if (text.trim().isNotEmpty) {
+          blocks.add(StructuredOutputTextBlock(text: text));
+        }
+      case 'reasoning':
+        final text = _reasoningTextFromOutputItem(item);
+        if (text.trim().isNotEmpty) {
+          blocks.add(
+            StructuredOutputReasoningBlock(
+              text: text,
+              done: _isReasoningDone(item, index, output.length),
+              duration: item['duration']?.toString(),
+            ),
+          );
+        }
+      case 'function_call':
+        final callId = item['call_id']?.toString() ?? '';
+        final resultItem = toolOutputs[callId];
+        blocks.add(
+          StructuredOutputToolCallBlock(
+            id: callId,
+            name: item['name']?.toString() ?? '',
+            arguments: item['arguments'] ?? '',
+            done: resultItem != null || _isDoneStatus(item['status']),
+            result: resultItem?['output'],
+            files: resultItem?['files'],
+            embeds: resultItem?['embeds'],
+          ),
+        );
+      case 'function_call_output':
+        continue;
+      case 'web_search_call':
+      case 'file_search_call':
+      case 'computer_call':
+        blocks.add(
+          StructuredOutputToolCallBlock(
+            id: item['id']?.toString() ?? '',
+            name: _openAiToolName(itemType),
+            arguments: '',
+            done: _isOpenAiToolDone(item, index, output.length),
+            result: _openAiToolSummary(item),
+          ),
+        );
+      case 'code_interpreter':
+      case 'open_webui:code_interpreter':
+        blocks.add(
+          StructuredOutputCodeInterpreterBlock(
+            code: item['code']?.toString() ?? '',
+            language: (item['language'] ?? item['lang'])?.toString() ?? '',
+            done: _isCodeInterpreterDone(item, index, output.length),
+            duration: item['duration']?.toString(),
+            output: item['output'],
+          ),
+        );
+    }
+  }
+
+  return List<StructuredOutputBlock>.unmodifiable(blocks);
+}
+
+Map<String, dynamic> _coerceJsonMap(Map<dynamic, dynamic> value) {
+  return value.map((key, value) => MapEntry(key.toString(), value));
+}
+
+String _messageTextFromOutputItem(Map<String, dynamic> item) {
+  final content = item['content'];
+  if (content is String) {
+    return content;
+  }
+  if (content is! List) {
+    return '';
+  }
+
+  final messageParts = <String>[];
+  for (final part in content) {
+    if (part is! Map) continue;
+    final partType = part['type']?.toString();
+    if (partType == 'text' || partType == 'output_text') {
+      final text = part['text']?.toString() ?? '';
+      if (text.isNotEmpty) {
+        messageParts.add(text);
+      }
+    }
+  }
+  return messageParts.join();
+}
+
+String _reasoningTextFromOutputItem(Map<String, dynamic> item) {
+  final summary = item['summary'];
+  final content = item['content'];
+  final summaryText = summary is List ? _textFromOutputParts(summary) : '';
+  if (summaryText.trim().isNotEmpty) {
+    return summaryText;
+  }
+  return content is List ? _textFromOutputParts(content) : '';
+}
+
+String _textFromOutputParts(List<dynamic> sourceList) {
+  final reasoningParts = <String>[];
+  for (final part in sourceList) {
+    if (part is! Map) continue;
+    final text = part['text']?.toString();
+    if (text != null && text.isNotEmpty) {
+      reasoningParts.add(text);
+    }
+  }
+  return reasoningParts.join();
+}
+
+bool _isReasoningDone(Map<String, dynamic> item, int index, int outputLength) {
+  final status = item['status']?.toString();
+  final hasDuration = item['duration'] != null;
+  final isLastItem = index == outputLength - 1;
+  return _isDoneStatus(status) ||
+      hasDuration ||
+      (status == null && !isLastItem);
+}
+
+bool _isCodeInterpreterDone(
+  Map<String, dynamic> item,
+  int index,
+  int outputLength,
+) {
+  final status = item['status']?.toString();
+  final hasDuration = item['duration'] != null;
+  final isLastItem = index == outputLength - 1;
+  return _isDoneStatus(status) || hasDuration || !isLastItem;
+}
+
+bool _isDoneStatus(Object? status) {
+  final normalized = status?.toString();
+  return normalized == 'completed' ||
+      normalized == 'failed' ||
+      normalized == 'incomplete';
+}
+
+String _openAiToolName(String itemType) {
+  return switch (itemType) {
+    'web_search_call' => 'Web Search',
+    'file_search_call' => 'File Search',
+    'computer_call' => 'Computer Use',
+    _ => itemType,
+  };
+}
+
+bool _isOpenAiToolDone(Map<String, dynamic> item, int index, int outputLength) {
+  final status = item['status']?.toString();
+  return _isDoneStatus(status) || index != outputLength - 1;
+}
+
+String _openAiToolSummary(Map<String, dynamic> item) {
+  final itemType = item['type']?.toString();
+  final action = item['action'];
+  if (itemType == 'web_search_call' && action is Map) {
+    final actionType = action['type']?.toString();
+    if (actionType == 'search') {
+      final queries = _stringList(action['queries']);
+      final query = action['query']?.toString() ?? '';
+      return queries.isNotEmpty
+          ? 'Search: ${queries.join(', ')}'
+          : query.isNotEmpty
+          ? 'Search: $query'
+          : '';
+    }
+    if (actionType == 'open_page') {
+      final url = action['url']?.toString() ?? '';
+      return url.isEmpty ? '' : 'Open page: $url';
+    }
+    if (actionType == 'find_in_page') {
+      final pattern = action['pattern']?.toString() ?? '';
+      return pattern.isEmpty ? '' : 'Find in page: $pattern';
+    }
+  }
+
+  if (itemType == 'file_search_call') {
+    final queries = _stringList(item['queries']);
+    return queries.isEmpty ? '' : 'Queries: ${queries.join(', ')}';
+  }
+
+  if (itemType == 'computer_call') {
+    if (action is Map && action['type'] != null) {
+      return 'Action: ${action['type']}';
+    }
+    final actions = item['actions'];
+    if (actions is List && actions.isNotEmpty) {
+      final actionTypes = actions
+          .map((action) {
+            if (action is Map && action['type'] != null) {
+              return action['type'].toString();
+            }
+            return '?';
+          })
+          .toList(growable: false);
+      return 'Actions: ${actionTypes.join(', ')}';
+    }
+  }
+
+  return '';
+}
+
+List<String> _stringList(Object? value) {
+  if (value is! List) return const [];
+  return [
+    for (final item in value)
+      if (item != null && item.toString().isNotEmpty) item.toString(),
+  ];
+}

--- a/lib/core/services/structured_output.dart
+++ b/lib/core/services/structured_output.dart
@@ -178,7 +178,7 @@ String _messageTextFromOutputItem(Map<String, dynamic> item) {
       }
     }
   }
-  return messageParts.join();
+  return messageParts.join('\n');
 }
 
 String _reasoningTextFromOutputItem(Map<String, dynamic> item) {
@@ -187,6 +187,9 @@ String _reasoningTextFromOutputItem(Map<String, dynamic> item) {
   final summaryText = summary is List ? _textFromOutputParts(summary) : '';
   if (summaryText.trim().isNotEmpty) {
     return summaryText;
+  }
+  if (content is String) {
+    return content;
   }
   return content is List ? _textFromOutputParts(content) : '';
 }
@@ -200,7 +203,7 @@ String _textFromOutputParts(List<dynamic> sourceList) {
       reasoningParts.add(text);
     }
   }
-  return reasoningParts.join();
+  return reasoningParts.join('\n');
 }
 
 bool _isReasoningDone(Map<String, dynamic> item, int index, int outputLength) {
@@ -225,9 +228,7 @@ bool _isCodeInterpreterDone(
 
 bool _isDoneStatus(Object? status, {bool includeCompleted = true}) {
   final normalized = status?.toString();
-  return (includeCompleted && normalized == 'completed') ||
-      normalized == 'failed' ||
-      normalized == 'incomplete';
+  return includeCompleted && normalized == 'completed';
 }
 
 String _openAiToolName(String itemType) {

--- a/lib/core/services/structured_output_renderer.dart
+++ b/lib/core/services/structured_output_renderer.dart
@@ -1,0 +1,101 @@
+import 'semantic_message_builder.dart';
+import 'structured_output.dart';
+
+String renderStructuredOutputBlocks(List<StructuredOutputBlock> blocks) {
+  return renderSemanticMessageBlocks(
+    structuredOutputBlocksToSemanticMessage(blocks),
+  );
+}
+
+String renderStructuredOutputBlocksWithContent(
+  List<StructuredOutputBlock> blocks,
+  String content,
+) {
+  return renderSemanticMessageBlocks(
+    structuredOutputBlocksToSemanticMessage(blocks, replacementText: content),
+  );
+}
+
+bool structuredOutputBlocksContainDetails(List<StructuredOutputBlock> blocks) {
+  return blocks.any((block) => block is! StructuredOutputTextBlock);
+}
+
+List<SemanticMessageBlock> structuredOutputBlocksToSemanticMessage(
+  List<StructuredOutputBlock> blocks, {
+  String? replacementText,
+}) {
+  if (blocks.isEmpty && (replacementText == null || replacementText.isEmpty)) {
+    return const [];
+  }
+
+  final semanticBlocks = <SemanticMessageBlock>[];
+  var insertedReplacementText = false;
+
+  for (final block in blocks) {
+    switch (block) {
+      case StructuredOutputTextBlock(:final text):
+        if (replacementText != null) {
+          if (!insertedReplacementText) {
+            semanticBlocks.add(SemanticTextBlock(replacementText));
+            insertedReplacementText = true;
+          }
+        } else {
+          semanticBlocks.add(SemanticTextBlock(text));
+        }
+      case StructuredOutputReasoningBlock(
+        :final text,
+        :final done,
+        :final duration,
+      ):
+        semanticBlocks.add(
+          SemanticDetailsBlock.reasoning(
+            text: text,
+            done: done,
+            duration: duration,
+          ),
+        );
+      case StructuredOutputToolCallBlock(
+        :final id,
+        :final name,
+        :final arguments,
+        :final done,
+        :final result,
+        :final files,
+        :final embeds,
+      ):
+        semanticBlocks.add(
+          SemanticDetailsBlock.toolCall(
+            id: id,
+            name: name,
+            arguments: arguments,
+            done: done,
+            result: result,
+            files: files,
+            embeds: embeds,
+          ),
+        );
+      case StructuredOutputCodeInterpreterBlock(
+        :final code,
+        :final language,
+        :final done,
+        :final duration,
+        :final output,
+      ):
+        semanticBlocks.add(
+          SemanticDetailsBlock.codeInterpreter(
+            code: code,
+            language: language,
+            done: done,
+            duration: duration,
+            output: output,
+          ),
+        );
+    }
+  }
+
+  if (replacementText != null && !insertedReplacementText) {
+    semanticBlocks.insert(0, SemanticTextBlock(replacementText));
+  }
+
+  return semanticBlocks;
+}

--- a/lib/core/services/structured_output_renderer.dart
+++ b/lib/core/services/structured_output_renderer.dart
@@ -104,7 +104,7 @@ List<SemanticMessageBlock> structuredOutputBlocksToSemanticMessage(
   }
 
   if (replacementText != null && replacementTextParts == null) {
-    semanticBlocks.insert(0, SemanticTextBlock(replacementText));
+    semanticBlocks.add(SemanticTextBlock(replacementText));
   }
 
   return semanticBlocks;

--- a/lib/core/services/structured_output_renderer.dart
+++ b/lib/core/services/structured_output_renderer.dart
@@ -20,6 +20,13 @@ bool structuredOutputBlocksContainDetails(List<StructuredOutputBlock> blocks) {
   return blocks.any((block) => block is! StructuredOutputTextBlock);
 }
 
+String structuredOutputBlocksPlainText(List<StructuredOutputBlock> blocks) {
+  return blocks
+      .whereType<StructuredOutputTextBlock>()
+      .map((block) => block.text)
+      .join();
+}
+
 List<SemanticMessageBlock> structuredOutputBlocksToSemanticMessage(
   List<StructuredOutputBlock> blocks, {
   String? replacementText,
@@ -29,15 +36,18 @@ List<SemanticMessageBlock> structuredOutputBlocksToSemanticMessage(
   }
 
   final semanticBlocks = <SemanticMessageBlock>[];
-  var insertedReplacementText = false;
+  final replacementTextParts = replacementText == null
+      ? null
+      : _replacementTextParts(blocks, replacementText);
+  var replacementTextIndex = 0;
 
   for (final block in blocks) {
     switch (block) {
       case StructuredOutputTextBlock(:final text):
-        if (replacementText != null) {
-          if (!insertedReplacementText) {
-            semanticBlocks.add(SemanticTextBlock(replacementText));
-            insertedReplacementText = true;
+        if (replacementTextParts != null) {
+          final replacementPart = replacementTextParts[replacementTextIndex++];
+          if (replacementPart.isNotEmpty) {
+            semanticBlocks.add(SemanticTextBlock(replacementPart));
           }
         } else {
           semanticBlocks.add(SemanticTextBlock(text));
@@ -93,9 +103,43 @@ List<SemanticMessageBlock> structuredOutputBlocksToSemanticMessage(
     }
   }
 
-  if (replacementText != null && !insertedReplacementText) {
+  if (replacementText != null && replacementTextParts == null) {
     semanticBlocks.insert(0, SemanticTextBlock(replacementText));
   }
 
   return semanticBlocks;
+}
+
+List<String>? _replacementTextParts(
+  List<StructuredOutputBlock> blocks,
+  String replacementText,
+) {
+  final textBlocks = blocks.whereType<StructuredOutputTextBlock>().toList();
+  if (textBlocks.isEmpty) {
+    return null;
+  }
+  if (textBlocks.length == 1) {
+    return [replacementText];
+  }
+
+  final originalText = textBlocks.map((block) => block.text).join();
+  if (originalText == replacementText) {
+    return textBlocks.map((block) => block.text).toList(growable: false);
+  }
+
+  final parts = <String>[];
+  var offset = 0;
+  for (var index = 0; index < textBlocks.length; index += 1) {
+    if (index == textBlocks.length - 1) {
+      parts.add(replacementText.substring(offset));
+      break;
+    }
+    final requestedNextOffset = offset + textBlocks[index].text.length;
+    final nextOffset = requestedNextOffset > replacementText.length
+        ? replacementText.length
+        : requestedNextOffset;
+    parts.add(replacementText.substring(offset, nextOffset));
+    offset = nextOffset;
+  }
+  return parts;
 }

--- a/lib/core/utils/message_tree_utils.dart
+++ b/lib/core/utils/message_tree_utils.dart
@@ -357,8 +357,13 @@ String? currentIdAfterOpenWebUiDelete<T>(
     childIds = current == null ? const <String>[] : childrenIdsOf(current);
   }
 
+  final visited = <String>{?currentId};
   while (childIds.isNotEmpty) {
-    currentId = childIds.last;
+    final nextId = childIds.last;
+    if (!visited.add(nextId)) {
+      break;
+    }
+    currentId = nextId;
     final current = messagesById[currentId];
     childIds = current == null ? const <String>[] : childrenIdsOf(current);
   }

--- a/lib/core/utils/message_tree_utils.dart
+++ b/lib/core/utils/message_tree_utils.dart
@@ -171,6 +171,262 @@ Set<String> chatMessageDescendantIds(
   return collectDescendantIds(messageId, chatMessageChildrenByParent(messages));
 }
 
+/// Computed OpenWebUI deletion plan for one message tree representation.
+class OpenWebUiDeletePlan {
+  const OpenWebUiDeletePlan({
+    required this.rootId,
+    required this.deletedIds,
+    required this.grandchildIds,
+    required this.deletedParentId,
+  });
+
+  final String rootId;
+  final Set<String> deletedIds;
+  final List<String> grandchildIds;
+  final String? deletedParentId;
+}
+
+class OpenWebUiRawDeleteResult {
+  const OpenWebUiRawDeleteResult({
+    required this.deletedIds,
+    required this.currentId,
+  });
+
+  final Set<String> deletedIds;
+  final String? currentId;
+}
+
+/// Builds the protocol-level delete plan shared by typed and raw adapters.
+///
+/// OpenWebUI removes the selected message and its direct children, then
+/// reparents grandchildren to the selected message's parent.
+OpenWebUiDeletePlan? buildOpenWebUiDeletePlan<T>(
+  Map<String, T> messagesById,
+  String messageId, {
+  required String? Function(T message) parentIdOf,
+  required Iterable<String> Function(T message) childrenIdsOf,
+}) {
+  final rootId = normalizeMessageId(messageId);
+  if (rootId == null) {
+    return null;
+  }
+  final message = messagesById[rootId];
+  if (message == null) {
+    return null;
+  }
+
+  final childIds = childrenIdsOf(
+    message,
+  ).where(messagesById.containsKey).toList(growable: false);
+  final grandchildIds = <String>[];
+  for (final childId in childIds) {
+    final child = messagesById[childId];
+    if (child == null) {
+      continue;
+    }
+    grandchildIds.addAll(childrenIdsOf(child).where(messagesById.containsKey));
+  }
+
+  return OpenWebUiDeletePlan(
+    rootId: rootId,
+    deletedParentId: parentIdOf(message),
+    deletedIds: {rootId, ...childIds},
+    grandchildIds: grandchildIds,
+  );
+}
+
+/// Returns the ids OpenWebUI 0.10 deletes for a message deletion request.
+///
+/// OpenWebUI removes the selected message and its direct children, then
+/// reparents grandchildren to the deleted message's parent.
+Set<String> openWebUiDeletedMessageIds(
+  Iterable<ChatMessage> messages,
+  String messageId,
+) {
+  final messagesById = chatMessagesById(messages);
+  final plan = buildOpenWebUiDeletePlan<ChatMessage>(
+    messagesById,
+    messageId,
+    parentIdOf: chatMessageParentId,
+    childrenIdsOf: chatMessageChildrenIds,
+  );
+  return plan?.deletedIds ?? const <String>{};
+}
+
+/// Applies OpenWebUI 0.10 message deletion semantics to local chat messages.
+List<ChatMessage> deleteOpenWebUiMessageFromChatMessages(
+  Iterable<ChatMessage> messages,
+  String messageId,
+) {
+  final rootId = normalizeMessageId(messageId);
+  if (rootId == null) {
+    return messages.toList(growable: false);
+  }
+
+  final original = messages.toList(growable: false);
+  final messagesById = chatMessagesById(original);
+  final plan = buildOpenWebUiDeletePlan<ChatMessage>(
+    messagesById,
+    rootId,
+    parentIdOf: chatMessageParentId,
+    childrenIdsOf: chatMessageChildrenIds,
+  );
+  if (plan == null) {
+    return original;
+  }
+
+  return [
+    for (final candidate in original)
+      if (!plan.deletedIds.contains(candidate.id))
+        _reparentAfterOpenWebUiDelete(
+          candidate,
+          deletedMessageId: plan.rootId,
+          deletedParentId: plan.deletedParentId,
+          grandchildIds: plan.grandchildIds,
+        ),
+  ];
+}
+
+/// Applies OpenWebUI deletion semantics to a mutable raw history message map.
+///
+/// The input map is updated in place. Values are expected to be cloned by the
+/// caller when preserving the original payload matters.
+Set<String>? deleteOpenWebUiMessageFromRawMessages(
+  Map<String, Map<String, dynamic>> messagesById,
+  String messageId,
+) {
+  final plan = buildOpenWebUiDeletePlan<Map<String, dynamic>>(
+    messagesById,
+    messageId,
+    parentIdOf: rawMessageParentId,
+    childrenIdsOf: rawMessageChildrenIds,
+  );
+  if (plan == null) {
+    return null;
+  }
+
+  messagesById.removeWhere((id, _) => plan.deletedIds.contains(id));
+
+  for (final entry in messagesById.entries) {
+    final id = entry.key;
+    final message = entry.value;
+    final children = rawMessageChildrenIds(
+      message,
+    ).where((id) => !plan.deletedIds.contains(id)).toList(growable: true);
+    if (plan.deletedParentId != null && id == plan.deletedParentId) {
+      for (final grandchildId in plan.grandchildIds) {
+        if (!children.contains(grandchildId)) {
+          children.add(grandchildId);
+        }
+      }
+    }
+    message['childrenIds'] = children;
+
+    if (plan.grandchildIds.contains(id)) {
+      if (plan.deletedParentId == null) {
+        message.remove('parentId');
+      } else {
+        message['parentId'] = plan.deletedParentId;
+      }
+    }
+  }
+
+  return plan.deletedIds;
+}
+
+/// Returns OpenWebUI's replacement current id after applying [plan].
+///
+/// OpenWebUI starts at the deleted message's parent, then repeatedly follows
+/// the last child until it reaches a leaf. For root deletes, it starts from the
+/// last remaining root message.
+String? currentIdAfterOpenWebUiDelete<T>(
+  Map<String, T> messagesById,
+  OpenWebUiDeletePlan plan, {
+  required String? Function(T message) parentIdOf,
+  required Iterable<String> Function(T message) childrenIdsOf,
+}) {
+  String? currentId = plan.deletedParentId;
+  Iterable<String> childIds;
+  if (currentId == null) {
+    childIds = [
+      for (final entry in messagesById.entries)
+        if (parentIdOf(entry.value) == null) entry.key,
+    ];
+  } else {
+    final current = messagesById[currentId];
+    childIds = current == null ? const <String>[] : childrenIdsOf(current);
+  }
+
+  while (childIds.isNotEmpty) {
+    currentId = childIds.last;
+    final current = messagesById[currentId];
+    childIds = current == null ? const <String>[] : childrenIdsOf(current);
+  }
+
+  return currentId != null && messagesById.containsKey(currentId)
+      ? currentId
+      : null;
+}
+
+/// Applies OpenWebUI deletion semantics to raw history messages and returns
+/// both deleted ids and the replacement OpenWebUI current id.
+OpenWebUiRawDeleteResult? deleteOpenWebUiMessageFromRawHistory(
+  Map<String, Map<String, dynamic>> messagesById,
+  String messageId,
+) {
+  final plan = buildOpenWebUiDeletePlan<Map<String, dynamic>>(
+    messagesById,
+    messageId,
+    parentIdOf: rawMessageParentId,
+    childrenIdsOf: rawMessageChildrenIds,
+  );
+  if (plan == null) {
+    return null;
+  }
+
+  deleteOpenWebUiMessageFromRawMessages(messagesById, messageId);
+  return OpenWebUiRawDeleteResult(
+    deletedIds: plan.deletedIds,
+    currentId: currentIdAfterOpenWebUiDelete<Map<String, dynamic>>(
+      messagesById,
+      plan,
+      parentIdOf: rawMessageParentId,
+      childrenIdsOf: rawMessageChildrenIds,
+    ),
+  );
+}
+
+ChatMessage _reparentAfterOpenWebUiDelete(
+  ChatMessage message, {
+  required String deletedMessageId,
+  required String? deletedParentId,
+  required List<String> grandchildIds,
+}) {
+  final metadata = Map<String, dynamic>.from(
+    message.metadata ?? const <String, dynamic>{},
+  );
+  var changed = false;
+
+  if (deletedParentId != null && message.id == deletedParentId) {
+    metadata['childrenIds'] = [
+      ...chatMessageChildrenIds(message).where((id) => id != deletedMessageId),
+      ...grandchildIds,
+    ];
+    changed = true;
+  }
+
+  if (grandchildIds.contains(message.id)) {
+    if (deletedParentId == null) {
+      changed = metadata.remove('parentId') != null || changed;
+    } else if (metadata['parentId'] != deletedParentId) {
+      metadata['parentId'] = deletedParentId;
+      changed = true;
+    }
+  }
+
+  return changed ? message.copyWith(metadata: metadata) : message;
+}
+
 /// Resolves the user parent for an assistant, falling back to earlier users.
 String? assistantParentUserMessageId({
   required List<ChatMessage> messages,

--- a/lib/features/chat/views/chat_page.dart
+++ b/lib/features/chat/views/chat_page.dart
@@ -2186,9 +2186,10 @@ class _ChatPageState extends ConsumerState<ChatPage> {
 
     final latestMessages = ref.read(chatMessagesProvider);
     final removedIds = _messageIdsToDelete(latestMessages, message.id);
-    final updatedMessages = latestMessages
-        .where((candidate) => !removedIds.contains(candidate.id))
-        .toList(growable: false);
+    final updatedMessages = message_tree.deleteOpenWebUiMessageFromChatMessages(
+      latestMessages,
+      message.id,
+    );
 
     final removedStreamingMessage = latestMessages
         .where((candidate) => removedIds.contains(candidate.id))
@@ -2254,7 +2255,7 @@ class _ChatPageState extends ConsumerState<ChatPage> {
   Set<String> _messageIdsToDelete(
     List<ChatMessage> messages,
     String messageId,
-  ) => message_tree.chatMessageDescendantIds(messages, messageId);
+  ) => message_tree.openWebUiDeletedMessageIds(messages, messageId);
 
   void _regenerateMessage(String assistantMessageId) async {
     try {

--- a/lib/features/chat/widgets/assistant_message_widget.dart
+++ b/lib/features/chat/widgets/assistant_message_widget.dart
@@ -1914,8 +1914,8 @@ class _AssistantMessageWidgetState extends ConsumerState<AssistantMessageWidget>
 
   List<_AssistantFooterAction> _buildFooterActions() {
     final l10n = AppLocalizations.of(context)!;
-    final ttsState = ref.watch(textToSpeechControllerProvider);
-    final isChatStreaming = ref.watch(isChatStreamingProvider);
+    final ttsState = ref.read(textToSpeechControllerProvider);
+    final isChatStreaming = ref.read(isChatStreamingProvider);
     final activeUsage = _resolveActiveUsage();
     final messageId = _messageId;
     final activeError = _getActiveError();

--- a/lib/features/chat/widgets/modern_chat_input.dart
+++ b/lib/features/chat/widgets/modern_chat_input.dart
@@ -142,7 +142,7 @@ class _ModernChatInputState extends ConsumerState<ModernChatInput>
   StreamSubscription<IosNativePastePayload>? _pasteSubscription;
   StreamSubscription<IosKeyboardAttachmentEvent>?
   _keyboardAttachmentSubscription;
-  late VoiceInputService _voiceService;
+  VoiceInputService? _voiceService;
   StreamSubscription<String>? _textSub;
   Timer? _contextSuggestionDebounce;
   String _baseTextAtStart = '';
@@ -167,7 +167,6 @@ class _ModernChatInputState extends ConsumerState<ModernChatInput>
   @override
   void initState() {
     super.initState();
-    _voiceService = ref.read(voiceInputServiceProvider);
 
     // Apply any prefilled text on first frame (focus handled via inputFocusTrigger)
     WidgetsBinding.instance.addPostFrameCallback((_) {
@@ -241,6 +240,13 @@ class _ModernChatInputState extends ConsumerState<ModernChatInput>
     // Do not auto-focus on mount; only focus on explicit user intent
   }
 
+  VoiceInputService get _voiceInputService {
+    final VoiceInputService service =
+        _voiceService ?? ref.read(voiceInputServiceProvider);
+    _voiceService = service;
+    return service;
+  }
+
   @override
   void dispose() {
     // Note: Avoid using ref in dispose as per Riverpod best practices
@@ -257,7 +263,7 @@ class _ModernChatInputState extends ConsumerState<ModernChatInput>
     if (!kIsWeb && Platform.isIOS) {
       unawaited(IosKeyboardAttachmentBridge.instance.hide());
     }
-    _voiceService.stopListening();
+    _voiceService?.stopListening();
     super.dispose();
   }
 
@@ -3419,7 +3425,7 @@ class _ModernChatInputState extends ConsumerState<ModernChatInput>
   Future<void> _startVoice() async {
     if (!widget.enabled) return;
     try {
-      final ok = await _voiceService.initialize();
+      final ok = await _voiceInputService.initialize();
       if (!mounted) return;
       if (!ok) {
         _showVoiceUnavailable(
@@ -3429,7 +3435,7 @@ class _ModernChatInputState extends ConsumerState<ModernChatInput>
         return;
       }
       // Centralized permission + start
-      final stream = await _voiceService.beginListening();
+      final stream = await _voiceInputService.beginListening();
       if (!mounted) return;
       setState(() {
         _isRecording = true;
@@ -3467,7 +3473,7 @@ class _ModernChatInputState extends ConsumerState<ModernChatInput>
   }
 
   Future<void> _stopVoice() async {
-    await _voiceService.stopListening();
+    await _voiceInputService.stopListening();
     if (!mounted) return;
     setState(() => _isRecording = false);
     ConduitHaptics.selectionClick();
@@ -3478,7 +3484,7 @@ class _ModernChatInputState extends ConsumerState<ModernChatInput>
       await _stopVoice();
       return;
     }
-    await _voiceService.stopListening();
+    await _voiceInputService.stopListening();
     if (!mounted) return;
     setState(() => _isRecording = false);
     ConduitHaptics.lightImpact();

--- a/test/core/models/server_backed_settings_models_test.dart
+++ b/test/core/models/server_backed_settings_models_test.dart
@@ -2,6 +2,7 @@ import 'package:checks/checks.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'package:conduit/core/models/account_metadata.dart';
+import 'package:conduit/core/models/backend_config.dart';
 import 'package:conduit/core/models/server_about_info.dart';
 import 'package:conduit/core/models/server_user_settings.dart';
 
@@ -140,6 +141,74 @@ void main() {
       check(about.ttsEngine).equals('kokoro');
       check(about.hasAvailableUpdate).isTrue();
       check(about.hasLicenseMetadata).isTrue();
+    });
+
+    test('parses Open WebUI 0.10 string defaults and nested audio flags', () {
+      final about = ServerAboutInfo.fromJson({
+        'name': 'Open WebUI',
+        'version': '0.10.1',
+        'default_models': 'gpt-4.1, claude-sonnet',
+        'features': {'enable_login_form': true},
+        'audio': {
+          'stt': {'engine': 'openai'},
+          'tts': {'engine': 'openai'},
+        },
+      });
+
+      check(about.defaultModels).deepEquals(['gpt-4.1', 'claude-sonnet']);
+      check(about.enableAudioInput).equals(true);
+      check(about.enableAudioOutput).equals(true);
+      check(about.sttEngine).equals('openai');
+      check(about.ttsEngine).equals('openai');
+    });
+  });
+
+  group('BackendConfig.fromJson', () {
+    test('parses Open WebUI 0.10 nested audio config', () {
+      final config = BackendConfig.fromJson({
+        'features': {
+          'enable_websocket': true,
+          'enable_ldap': true,
+          'enable_login_form': false,
+        },
+        'audio': {
+          'stt': {'engine': 'openai'},
+          'tts': {
+            'engine': 'openai',
+            'voice': 'alloy',
+            'split_on': 'punctuation',
+          },
+        },
+        'oauth': {
+          'providers': {'github': 'GitHub'},
+        },
+      });
+
+      check(config.enableWebsocket).equals(true);
+      check(config.enableLdap).isTrue();
+      check(config.enableLoginForm).isFalse();
+      check(config.enableAudioInput).equals(true);
+      check(config.enableAudioOutput).equals(true);
+      check(config.sttProvider).equals('openai');
+      check(config.ttsProvider).equals('openai');
+      check(config.ttsVoice).equals('alloy');
+      check(config.ttsSplitOn).equals('punctuation');
+      check(config.oauthProviders.github).equals('GitHub');
+    });
+
+    test('explicit nested audio feature flags override engine inference', () {
+      final config = BackendConfig.fromJson({
+        'features': {'enable_audio_input': false, 'enable_audio_output': false},
+        'audio': {
+          'stt': {'engine': 'openai'},
+          'tts': {'engine': 'openai'},
+        },
+      });
+
+      check(config.enableAudioInput).equals(false);
+      check(config.enableAudioOutput).equals(false);
+      check(config.sttProvider).equals('openai');
+      check(config.ttsProvider).equals('openai');
     });
   });
 }

--- a/test/core/services/api_service_chat_completion_test.dart
+++ b/test/core/services/api_service_chat_completion_test.dart
@@ -2154,6 +2154,49 @@ void main() {
     });
 
     test(
+      'getKnowledgeBaseItems falls back on non-json files response',
+      () async {
+        final adapter = _QueuedFakeAdapter([
+          _FakeAdapter.raw(
+            bytes: utf8.encode('<html>not json</html>'),
+            headers: {
+              'content-type': ['text/html; charset=utf-8'],
+            },
+          ),
+          _FakeAdapter.raw(
+            bytes: utf8.encode(
+              jsonEncode([
+                {
+                  'id': 'item-1',
+                  'title': 'Legacy note',
+                  'content': 'Saved text',
+                  'created_at': 1700000000,
+                  'updated_at': 1700000001,
+                },
+              ]),
+            ),
+            headers: {
+              'content-type': ['application/json; charset=utf-8'],
+            },
+          ),
+        ]);
+        final api = _buildApiServiceForTest(adapter);
+
+        final items = await api.getKnowledgeBaseItems('kb-1');
+
+        check(
+          adapter.requests.map((request) => request.path).toList(),
+        ).deepEquals([
+          '/api/v1/knowledge/kb-1/files',
+          '/api/v1/knowledge/kb-1/items',
+        ]);
+        check(items).length.equals(1);
+        check(items.single.id).equals('item-1');
+        check(items.single.content).equals('Saved text');
+      },
+    );
+
+    test(
       'addFileToKnowledgeBase falls back to legacy file add route',
       () async {
         final adapter = _QueuedFakeAdapter([
@@ -2281,6 +2324,29 @@ void main() {
         ).deepEquals(['POST /api/v1/files/']);
       },
     );
+
+    test('addFileToKnowledgeBase ignores unrelated nested ids', () async {
+      final adapter = _QueuedFakeAdapter([
+        _FakeAdapter.json({
+          'user': {'id': 'user-1'},
+          'collection': {'uuid': 'collection-1'},
+        }),
+      ]);
+      final api = _buildApiServiceForTest(adapter);
+
+      await expectLater(
+        api.addFileToKnowledgeBase(
+          'kb-1',
+          filename: 'guide.md',
+          content: utf8.encode('hello'),
+        ),
+        throwsA(isA<StateError>()),
+      );
+
+      check(
+        adapter.requests.map((request) => '${request.method} ${request.path}'),
+      ).deepEquals(['POST /api/v1/files/']);
+    });
 
     test(
       'addFileToKnowledgeBase does not legacy reupload unprocessed file',

--- a/test/core/services/api_service_chat_completion_test.dart
+++ b/test/core/services/api_service_chat_completion_test.dart
@@ -1872,27 +1872,35 @@ void main() {
       ).deepEquals(['/api/v1/chats/chat-1/pinned', '/api/v1/chats/chat-1/pin']);
     });
 
-    test('pinConversation does not retry stateless toggle post', () async {
-      final adapter = _QueuedFakeAdapter([
-        _FakeAdapter.raw(
-          bytes: utf8.encode('false'),
-          headers: {
-            'content-type': ['application/json; charset=utf-8'],
-          },
-        ),
-        _FakeAdapter.json({'pinned': false}),
-      ]);
-      final api = _buildApiServiceForTest(adapter);
+    test(
+      'pinConversation surfaces mismatched state after toggle post',
+      () async {
+        final adapter = _QueuedFakeAdapter([
+          _FakeAdapter.raw(
+            bytes: utf8.encode('false'),
+            headers: {
+              'content-type': ['application/json; charset=utf-8'],
+            },
+          ),
+          _FakeAdapter.json({'pinned': false}),
+        ]);
+        final api = _buildApiServiceForTest(adapter);
 
-      await api.pinConversation('chat-1', true);
+        await expectLater(
+          api.pinConversation('chat-1', true),
+          throwsA(isA<StateError>()),
+        );
 
-      check(
-        adapter.requests.map((request) => '${request.method} ${request.path}'),
-      ).deepEquals([
-        'GET /api/v1/chats/chat-1/pinned',
-        'POST /api/v1/chats/chat-1/pin',
-      ]);
-    });
+        check(
+          adapter.requests.map(
+            (request) => '${request.method} ${request.path}',
+          ),
+        ).deepEquals([
+          'GET /api/v1/chats/chat-1/pinned',
+          'POST /api/v1/chats/chat-1/pin',
+        ]);
+      },
+    );
 
     test('pinConversation surfaces unknown state after toggle post', () async {
       final adapter = _QueuedFakeAdapter([
@@ -1986,7 +1994,14 @@ void main() {
 
     test('getBackendConfig preserves older audio config defaults', () async {
       final adapter = _QueuedFakeAdapter([
-        _FakeAdapter.json({'features': {}}),
+        _FakeAdapter.json({
+          'features': {},
+          'tts_voice': 'legacy-voice',
+          'tts_split_on': 'legacy-split',
+          'tts_voices': [
+            {'id': 'legacy', 'name': 'Legacy Voice'},
+          ],
+        }),
         _FakeAdapter.json({
           'tts': {'VOICE': 'nova', 'SPLIT_ON': 'paragraphs'},
         }),
@@ -2006,7 +2021,8 @@ void main() {
       check(config).isNotNull();
       check(config!.ttsVoice).equals('nova');
       check(config.ttsSplitOn).equals('paragraphs');
-      check(config.ttsVoices).isEmpty();
+      check(config.ttsVoices).length.equals(1);
+      check(config.ttsVoices.single.id).equals('legacy');
     });
 
     test('knowledge create update delete fall back to legacy routes', () async {
@@ -2043,6 +2059,32 @@ void main() {
         'DELETE /api/v1/knowledge/kb-1',
       ]);
     });
+
+    test(
+      'deleteKnowledgeBase throws when new delete route returns false',
+      () async {
+        final adapter = _QueuedFakeAdapter([
+          _FakeAdapter.raw(
+            bytes: utf8.encode('false'),
+            headers: {
+              'content-type': ['application/json; charset=utf-8'],
+            },
+          ),
+        ]);
+        final api = _buildApiServiceForTest(adapter);
+
+        await expectLater(
+          api.deleteKnowledgeBase('kb-1'),
+          throwsA(isA<StateError>()),
+        );
+
+        check(
+          adapter.requests.map(
+            (request) => '${request.method} ${request.path}',
+          ),
+        ).deepEquals(['DELETE /api/v1/knowledge/kb-1/delete']);
+      },
+    );
 
     test(
       'knowledge validation 400 does not fall back to legacy route',

--- a/test/core/services/api_service_chat_completion_test.dart
+++ b/test/core/services/api_service_chat_completion_test.dart
@@ -1894,6 +1894,31 @@ void main() {
       ]);
     });
 
+    test(
+      'updateKnowledgeBase falls back when prefetch rejects new route',
+      () async {
+        final adapter = _QueuedFakeAdapter([
+          _FakeAdapter.json({'detail': 'Invalid route'}, statusCode: 422),
+          _FakeAdapter.json({}),
+        ]);
+        final api = _buildApiServiceForTest(adapter);
+
+        await api.updateKnowledgeBase('kb-1', name: 'Docs');
+
+        check(
+          adapter.requests.map(
+            (request) => '${request.method} ${request.path}',
+          ),
+        ).deepEquals([
+          'GET /api/v1/knowledge/kb-1',
+          'PUT /api/v1/knowledge/kb-1',
+        ]);
+        check(
+          adapter.requests.last.data as Map<String, dynamic>,
+        ).deepEquals({'name': 'Docs'});
+      },
+    );
+
     test('getKnowledgeBaseItems reads the 0.10 file-backed endpoint', () async {
       final adapter = _QueuedFakeAdapter([
         _FakeAdapter.json({

--- a/test/core/services/api_service_chat_completion_test.dart
+++ b/test/core/services/api_service_chat_completion_test.dart
@@ -1133,6 +1133,55 @@ void main() {
     );
 
     test(
+      'syncConversationMessages preserves assistant version output',
+      () async {
+        final adapter = _FakeAdapter.json({});
+        final api = _buildApiServiceForTest(adapter);
+
+        final messages = [
+          ChatMessage(
+            id: 'user-1',
+            role: 'user',
+            content: 'hello',
+            timestamp: DateTime.fromMillisecondsSinceEpoch(1700000000000),
+          ),
+          ChatMessage(
+            id: 'asst-1',
+            role: 'assistant',
+            content: 'Current answer',
+            timestamp: DateTime.fromMillisecondsSinceEpoch(1700000001000),
+            versions: [
+              ChatMessageVersion(
+                id: 'asst-alt',
+                content: 'Alternate answer',
+                timestamp: DateTime.fromMillisecondsSinceEpoch(1700000002000),
+                output: const [
+                  {
+                    'type': 'message',
+                    'content': [
+                      {'type': 'output_text', 'text': 'Alternate answer'},
+                    ],
+                  },
+                ],
+              ),
+            ],
+          ),
+        ];
+
+        await api.syncConversationMessages('conv-1', messages, model: 'gpt-4');
+
+        final body = adapter.lastRequest!.data as Map<String, dynamic>;
+        final chat = body['chat'] as Map<String, dynamic>;
+        final history = chat['history'] as Map<String, dynamic>;
+        final historyMessages = history['messages'] as Map<String, dynamic>;
+        final versionMessage =
+            historyMessages['asst-alt'] as Map<String, dynamic>;
+
+        check(versionMessage['output']).isA<List>().length.equals(1);
+      },
+    );
+
+    test(
       'createConversation omits done for streaming assistant placeholders',
       () async {
         final adapter = _FakeAdapter.json({

--- a/test/core/services/api_service_chat_completion_test.dart
+++ b/test/core/services/api_service_chat_completion_test.dart
@@ -2199,6 +2199,31 @@ void main() {
       ).deepEquals({'file_id': 'file-1'});
     });
 
+    test('addFileToKnowledgeBase recognizes camelCase upload id', () async {
+      final adapter = _QueuedFakeAdapter([
+        _FakeAdapter.json({'fileId': 'file-1'}),
+        _FakeAdapter.json({'status': true}),
+      ]);
+      final api = _buildApiServiceForTest(adapter);
+
+      final file = await api.addFileToKnowledgeBase(
+        'kb-1',
+        filename: 'guide.md',
+        content: utf8.encode('hello'),
+      );
+
+      check(file?['fileId']).equals('file-1');
+      check(
+        adapter.requests.map((request) => '${request.method} ${request.path}'),
+      ).deepEquals([
+        'POST /api/v1/files/',
+        'POST /api/v1/knowledge/kb-1/file/add',
+      ]);
+      check(
+        adapter.requests.last.data as Map<String, dynamic>,
+      ).deepEquals({'file_id': 'file-1'});
+    });
+
     test(
       'addFileToKnowledgeBase falls back when attach route rejects file id body',
       () async {

--- a/test/core/services/api_service_chat_completion_test.dart
+++ b/test/core/services/api_service_chat_completion_test.dart
@@ -1894,6 +1894,35 @@ void main() {
       ]);
     });
 
+    test('pinConversation surfaces unknown state after toggle post', () async {
+      final adapter = _QueuedFakeAdapter([
+        _FakeAdapter.raw(
+          bytes: utf8.encode('false'),
+          headers: {
+            'content-type': ['application/json; charset=utf-8'],
+          },
+        ),
+        _FakeAdapter.json({'ok': true}),
+        _FakeAdapter.json({}),
+        _FakeAdapter.json({'id': 'chat-1'}),
+      ]);
+      final api = _buildApiServiceForTest(adapter);
+
+      await expectLater(
+        api.pinConversation('chat-1', true),
+        throwsA(isA<StateError>()),
+      );
+
+      check(
+        adapter.requests.map((request) => '${request.method} ${request.path}'),
+      ).deepEquals([
+        'GET /api/v1/chats/chat-1/pinned',
+        'POST /api/v1/chats/chat-1/pin',
+        'GET /api/v1/chats/chat-1/pinned',
+        'GET /api/v1/chats/chat-1',
+      ]);
+    });
+
     test(
       'pinConversation does not toggle when current state is unknown',
       () async {
@@ -2328,8 +2357,10 @@ void main() {
     test('addFileToKnowledgeBase ignores unrelated nested ids', () async {
       final adapter = _QueuedFakeAdapter([
         _FakeAdapter.json({
-          'user': {'id': 'user-1'},
-          'collection': {'uuid': 'collection-1'},
+          'data': {
+            'user': {'id': 'user-1'},
+            'collection': {'uuid': 'collection-1'},
+          },
         }),
       ]);
       final api = _buildApiServiceForTest(adapter);

--- a/test/core/services/api_service_chat_completion_test.dart
+++ b/test/core/services/api_service_chat_completion_test.dart
@@ -2025,6 +2025,26 @@ void main() {
       check(config.ttsVoices.single.id).equals('legacy');
     });
 
+    test(
+      'getBackendConfig preserves split default when audio omits it',
+      () async {
+        final adapter = _QueuedFakeAdapter([
+          _FakeAdapter.json({'features': {}, 'tts_split_on': 'legacy-split'}),
+          _FakeAdapter.json({
+            'tts': {'VOICE': 'nova'},
+          }),
+          _FakeAdapter.json({'detail': 'Not found'}, statusCode: 404),
+        ]);
+        final api = _buildApiServiceForTest(adapter);
+
+        final config = await api.getBackendConfig();
+
+        check(config).isNotNull();
+        check(config!.ttsVoice).equals('nova');
+        check(config.ttsSplitOn).equals('legacy-split');
+      },
+    );
+
     test('knowledge create update delete fall back to legacy routes', () async {
       final adapter = _QueuedFakeAdapter([
         _FakeAdapter.json({'detail': 'Invalid body'}, statusCode: 422),
@@ -2370,6 +2390,34 @@ void main() {
         ).deepEquals({'file_id': 'file-1'});
       },
     );
+
+    test('addFileToKnowledgeBase recognizes file-wrapped nested id', () async {
+      final adapter = _QueuedFakeAdapter([
+        _FakeAdapter.json({
+          'file': {
+            'data': {'identifier': 'file-1'},
+          },
+        }),
+        _FakeAdapter.json({'status': true}),
+      ]);
+      final api = _buildApiServiceForTest(adapter);
+
+      await api.addFileToKnowledgeBase(
+        'kb-1',
+        filename: 'guide.md',
+        content: utf8.encode('hello'),
+      );
+
+      check(
+        adapter.requests.map((request) => '${request.method} ${request.path}'),
+      ).deepEquals([
+        'POST /api/v1/files/',
+        'POST /api/v1/knowledge/kb-1/file/add',
+      ]);
+      check(
+        adapter.requests.last.data as Map<String, dynamic>,
+      ).deepEquals({'file_id': 'file-1'});
+    });
 
     test(
       'addFileToKnowledgeBase does not legacy reupload without file id',

--- a/test/core/services/api_service_chat_completion_test.dart
+++ b/test/core/services/api_service_chat_completion_test.dart
@@ -2152,6 +2152,36 @@ void main() {
       },
     );
 
+    test(
+      'updateKnowledgeBase legacy update preserves prefetched fields',
+      () async {
+        final adapter = _QueuedFakeAdapter([
+          _FakeAdapter.json({
+            'name': 'Docs',
+            'description': 'Existing description',
+          }),
+          _FakeAdapter.json({'detail': 'Not found'}, statusCode: 404),
+          _FakeAdapter.json({}),
+        ]);
+        final api = _buildApiServiceForTest(adapter);
+
+        await api.updateKnowledgeBase('kb-1', name: 'Docs 2');
+
+        check(
+          adapter.requests.map(
+            (request) => '${request.method} ${request.path}',
+          ),
+        ).deepEquals([
+          'GET /api/v1/knowledge/kb-1',
+          'POST /api/v1/knowledge/kb-1/update',
+          'PUT /api/v1/knowledge/kb-1',
+        ]);
+        check(
+          adapter.requests.last.data as Map<String, dynamic>,
+        ).deepEquals({'name': 'Docs 2', 'description': 'Existing description'});
+      },
+    );
+
     test('getKnowledgeBaseItems reads the 0.10 file-backed endpoint', () async {
       final adapter = _QueuedFakeAdapter([
         _FakeAdapter.json({
@@ -2450,6 +2480,32 @@ void main() {
           'data': {
             'user': {'id': 'user-1'},
             'collection': {'uuid': 'collection-1'},
+          },
+        }),
+      ]);
+      final api = _buildApiServiceForTest(adapter);
+
+      await expectLater(
+        api.addFileToKnowledgeBase(
+          'kb-1',
+          filename: 'guide.md',
+          content: utf8.encode('hello'),
+        ),
+        throwsA(isA<StateError>()),
+      );
+
+      check(
+        adapter.requests.map((request) => '${request.method} ${request.path}'),
+      ).deepEquals(['POST /api/v1/files/']);
+    });
+
+    test('addFileToKnowledgeBase ignores arbitrary nested file ids', () async {
+      final adapter = _QueuedFakeAdapter([
+        _FakeAdapter.json({
+          'file': {
+            'data': {
+              'attributes': {'id': 'attribute-1'},
+            },
           },
         }),
       ]);

--- a/test/core/services/api_service_chat_completion_test.dart
+++ b/test/core/services/api_service_chat_completion_test.dart
@@ -2226,6 +2226,38 @@ void main() {
     });
 
     test(
+      'addFileToKnowledgeBase recognizes nested identifier upload id',
+      () async {
+        final adapter = _QueuedFakeAdapter([
+          _FakeAdapter.json({
+            'upload': {'identifier': 'file-1'},
+          }),
+          _FakeAdapter.json({'status': true}),
+        ]);
+        final api = _buildApiServiceForTest(adapter);
+
+        final file = await api.addFileToKnowledgeBase(
+          'kb-1',
+          filename: 'guide.md',
+          content: utf8.encode('hello'),
+        );
+
+        check(file?['upload']).isA<Map>().containsKey('identifier');
+        check(
+          adapter.requests.map(
+            (request) => '${request.method} ${request.path}',
+          ),
+        ).deepEquals([
+          'POST /api/v1/files/',
+          'POST /api/v1/knowledge/kb-1/file/add',
+        ]);
+        check(
+          adapter.requests.last.data as Map<String, dynamic>,
+        ).deepEquals({'file_id': 'file-1'});
+      },
+    );
+
+    test(
       'addFileToKnowledgeBase does not legacy reupload without file id',
       () async {
         final adapter = _QueuedFakeAdapter([

--- a/test/core/services/api_service_chat_completion_test.dart
+++ b/test/core/services/api_service_chat_completion_test.dart
@@ -1150,7 +1150,7 @@ void main() {
                   'role': 'user',
                   'content': 'hello',
                   'timestamp': 1700000000,
-                  'childrenIds': ['asst-1'],
+                  'childrenIds': ['asst-1', 'asst-newer'],
                 },
                 'asst-1': {
                   'id': 'asst-1',
@@ -1238,7 +1238,7 @@ void main() {
                   'role': 'user',
                   'content': 'hello',
                   'timestamp': 1700000000,
-                  'childrenIds': ['asst-1'],
+                  'childrenIds': ['asst-1', 'asst-newer'],
                 },
                 'asst-1': {
                   'id': 'asst-1',
@@ -1395,17 +1395,599 @@ void main() {
       final adapter = _FakeAdapter.json({});
       final api = _buildApiServiceForTest(adapter);
 
-      await api.updateUserInfo({
-        'location': '12.346, 67.890 (lat, long)',
-      });
+      await api.updateUserInfo({'location': '12.346, 67.890 (lat, long)'});
 
       final request = adapter.lastRequest!;
       check(request.path).equals('/api/v1/users/user/info/update');
       final body = request.data as Map<String, dynamic>;
-      check(body).deepEquals({
-        'location': '12.346, 67.890 (lat, long)',
-      });
+      check(body).deepEquals({'location': '12.346, 67.890 (lat, long)'});
     });
+  });
+
+  group('Open WebUI 0.10.1 compatibility', () {
+    test(
+      'getDefaultModel parses comma-separated /api/config defaults',
+      () async {
+        final adapter = _QueuedFakeAdapter([
+          _FakeAdapter.json({'ui': {}}),
+          _FakeAdapter.json({'default_models': 'gpt-4.1, claude-sonnet'}),
+        ]);
+        final api = _buildApiServiceForTest(adapter);
+
+        final model = await api.getDefaultModel();
+
+        check(model).equals('gpt-4.1');
+        check(
+          adapter.requests.map((request) => request.path).toList(),
+        ).deepEquals(['/api/v1/users/user/settings', '/api/config']);
+      },
+    );
+
+    test('getSuggestions reads prompt suggestions from /api/config', () async {
+      final adapter = _FakeAdapter.json({
+        'default_prompt_suggestions': [
+          {
+            'title': ['Help me write'],
+            'content': 'Draft a concise project update.',
+          },
+          {
+            'title': ['Fallback title'],
+            'content': '',
+          },
+        ],
+      });
+      final api = _buildApiServiceForTest(adapter);
+
+      final suggestions = await api.getSuggestions();
+
+      check(adapter.lastRequest!.path).equals('/api/config');
+      check(
+        suggestions,
+      ).deepEquals(['Draft a concise project update.', 'Fallback title']);
+    });
+
+    test('getSuggestions falls back to older suggestions endpoint', () async {
+      final adapter = _QueuedFakeAdapter([
+        _FakeAdapter.json({}),
+        _FakeAdapter.raw(
+          bytes: utf8.encode(
+            jsonEncode([
+              {
+                'title': ['Fallback title'],
+                'content': 'Legacy prompt suggestion.',
+              },
+            ]),
+          ),
+          headers: {
+            'content-type': ['application/json; charset=utf-8'],
+          },
+        ),
+      ]);
+      final api = _buildApiServiceForTest(adapter);
+
+      final suggestions = await api.getSuggestions();
+
+      check(
+        adapter.requests.map((request) => request.path).toList(),
+      ).deepEquals(['/api/config', '/api/v1/configs/suggestions']);
+      check(suggestions).deepEquals(['Legacy prompt suggestion.']);
+    });
+
+    test(
+      'cloneConversation sends the CloneForm body required upstream',
+      () async {
+        final adapter = _FakeAdapter.json(
+          _legacyChatPayload(
+            historyMessages: const {
+              'root': {
+                'id': 'root',
+                'role': 'user',
+                'content': 'hello',
+                'timestamp': 1700000000,
+              },
+            },
+            currentId: 'root',
+          ),
+        );
+        final api = _buildApiServiceForTest(adapter);
+
+        await api.cloneConversation('chat-1');
+
+        final request = adapter.lastRequest!;
+        check(request.path).equals('/api/v1/chats/chat-1/clone');
+        check(
+          request.data as Map<String, dynamic>,
+        ).deepEquals(<String, dynamic>{});
+      },
+    );
+
+    test('deleteConversationMessage uses upstream delete route', () async {
+      final adapter = _FakeAdapter.json({});
+      final api = _buildApiServiceForTest(adapter);
+
+      await api.deleteConversationMessage('chat-1', 'msg-1');
+
+      final request = adapter.lastRequest!;
+      check(request.method).equals('DELETE');
+      check(request.path).equals('/api/v1/chats/chat-1/messages/msg-1');
+    });
+
+    test('deleteConversationMessage falls back for older servers', () async {
+      final adapter = _QueuedFakeAdapter([
+        _FakeAdapter.json({'detail': 'Not found'}, statusCode: 404),
+        _FakeAdapter.json(
+          _legacyChatPayload(
+            currentId: 'asst-1',
+            historyMessages: const {
+              'user-1': {
+                'id': 'user-1',
+                'role': 'user',
+                'content': 'hello',
+                'timestamp': 1700000000,
+                'childrenIds': ['asst-1'],
+              },
+              'asst-1': {
+                'id': 'asst-1',
+                'role': 'assistant',
+                'content': 'hi',
+                'timestamp': 1700000001,
+                'parentId': 'user-1',
+              },
+            },
+          ),
+        ),
+        _FakeAdapter.json({}),
+      ]);
+      final api = _buildApiServiceForTest(adapter);
+
+      await api.deleteConversationMessage('chat-1', 'asst-1');
+
+      check(
+        adapter.requests.map((request) => '${request.method} ${request.path}'),
+      ).deepEquals([
+        'DELETE /api/v1/chats/chat-1/messages/asst-1',
+        'GET /api/v1/chats/chat-1',
+        'POST /api/v1/chats/chat-1',
+      ]);
+      final posted = adapter.requests.last.data as Map<String, dynamic>;
+      final chat = posted['chat'] as Map<String, dynamic>;
+      final history = chat['history'] as Map<String, dynamic>;
+      final messages = history['messages'] as Map<String, dynamic>;
+      check(messages.keys.toList()).deepEquals(['user-1']);
+      check(history['currentId']).equals('user-1');
+    });
+
+    test(
+      'deleteConversationMessage fallback reparents grandchildren',
+      () async {
+        final adapter = _QueuedFakeAdapter([
+          _FakeAdapter.json({'detail': 'Not found'}, statusCode: 404),
+          _FakeAdapter.json(
+            _legacyChatPayload(
+              currentId: 'asst-2',
+              historyMessages: const {
+                'user-1': {
+                  'id': 'user-1',
+                  'role': 'user',
+                  'content': 'hello',
+                  'timestamp': 1700000000,
+                  'childrenIds': ['asst-1', 'asst-newer'],
+                },
+                'asst-1': {
+                  'id': 'asst-1',
+                  'role': 'assistant',
+                  'content': 'calling tool',
+                  'timestamp': 1700000001,
+                  'parentId': 'user-1',
+                  'childrenIds': ['tool-1'],
+                },
+                'asst-newer': {
+                  'id': 'asst-newer',
+                  'role': 'assistant',
+                  'content': 'newer sibling',
+                  'timestamp': 1700000004,
+                  'parentId': 'user-1',
+                },
+                'tool-1': {
+                  'id': 'tool-1',
+                  'role': 'tool',
+                  'content': 'tool result',
+                  'timestamp': 1700000002,
+                  'parentId': 'asst-1',
+                  'childrenIds': ['asst-2'],
+                },
+                'asst-2': {
+                  'id': 'asst-2',
+                  'role': 'assistant',
+                  'content': 'final answer',
+                  'timestamp': 1700000003,
+                  'parentId': 'tool-1',
+                },
+              },
+            ),
+          ),
+          _FakeAdapter.json({}),
+        ]);
+        final api = _buildApiServiceForTest(adapter);
+
+        await api.deleteConversationMessage('chat-1', 'asst-1');
+
+        final posted = adapter.requests.last.data as Map<String, dynamic>;
+        final chat = posted['chat'] as Map<String, dynamic>;
+        final history = chat['history'] as Map<String, dynamic>;
+        final messages = history['messages'] as Map<String, dynamic>;
+        final user = messages['user-1'] as Map<String, dynamic>;
+        final assistant = messages['asst-2'] as Map<String, dynamic>;
+        final serializedMessages = chat['messages'] as List<dynamic>;
+
+        check(
+          messages.keys.toList(),
+        ).deepEquals(['user-1', 'asst-newer', 'asst-2']);
+        check(
+          user['childrenIds'] as List<dynamic>,
+        ).deepEquals(['asst-newer', 'asst-2']);
+        check(assistant['parentId']).equals('user-1');
+        check(history['currentId']).equals('asst-2');
+        check(
+          serializedMessages
+              .map((message) => (message as Map<String, dynamic>)['id'])
+              .toList(),
+        ).deepEquals(['user-1', 'asst-2']);
+      },
+    );
+
+    test('addTagToConversation falls back to legacy tag body', () async {
+      final adapter = _QueuedFakeAdapter([
+        _FakeAdapter.json({'detail': 'Invalid body'}, statusCode: 422),
+        _FakeAdapter.json({}),
+      ]);
+      final api = _buildApiServiceForTest(adapter);
+
+      await api.addTagToConversation('chat-1', 'work');
+
+      check(
+        adapter.requests.map((request) => request.path).toList(),
+      ).deepEquals(['/api/v1/chats/chat-1/tags', '/api/v1/chats/chat-1/tags']);
+      check(
+        adapter.requests.first.data as Map<String, dynamic>,
+      ).deepEquals({'name': 'work'});
+      check(
+        adapter.requests.last.data as Map<String, dynamic>,
+      ).deepEquals({'tag': 'work'});
+    });
+
+    test('getAllTags falls back to legacy tags route', () async {
+      final adapter = _QueuedFakeAdapter([
+        _FakeAdapter.json({'detail': 'Not found'}, statusCode: 404),
+        _FakeAdapter.raw(
+          bytes: utf8.encode(jsonEncode(['work', 'personal'])),
+          headers: {
+            'content-type': ['application/json; charset=utf-8'],
+          },
+        ),
+      ]);
+      final api = _buildApiServiceForTest(adapter);
+
+      final tags = await api.getAllTags();
+
+      check(tags).deepEquals(['work', 'personal']);
+      check(
+        adapter.requests.map((request) => request.path).toList(),
+      ).deepEquals(['/api/v1/chats/all/tags', '/api/v1/chats/tags']);
+    });
+
+    test('removeTagFromConversation falls back to legacy tag route', () async {
+      final adapter = _QueuedFakeAdapter([
+        _FakeAdapter.json({'detail': 'Not found'}, statusCode: 404),
+        _FakeAdapter.json({}),
+      ]);
+      final api = _buildApiServiceForTest(adapter);
+
+      await api.removeTagFromConversation('chat-1', 'work tag');
+
+      check(
+        adapter.requests.map((request) => request.path).toList(),
+      ).deepEquals([
+        '/api/v1/chats/chat-1/tags',
+        '/api/v1/chats/chat-1/tags/work%20tag',
+      ]);
+      check(
+        adapter.requests.first.data as Map<String, dynamic>,
+      ).deepEquals({'name': 'work tag'});
+    });
+
+    test('getConversationsByTag falls back to legacy tag route', () async {
+      final adapter = _QueuedFakeAdapter([
+        _FakeAdapter.json({'detail': 'Not found'}, statusCode: 404),
+        _FakeAdapter.raw(
+          bytes: utf8.encode('[]'),
+          headers: {
+            'content-type': ['application/json; charset=utf-8'],
+          },
+        ),
+      ]);
+      final api = _buildApiServiceForTest(adapter);
+
+      final conversations = await api.getConversationsByTag('work');
+
+      check(conversations).isEmpty();
+      check(
+        adapter.requests.map((request) => request.path).toList(),
+      ).deepEquals(['/api/v1/chats/tags', '/api/v1/chats/tags/work']);
+      check(
+        adapter.requests.first.data as Map<String, dynamic>,
+      ).deepEquals({'name': 'work'});
+      check(adapter.requests.last.method).equals('GET');
+    });
+
+    test(
+      'pinConversation skips toggle when server state already matches',
+      () async {
+        final adapter = _QueuedFakeAdapter([
+          _FakeAdapter.json({'id': 'chat-1', 'pinned': true}),
+        ]);
+        final api = _buildApiServiceForTest(adapter);
+
+        await api.pinConversation('chat-1', true);
+
+        check(
+          adapter.requests.map((request) => request.path).toList(),
+        ).deepEquals(['/api/v1/chats/chat-1']);
+      },
+    );
+
+    test('pinConversation toggles when server state differs', () async {
+      final adapter = _QueuedFakeAdapter([
+        _FakeAdapter.json({'id': 'chat-1', 'pinned': false}),
+        _FakeAdapter.json({'id': 'chat-1', 'pinned': true}),
+      ]);
+      final api = _buildApiServiceForTest(adapter);
+
+      await api.pinConversation('chat-1', true);
+
+      check(
+        adapter.requests.map((request) => request.path).toList(),
+      ).deepEquals(['/api/v1/chats/chat-1', '/api/v1/chats/chat-1/pin']);
+    });
+
+    test('sendChatCompleted includes nullable session_id key', () async {
+      final adapter = _FakeAdapter.json({'ok': true});
+      final api = _buildApiServiceForTest(adapter);
+
+      await api.sendChatCompleted(
+        chatId: 'chat-1',
+        messageId: 'msg-1',
+        messages: const [
+          {'id': 'msg-1', 'role': 'assistant', 'content': 'Done'},
+        ],
+        model: 'gpt-4.1',
+      );
+
+      final body = adapter.lastRequest!.data as Map<String, dynamic>;
+      check(body.containsKey('session_id')).isTrue();
+      check(body['session_id']).isNull();
+    });
+
+    test('getBackendConfig preserves older audio config defaults', () async {
+      final adapter = _QueuedFakeAdapter([
+        _FakeAdapter.json({'features': {}}),
+        _FakeAdapter.json({
+          'tts': {'VOICE': 'nova', 'SPLIT_ON': 'paragraphs'},
+        }),
+        _FakeAdapter.json({'detail': 'Not found'}, statusCode: 404),
+      ]);
+      final api = _buildApiServiceForTest(adapter);
+
+      final config = await api.getBackendConfig();
+
+      check(
+        adapter.requests.map((request) => request.path).toList(),
+      ).deepEquals([
+        '/api/config',
+        '/api/v1/audio/config',
+        '/api/v1/audio/voices',
+      ]);
+      check(config).isNotNull();
+      check(config!.ttsVoice).equals('nova');
+      check(config.ttsSplitOn).equals('paragraphs');
+      check(config.ttsVoices).isEmpty();
+    });
+
+    test('knowledge create update delete fall back to legacy routes', () async {
+      final adapter = _QueuedFakeAdapter([
+        _FakeAdapter.json({'detail': 'Not found'}, statusCode: 404),
+        _FakeAdapter.json({'id': 'kb-1', 'name': 'Docs'}),
+        _FakeAdapter.json({'detail': 'Not found'}, statusCode: 404),
+        _FakeAdapter.json({}),
+        _FakeAdapter.json({'detail': 'Not found'}, statusCode: 404),
+        _FakeAdapter.json({}),
+      ]);
+      final api = _buildApiServiceForTest(adapter);
+
+      final created = await api.createKnowledgeBase(
+        name: 'Docs',
+        description: 'Team docs',
+      );
+      await api.updateKnowledgeBase(
+        'kb-1',
+        name: 'Docs 2',
+        description: 'Updated',
+      );
+      await api.deleteKnowledgeBase('kb-1');
+
+      check(created['id']).equals('kb-1');
+      check(
+        adapter.requests.map((request) => '${request.method} ${request.path}'),
+      ).deepEquals([
+        'POST /api/v1/knowledge/create',
+        'POST /api/v1/knowledge/',
+        'POST /api/v1/knowledge/kb-1/update',
+        'PUT /api/v1/knowledge/kb-1',
+        'DELETE /api/v1/knowledge/kb-1/delete',
+        'DELETE /api/v1/knowledge/kb-1',
+      ]);
+    });
+
+    test('getKnowledgeBaseItems reads the 0.10 file-backed endpoint', () async {
+      final adapter = _QueuedFakeAdapter([
+        _FakeAdapter.json({
+          'items': [
+            {
+              'id': 'file-1',
+              'filename': 'guide.md',
+              'created_at': 1700000000,
+              'updated_at': 1700000001,
+              'meta': {'name': 'Guide'},
+            },
+          ],
+          'total': 2,
+        }),
+        _FakeAdapter.json({
+          'items': [
+            {
+              'id': 'file-2',
+              'filename': 'notes.md',
+              'created_at': 1700000002,
+              'updated_at': 1700000003,
+            },
+          ],
+          'total': 2,
+        }),
+      ]);
+      final api = _buildApiServiceForTest(adapter);
+
+      final items = await api.getKnowledgeBaseItems('kb-1');
+
+      check(
+        adapter.requests.map((request) => request.path).toList(),
+      ).deepEquals([
+        '/api/v1/knowledge/kb-1/files',
+        '/api/v1/knowledge/kb-1/files',
+      ]);
+      check(
+        adapter.requests
+            .map((request) => request.queryParameters['page'])
+            .toList(),
+      ).deepEquals([1, 2]);
+      check(items).length.equals(2);
+      check(items.first.id).equals('file-1');
+      check(items.first.title).equals('guide.md');
+      check(items.first.content).equals('');
+      check(items[1].id).equals('file-2');
+    });
+
+    test('getKnowledgeBaseItems falls back to legacy items route', () async {
+      final adapter = _QueuedFakeAdapter([
+        _FakeAdapter.json({'detail': 'Not found'}, statusCode: 404),
+        _FakeAdapter.raw(
+          bytes: utf8.encode(
+            jsonEncode([
+              {
+                'id': 'item-1',
+                'title': 'Legacy note',
+                'content': 'Saved text',
+                'created_at': 1700000000,
+                'updated_at': 1700000001,
+              },
+            ]),
+          ),
+          headers: {
+            'content-type': ['application/json; charset=utf-8'],
+          },
+        ),
+      ]);
+      final api = _buildApiServiceForTest(adapter);
+
+      final items = await api.getKnowledgeBaseItems('kb-1');
+
+      check(
+        adapter.requests.map((request) => request.path).toList(),
+      ).deepEquals([
+        '/api/v1/knowledge/kb-1/files',
+        '/api/v1/knowledge/kb-1/items',
+      ]);
+      check(items).length.equals(1);
+      check(items.single.id).equals('item-1');
+      check(items.single.title).equals('Legacy note');
+      check(items.single.content).equals('Saved text');
+    });
+
+    test(
+      'addFileToKnowledgeBase falls back to legacy file add route',
+      () async {
+        final adapter = _QueuedFakeAdapter([
+          _FakeAdapter.json({'detail': 'Not found'}, statusCode: 404),
+          _FakeAdapter.json({'id': 'file-1'}),
+        ]);
+        final api = _buildApiServiceForTest(adapter);
+
+        final file = await api.addFileToKnowledgeBase(
+          'kb-1',
+          filename: 'guide.md',
+          content: utf8.encode('hello'),
+        );
+
+        check(file?['id']).equals('file-1');
+        check(
+          adapter.requests.map((request) => request.path).toList(),
+        ).deepEquals(['/api/v1/files/', '/api/v1/knowledge/kb-1/file/add']);
+      },
+    );
+
+    test('addFileToKnowledgeBase explicitly attaches uploaded file', () async {
+      final adapter = _QueuedFakeAdapter([
+        _FakeAdapter.json({'id': 'file-1'}),
+        _FakeAdapter.json({'status': true}),
+      ]);
+      final api = _buildApiServiceForTest(adapter);
+
+      final file = await api.addFileToKnowledgeBase(
+        'kb-1',
+        filename: 'guide.md',
+        content: utf8.encode('hello'),
+      );
+
+      check(file?['id']).equals('file-1');
+      check(
+        adapter.requests.map((request) => '${request.method} ${request.path}'),
+      ).deepEquals([
+        'POST /api/v1/files/',
+        'POST /api/v1/knowledge/kb-1/file/add',
+      ]);
+      check(
+        adapter.requests.last.data as Map<String, dynamic>,
+      ).deepEquals({'file_id': 'file-1'});
+    });
+
+    test(
+      'addFileToKnowledgeBase falls back when attach route rejects file id body',
+      () async {
+        final adapter = _QueuedFakeAdapter([
+          _FakeAdapter.json({'id': 'file-1'}),
+          _FakeAdapter.json({'detail': 'Invalid body'}, statusCode: 422),
+          _FakeAdapter.json({'status': true}),
+          _FakeAdapter.json({'id': 'legacy-file'}),
+        ]);
+        final api = _buildApiServiceForTest(adapter);
+
+        final file = await api.addFileToKnowledgeBase(
+          'kb-1',
+          filename: 'guide.md',
+          content: utf8.encode('hello'),
+        );
+
+        check(file?['id']).equals('legacy-file');
+        check(
+          adapter.requests.map((request) => request.path).toList(),
+        ).deepEquals([
+          '/api/v1/files/',
+          '/api/v1/knowledge/kb-1/file/add',
+          '/api/v1/files/file-1',
+          '/api/v1/knowledge/kb-1/file/add',
+        ]);
+        check(adapter.requests[2].method).equals('DELETE');
+      },
+    );
   });
 
   group('getChannels feature flag', () {

--- a/test/core/services/api_service_chat_completion_test.dart
+++ b/test/core/services/api_service_chat_completion_test.dart
@@ -1914,6 +1914,30 @@ void main() {
       },
     );
 
+    test(
+      'archiveConversation reads wrapped chat state before toggling',
+      () async {
+        final adapter = _QueuedFakeAdapter([
+          _FakeAdapter.json({
+            'chat': {'archived': false},
+          }),
+          _FakeAdapter.json({'id': 'chat-1', 'archived': true}),
+        ]);
+        final api = _buildApiServiceForTest(adapter);
+
+        await api.archiveConversation('chat-1', true);
+
+        check(
+          adapter.requests.map(
+            (request) => '${request.method} ${request.path}',
+          ),
+        ).deepEquals([
+          'GET /api/v1/chats/chat-1',
+          'POST /api/v1/chats/chat-1/archive',
+        ]);
+      },
+    );
+
     test('sendChatCompleted omits null session_id', () async {
       final adapter = _FakeAdapter.json({'ok': true});
       final api = _buildApiServiceForTest(adapter);
@@ -2043,11 +2067,10 @@ void main() {
           'items': [
             {
               'id': 'file-1',
-              'filename': 'guide.md',
               'content': 'Guide text',
               'created_at': 1700000000,
               'updated_at': 1700000001,
-              'meta': {'name': 'Guide'},
+              'meta': {'filename': 'guide.md', 'name': 'Guide'},
             },
           ],
           'total': 2,

--- a/test/core/services/api_service_chat_completion_test.dart
+++ b/test/core/services/api_service_chat_completion_test.dart
@@ -1865,6 +1865,28 @@ void main() {
       ).deepEquals(['/api/v1/chats/chat-1/pinned', '/api/v1/chats/chat-1/pin']);
     });
 
+    test('pinConversation does not retry stateless toggle post', () async {
+      final adapter = _QueuedFakeAdapter([
+        _FakeAdapter.raw(
+          bytes: utf8.encode('false'),
+          headers: {
+            'content-type': ['application/json; charset=utf-8'],
+          },
+        ),
+        _FakeAdapter.json({'pinned': false}),
+      ]);
+      final api = _buildApiServiceForTest(adapter);
+
+      await api.pinConversation('chat-1', true);
+
+      check(
+        adapter.requests.map((request) => '${request.method} ${request.path}'),
+      ).deepEquals([
+        'GET /api/v1/chats/chat-1/pinned',
+        'POST /api/v1/chats/chat-1/pin',
+      ]);
+    });
+
     test(
       'pinConversation does not toggle when current state is unknown',
       () async {
@@ -1961,6 +1983,27 @@ void main() {
         'DELETE /api/v1/knowledge/kb-1',
       ]);
     });
+
+    test(
+      'knowledge validation 400 does not fall back to legacy route',
+      () async {
+        final adapter = _QueuedFakeAdapter([
+          _FakeAdapter.json({'detail': 'Name is required'}, statusCode: 400),
+        ]);
+        final api = _buildApiServiceForTest(adapter);
+
+        await expectLater(
+          api.createKnowledgeBase(name: '', description: ''),
+          throwsA(isA<DioException>()),
+        );
+
+        check(
+          adapter.requests.map(
+            (request) => '${request.method} ${request.path}',
+          ),
+        ).deepEquals(['POST /api/v1/knowledge/create']);
+      },
+    );
 
     test(
       'updateKnowledgeBase falls back when prefetch rejects new route',

--- a/test/core/services/api_service_chat_completion_test.dart
+++ b/test/core/services/api_service_chat_completion_test.dart
@@ -1177,7 +1177,14 @@ void main() {
         final versionMessage =
             historyMessages['asst-alt'] as Map<String, dynamic>;
 
-        check(versionMessage['output']).isA<List>().length.equals(1);
+        check(versionMessage['output'] as List<dynamic>).deepEquals([
+          {
+            'type': 'message',
+            'content': [
+              {'type': 'output_text', 'text': 'Alternate answer'},
+            ],
+          },
+        ]);
       },
     );
 

--- a/test/core/services/api_service_chat_completion_test.dart
+++ b/test/core/services/api_service_chat_completion_test.dart
@@ -1846,6 +1846,25 @@ void main() {
       ).deepEquals(['/api/v1/chats/chat-1/pinned', '/api/v1/chats/chat-1/pin']);
     });
 
+    test('pinConversation treats null pinned state as false', () async {
+      final adapter = _QueuedFakeAdapter([
+        _FakeAdapter.raw(
+          bytes: utf8.encode('null'),
+          headers: {
+            'content-type': ['application/json; charset=utf-8'],
+          },
+        ),
+        _FakeAdapter.json({'id': 'chat-1', 'pinned': true}),
+      ]);
+      final api = _buildApiServiceForTest(adapter);
+
+      await api.pinConversation('chat-1', true);
+
+      check(
+        adapter.requests.map((request) => request.path).toList(),
+      ).deepEquals(['/api/v1/chats/chat-1/pinned', '/api/v1/chats/chat-1/pin']);
+    });
+
     test(
       'pinConversation does not toggle when current state is unknown',
       () async {

--- a/test/core/services/api_service_chat_completion_test.dart
+++ b/test/core/services/api_service_chat_completion_test.dart
@@ -2067,7 +2067,7 @@ void main() {
           'items': [
             {
               'id': 'file-1',
-              'content': 'Guide text',
+              'data': {'content': 'Guide text'},
               'created_at': 1700000000,
               'updated_at': 1700000001,
               'meta': {'filename': 'guide.md', 'name': 'Guide'},

--- a/test/core/services/api_service_chat_completion_test.dart
+++ b/test/core/services/api_service_chat_completion_test.dart
@@ -1716,15 +1716,57 @@ void main() {
       ).deepEquals(['/api/v1/chats/tags', '/api/v1/chats/tags/work']);
       check(
         adapter.requests.first.data as Map<String, dynamic>,
-      ).deepEquals({'name': 'work'});
+      ).deepEquals({'name': 'work', 'skip': 0, 'limit': 50});
       check(adapter.requests.last.method).equals('GET');
+    });
+
+    test('getConversationsByTag paginates the 0.10 tag filter route', () async {
+      Map<String, dynamic> taggedChat(int index) => {
+        'id': 'chat-$index',
+        'title': 'Chat $index',
+        'updated_at': 1700000000 + index,
+        'created_at': 1700000000,
+      };
+
+      final adapter = _QueuedFakeAdapter([
+        _FakeAdapter.raw(
+          bytes: utf8.encode(
+            jsonEncode([for (var i = 0; i < 50; i += 1) taggedChat(i)]),
+          ),
+          headers: {
+            'content-type': ['application/json; charset=utf-8'],
+          },
+        ),
+        _FakeAdapter.raw(
+          bytes: utf8.encode(jsonEncode([taggedChat(50)])),
+          headers: {
+            'content-type': ['application/json; charset=utf-8'],
+          },
+        ),
+      ]);
+      final api = _buildApiServiceForTest(adapter);
+
+      final conversations = await api.getConversationsByTag('work');
+
+      check(conversations).length.equals(51);
+      check(
+        adapter.requests.map((request) => request.data).cast<Map>().toList(),
+      ).deepEquals([
+        {'name': 'work', 'skip': 0, 'limit': 50},
+        {'name': 'work', 'skip': 50, 'limit': 50},
+      ]);
     });
 
     test(
       'pinConversation skips toggle when server state already matches',
       () async {
         final adapter = _QueuedFakeAdapter([
-          _FakeAdapter.json({'id': 'chat-1', 'pinned': true}),
+          _FakeAdapter.raw(
+            bytes: utf8.encode('true'),
+            headers: {
+              'content-type': ['application/json; charset=utf-8'],
+            },
+          ),
         ]);
         final api = _buildApiServiceForTest(adapter);
 
@@ -1732,13 +1774,18 @@ void main() {
 
         check(
           adapter.requests.map((request) => request.path).toList(),
-        ).deepEquals(['/api/v1/chats/chat-1']);
+        ).deepEquals(['/api/v1/chats/chat-1/pinned']);
       },
     );
 
     test('pinConversation toggles when server state differs', () async {
       final adapter = _QueuedFakeAdapter([
-        _FakeAdapter.json({'id': 'chat-1', 'pinned': false}),
+        _FakeAdapter.raw(
+          bytes: utf8.encode('false'),
+          headers: {
+            'content-type': ['application/json; charset=utf-8'],
+          },
+        ),
         _FakeAdapter.json({'id': 'chat-1', 'pinned': true}),
       ]);
       final api = _buildApiServiceForTest(adapter);
@@ -1747,10 +1794,30 @@ void main() {
 
       check(
         adapter.requests.map((request) => request.path).toList(),
-      ).deepEquals(['/api/v1/chats/chat-1', '/api/v1/chats/chat-1/pin']);
+      ).deepEquals(['/api/v1/chats/chat-1/pinned', '/api/v1/chats/chat-1/pin']);
     });
 
-    test('sendChatCompleted includes nullable session_id key', () async {
+    test(
+      'pinConversation does not toggle when current state is unknown',
+      () async {
+        final adapter = _QueuedFakeAdapter([
+          _FakeAdapter.json({}),
+          _FakeAdapter.json({'id': 'chat-1'}),
+        ]);
+        final api = _buildApiServiceForTest(adapter);
+
+        await expectLater(
+          api.pinConversation('chat-1', true),
+          throwsA(isA<StateError>()),
+        );
+
+        check(
+          adapter.requests.map((request) => request.path).toList(),
+        ).deepEquals(['/api/v1/chats/chat-1/pinned', '/api/v1/chats/chat-1']);
+      },
+    );
+
+    test('sendChatCompleted omits null session_id', () async {
       final adapter = _FakeAdapter.json({'ok': true});
       final api = _buildApiServiceForTest(adapter);
 
@@ -1764,8 +1831,7 @@ void main() {
       );
 
       final body = adapter.lastRequest!.data as Map<String, dynamic>;
-      check(body.containsKey('session_id')).isTrue();
-      check(body['session_id']).isNull();
+      check(body.containsKey('session_id')).isFalse();
     });
 
     test('getBackendConfig preserves older audio config defaults', () async {
@@ -1795,11 +1861,11 @@ void main() {
 
     test('knowledge create update delete fall back to legacy routes', () async {
       final adapter = _QueuedFakeAdapter([
-        _FakeAdapter.json({'detail': 'Not found'}, statusCode: 404),
+        _FakeAdapter.json({'detail': 'Invalid body'}, statusCode: 422),
         _FakeAdapter.json({'id': 'kb-1', 'name': 'Docs'}),
-        _FakeAdapter.json({'detail': 'Not found'}, statusCode: 404),
+        _FakeAdapter.json({'detail': 'Invalid body'}, statusCode: 400),
         _FakeAdapter.json({}),
-        _FakeAdapter.json({'detail': 'Not found'}, statusCode: 404),
+        _FakeAdapter.json({'detail': 'Invalid body'}, statusCode: 422),
         _FakeAdapter.json({}),
       ]);
       final api = _buildApiServiceForTest(adapter);
@@ -1835,6 +1901,7 @@ void main() {
             {
               'id': 'file-1',
               'filename': 'guide.md',
+              'content': 'Guide text',
               'created_at': 1700000000,
               'updated_at': 1700000001,
               'meta': {'name': 'Guide'},
@@ -1847,6 +1914,7 @@ void main() {
             {
               'id': 'file-2',
               'filename': 'notes.md',
+              'content': 'Notes text',
               'created_at': 1700000002,
               'updated_at': 1700000003,
             },
@@ -1869,11 +1937,17 @@ void main() {
             .map((request) => request.queryParameters['page'])
             .toList(),
       ).deepEquals([1, 2]);
+      check(
+        adapter.requests
+            .map((request) => request.queryParameters['include_content'])
+            .toList(),
+      ).deepEquals([true, true]);
       check(items).length.equals(2);
       check(items.first.id).equals('file-1');
       check(items.first.title).equals('guide.md');
-      check(items.first.content).equals('');
+      check(items.first.content).equals('Guide text');
       check(items[1].id).equals('file-2');
+      check(items[1].content).equals('Notes text');
     });
 
     test('getKnowledgeBaseItems falls back to legacy items route', () async {
@@ -1964,7 +2038,7 @@ void main() {
       () async {
         final adapter = _QueuedFakeAdapter([
           _FakeAdapter.json({'id': 'file-1'}),
-          _FakeAdapter.json({'detail': 'Invalid body'}, statusCode: 422),
+          _FakeAdapter.json({'detail': 'Invalid body'}, statusCode: 400),
           _FakeAdapter.json({'status': true}),
           _FakeAdapter.json({'id': 'legacy-file'}),
         ]);

--- a/test/core/services/api_service_chat_completion_test.dart
+++ b/test/core/services/api_service_chat_completion_test.dart
@@ -2067,6 +2067,7 @@ void main() {
           'items': [
             {
               'id': 'file-1',
+              'content': '',
               'data': {'content': 'Guide text'},
               'created_at': 1700000000,
               'updated_at': 1700000001,
@@ -2223,6 +2224,62 @@ void main() {
         adapter.requests.last.data as Map<String, dynamic>,
       ).deepEquals({'file_id': 'file-1'});
     });
+
+    test(
+      'addFileToKnowledgeBase does not legacy reupload without file id',
+      () async {
+        final adapter = _QueuedFakeAdapter([
+          _FakeAdapter.json({'status': true}),
+        ]);
+        final api = _buildApiServiceForTest(adapter);
+
+        await expectLater(
+          api.addFileToKnowledgeBase(
+            'kb-1',
+            filename: 'guide.md',
+            content: utf8.encode('hello'),
+          ),
+          throwsA(isA<StateError>()),
+        );
+
+        check(
+          adapter.requests.map(
+            (request) => '${request.method} ${request.path}',
+          ),
+        ).deepEquals(['POST /api/v1/files/']);
+      },
+    );
+
+    test(
+      'addFileToKnowledgeBase does not legacy reupload unprocessed file',
+      () async {
+        final adapter = _QueuedFakeAdapter([
+          _FakeAdapter.json({'id': 'file-1'}),
+          _FakeAdapter.json({'detail': 'FILE_NOT_PROCESSED'}, statusCode: 400),
+          _FakeAdapter.json({'status': true}),
+        ]);
+        final api = _buildApiServiceForTest(adapter);
+
+        await expectLater(
+          api.addFileToKnowledgeBase(
+            'kb-1',
+            filename: 'guide.md',
+            content: utf8.encode('hello'),
+          ),
+          throwsA(isA<DioException>()),
+        );
+
+        check(
+          adapter.requests.map(
+            (request) => '${request.method} ${request.path}',
+          ),
+        ).deepEquals([
+          'POST /api/v1/files/',
+          'POST /api/v1/knowledge/kb-1/file/add',
+          'DELETE /api/v1/files/file-1',
+        ]);
+      },
+    );
 
     test(
       'addFileToKnowledgeBase falls back when attach route rejects file id body',

--- a/test/core/services/conversation_parsing_test.dart
+++ b/test/core/services/conversation_parsing_test.dart
@@ -463,6 +463,7 @@ void main() {
                     '<summary>Thought for 0 seconds</summary>\n'
                     '&gt; stale\n'
                     '</details>\n'
+                    '<details><summary>User details</summary>Keep me</details>\n'
                     'Final answer',
                 'output': [
                   {
@@ -489,6 +490,8 @@ void main() {
         final content = messages.first['content'] as String;
         check('<details'.allMatches(content).length).equals(1);
         check(content).not((it) => it.contains('&gt; stale'));
+        check(content).contains('&lt;details&gt;&lt;summary&gt;User details');
+        check(content).contains('Keep me');
         check('Final answer'.allMatches(content).length).equals(1);
       });
 

--- a/test/core/services/conversation_parsing_test.dart
+++ b/test/core/services/conversation_parsing_test.dart
@@ -507,6 +507,7 @@ void main() {
                     '<details type="tool_calls" done="false">\n'
                     '<summary>Executing...</summary>\n'
                     '</details>\n'
+                    '<details><summary>User details</summary>Keep me</details>\n'
                     'Final answer',
                 'output': [
                   {
@@ -523,7 +524,11 @@ void main() {
         });
 
         final messages = result['messages'] as List<Map<String, dynamic>>;
-        check(messages.first['content']).equals('Final answer');
+        final content = messages.first['content'] as String;
+        check(content).contains('&lt;details&gt;&lt;summary&gt;User details');
+        check(content).contains('Keep me');
+        check('Final answer'.allMatches(content).length).equals(1);
+        check(content).not((it) => it.contains('Executing...'));
       });
 
       test('falls back to history output when reloading message chain', () {

--- a/test/core/services/conversation_parsing_test.dart
+++ b/test/core/services/conversation_parsing_test.dart
@@ -463,6 +463,54 @@ void main() {
         ).isA<List>().has((it) => it.length, 'length').equals(1);
       });
 
+      test('uses history output when message output list is empty', () {
+        final result = parseFullConversation({
+          'id': 'conv-1',
+          'chat': {
+            'messages': [
+              {
+                'id': 'msg-1',
+                'role': 'user',
+                'content': 'Hello',
+                'timestamp': 1700000000,
+              },
+              {
+                'id': 'msg-2',
+                'role': 'assistant',
+                'content': '',
+                'output': const <dynamic>[],
+                'timestamp': 1700000001,
+              },
+            ],
+            'history': {
+              'currentId': 'msg-2',
+              'messages': {
+                'msg-2': {
+                  'role': 'assistant',
+                  'content': '',
+                  'timestamp': 1700000001,
+                  'output': [
+                    {
+                      'type': 'message',
+                      'content': [
+                        {'type': 'output_text', 'text': 'History answer'},
+                      ],
+                    },
+                  ],
+                },
+              },
+            },
+          },
+        });
+
+        final messages = result['messages'] as List<Map<String, dynamic>>;
+        check(messages).length.equals(1);
+        check(messages.first['content']).equals('History answer');
+        check(
+          messages.first['output'],
+        ).isA<List>().has((it) => it.length, 'length').equals(1);
+      });
+
       test('renders structured output for assistant sibling versions', () {
         final result = parseFullConversation({
           'id': 'conv-1',

--- a/test/core/services/conversation_parsing_test.dart
+++ b/test/core/services/conversation_parsing_test.dart
@@ -495,6 +495,37 @@ void main() {
         check('Final answer'.allMatches(content).length).equals(1);
       });
 
+      test('plain structured output clears stale rendered details', () {
+        final result = parseFullConversation({
+          'id': 'conv-1',
+          'chat': {
+            'messages': [
+              {
+                'id': 'msg-1',
+                'role': 'assistant',
+                'content':
+                    '<details type="tool_calls" done="false">\n'
+                    '<summary>Executing...</summary>\n'
+                    '</details>\n'
+                    'Final answer',
+                'output': [
+                  {
+                    'type': 'message',
+                    'content': [
+                      {'type': 'output_text', 'text': 'Final answer'},
+                    ],
+                  },
+                ],
+                'timestamp': 1700000000,
+              },
+            ],
+          },
+        });
+
+        final messages = result['messages'] as List<Map<String, dynamic>>;
+        check(messages.first['content']).equals('Final answer');
+      });
+
       test('falls back to history output when reloading message chain', () {
         final result = parseFullConversation({
           'id': 'conv-1',

--- a/test/core/services/conversation_parsing_test.dart
+++ b/test/core/services/conversation_parsing_test.dart
@@ -356,6 +356,169 @@ void main() {
         check(messages.first['content']).equals('Hello world');
       });
 
+      test('falls back to structured output for empty persisted content', () {
+        final result = parseFullConversation({
+          'id': 'conv-1',
+          'chat': {
+            'messages': [
+              {
+                'id': 'msg-1',
+                'role': 'assistant',
+                'content': '',
+                'output': [
+                  {
+                    'type': 'message',
+                    'content': [
+                      {'type': 'output_text', 'text': 'Structured answer'},
+                    ],
+                  },
+                ],
+                'timestamp': 1700000000,
+              },
+            ],
+          },
+        });
+
+        final messages = result['messages'] as List<Map<String, dynamic>>;
+        check(messages.first['content']).equals('Structured answer');
+        check(
+          messages.first['output'],
+        ).isA<List>().has((it) => it.length, 'length').equals(1);
+      });
+
+      test('preserves structured details with persisted content', () {
+        final result = parseFullConversation({
+          'id': 'conv-1',
+          'chat': {
+            'messages': [
+              {
+                'id': 'msg-1',
+                'role': 'assistant',
+                'content': 'Final answer',
+                'output': [
+                  {
+                    'type': 'reasoning',
+                    'status': 'completed',
+                    'summary': [
+                      {'type': 'summary_text', 'text': 'checked docs'},
+                    ],
+                  },
+                  {
+                    'type': 'message',
+                    'content': [
+                      {'type': 'output_text', 'text': 'Final answer'},
+                    ],
+                  },
+                ],
+                'timestamp': 1700000000,
+              },
+            ],
+          },
+        });
+
+        final messages = result['messages'] as List<Map<String, dynamic>>;
+        final content = messages.first['content'] as String;
+        check(content).contains('<details type="reasoning"');
+        check(content).contains('Final answer');
+        check('Final answer'.allMatches(content).length).equals(1);
+      });
+
+      test('falls back to history output when reloading message chain', () {
+        final result = parseFullConversation({
+          'id': 'conv-1',
+          'chat': {
+            'history': {
+              'currentId': 'msg-2',
+              'messages': {
+                'msg-1': {
+                  'role': 'user',
+                  'content': 'Hello',
+                  'timestamp': 1700000000,
+                  'childrenIds': ['msg-2'],
+                },
+                'msg-2': {
+                  'role': 'assistant',
+                  'content': '',
+                  'parentId': 'msg-1',
+                  'timestamp': 1700000001,
+                  'output': [
+                    {
+                      'type': 'message',
+                      'content': [
+                        {'type': 'output_text', 'text': 'Reloaded answer'},
+                      ],
+                    },
+                  ],
+                },
+              },
+            },
+          },
+        });
+
+        final messages = result['messages'] as List<Map<String, dynamic>>;
+        check(messages).length.equals(2);
+        check(messages[1]['content']).equals('Reloaded answer');
+        check(
+          messages[1]['output'],
+        ).isA<List>().has((it) => it.length, 'length').equals(1);
+      });
+
+      test('renders structured output for assistant sibling versions', () {
+        final result = parseFullConversation({
+          'id': 'conv-1',
+          'chat': {
+            'history': {
+              'currentId': 'current-asst',
+              'messages': {
+                'user-1': {
+                  'role': 'user',
+                  'content': 'Hello',
+                  'timestamp': 1700000000,
+                  'childrenIds': ['alt-asst', 'current-asst'],
+                },
+                'alt-asst': {
+                  'role': 'assistant',
+                  'content': '',
+                  'parentId': 'user-1',
+                  'timestamp': 1700000001,
+                  'output': [
+                    {
+                      'type': 'reasoning',
+                      'status': 'completed',
+                      'summary': [
+                        {'type': 'summary_text', 'text': 'checked docs'},
+                      ],
+                    },
+                    {
+                      'type': 'message',
+                      'content': [
+                        {'type': 'output_text', 'text': 'Alt answer'},
+                      ],
+                    },
+                  ],
+                },
+                'current-asst': {
+                  'role': 'assistant',
+                  'content': 'Current answer',
+                  'parentId': 'user-1',
+                  'timestamp': 1700000002,
+                },
+              },
+            },
+          },
+        });
+
+        final messages = result['messages'] as List<Map<String, dynamic>>;
+        final versions = messages[1]['versions'] as List<dynamic>;
+        final version = versions.single as Map<String, dynamic>;
+        final content = version['content'] as String;
+        check(content).contains('<details type="reasoning"');
+        check(content).contains('Alt answer');
+        check(
+          version['output'],
+        ).isA<List>().has((it) => it.length, 'length').equals(2);
+      });
+
       test('normalizes assistant embeds from message payloads', () {
         final result = parseFullConversation({
           'id': 'conv-1',

--- a/test/core/services/conversation_parsing_test.dart
+++ b/test/core/services/conversation_parsing_test.dart
@@ -531,6 +531,37 @@ void main() {
         check(content).not((it) => it.contains('Executing...'));
       });
 
+      test('plain structured output replaces stale stripped text', () {
+        final result = parseFullConversation({
+          'id': 'conv-1',
+          'chat': {
+            'messages': [
+              {
+                'id': 'msg-1',
+                'role': 'assistant',
+                'content':
+                    '<details type="tool_calls" done="false">\n'
+                    '<summary>Executing...</summary>\n'
+                    '</details>\n'
+                    'Partial',
+                'output': [
+                  {
+                    'type': 'message',
+                    'content': [
+                      {'type': 'output_text', 'text': 'Final answer'},
+                    ],
+                  },
+                ],
+                'timestamp': 1700000000,
+              },
+            ],
+          },
+        });
+
+        final messages = result['messages'] as List<Map<String, dynamic>>;
+        check(messages.first['content']).equals('Final answer');
+      });
+
       test('falls back to history output when reloading message chain', () {
         final result = parseFullConversation({
           'id': 'conv-1',

--- a/test/core/services/conversation_parsing_test.dart
+++ b/test/core/services/conversation_parsing_test.dart
@@ -450,6 +450,48 @@ void main() {
         check(messages.first['content']).equals('Partial final answer');
       });
 
+      test('does not reuse rendered details as replacement text', () {
+        final result = parseFullConversation({
+          'id': 'conv-1',
+          'chat': {
+            'messages': [
+              {
+                'id': 'msg-1',
+                'role': 'assistant',
+                'content':
+                    '<details type="reasoning" done="true">\n'
+                    '<summary>Thought for 0 seconds</summary>\n'
+                    '&gt; stale\n'
+                    '</details>\n'
+                    'Final answer',
+                'output': [
+                  {
+                    'type': 'reasoning',
+                    'status': 'completed',
+                    'summary': [
+                      {'type': 'summary_text', 'text': 'fresh'},
+                    ],
+                  },
+                  {
+                    'type': 'message',
+                    'content': [
+                      {'type': 'output_text', 'text': 'Final answer'},
+                    ],
+                  },
+                ],
+                'timestamp': 1700000000,
+              },
+            ],
+          },
+        });
+
+        final messages = result['messages'] as List<Map<String, dynamic>>;
+        final content = messages.first['content'] as String;
+        check('<details'.allMatches(content).length).equals(1);
+        check(content).not((it) => it.contains('&gt; stale'));
+        check('Final answer'.allMatches(content).length).equals(1);
+      });
+
       test('falls back to history output when reloading message chain', () {
         final result = parseFullConversation({
           'id': 'conv-1',

--- a/test/core/services/conversation_parsing_test.dart
+++ b/test/core/services/conversation_parsing_test.dart
@@ -423,6 +423,33 @@ void main() {
         check('Final answer'.allMatches(content).length).equals(1);
       });
 
+      test('prefers longer structured output text over stale content', () {
+        final result = parseFullConversation({
+          'id': 'conv-1',
+          'chat': {
+            'messages': [
+              {
+                'id': 'msg-1',
+                'role': 'assistant',
+                'content': 'Partial',
+                'output': [
+                  {
+                    'type': 'message',
+                    'content': [
+                      {'type': 'output_text', 'text': 'Partial final answer'},
+                    ],
+                  },
+                ],
+                'timestamp': 1700000000,
+              },
+            ],
+          },
+        });
+
+        final messages = result['messages'] as List<Map<String, dynamic>>;
+        check(messages.first['content']).equals('Partial final answer');
+      });
+
       test('falls back to history output when reloading message chain', () {
         final result = parseFullConversation({
           'id': 'conv-1',

--- a/test/core/services/openwebui_stream_parser_test.dart
+++ b/test/core/services/openwebui_stream_parser_test.dart
@@ -459,6 +459,51 @@ void main() {
       check(serialized).equals(' hello &lt;world&gt;\n');
     });
 
+    test('extracts text-bearing message parts without a type', () {
+      final serialized = renderStructuredOutputBlocks(
+        parseOpenWebUIStructuredOutput([
+          {
+            'type': 'message',
+            'content': [
+              {'text': 'typeless text'},
+            ],
+          },
+        ]),
+      );
+
+      check(serialized).equals('typeless text');
+    });
+
+    test('replacement text preserves text block ordering around details', () {
+      final rendered = renderStructuredOutputBlocksWithContent(
+        parseOpenWebUIStructuredOutput([
+          {
+            'type': 'message',
+            'content': [
+              {'type': 'output_text', 'text': 'A'},
+            ],
+          },
+          {
+            'type': 'reasoning',
+            'status': 'completed',
+            'summary': [
+              {'type': 'summary_text', 'text': 'thinking'},
+            ],
+          },
+          {
+            'type': 'message',
+            'content': [
+              {'type': 'output_text', 'text': 'B'},
+            ],
+          },
+        ]),
+        'AB',
+      );
+
+      check(rendered).startsWith('A\n<details type="reasoning"');
+      check(rendered).endsWith('</details>\nB');
+    });
+
     test('escapes generated details body and attributes', () {
       final serialized = renderStructuredOutputBlocks(
         parseOpenWebUIStructuredOutput([

--- a/test/core/services/openwebui_stream_parser_test.dart
+++ b/test/core/services/openwebui_stream_parser_test.dart
@@ -540,6 +540,27 @@ void main() {
       check(serialized).contains('done="false"');
     });
 
+    test('renders custom tool call output as details', () {
+      final blocks = parseOpenWebUIStructuredOutput([
+        {
+          'type': 'custom_tool_call',
+          'id': 'custom-1',
+          'name': 'lookup',
+          'input': {'query': 'docs'},
+        },
+        {
+          'type': 'custom_tool_call_output',
+          'id': 'custom-1',
+          'content': 'result',
+        },
+      ]);
+      final toolBlock = blocks.single as StructuredOutputToolCallBlock;
+
+      check(toolBlock.name).equals('lookup');
+      check(toolBlock.result).equals('result');
+      check(toolBlock.done).isTrue();
+    });
+
     test('code interpreter fence grows around untrusted backticks', () {
       final rendered = renderStructuredOutputBlocks(
         parseOpenWebUIStructuredOutput([

--- a/test/core/services/openwebui_stream_parser_test.dart
+++ b/test/core/services/openwebui_stream_parser_test.dart
@@ -504,6 +504,22 @@ void main() {
       check(rendered).endsWith('</details>\nB');
     });
 
+    test('code interpreter fence grows around untrusted backticks', () {
+      final rendered = renderStructuredOutputBlocks(
+        parseOpenWebUIStructuredOutput([
+          {
+            'type': 'code_interpreter',
+            'status': 'completed',
+            'language': 'dart',
+            'code': 'print("before");\n```\nprint("after");',
+          },
+        ]),
+      );
+
+      check(rendered).contains('````dart');
+      check(rendered).contains('print(&quot;after&quot;);');
+    });
+
     test('escapes generated details body and attributes', () {
       final serialized = renderStructuredOutputBlocks(
         parseOpenWebUIStructuredOutput([

--- a/test/core/services/openwebui_stream_parser_test.dart
+++ b/test/core/services/openwebui_stream_parser_test.dart
@@ -3,6 +3,8 @@ import 'dart:convert';
 
 import 'package:checks/checks.dart';
 import 'package:conduit/core/services/openwebui_stream_parser.dart';
+import 'package:conduit/core/services/structured_output.dart';
+import 'package:conduit/core/services/structured_output_renderer.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
@@ -345,7 +347,77 @@ void main() {
           .isA<OpenWebUIOutputUpdate>()
           .has((u) => u.output.length, 'output.length')
           .equals(1);
+      check(updates[0])
+          .isA<OpenWebUIOutputUpdate>()
+          .has((u) => u.blocks.length, 'blocks.length')
+          .equals(1);
+      check(updates[0])
+          .isA<OpenWebUIOutputUpdate>()
+          .has((u) => u.blocks.single, 'block')
+          .isA<StructuredOutputTextBlock>()
+          .has((block) => block.text, 'text')
+          .equals('hello');
       check(updates[1]).isA<OpenWebUIStreamDone>();
+    });
+
+    test('emits delta before output for mixed stream chunks', () async {
+      final updates = await parseOpenWebUIStream(
+        Stream<List<int>>.fromIterable([
+          utf8.encode(
+            'data: ${jsonEncode({
+              'output': [
+                {
+                  'type': 'message',
+                  'content': [
+                    {'type': 'output_text', 'text': 'Hello'},
+                  ],
+                },
+              ],
+              'choices': [
+                {
+                  'delta': {'content': 'Hello'},
+                },
+              ],
+            })}\n\n',
+          ),
+        ]),
+      ).toList();
+
+      check(updates).has((it) => it.length, 'length').equals(2);
+      check(updates[0]).isA<OpenWebUIContentDelta>();
+      check(updates[1]).isA<OpenWebUIOutputUpdate>();
+    });
+
+    test('emits usage and output from the same stream chunk', () async {
+      final updates = await parseOpenWebUIStream(
+        Stream<List<int>>.fromIterable([
+          utf8.encode(
+            'data: ${jsonEncode({
+              'usage': {'total_tokens': 7},
+              'output': [
+                {
+                  'type': 'message',
+                  'content': [
+                    {'type': 'output_text', 'text': 'Hello'},
+                  ],
+                },
+              ],
+            })}\n\n',
+          ),
+        ]),
+      ).toList();
+
+      check(updates).has((it) => it.length, 'length').equals(2);
+      check(updates[0])
+          .isA<OpenWebUIUsageUpdate>()
+          .has((update) => update.usage['total_tokens'], 'total_tokens')
+          .equals(7);
+      check(updates[1])
+          .isA<OpenWebUIOutputUpdate>()
+          .has((update) => update.blocks.single, 'block')
+          .isA<StructuredOutputTextBlock>()
+          .has((block) => block.text, 'text')
+          .equals('Hello');
     });
 
     test('parses both reasoning_content and content in same delta', () async {
@@ -367,6 +439,239 @@ void main() {
           .isA<OpenWebUIContentDelta>()
           .has((u) => u.content, 'content')
           .equals('say');
+    });
+  });
+
+  group('structured output rendering', () {
+    test('preserves multipart message text as one escaped block', () {
+      final serialized = renderStructuredOutputBlocks(
+        parseOpenWebUIStructuredOutput([
+          {
+            'type': 'message',
+            'content': [
+              {'type': 'output_text', 'text': ' hello '},
+              {'type': 'text', 'text': '<world>\n'},
+            ],
+          },
+        ]),
+      );
+
+      check(serialized).equals(' hello &lt;world&gt;\n');
+    });
+
+    test('escapes generated details body and attributes', () {
+      final serialized = renderStructuredOutputBlocks(
+        parseOpenWebUIStructuredOutput([
+          {
+            'type': 'reasoning',
+            'duration': '1" autofocus="true',
+            'summary': [
+              {
+                'type': 'summary_text',
+                'text': '</details><script>alert(1)</script>',
+              },
+            ],
+          },
+          {
+            'type': 'function_call',
+            'call_id': 'call" onmouseover="x',
+            'name': 'tool<script>',
+            'arguments': {'q': '" onclick="x'},
+          },
+          {
+            'type': 'function_call_output',
+            'call_id': 'call" onmouseover="x',
+            'output': '</details><img src=x onerror=alert(1)>',
+          },
+          {
+            'type': 'code_interpreter',
+            'status': 'completed',
+            'duration': '2',
+            'language': 'dart',
+            'code': '</details><script>alert(1)</script>',
+            'output': {'stdout': '<ok>'},
+          },
+        ]),
+      );
+
+      check(serialized).contains('&lt;&#47;details&gt;');
+      check(serialized).contains('duration="1&quot; autofocus=&quot;true"');
+      check(serialized).contains('id="call&quot; onmouseover=&quot;x"');
+      check(serialized).contains('name="tool&lt;script&gt;"');
+      check(serialized).not((it) => it.contains('<script>'));
+      check(serialized).not((it) => it.contains('onmouseover="x"'));
+      check(serialized).not((it) => it.contains('<img src=x'));
+    });
+
+    test('keeps in-progress reasoning open even when more output follows', () {
+      final blocks = parseOpenWebUIStructuredOutput([
+        {
+          'type': 'reasoning',
+          'status': 'in_progress',
+          'summary': [
+            {'type': 'summary_text', 'text': 'thinking'},
+          ],
+        },
+        {
+          'type': 'message',
+          'content': [
+            {'type': 'output_text', 'text': 'answer'},
+          ],
+        },
+      ]);
+      final serialized = renderStructuredOutputBlocks(blocks);
+
+      check(blocks.first)
+          .isA<StructuredOutputReasoningBlock>()
+          .has((block) => block.done, 'done')
+          .equals(false);
+      check(serialized).contains('<details type="reasoning" done="false">');
+    });
+
+    test('falls back from empty reasoning summary to content', () {
+      final blocks = parseOpenWebUIStructuredOutput([
+        {
+          'type': 'reasoning',
+          'summary': [
+            {'type': 'summary_text', 'text': ''},
+          ],
+          'content': [
+            {'type': 'output_text', 'text': 'content reasoning'},
+          ],
+        },
+      ]);
+      final serialized = renderStructuredOutputBlocks(blocks);
+
+      check(blocks.single)
+          .isA<StructuredOutputReasoningBlock>()
+          .has((block) => block.text, 'text')
+          .equals('content reasoning');
+      check(serialized).contains('&gt; content reasoning');
+    });
+
+    test('serializes upstream code interpreter output shape', () {
+      final blocks = parseOpenWebUIStructuredOutput([
+        {
+          'type': 'open_webui:code_interpreter',
+          'status': 'completed',
+          'lang': 'python',
+          'code': 'print("ok")',
+          'output': {'stdout': 'ok'},
+        },
+      ]);
+      final serialized = renderStructuredOutputBlocks(blocks);
+
+      check(blocks.single)
+          .isA<StructuredOutputCodeInterpreterBlock>()
+          .has((block) => block.language, 'language')
+          .equals('python');
+      check(serialized).contains('<details type="code_interpreter"');
+      check(serialized).contains('```python');
+      check(serialized).contains('print(&quot;ok&quot;)');
+    });
+
+    test('marks non-last code interpreter output done without status', () {
+      final blocks = parseOpenWebUIStructuredOutput([
+        {
+          'type': 'open_webui:code_interpreter',
+          'lang': 'python',
+          'code': 'print("ok")',
+        },
+        {
+          'type': 'message',
+          'content': [
+            {'type': 'output_text', 'text': 'answer'},
+          ],
+        },
+      ]);
+      final codeBlock = blocks.first as StructuredOutputCodeInterpreterBlock;
+      final serialized = renderStructuredOutputBlocks(blocks);
+
+      check(codeBlock.done).isTrue();
+      check(
+        serialized,
+      ).contains('<details type="code_interpreter" done="true"');
+    });
+
+    test('marks completed function call done without output item', () {
+      final blocks = parseOpenWebUIStructuredOutput([
+        {
+          'type': 'function_call',
+          'call_id': 'call-1',
+          'name': 'search',
+          'status': 'completed',
+          'arguments': {'query': 'docs'},
+        },
+      ]);
+      final toolBlock = blocks.single as StructuredOutputToolCallBlock;
+      final serialized = renderStructuredOutputBlocks(blocks);
+
+      check(toolBlock.done).isTrue();
+      check(serialized).contains('<summary>Tool Executed</summary>');
+      check(serialized).contains('done="true"');
+    });
+
+    test('renders OpenAI built-in tool output types as details', () {
+      final blocks = parseOpenWebUIStructuredOutput([
+        {
+          'type': 'web_search_call',
+          'id': 'web-1',
+          'status': 'completed',
+          'action': {
+            'type': 'search',
+            'queries': ['cats', 'dogs'],
+          },
+        },
+        {
+          'type': 'file_search_call',
+          'id': 'file-1',
+          'status': 'in_progress',
+          'queries': ['notes'],
+        },
+        {
+          'type': 'computer_call',
+          'id': 'computer-1',
+          'status': 'completed',
+          'action': {'type': 'click'},
+        },
+      ]);
+      final serialized = renderStructuredOutputBlocks(blocks);
+
+      check(blocks).has((items) => items.length, 'length').equals(3);
+      check(serialized).contains('name="Web Search"');
+      check(serialized).contains('name="File Search"');
+      check(serialized).contains('name="Computer Use"');
+      check(serialized).contains('result="&quot;Search: cats, dogs&quot;"');
+      check(serialized).contains('result="&quot;Queries: notes&quot;"');
+      check(serialized).contains('result="&quot;Action: click&quot;"');
+    });
+
+    test('preserves raw structured tool output values until rendering', () {
+      final blocks = parseOpenWebUIStructuredOutput([
+        {
+          'type': 'function_call',
+          'call_id': 'call-1',
+          'name': 'search',
+          'arguments': {'query': 'cats'},
+        },
+        {
+          'type': 'function_call_output',
+          'call_id': 'call-1',
+          'output': [
+            {'text': 'one'},
+            {'text': 'two'},
+          ],
+        },
+      ]);
+
+      final toolBlock = blocks.single as StructuredOutputToolCallBlock;
+      check(
+        toolBlock.result,
+      ).isA<List<dynamic>>().has((items) => items.length, 'length').equals(2);
+      final serialized = renderStructuredOutputBlocks(blocks);
+      check(serialized).contains(
+        'result="[{&quot;text&quot;:&quot;one&quot;},{&quot;text&quot;:&quot;two&quot;}]"',
+      );
     });
   });
 }

--- a/test/core/services/openwebui_stream_parser_test.dart
+++ b/test/core/services/openwebui_stream_parser_test.dart
@@ -504,6 +504,42 @@ void main() {
       check(rendered).endsWith('</details>\nB');
     });
 
+    test('replacement text is appended after detail-only output', () {
+      final rendered = renderStructuredOutputBlocksWithContent(
+        parseOpenWebUIStructuredOutput([
+          {
+            'type': 'reasoning',
+            'status': 'completed',
+            'summary': [
+              {'type': 'summary_text', 'text': 'thinking'},
+            ],
+          },
+        ]),
+        'Final answer',
+      );
+
+      check(rendered).startsWith('<details type="reasoning"');
+      check(rendered).endsWith('</details>\nFinal answer');
+    });
+
+    test('completed function call stays pending until output arrives', () {
+      final blocks = parseOpenWebUIStructuredOutput([
+        {
+          'type': 'function_call',
+          'call_id': 'call-1',
+          'name': 'search',
+          'status': 'completed',
+          'arguments': {'query': 'docs'},
+        },
+      ]);
+      final toolBlock = blocks.single as StructuredOutputToolCallBlock;
+      final serialized = renderStructuredOutputBlocks(blocks);
+
+      check(toolBlock.done).isFalse();
+      check(serialized).contains('<summary>Executing...</summary>');
+      check(serialized).contains('done="false"');
+    });
+
     test('code interpreter fence grows around untrusted backticks', () {
       final rendered = renderStructuredOutputBlocks(
         parseOpenWebUIStructuredOutput([
@@ -654,7 +690,7 @@ void main() {
       ).contains('<details type="code_interpreter" done="true"');
     });
 
-    test('marks completed function call done without output item', () {
+    test('marks function call done when output item is present', () {
       final blocks = parseOpenWebUIStructuredOutput([
         {
           'type': 'function_call',
@@ -662,6 +698,11 @@ void main() {
           'name': 'search',
           'status': 'completed',
           'arguments': {'query': 'docs'},
+        },
+        {
+          'type': 'function_call_output',
+          'call_id': 'call-1',
+          'output': 'result',
         },
       ]);
       final toolBlock = blocks.single as StructuredOutputToolCallBlock;

--- a/test/core/services/openwebui_stream_parser_test.dart
+++ b/test/core/services/openwebui_stream_parser_test.dart
@@ -456,7 +456,7 @@ void main() {
         ]),
       );
 
-      check(serialized).equals(' hello &lt;world&gt;\n');
+      check(serialized).equals(' hello \n&lt;world&gt;\n');
     });
 
     test('extracts text-bearing message parts without a type', () {
@@ -665,6 +665,42 @@ void main() {
           .has((block) => block.text, 'text')
           .equals('content reasoning');
       check(serialized).contains('&gt; content reasoning');
+    });
+
+    test('reads string reasoning content', () {
+      final blocks = parseOpenWebUIStructuredOutput([
+        {'type': 'reasoning', 'content': 'plain reasoning'},
+      ]);
+
+      check(blocks.single)
+          .isA<StructuredOutputReasoningBlock>()
+          .has((block) => block.text, 'text')
+          .equals('plain reasoning');
+    });
+
+    test('keeps failed tool calls and code interpreter blocks open', () {
+      final blocks = parseOpenWebUIStructuredOutput([
+        {
+          'type': 'function_call',
+          'call_id': 'call-1',
+          'name': 'search',
+          'status': 'failed',
+        },
+        {
+          'type': 'code_interpreter',
+          'status': 'incomplete',
+          'code': 'print(1)',
+        },
+      ]);
+
+      check(blocks[0])
+          .isA<StructuredOutputToolCallBlock>()
+          .has((block) => block.done, 'done')
+          .isFalse();
+      check(blocks[1])
+          .isA<StructuredOutputCodeInterpreterBlock>()
+          .has((block) => block.done, 'done')
+          .isFalse();
     });
 
     test('serializes upstream code interpreter output shape', () {

--- a/test/core/services/streaming_helper_transport_test.dart
+++ b/test/core/services/streaming_helper_transport_test.dart
@@ -1354,7 +1354,8 @@ void main() {
         await pumpMicrotasks();
 
         registrar.emitChatEvent('chat:completion', {
-          'content': 'Final answer',
+          'content':
+              '<details><summary>User details</summary>Keep me</details>\nFinal answer',
         }, messageId: 'msg-1');
         await pumpMicrotasks();
 
@@ -1381,7 +1382,11 @@ void main() {
         }, messageId: 'msg-1');
         await pumpMicrotasks();
 
-        check(log.messages.last.content).equals('Final answer');
+        final content = log.messages.last.content;
+        check(content).contains('<details><summary>User details</summary>');
+        check(content).contains('Keep me');
+        check(content).contains('Final answer');
+        check(content).not((it) => it.contains('Executing...'));
       },
     );
 

--- a/test/core/services/streaming_helper_transport_test.dart
+++ b/test/core/services/streaming_helper_transport_test.dart
@@ -1106,6 +1106,66 @@ void main() {
     );
 
     test(
+      'chat:completion text snapshot remains raw for later details',
+      () async {
+        final log = _CallbackLog();
+        final registrar = FakeSocketInjector();
+
+        _attach(
+          session: ChatCompletionSession.taskSocket(
+            messageId: 'msg-1',
+            sessionId: 'sess-1',
+            taskId: 'task-1',
+          ),
+          log: log,
+          socketService: _MockSocketService(registrar),
+        );
+
+        await pumpMicrotasks();
+
+        registrar.emitChatEvent('chat:completion', {
+          'output': [
+            {
+              'type': 'message',
+              'content': [
+                {'type': 'output_text', 'text': '2 < 3'},
+              ],
+            },
+          ],
+        }, messageId: 'msg-1');
+        await pumpMicrotasks();
+
+        registrar.emitChatEvent('chat:completion', {
+          'output': [
+            {
+              'type': 'message',
+              'content': [
+                {'type': 'output_text', 'text': '2 < 3'},
+              ],
+            },
+            {
+              'type': 'function_call',
+              'call_id': 'call-1',
+              'name': 'compare',
+              'arguments': {'left': 2, 'right': 3},
+            },
+            {
+              'type': 'function_call_output',
+              'call_id': 'call-1',
+              'output': 'true',
+            },
+          ],
+        }, messageId: 'msg-1');
+        await pumpMicrotasks();
+
+        final content = log.messages.last.content;
+        check(content).contains('2 &lt; 3');
+        check(content).not((it) => it.contains('&amp;lt;'));
+        check(content).contains('<details type="tool_calls"');
+      },
+    );
+
+    test(
       'chat:completion output snapshot replaces pending tool placeholder',
       () async {
         final log = _CallbackLog();
@@ -1837,6 +1897,67 @@ void main() {
         check(log.finishCount).equals(1);
         check(log.messages.last.isStreaming).isFalse();
         check(log.messages.last.content).equals('Hello there.');
+      },
+    );
+
+    test(
+      'taskSocket HTTP completion recovery does not locally finish stable partial snapshots',
+      () async {
+        final previousDelay = debugTaskSocketTerminalRecoveryDelay;
+        final previousLimit = debugTaskSocketStableNonTerminalRecoveryLimit;
+        debugTaskSocketTerminalRecoveryDelay = const Duration(milliseconds: 10);
+        debugTaskSocketStableNonTerminalRecoveryLimit = 2;
+        addTearDown(() {
+          debugTaskSocketTerminalRecoveryDelay = previousDelay;
+          debugTaskSocketStableNonTerminalRecoveryLimit = previousLimit;
+        });
+
+        final log = _CallbackLog();
+        final registrar = FakeSocketInjector();
+        final api = _buildFakeApi(
+          pollResponse: _serverConversationResponse(
+            messages: [
+              {
+                'id': 'msg-1',
+                'role': 'assistant',
+                'content': 'Partial answer',
+                'timestamp': DateTime.now().millisecondsSinceEpoch ~/ 1000,
+                'done': false,
+                'isStreaming': true,
+              },
+            ],
+          ),
+        );
+
+        _attach(
+          session: ChatCompletionSession.taskSocket(
+            messageId: 'msg-1',
+            sessionId: 'sess-1',
+            conversationId: 'conv-1',
+            taskId: 'task-1',
+          ),
+          log: log,
+          api: api,
+          activeConversationId: 'conv-1',
+          socketService: _MockSocketService(registrar),
+        );
+
+        await pumpMicrotasks();
+        await Future<void>.delayed(const Duration(milliseconds: 60));
+        for (var i = 0; i < 8; i += 1) {
+          await pumpMicrotasks();
+        }
+
+        check(log.messages.last.content).equals('Partial answer');
+        check(log.finishCount).equals(0);
+        check(log.messages.last.isStreaming).isTrue();
+
+        registrar.emitChatEvent('chat:completion', {
+          'done': true,
+        }, messageId: 'msg-1');
+        await pumpMicrotasks();
+
+        check(log.finishCount).equals(1);
       },
     );
 

--- a/test/core/services/streaming_helper_transport_test.dart
+++ b/test/core/services/streaming_helper_transport_test.dart
@@ -1336,6 +1336,56 @@ void main() {
     );
 
     test(
+      'chat:completion plain output clears stale pending tool details',
+      () async {
+        final log = _CallbackLog();
+        final registrar = FakeSocketInjector();
+
+        _attach(
+          session: ChatCompletionSession.taskSocket(
+            messageId: 'msg-1',
+            sessionId: 'sess-1',
+            taskId: 'task-1',
+          ),
+          log: log,
+          socketService: _MockSocketService(registrar),
+        );
+
+        await pumpMicrotasks();
+
+        registrar.emitChatEvent('chat:completion', {
+          'content': 'Final answer',
+        }, messageId: 'msg-1');
+        await pumpMicrotasks();
+
+        registrar.emitChatEvent('chat:completion', {
+          'tool_calls': [
+            {
+              'id': 'call-1',
+              'function': {'name': 'search'},
+            },
+          ],
+        }, messageId: 'msg-1');
+        await pumpMicrotasks();
+        check(log.messages.last.content).contains('<summary>Executing...');
+
+        registrar.emitChatEvent('chat:completion', {
+          'output': [
+            {
+              'type': 'message',
+              'content': [
+                {'type': 'output_text', 'text': 'Final answer'},
+              ],
+            },
+          ],
+        }, messageId: 'msg-1');
+        await pumpMicrotasks();
+
+        check(log.messages.last.content).equals('Final answer');
+      },
+    );
+
+    test(
       'chat:completion output snapshot keeps answer after reasoning-only state',
       () async {
         final log = _CallbackLog();

--- a/test/core/services/streaming_helper_transport_test.dart
+++ b/test/core/services/streaming_helper_transport_test.dart
@@ -1386,6 +1386,53 @@ void main() {
     );
 
     test(
+      'chat:completion structured tool snapshot suppresses duplicate pending status',
+      () async {
+        final log = _CallbackLog();
+        final registrar = FakeSocketInjector();
+
+        _attach(
+          session: ChatCompletionSession.taskSocket(
+            messageId: 'msg-1',
+            sessionId: 'sess-1',
+            taskId: 'task-1',
+          ),
+          log: log,
+          socketService: _MockSocketService(registrar),
+        );
+
+        await pumpMicrotasks();
+
+        registrar.emitChatEvent('chat:completion', {
+          'output': [
+            {
+              'type': 'function_call',
+              'call_id': 'call-1',
+              'name': 'search',
+              'arguments': {'query': 'docs'},
+            },
+          ],
+        }, messageId: 'msg-1');
+        await pumpMicrotasks();
+
+        registrar.emitChatEvent('chat:completion', {
+          'tool_calls': [
+            {
+              'id': 'call-1',
+              'function': {'name': 'search'},
+            },
+          ],
+        }, messageId: 'msg-1');
+        await pumpMicrotasks();
+
+        final content = log.messages.last.content;
+        check(
+          '<details type="tool_calls"'.allMatches(content).length,
+        ).equals(1);
+      },
+    );
+
+    test(
       'chat:completion output snapshot keeps answer after reasoning-only state',
       () async {
         final log = _CallbackLog();

--- a/test/core/services/streaming_helper_transport_test.dart
+++ b/test/core/services/streaming_helper_transport_test.dart
@@ -486,6 +486,133 @@ void main() {
       ).equals(1);
     });
 
+    test('httpStream renders output-only structured snapshots', () async {
+      final log = _CallbackLog();
+      final byteStream = Stream<List<int>>.fromIterable([
+        _sseFrame({
+          'output': [
+            {
+              'type': 'message',
+              'content': [
+                {'type': 'output_text', 'text': 'Partial stream'},
+              ],
+            },
+          ],
+        }),
+        _sseFrame({
+          'output': [
+            {
+              'type': 'message',
+              'content': [
+                {'type': 'output_text', 'text': 'Structured stream'},
+              ],
+            },
+          ],
+        }),
+        _sseDone(),
+      ]);
+
+      _attach(
+        session: ChatCompletionSession.httpStream(
+          messageId: 'msg-1',
+          sessionId: 'sess-1',
+          byteStream: byteStream,
+          abort: () async {},
+        ),
+        log: log,
+      );
+
+      await pumpMicrotasks();
+      await pumpMicrotasks();
+      await Future<void>.delayed(const Duration(milliseconds: 10));
+
+      check(
+        log.replacedContents,
+      ).deepEquals(['Partial stream', 'Structured stream']);
+      check(log.messages.last.content).equals('Structured stream');
+      check(log.finishCount).equals(1);
+    });
+
+    test(
+      'httpStream does not duplicate mixed output and delta content',
+      () async {
+        final log = _CallbackLog();
+        final byteStream = Stream<List<int>>.fromIterable([
+          _sseFrame({
+            'output': [
+              {
+                'type': 'message',
+                'content': [
+                  {'type': 'output_text', 'text': 'Hello'},
+                ],
+              },
+            ],
+            'choices': [
+              {
+                'delta': {'content': 'Hel'},
+              },
+            ],
+          }),
+          _sseDone(),
+        ]);
+
+        _attach(
+          session: ChatCompletionSession.httpStream(
+            messageId: 'msg-1',
+            sessionId: 'sess-1',
+            byteStream: byteStream,
+            abort: () async {},
+          ),
+          log: log,
+        );
+
+        await pumpMicrotasks();
+        await pumpMicrotasks();
+        await Future<void>.delayed(const Duration(milliseconds: 10));
+
+        check(log.appendedChunks).deepEquals(['Hel']);
+        check(log.messages.last.content).equals('Hello');
+        check(log.finishCount).equals(1);
+      },
+    );
+
+    test(
+      'chat:completion tracks tool placeholders without string scans',
+      () async {
+        final log = _CallbackLog();
+        final registrar = FakeSocketInjector();
+
+        _attach(
+          session: ChatCompletionSession.taskSocket(
+            messageId: 'msg-1',
+            sessionId: 'sess-1',
+            taskId: 'task-1',
+          ),
+          log: log,
+          socketService: _MockSocketService(registrar),
+        );
+
+        await pumpMicrotasks();
+
+        final payload = {
+          'tool_calls': [
+            {
+              'id': 'call-1',
+              'function': {'name': 'search'},
+            },
+          ],
+        };
+        registrar.emitChatEvent('chat:completion', payload, messageId: 'msg-1');
+        await pumpMicrotasks();
+        registrar.emitChatEvent('chat:completion', payload, messageId: 'msg-1');
+        await pumpMicrotasks();
+
+        check(log.appendedChunks).length.equals(1);
+        check(log.appendedChunks.single).contains('type="tool_calls"');
+        check(log.appendedChunks.single).contains('name="search"');
+      },
+    );
+
     test('httpStream handles emitter delta and status events', () async {
       final log = _CallbackLog();
       final byteStream = Stream<List<int>>.fromIterable([
@@ -835,6 +962,325 @@ void main() {
     );
 
     test(
+      'chat:completion output snapshots replace visible empty content',
+      () async {
+        final log = _CallbackLog();
+        final registrar = FakeSocketInjector();
+
+        _attach(
+          session: ChatCompletionSession.taskSocket(
+            messageId: 'msg-1',
+            sessionId: 'sess-1',
+            taskId: 'task-1',
+          ),
+          log: log,
+          socketService: _MockSocketService(registrar),
+        );
+
+        await pumpMicrotasks();
+
+        registrar.emitChatEvent('chat:completion', {
+          'content': '',
+          'output': [
+            {
+              'type': 'message',
+              'content': [
+                {'type': 'output_text', 'text': 'first'},
+              ],
+            },
+          ],
+        }, messageId: 'msg-1');
+        await pumpMicrotasks();
+
+        registrar.emitChatEvent('chat:completion', {
+          'output': [
+            {
+              'type': 'message',
+              'content': [
+                {'type': 'output_text', 'text': 'final'},
+              ],
+            },
+          ],
+        }, messageId: 'msg-1');
+        await pumpMicrotasks();
+
+        check(log.replacedContents).deepEquals(['first', 'final']);
+        check(log.messages.last.content).equals('final');
+      },
+    );
+
+    test(
+      'chat:completion output snapshot preserves streamed text with details',
+      () async {
+        final log = _CallbackLog();
+        final registrar = FakeSocketInjector();
+
+        _attach(
+          session: ChatCompletionSession.taskSocket(
+            messageId: 'msg-1',
+            sessionId: 'sess-1',
+            taskId: 'task-1',
+          ),
+          log: log,
+          socketService: _MockSocketService(registrar),
+        );
+
+        await pumpMicrotasks();
+
+        registrar.emitChatEvent('chat:completion', {
+          'choices': [
+            {
+              'delta': {'content': 'Visible answer'},
+            },
+          ],
+        }, messageId: 'msg-1');
+        await pumpMicrotasks();
+
+        registrar.emitChatEvent('chat:completion', {
+          'output': [
+            {
+              'type': 'function_call',
+              'call_id': 'call-1',
+              'name': 'search',
+              'arguments': {'query': 'docs'},
+            },
+            {
+              'type': 'function_call_output',
+              'call_id': 'call-1',
+              'output': 'tool result',
+            },
+          ],
+        }, messageId: 'msg-1');
+        await pumpMicrotasks();
+
+        check(log.appendedChunks).deepEquals(['Visible answer']);
+        check(log.replacedContents).has((it) => it.length, 'length').equals(1);
+        check(log.messages.last.content).contains('Visible answer');
+        check(log.messages.last.content).contains('<details type="tool_calls"');
+        check(log.messages.last.content).contains('name="search"');
+        check(
+          log.messages.last.output,
+        ).has((it) => it?.length, 'length').equals(2);
+      },
+    );
+
+    test(
+      'chat:completion text-only output snapshot completes streamed delta',
+      () async {
+        final log = _CallbackLog();
+        final registrar = FakeSocketInjector();
+
+        _attach(
+          session: ChatCompletionSession.taskSocket(
+            messageId: 'msg-1',
+            sessionId: 'sess-1',
+            taskId: 'task-1',
+          ),
+          log: log,
+          socketService: _MockSocketService(registrar),
+        );
+
+        await pumpMicrotasks();
+
+        registrar.emitChatEvent('chat:completion', {
+          'choices': [
+            {
+              'delta': {'content': 'Hel'},
+            },
+          ],
+          'output': [
+            {
+              'type': 'message',
+              'content': [
+                {'type': 'output_text', 'text': 'Hello'},
+              ],
+            },
+          ],
+        }, messageId: 'msg-1');
+        await pumpMicrotasks();
+
+        check(log.appendedChunks).deepEquals(['Hel']);
+        check(log.messages.last.content).equals('Hello');
+        check(log.messages.last.output).isNotNull();
+      },
+    );
+
+    test(
+      'chat:completion output snapshot replaces pending tool placeholder',
+      () async {
+        final log = _CallbackLog();
+        final registrar = FakeSocketInjector();
+
+        _attach(
+          session: ChatCompletionSession.taskSocket(
+            messageId: 'msg-1',
+            sessionId: 'sess-1',
+            taskId: 'task-1',
+          ),
+          log: log,
+          socketService: _MockSocketService(registrar),
+        );
+
+        await pumpMicrotasks();
+
+        registrar.emitChatEvent('chat:completion', {
+          'tool_calls': [
+            {
+              'id': 'call-1',
+              'function': {'name': 'search'},
+            },
+          ],
+        }, messageId: 'msg-1');
+        await pumpMicrotasks();
+
+        check(log.messages.last.content).contains('<summary>Executing...');
+
+        registrar.emitChatEvent('chat:completion', {
+          'output': [
+            {
+              'type': 'function_call',
+              'call_id': 'call-1',
+              'name': 'search',
+              'arguments': {'query': 'docs'},
+            },
+            {
+              'type': 'function_call_output',
+              'call_id': 'call-1',
+              'output': 'tool result',
+            },
+          ],
+        }, messageId: 'msg-1');
+        await pumpMicrotasks();
+
+        final content = log.messages.last.content;
+        check(
+          '<details type="tool_calls"'.allMatches(content).length,
+        ).equals(1);
+        check(content).contains('<summary>Tool Executed</summary>');
+        check(content).contains('tool result');
+        check(content).not((it) => it.contains('Executing...'));
+        check(content).not((it) => it.contains('&lt;details'));
+      },
+    );
+
+    test(
+      'chat:completion output snapshot keeps answer after reasoning-only state',
+      () async {
+        final log = _CallbackLog();
+        final registrar = FakeSocketInjector();
+
+        _attach(
+          session: ChatCompletionSession.taskSocket(
+            messageId: 'msg-1',
+            sessionId: 'sess-1',
+            taskId: 'task-1',
+          ),
+          log: log,
+          socketService: _MockSocketService(registrar),
+        );
+
+        await pumpMicrotasks();
+
+        registrar.emitChatEvent('chat:completion', {
+          'choices': [
+            {
+              'delta': {'reasoning_content': 'thinking'},
+            },
+          ],
+        }, messageId: 'msg-1');
+        await pumpMicrotasks();
+
+        registrar.emitChatEvent('chat:completion', {
+          'output': [
+            {
+              'type': 'reasoning',
+              'status': 'completed',
+              'summary': [
+                {'type': 'summary_text', 'text': 'thinking'},
+              ],
+            },
+            {
+              'type': 'message',
+              'content': [
+                {'type': 'output_text', 'text': 'Final answer'},
+              ],
+            },
+          ],
+        }, messageId: 'msg-1');
+        await pumpMicrotasks();
+
+        check(log.messages.last.content).contains('<details type="reasoning"');
+        check(log.messages.last.content).contains('Final answer');
+      },
+    );
+
+    test(
+      'chat:completion repeated output snapshots keep one details block',
+      () async {
+        final log = _CallbackLog();
+        final registrar = FakeSocketInjector();
+
+        _attach(
+          session: ChatCompletionSession.taskSocket(
+            messageId: 'msg-1',
+            sessionId: 'sess-1',
+            taskId: 'task-1',
+          ),
+          log: log,
+          socketService: _MockSocketService(registrar),
+        );
+
+        await pumpMicrotasks();
+
+        registrar.emitChatEvent('chat:completion', {
+          'choices': [
+            {
+              'delta': {'content': 'Visible answer'},
+            },
+          ],
+        }, messageId: 'msg-1');
+        await pumpMicrotasks();
+
+        Map<String, Object?> outputPayload(String result) => {
+          'output': [
+            {
+              'type': 'function_call',
+              'call_id': 'call-1',
+              'name': 'search',
+              'arguments': {'query': 'docs'},
+            },
+            {
+              'type': 'function_call_output',
+              'call_id': 'call-1',
+              'output': result,
+            },
+          ],
+        };
+
+        registrar.emitChatEvent(
+          'chat:completion',
+          outputPayload('first result'),
+          messageId: 'msg-1',
+        );
+        await pumpMicrotasks();
+        registrar.emitChatEvent(
+          'chat:completion',
+          outputPayload('second result'),
+          messageId: 'msg-1',
+        );
+        await pumpMicrotasks();
+
+        final content = log.messages.last.content;
+        check(
+          '<details type="tool_calls"'.allMatches(content).length,
+        ).equals(1);
+        check(content).contains('Visible answer');
+        check(content).contains('second result');
+        check(content).not((it) => it.contains('&lt;details'));
+      },
+    );
+
+    test(
       'taskSocket channel stream preserves malformed payload fallback',
       () async {
         final log = _CallbackLog();
@@ -1080,6 +1526,47 @@ void main() {
         check(log.finishCount).equals(1);
         check(log.messages.last.isStreaming).isFalse();
         expect(log.messages.last.content, equals('Hello there.'));
+      },
+    );
+
+    test(
+      'taskSocket HTTP completion starts poll recovery when socket events are missing',
+      () async {
+        final previousDelay = debugTaskSocketTerminalRecoveryDelay;
+        debugTaskSocketTerminalRecoveryDelay = const Duration(milliseconds: 10);
+        addTearDown(() {
+          debugTaskSocketTerminalRecoveryDelay = previousDelay;
+        });
+
+        final log = _CallbackLog();
+        final registrar = FakeSocketInjector();
+        final api = _buildFakeApi(
+          pollResponse: _serverConversationResponse(
+            messages: [_serverAssistantMessage(content: 'Recovered from poll')],
+          ),
+        );
+        final adapter = api.dio.httpClientAdapter as _StubAdapter;
+
+        _attach(
+          session: ChatCompletionSession.taskSocket(
+            messageId: 'msg-1',
+            sessionId: 'sess-1',
+            conversationId: 'conv-1',
+            taskId: 'task-1',
+          ),
+          log: log,
+          api: api,
+          activeConversationId: 'conv-1',
+          socketService: _MockSocketService(registrar),
+        );
+
+        await Future<void>.delayed(const Duration(milliseconds: 50));
+
+        check(
+          adapter.requestCount(method: 'GET', path: '/api/v1/chats/conv-1'),
+        ).isGreaterThan(0);
+        check(log.messages.last.content).equals('Recovered from poll');
+        check(log.finishCount).equals(1);
       },
     );
 
@@ -1700,6 +2187,86 @@ void main() {
       check(log.finishCount).equals(1);
     });
 
+    test('jsonCompletion renders output-only payloads', () async {
+      final log = _CallbackLog();
+
+      _attach(
+        session: ChatCompletionSession.jsonCompletion(
+          messageId: 'msg-1',
+          sessionId: 'sess-1',
+          jsonPayload: {
+            'choices': [
+              {
+                'message': {'content': ''},
+              },
+            ],
+            'output': [
+              {
+                'type': 'message',
+                'content': [
+                  {'type': 'output_text', 'text': 'Structured JSON reply'},
+                ],
+              },
+            ],
+          },
+        ),
+        log: log,
+      );
+
+      await pumpMicrotasks();
+      await pumpMicrotasks();
+
+      check(log.replacedContents).deepEquals(['Structured JSON reply']);
+      check(log.messages.last.content).equals('Structured JSON reply');
+      check(log.messages.last.output).isNotNull();
+      check(log.finishCount).equals(1);
+    });
+
+    test('jsonCompletion preserves content with structured details', () async {
+      final log = _CallbackLog();
+
+      _attach(
+        session: ChatCompletionSession.jsonCompletion(
+          messageId: 'msg-1',
+          sessionId: 'sess-1',
+          jsonPayload: {
+            'choices': [
+              {
+                'message': {'content': 'Direct reply'},
+              },
+            ],
+            'output': [
+              {
+                'type': 'reasoning',
+                'status': 'completed',
+                'summary': [
+                  {'type': 'summary_text', 'text': 'checked docs'},
+                ],
+              },
+              {
+                'type': 'message',
+                'content': [
+                  {'type': 'output_text', 'text': 'Direct reply'},
+                ],
+              },
+            ],
+          },
+        ),
+        log: log,
+      );
+
+      await pumpMicrotasks();
+      await pumpMicrotasks();
+
+      check(log.messages.last.content).contains('<details type="reasoning"');
+      check(log.messages.last.content).contains('Direct reply');
+      check(
+        'Direct reply'.allMatches(log.messages.last.content).length,
+      ).equals(1);
+      check(log.messages.last.output).isNotNull();
+      check(log.finishCount).equals(1);
+    });
+
     // -----------------------------------------------------------------------
     // 4. jsonCompletion applies usage, sources, and error
     // -----------------------------------------------------------------------
@@ -1858,6 +2425,48 @@ void main() {
         log.messages.last.usage,
         equals({'prompt_tokens': 10, 'completion_tokens': 5}),
       );
+    });
+
+    test('httpStream applies usage and output from one frame', () async {
+      final log = _CallbackLog();
+
+      final byteStream = Stream<List<int>>.fromIterable([
+        _sseFrame({
+          'usage': {'prompt_tokens': 10, 'completion_tokens': 5},
+          'output': [
+            {
+              'type': 'message',
+              'content': [
+                {'type': 'output_text', 'text': 'Structured with usage'},
+              ],
+            },
+          ],
+        }),
+        _sseDone(),
+      ]);
+
+      _attach(
+        session: ChatCompletionSession.httpStream(
+          messageId: 'msg-1',
+          sessionId: 'sess-1',
+          byteStream: byteStream,
+          abort: () async {},
+        ),
+        log: log,
+      );
+
+      await pumpMicrotasks();
+      await pumpMicrotasks();
+
+      expect(
+        log.messages.last.usage,
+        equals({'prompt_tokens': 10, 'completion_tokens': 5}),
+      );
+      check(log.messages.last.content).equals('Structured with usage');
+      check(log.messages.last.output).isNotNull();
+      check(
+        log.messages.last.output!,
+      ).has((it) => it.length, 'length').equals(1);
     });
 
     test('httpStream applies selected model update', () async {
@@ -2109,7 +2718,7 @@ void main() {
         await pumpMicrotasks();
 
         check(log.finishCount).equals(1);
-        check(log.messages.last.content).equals('');
+        check(log.messages.last.content).equals('tool output');
 
         await Future<void>.delayed(const Duration(milliseconds: 2600));
         for (var i = 0; i < 5; i++) {

--- a/test/core/services/streaming_helper_transport_test.dart
+++ b/test/core/services/streaming_helper_transport_test.dart
@@ -1166,6 +1166,68 @@ void main() {
     );
 
     test(
+      'chat:completion full structured snapshot keeps raw plain text',
+      () async {
+        final log = _CallbackLog();
+        final registrar = FakeSocketInjector();
+
+        _attach(
+          session: ChatCompletionSession.taskSocket(
+            messageId: 'msg-1',
+            sessionId: 'sess-1',
+            taskId: 'task-1',
+          ),
+          log: log,
+          socketService: _MockSocketService(registrar),
+        );
+
+        await pumpMicrotasks();
+
+        registrar.emitChatEvent('chat:completion', {
+          'output': [
+            {
+              'type': 'message',
+              'content': [
+                {'type': 'output_text', 'text': '2 < 3'},
+              ],
+            },
+            {
+              'type': 'reasoning',
+              'status': 'completed',
+              'summary': [
+                {'type': 'summary_text', 'text': 'checked'},
+              ],
+            },
+          ],
+        }, messageId: 'msg-1');
+        await pumpMicrotasks();
+
+        registrar.emitChatEvent('chat:completion', {
+          'output': [
+            {
+              'type': 'message',
+              'content': [
+                {'type': 'output_text', 'text': '2 < 3'},
+              ],
+            },
+            {
+              'type': 'function_call',
+              'call_id': 'call-1',
+              'name': 'compare',
+              'arguments': const <String, dynamic>{},
+            },
+          ],
+        }, messageId: 'msg-1');
+        await pumpMicrotasks();
+
+        final content = log.messages.last.content;
+        check(content).contains('2 &lt; 3');
+        check(content).not((it) => it.contains('&amp;lt;'));
+        check(content).contains('<details type="tool_calls"');
+      },
+    );
+
+    test(
       'chat:completion output snapshot replaces pending tool placeholder',
       () async {
         final log = _CallbackLog();

--- a/test/core/services/streaming_helper_transport_test.dart
+++ b/test/core/services/streaming_helper_transport_test.dart
@@ -1140,7 +1140,7 @@ void main() {
             {
               'type': 'message',
               'content': [
-                {'type': 'output_text', 'text': '2 < 3'},
+                {'type': 'output_text', 'text': '2 < 3 and 4 > 1'},
               ],
             },
             {
@@ -1159,7 +1159,7 @@ void main() {
         await pumpMicrotasks();
 
         final content = log.messages.last.content;
-        check(content).contains('2 &lt; 3');
+        check(content).contains('2 &lt; 3 and 4 &gt; 1');
         check(content).not((it) => it.contains('&amp;lt;'));
         check(content).contains('<details type="tool_calls"');
       },
@@ -1282,6 +1282,56 @@ void main() {
         check(content).contains('tool result');
         check(content).not((it) => it.contains('Executing...'));
         check(content).not((it) => it.contains('&lt;details'));
+      },
+    );
+
+    test(
+      'chat:completion content replacement lets pending tool status reappear',
+      () async {
+        final log = _CallbackLog();
+        final registrar = FakeSocketInjector();
+
+        _attach(
+          session: ChatCompletionSession.taskSocket(
+            messageId: 'msg-1',
+            sessionId: 'sess-1',
+            taskId: 'task-1',
+          ),
+          log: log,
+          socketService: _MockSocketService(registrar),
+        );
+
+        await pumpMicrotasks();
+
+        final toolCallPayload = {
+          'tool_calls': [
+            {
+              'id': 'call-1',
+              'function': {'name': 'search'},
+            },
+          ],
+        };
+        registrar.emitChatEvent(
+          'chat:completion',
+          toolCallPayload,
+          messageId: 'msg-1',
+        );
+        await pumpMicrotasks();
+        check(log.messages.last.content).contains('<summary>Executing...');
+
+        registrar.emitChatEvent('chat:completion', {
+          'content': 'intermediate answer',
+        }, messageId: 'msg-1');
+        await pumpMicrotasks();
+        check(log.messages.last.content).equals('intermediate answer');
+
+        registrar.emitChatEvent(
+          'chat:completion',
+          toolCallPayload,
+          messageId: 'msg-1',
+        );
+        await pumpMicrotasks();
+        check(log.messages.last.content).contains('<summary>Executing...');
       },
     );
 

--- a/test/core/services/streaming_helper_transport_test.dart
+++ b/test/core/services/streaming_helper_transport_test.dart
@@ -1390,6 +1390,54 @@ void main() {
       },
     );
 
+    test('chat:completion plain output replaces stale partial text', () async {
+      final log = _CallbackLog();
+      final registrar = FakeSocketInjector();
+
+      _attach(
+        session: ChatCompletionSession.taskSocket(
+          messageId: 'msg-1',
+          sessionId: 'sess-1',
+          taskId: 'task-1',
+        ),
+        log: log,
+        socketService: _MockSocketService(registrar),
+      );
+
+      await pumpMicrotasks();
+
+      registrar.emitChatEvent('chat:completion', {
+        'content': 'Partial',
+      }, messageId: 'msg-1');
+      await pumpMicrotasks();
+
+      registrar.emitChatEvent('chat:completion', {
+        'tool_calls': [
+          {
+            'id': 'call-1',
+            'function': {'name': 'search'},
+          },
+        ],
+      }, messageId: 'msg-1');
+      await pumpMicrotasks();
+      check(log.messages.last.content).contains('Partial');
+      check(log.messages.last.content).contains('<summary>Executing...');
+
+      registrar.emitChatEvent('chat:completion', {
+        'output': [
+          {
+            'type': 'message',
+            'content': [
+              {'type': 'output_text', 'text': 'Final answer'},
+            ],
+          },
+        ],
+      }, messageId: 'msg-1');
+      await pumpMicrotasks();
+
+      check(log.messages.last.content).equals('Final answer');
+    });
+
     test(
       'chat:completion structured tool snapshot suppresses duplicate pending status',
       () async {

--- a/test/core/utils/message_tree_utils_test.dart
+++ b/test/core/utils/message_tree_utils_test.dart
@@ -32,6 +32,70 @@ void main() {
     expect(chatMessageDescendantIds(messages, 'child'), {'child', 'leaf'});
   });
 
+  test('applies OpenWebUI delete semantics by reparenting grandchildren', () {
+    final messages = [
+      _message('root', childrenIds: const ['child']),
+      _message('child', parentId: 'root', childrenIds: const ['leaf']),
+      _message('leaf', parentId: 'child'),
+      _message('sibling', parentId: 'root'),
+    ];
+
+    expect(openWebUiDeletedMessageIds(messages, 'child'), {'child', 'leaf'});
+
+    final updated = deleteOpenWebUiMessageFromChatMessages(messages, 'child');
+
+    expect(updated.map((message) => message.id), ['root', 'sibling']);
+    expect(chatMessageChildrenIds(updated.first), isEmpty);
+  });
+
+  test('OpenWebUI delete reparents grandchildren to the deleted parent', () {
+    final messages = [
+      _message('root', childrenIds: const ['child']),
+      _message('child', parentId: 'root', childrenIds: const ['leaf']),
+      _message('leaf', parentId: 'child', childrenIds: const ['grandchild']),
+      _message('grandchild', parentId: 'leaf'),
+    ];
+
+    final updated = deleteOpenWebUiMessageFromChatMessages(messages, 'child');
+    final root = updated.singleWhere((message) => message.id == 'root');
+    final grandchild = updated.singleWhere(
+      (message) => message.id == 'grandchild',
+    );
+
+    expect(updated.map((message) => message.id), ['root', 'grandchild']);
+    expect(chatMessageChildrenIds(root), ['grandchild']);
+    expect(chatMessageParentId(grandchild), 'root');
+  });
+
+  test('OpenWebUI raw delete uses the same direct-child reparent plan', () {
+    final messages = <String, Map<String, dynamic>>{
+      'root': {
+        'id': 'root',
+        'childrenIds': ['child', 'sibling'],
+      },
+      'child': {
+        'id': 'child',
+        'parentId': 'root',
+        'childrenIds': ['leaf'],
+      },
+      'sibling': {'id': 'sibling', 'parentId': 'root'},
+      'leaf': {
+        'id': 'leaf',
+        'parentId': 'child',
+        'childrenIds': ['grandchild'],
+      },
+      'grandchild': {'id': 'grandchild', 'parentId': 'leaf'},
+    };
+
+    final result = deleteOpenWebUiMessageFromRawHistory(messages, 'child');
+
+    expect(result?.deletedIds, {'child', 'leaf'});
+    expect(result?.currentId, 'grandchild');
+    expect(messages.keys, ['root', 'sibling', 'grandchild']);
+    expect(messages['root']!['childrenIds'], ['sibling', 'grandchild']);
+    expect(messages['grandchild']!['parentId'], 'root');
+  });
+
   test('guards chain traversal against cycles', () {
     final messages = {
       'a': {'id': 'a', 'parentId': 'b'},

--- a/test/core/utils/message_tree_utils_test.dart
+++ b/test/core/utils/message_tree_utils_test.dart
@@ -34,7 +34,7 @@ void main() {
 
   test('applies OpenWebUI delete semantics by reparenting grandchildren', () {
     final messages = [
-      _message('root', childrenIds: const ['child']),
+      _message('root', childrenIds: const ['child', 'sibling']),
       _message('child', parentId: 'root', childrenIds: const ['leaf']),
       _message('leaf', parentId: 'child'),
       _message('sibling', parentId: 'root'),
@@ -45,7 +45,7 @@ void main() {
     final updated = deleteOpenWebUiMessageFromChatMessages(messages, 'child');
 
     expect(updated.map((message) => message.id), ['root', 'sibling']);
-    expect(chatMessageChildrenIds(updated.first), isEmpty);
+    expect(chatMessageChildrenIds(updated.first), ['sibling']);
   });
 
   test('OpenWebUI delete reparents grandchildren to the deleted parent', () {

--- a/test/core/utils/message_tree_utils_test.dart
+++ b/test/core/utils/message_tree_utils_test.dart
@@ -96,6 +96,40 @@ void main() {
     expect(messages['grandchild']!['parentId'], 'root');
   });
 
+  test('OpenWebUI current id traversal stops on children cycles', () {
+    final messages = <String, Map<String, dynamic>>{
+      'root': {
+        'id': 'root',
+        'childrenIds': ['a'],
+      },
+      'a': {
+        'id': 'a',
+        'parentId': 'root',
+        'childrenIds': ['b'],
+      },
+      'b': {
+        'id': 'b',
+        'parentId': 'a',
+        'childrenIds': ['a'],
+      },
+    };
+    const plan = OpenWebUiDeletePlan(
+      rootId: 'deleted',
+      deletedIds: <String>{},
+      deletedParentId: 'root',
+      grandchildIds: <String>[],
+    );
+
+    final currentId = currentIdAfterOpenWebUiDelete<Map<String, dynamic>>(
+      messages,
+      plan,
+      parentIdOf: rawMessageParentId,
+      childrenIdsOf: rawMessageChildrenIds,
+    );
+
+    expect(currentId, 'b');
+  });
+
   test('guards chain traversal against cycles', () {
     final messages = {
       'a': {'id': 'a', 'parentId': 'b'},


### PR DESCRIPTION
## Summary
- Updates Conduit for Open WebUI 0.10.1+ API behavior, including config/audio parsing, tags, knowledge/files, message deletion, and chat completion compatibility.
- Adds typed structured-output parsing plus semantic details rendering for reasoning, tool calls, code interpreter, and OpenAI built-in tool output items.
- Preserves backward compatibility with legacy Open WebUI routes and older streaming/task-socket behaviors through targeted fallbacks and recovery logic.

## Test plan
- `flutter test test/core/services/openwebui_stream_parser_test.dart test/core/services/streaming_helper_transport_test.dart test/core/services/conversation_parsing_test.dart`
- `flutter analyze`
- Thermos loop bug pass 4: no actionable findings
- Thermos loop quality pass 4: no actionable blockers

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add Open WebUI 0.10 API compatibility for streaming, message deletion, tags, and knowledge bases
> - Introduces a structured output pipeline (`structured_output.dart`, `structured_output_renderer.dart`, `semantic_message_builder.dart`) that parses Open WebUI `output` arrays into typed blocks and renders them as `<details>` HTML sections alongside streamed message content.
> - Extends the streaming layer in [`streaming_helper.dart`](https://github.com/cogwheel0/conduit/pull/543/files#diff-798cd51b9c90e33f1996e46793ed52481d6afe68244655a6660e89a28ff823dc) to parse and render structured output snapshots, deduplicate tool-call placeholders, maintain a separate plain-text view, and support configurable terminal recovery.
> - Updates [`api_service.dart`](https://github.com/cogwheel0/conduit/pull/543/files#diff-2bd4fc55cec75446711de77327c23c8d5323d96d468b1b03070719b2db4482b5) to use new Open WebUI 0.10 endpoints for message deletion (DELETE per-message with legacy fallback), tag management (paginated POST/DELETE), knowledge base CRUD (new create/update/delete/list endpoints with fallbacks), pin/archive toggles (read-verify-write flow), and prompt suggestions (sourced from `/api/config`).
> - Updates [`backend_config.dart`](https://github.com/cogwheel0/conduit/pull/543/files#diff-65dd75f4cfa14801682fdf41a70591607f385fe649d590169f8bdb6e1518dd6c) and [`server_about_info.dart`](https://github.com/cogwheel0/conduit/pull/543/files#diff-e655aa357454f67bb75212966e373b4602dbb24e9cc8ab44ff685c147349f62a) to parse nested `audio.tts`/`audio.stt` config blocks and auto-enable audio input/output when engines are present.
> - Replaces manual message-deletion logic in [`chat_page.dart`](https://github.com/cogwheel0/conduit/pull/543/files#diff-84403526b0e1de6a48ac9f2c5ba0a7c0d9ebe6626d63e1494d6f4f1fc629d109) with new `deleteOpenWebUiMessageFromChatMessages` helpers in [`message_tree_utils.dart`](https://github.com/cogwheel0/conduit/pull/543/files#diff-d5153fe2ed5ca5d59da5ba242b23e4563ffb99c37808b46bd1a4dfcad72f2140) that reparent grandchildren after deletion.
> - Risk: Several API paths now fall back silently to legacy endpoints on 404/405/422; mismatches between old and new server shapes may produce unexpected content if heuristics select the wrong authoritative text source.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d651760.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added richer rendering for OpenWebUI structured responses, including reasoning, tool-call status/details, and code-interpreter blocks, merged into the final assistant message.
* **Bug Fixes**
  * Fixed OpenWebUI streaming update ordering and ensured structured output is emitted after reasoning/content deltas to avoid duplication.
  * Improved backend configuration parsing for nested audio/TTS/STT and OAuth, including comma-separated defaults and derived enablement behavior.
  * Refined message deletion behavior and conversation pin/archive toggling; improved knowledge-base upload/attach flow.
* **Chores / Tests**
  * Expanded automated coverage for structured output parsing/rendering, streaming, deletion semantics, and Open WebUI compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds Open WebUI 0.10 compatibility across the client. The main changes are:

- New API handling for config, audio, tags, knowledge files, message deletion, and chat completion.
- Structured output parsing and rendering for reasoning, tool calls, code interpreter blocks, and built-in tool output.
- Streaming updates that merge structured output with plain assistant content.
- Local and legacy-server message deletion helpers that match Open WebUI deletion behavior.
- Tests for the updated API, parsing, streaming, and message-tree paths.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

This looks safe to merge.

- No blocking issues found in the changed code.


</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| lib/core/services/api_service.dart | Updates Open WebUI endpoint handling for toggles, deletion, tags, knowledge operations, uploads, suggestions, audio config, and chat completion payloads. |
| lib/core/utils/message_tree_utils.dart | Adds shared Open WebUI message deletion helpers for local message lists and raw server history. |
| lib/core/services/streaming_helper.dart | Adds structured output rendering and recovery behavior to the streaming pipeline. |
| lib/core/services/conversation_parsing.dart | Merges structured output into parsed assistant messages while preserving the raw output data. |
| lib/core/services/structured_output.dart | Adds typed parsing for Open WebUI structured output items. |
| lib/core/services/structured_output_renderer.dart | Renders structured output blocks into the app's semantic assistant-message format. |
| lib/core/services/semantic_message_builder.dart | Adds reusable semantic message blocks for text, reasoning, tool calls, and code interpreter details. |

</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (2)</h3></summary>

1. General comment 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **OpenAI code_interpreter_call output items are dropped**

   - **Bug**
     - The validation fixture includes an OpenAI-style `code_interpreter_call` item with `code: print(2 + 2)`, `language: python`, and `outputs` logs. On head, `parseOpenWebUIStructuredOutput` returns reasoning, function tool call, web search tool call, and final text blocks, but no `code_interpreter` block. Consequently the rendered semantic detail text omits the code and output logs, so one of the claimed item types has no before/after improvement.
   - **Cause**
     - `lib/core/services/structured_output.dart` switches on `itemType` for `code_interpreter` and `open_webui:code_interpreter` only. It does not handle OpenAI Responses API `code_interpreter_call`, and it reads `item['output']` rather than the OpenAI-style `outputs` field.
   - **Fix**
     - Add `code_interpreter_call` to the code interpreter cases in `parseOpenWebUIStructuredOutput`, map `outputs` as the block output when `output` is absent, and add/adjust tests to assert parsed and rendered details include the code and outputs for OpenAI-style code interpreter calls.

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>

2. `lib/core/services/api_service.dart`, line 3657 ([link](https://github.com/cogwheel0/conduit/blob/d5e9c563293b3632def73bbb6672582a2a556f7c/lib/core/services/api_service.dart#L3657)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Knowledge Files Skip Fallback**

   When an older Open WebUI server does not expose `/api/v1/knowledge/$id/files`, this call rethrows instead of using the legacy knowledge item route that the neighboring item-listing path already supports. Any workflow that lists knowledge-base files can still fail on the same legacy servers where create, update, delete, and item listing now recover.

   **Context Used:** AGENTS.md ([source](https://app.greptile.com/cogwheel/-/custom-context?memory=871e7f39-32ad-42bc-9cb3-4f44ae78faec))
   
   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (13): Last reviewed commit: ["Tighten knowledge fallback and upload ID..."](https://github.com/cogwheel0/conduit/commit/d6517601867c07f3e2b709ca6cbc5ba5502010fb) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40800132)</sub>

**Context used:**

- Context used - AGENTS.md ([source](https://app.greptile.com/cogwheel/-/custom-context?memory=871e7f39-32ad-42bc-9cb3-4f44ae78faec))

<!-- /greptile_comment -->