### PR TITLE
feat: gate app on unsupported Open WebUI server versions

### DIFF
--- a/lib/core/models/backend_config.dart
+++ b/lib/core/models/backend_config.dart
@@ -1,5 +1,7 @@
 import 'package:flutter/foundation.dart';
 
+import '../utils/server_version_compat.dart';
+
 /// Represents the available OAuth providers configured on the server.
 @immutable
 class OAuthProviders {
@@ -107,6 +109,7 @@ class BackendTtsVoice {
 @immutable
 class BackendConfig {
   const BackendConfig({
+    this.version,
     this.enableWebsocket,
     this.enableWebSearch,
     this.enableAudioInput,
@@ -124,6 +127,10 @@ class BackendConfig {
     this.enableLdap = false,
     this.enableLoginForm = true,
   });
+
+  /// The Open WebUI server version string reported by `/api/config`
+  /// (e.g. `0.10.1`). `null` when the server omitted it or it was not parsed.
+  final String? version;
 
   /// Mirrors `features.enable_websocket` from OpenWebUI.
   final bool? enableWebsocket;
@@ -155,8 +162,14 @@ class BackendConfig {
   /// Whether SSO (OAuth) login is available.
   bool get hasSsoEnabled => oauthProviders.hasAnyProvider;
 
+  /// Whether the reported [version] is within the range this app supports.
+  ///
+  /// See [ServerVersionCompat]. Fails open for unknown/unparseable versions.
+  bool get isVersionSupported => ServerVersionCompat.isSupported(version);
+
   /// Returns a copy with updated fields.
   BackendConfig copyWith({
+    String? version,
     bool? enableWebsocket,
     bool? enableWebSearch,
     bool? enableAudioInput,
@@ -175,6 +188,7 @@ class BackendConfig {
     bool? enableLoginForm,
   }) {
     return BackendConfig(
+      version: version ?? this.version,
       enableWebsocket: enableWebsocket ?? this.enableWebsocket,
       enableWebSearch: enableWebSearch ?? this.enableWebSearch,
       enableAudioInput: enableAudioInput ?? this.enableAudioInput,
@@ -215,6 +229,7 @@ class BackendConfig {
 
   Map<String, dynamic> toJson() {
     return <String, dynamic>{
+      'version': version,
       'enable_websocket': enableWebsocket,
       'enable_web_search': enableWebSearch,
       'enable_audio_input': enableAudioInput,
@@ -235,6 +250,7 @@ class BackendConfig {
   }
 
   static BackendConfig fromJson(Map<String, dynamic> json) {
+    String? version;
     bool? enableWebsocket;
     bool? enableWebSearch;
     bool? enableAudioInput;
@@ -251,6 +267,11 @@ class BackendConfig {
     OAuthProviders oauthProviders = const OAuthProviders();
     bool enableLdap = false;
     bool enableLoginForm = true;
+
+    final versionValue = json['version'];
+    if (versionValue is String && versionValue.trim().isNotEmpty) {
+      version = versionValue.trim();
+    }
 
     // Try canonical format first
     final value = json['enable_websocket'];
@@ -401,6 +422,7 @@ class BackendConfig {
     }
 
     return BackendConfig(
+      version: version,
       enableWebsocket: enableWebsocket,
       enableWebSearch: enableWebSearch,
       enableAudioInput: enableAudioInput,

--- a/lib/core/models/backend_config.dart
+++ b/lib/core/models/backend_config.dart
@@ -110,6 +110,7 @@ class BackendTtsVoice {
 class BackendConfig {
   const BackendConfig({
     this.version,
+    this.serverId,
     this.enableWebsocket,
     this.enableWebSearch,
     this.enableAudioInput,
@@ -131,6 +132,13 @@ class BackendConfig {
   /// The Open WebUI server version string reported by `/api/config`
   /// (e.g. `0.10.1`). `null` when the server omitted it or it was not parsed.
   final String? version;
+
+  /// Id of the [ServerConfig] this config was fetched from. The cached config
+  /// is global (single key), so consumers that care about *which* server a
+  /// version belongs to (e.g. the compatibility gate) compare this against the
+  /// active server id and ignore the config when it doesn't match. `null` for
+  /// configs fetched before this was tracked or never tagged.
+  final String? serverId;
 
   /// Mirrors `features.enable_websocket` from OpenWebUI.
   final bool? enableWebsocket;
@@ -170,6 +178,7 @@ class BackendConfig {
   /// Returns a copy with updated fields.
   BackendConfig copyWith({
     String? version,
+    String? serverId,
     bool? enableWebsocket,
     bool? enableWebSearch,
     bool? enableAudioInput,
@@ -189,6 +198,7 @@ class BackendConfig {
   }) {
     return BackendConfig(
       version: version ?? this.version,
+      serverId: serverId ?? this.serverId,
       enableWebsocket: enableWebsocket ?? this.enableWebsocket,
       enableWebSearch: enableWebSearch ?? this.enableWebSearch,
       enableAudioInput: enableAudioInput ?? this.enableAudioInput,
@@ -230,6 +240,7 @@ class BackendConfig {
   Map<String, dynamic> toJson() {
     return <String, dynamic>{
       'version': version,
+      'server_id': serverId,
       'enable_websocket': enableWebsocket,
       'enable_web_search': enableWebSearch,
       'enable_audio_input': enableAudioInput,
@@ -251,6 +262,7 @@ class BackendConfig {
 
   static BackendConfig fromJson(Map<String, dynamic> json) {
     String? version;
+    String? serverId;
     bool? enableWebsocket;
     bool? enableWebSearch;
     bool? enableAudioInput;
@@ -271,6 +283,11 @@ class BackendConfig {
     final versionValue = json['version'];
     if (versionValue is String && versionValue.trim().isNotEmpty) {
       version = versionValue.trim();
+    }
+
+    final serverIdValue = json['server_id'];
+    if (serverIdValue is String && serverIdValue.isNotEmpty) {
+      serverId = serverIdValue;
     }
 
     // Try canonical format first
@@ -423,6 +440,7 @@ class BackendConfig {
 
     return BackendConfig(
       version: version,
+      serverId: serverId,
       enableWebsocket: enableWebsocket,
       enableWebSearch: enableWebSearch,
       enableAudioInput: enableAudioInput,

--- a/lib/core/providers/app_providers.dart
+++ b/lib/core/providers/app_providers.dart
@@ -217,15 +217,25 @@ final serverConnectionStateProvider = Provider<bool>((ref) {
   );
 });
 
-/// Whether the connected server reports a version newer than this app build
-/// is known to support (see [ServerVersionCompat]).
+/// Whether the *active* server reports a version newer than this app build is
+/// known to support (see [ServerVersionCompat]).
 ///
-/// Fails open while the backend config is still loading or the version is
-/// unknown, so the compatibility gate never flashes during normal startup and
-/// never locks users out of a server whose version we can't parse.
+/// The cached backend config is global, not per-server, so this gates only
+/// when the config was fetched from the currently-active server
+/// ([BackendConfig.serverId] matches). That makes the decision robust against
+/// a stale config from a previously-active server — whether left over after a
+/// server switch, an out-of-order refresh, or restored from disk on a cold
+/// start — which would otherwise trap a supported server on the gate.
+///
+/// Fails open while the active server or backend config is still loading, when
+/// the config belongs to a different server, or when the version is unknown, so
+/// the gate never flashes during startup and never locks users out of a server
+/// whose version we can't parse.
 final serverIncompatibleProvider = Provider<bool>((ref) {
+  final activeId = ref.watch(activeServerProvider).asData?.value?.id;
   final config = ref.watch(backendConfigProvider).asData?.value;
-  if (config == null) return false;
+  if (activeId == null || config == null) return false;
+  if (config.serverId != activeId) return false; // stale/foreign — fail open
   return ServerVersionCompat.isUnsupported(config.version);
 });
 
@@ -233,37 +243,9 @@ final serverIncompatibleProvider = Provider<bool>((ref) {
 class BackendConfigNotifier extends _$BackendConfigNotifier {
   late final OptimizedStorageService _storage;
 
-  /// Tracks the last non-null active server id so a genuine A->B switch is
-  /// detected even when [activeServerProvider] passes through a transient
-  /// loading/null state (e.g. on `ref.invalidate`).
-  String? _lastKnownServerId;
-
   @override
   Future<BackendConfig?> build() async {
     _storage = ref.watch(optimizedStorageServiceProvider);
-
-    // The cached backend config (and its version) is global, not per-server.
-    // When the active server changes to a *different* one, the cached config
-    // belongs to the previous server and must not be used to gate the new one
-    // (see serverIncompatibleProvider). Drop it immediately — failing open
-    // until a fresh /api/config is fetched for the newly selected server — so
-    // a user can't get stranded on the incompatibility gate after switching
-    // from an unsupported server to a supported one.
-    _lastKnownServerId = ref.read(activeServerProvider).asData?.value?.id;
-    ref.listen(activeServerProvider.select((s) => s.asData?.value?.id), (
-      previous,
-      next,
-    ) {
-      if (next == null) return; // ignore transient loading/none states
-      final previousId = _lastKnownServerId;
-      _lastKnownServerId = next;
-      if (previousId != null && previousId != next) {
-        state = const AsyncData(null);
-        unawaited(_storage.saveLocalBackendConfig(null));
-        unawaited(_refreshBackendConfig());
-      }
-    });
-
     final cached = await _storage.getLocalBackendConfig();
     unawaited(_refreshBackendConfig());
     return cached;
@@ -313,7 +295,11 @@ Future<BackendConfig?> _loadBackendConfig(Ref ref) async {
         }
       }
     }
-    return config;
+    // Tag the config with the server it was fetched from so the compatibility
+    // gate can ignore a globally-cached config that belongs to a different
+    // server (e.g. after a server switch, or a stale config restored on a
+    // cold start). See serverIncompatibleProvider.
+    return config?.copyWith(serverId: server.id);
   } catch (_) {
     return null;
   }

--- a/lib/core/providers/app_providers.dart
+++ b/lib/core/providers/app_providers.dart
@@ -235,7 +235,13 @@ final serverIncompatibleProvider = Provider<bool>((ref) {
   final activeId = ref.watch(activeServerProvider).asData?.value?.id;
   final config = ref.watch(backendConfigProvider).asData?.value;
   if (activeId == null || config == null) return false;
-  if (config.serverId != activeId) return false; // stale/foreign — fail open
+  // A config explicitly tagged for a *different* server is stale/foreign —
+  // fail open so it can't gate the current server. A null serverId means a
+  // legacy cache (written before tagging) or a not-yet-tagged fetch; treat it
+  // as the active server's so an unsupported server restored from an older
+  // install still triggers the gate on a cold start. Fresh configs are always
+  // tagged in _loadBackendConfig, so this can't reintroduce the switch trap.
+  if (config.serverId != null && config.serverId != activeId) return false;
   return ServerVersionCompat.isUnsupported(config.version);
 });
 

--- a/lib/core/providers/app_providers.dart
+++ b/lib/core/providers/app_providers.dart
@@ -235,13 +235,21 @@ final serverIncompatibleProvider = Provider<bool>((ref) {
   final activeId = ref.watch(activeServerProvider).asData?.value?.id;
   final config = ref.watch(backendConfigProvider).asData?.value;
   if (activeId == null || config == null) return false;
-  // A config explicitly tagged for a *different* server is stale/foreign —
-  // fail open so it can't gate the current server. A null serverId means a
-  // legacy cache (written before tagging) or a not-yet-tagged fetch; treat it
-  // as the active server's so an unsupported server restored from an older
-  // install still triggers the gate on a cold start. Fresh configs are always
-  // tagged in _loadBackendConfig, so this can't reintroduce the switch trap.
-  if (config.serverId != null && config.serverId != activeId) return false;
+  // Gate only on a config confirmed to belong to the active server — i.e. one
+  // tagged (in _loadBackendConfig) with the active server id. Anything else
+  // fails open:
+  //  - a config tagged for a *different* server is stale after a switch and
+  //    must not trap the (possibly supported) new server;
+  //  - a null serverId is a legacy cache written before tagging existed, or a
+  //    not-yet-tagged fetch — we can't attribute it to a server, so we don't
+  //    act on it.
+  // The trade-off is that, right after upgrading the app while connected to an
+  // unsupported server, the gate stays open until the refresh kicked off in
+  // BackendConfigNotifier.build() returns a freshly-tagged config (~one
+  // round-trip). That's intentional: gating off a possibly-stale cache and
+  // risking locking a user out of a valid server is worse than a brief,
+  // self-healing delay before gating an unsupported one.
+  if (config.serverId != activeId) return false;
   return ServerVersionCompat.isUnsupported(config.version);
 });
 

--- a/lib/core/providers/app_providers.dart
+++ b/lib/core/providers/app_providers.dart
@@ -34,6 +34,7 @@ import '../services/connectivity_service.dart';
 import '../persistence/preferences_store.dart';
 import '../persistence/persistence_keys.dart';
 import '../utils/debug_logger.dart';
+import '../utils/server_version_compat.dart';
 import '../services/worker_manager.dart';
 import '../../shared/theme/tweakcn_themes.dart';
 import '../../shared/theme/app_theme.dart';
@@ -214,6 +215,18 @@ final serverConnectionStateProvider = Provider<bool>((ref) {
     data: (server) => server != null,
     orElse: () => false,
   );
+});
+
+/// Whether the connected server reports a version newer than this app build
+/// is known to support (see [ServerVersionCompat]).
+///
+/// Fails open while the backend config is still loading or the version is
+/// unknown, so the compatibility gate never flashes during normal startup and
+/// never locks users out of a server whose version we can't parse.
+final serverIncompatibleProvider = Provider<bool>((ref) {
+  final config = ref.watch(backendConfigProvider).asData?.value;
+  if (config == null) return false;
+  return ServerVersionCompat.isUnsupported(config.version);
 });
 
 @Riverpod(keepAlive: true)

--- a/lib/core/providers/app_providers.dart
+++ b/lib/core/providers/app_providers.dart
@@ -233,9 +233,37 @@ final serverIncompatibleProvider = Provider<bool>((ref) {
 class BackendConfigNotifier extends _$BackendConfigNotifier {
   late final OptimizedStorageService _storage;
 
+  /// Tracks the last non-null active server id so a genuine A->B switch is
+  /// detected even when [activeServerProvider] passes through a transient
+  /// loading/null state (e.g. on `ref.invalidate`).
+  String? _lastKnownServerId;
+
   @override
   Future<BackendConfig?> build() async {
     _storage = ref.watch(optimizedStorageServiceProvider);
+
+    // The cached backend config (and its version) is global, not per-server.
+    // When the active server changes to a *different* one, the cached config
+    // belongs to the previous server and must not be used to gate the new one
+    // (see serverIncompatibleProvider). Drop it immediately — failing open
+    // until a fresh /api/config is fetched for the newly selected server — so
+    // a user can't get stranded on the incompatibility gate after switching
+    // from an unsupported server to a supported one.
+    _lastKnownServerId = ref.read(activeServerProvider).asData?.value?.id;
+    ref.listen(activeServerProvider.select((s) => s.asData?.value?.id), (
+      previous,
+      next,
+    ) {
+      if (next == null) return; // ignore transient loading/none states
+      final previousId = _lastKnownServerId;
+      _lastKnownServerId = next;
+      if (previousId != null && previousId != next) {
+        state = const AsyncData(null);
+        unawaited(_storage.saveLocalBackendConfig(null));
+        unawaited(_refreshBackendConfig());
+      }
+    });
+
     final cached = await _storage.getLocalBackendConfig();
     unawaited(_refreshBackendConfig());
     return cached;

--- a/lib/core/router/app_router.dart
+++ b/lib/core/router/app_router.dart
@@ -16,6 +16,7 @@ import '../../features/auth/views/connect_signin_page.dart';
 import '../../features/auth/views/connection_issue_page.dart';
 import '../../features/auth/views/proxy_auth_page.dart';
 import '../../features/auth/views/server_connection_page.dart';
+import '../../features/auth/views/server_incompatible_page.dart';
 import '../../features/auth/views/sso_auth_page.dart';
 import '../../features/chat/views/chat_page.dart';
 import '../../features/navigation/views/folder_page.dart';
@@ -47,6 +48,7 @@ class RouterNotifier extends ChangeNotifier {
         authNavigationStateProvider,
         _onStateChanged,
       ),
+      ref.listen<bool>(serverIncompatibleProvider, _onStateChanged),
     ];
   }
 
@@ -111,6 +113,24 @@ class RouterNotifier extends ChangeNotifier {
         return null;
       }
       return Routes.serverConnection;
+    }
+
+    // Compatibility gate: when the connected server runs a version newer than
+    // this app build supports, block every in-app route and surface the
+    // incompatibility page. The server-connection route stays reachable so the
+    // user can point the app at a different (supported) server.
+    final serverIncompatible = ref.read(serverIncompatibleProvider);
+    if (serverIncompatible) {
+      if (location == Routes.serverIncompatible ||
+          location == Routes.serverConnection) {
+        return null;
+      }
+      return Routes.serverIncompatible;
+    }
+    // Server is compatible again (e.g. user downgraded or switched servers):
+    // don't strand them on the gate page — re-enter the normal flow.
+    if (location == Routes.serverIncompatible) {
+      return Routes.splash;
     }
 
     final authState = ref.read(authNavigationStateProvider);
@@ -269,6 +289,14 @@ final goRouterProvider = Provider<GoRouter>((ref) {
       name: RouteNames.connectionIssue,
       pageBuilder: (context, state) =>
           _buildPlatformPage(state: state, child: const ConnectionIssuePage()),
+    ),
+    GoRoute(
+      path: Routes.serverIncompatible,
+      name: RouteNames.serverIncompatible,
+      pageBuilder: (context, state) => _buildPlatformPage(
+        state: state,
+        child: const ServerIncompatiblePage(),
+      ),
     ),
     GoRoute(
       path: Routes.authentication,

--- a/lib/core/router/app_router.dart
+++ b/lib/core/router/app_router.dart
@@ -216,7 +216,22 @@ class RouterNotifier extends ChangeNotifier {
     } else {
       targetUrl = null;
     }
-    return targetUrl != null && targetUrl != activeServer.url;
+    if (targetUrl == null) return false;
+    // Canonicalize before comparing so a trailing slash or case difference in
+    // how the same server's URL was entered/stored doesn't read as a different
+    // server (which would loosen the gate exemption).
+    return _canonicalUrl(targetUrl) != _canonicalUrl(activeServer.url);
+  }
+
+  /// Comparison-only canonicalization of a server base URL: trims whitespace
+  /// and trailing slashes and lowercases. Used solely to decide gate
+  /// exemption, never to construct requests.
+  String _canonicalUrl(String url) {
+    var u = url.trim();
+    while (u.endsWith('/')) {
+      u = u.substring(0, u.length - 1);
+    }
+    return u.toLowerCase();
   }
 
   @override

--- a/lib/core/router/app_router.dart
+++ b/lib/core/router/app_router.dart
@@ -117,13 +117,15 @@ class RouterNotifier extends ChangeNotifier {
 
     // Compatibility gate: when the connected server runs a version newer than
     // this app build supports, block every in-app route and surface the
-    // incompatibility page. The auth/connection flow stays reachable so the
-    // user can recover by pointing the app at a different (supported) server —
-    // the connect-time gate prevents authenticating into another unsupported
-    // server, so opening those pages here is safe.
+    // incompatibility page. Reachable exceptions: the gate page itself, the
+    // server-connection form, and an in-progress connection/auth flow that
+    // targets a DIFFERENT server (the "use a different server" recovery).
+    // Re-authenticating into the same unsupported server stays gated.
     final serverIncompatible = ref.read(serverIncompatibleProvider);
     if (serverIncompatible) {
-      if (location == Routes.serverIncompatible || _isAuthLocation(location)) {
+      if (location == Routes.serverIncompatible ||
+          location == Routes.serverConnection ||
+          _isConnectFlowToDifferentServer(state, activeServer)) {
         return null;
       }
       return Routes.serverIncompatible;
@@ -190,6 +192,31 @@ class RouterNotifier extends ChangeNotifier {
         location == Routes.connectionIssue ||
         location == Routes.ssoAuth ||
         location == Routes.proxyAuth;
+  }
+
+  /// Whether [state] is an in-progress connection/auth flow whose target server
+  /// differs from [activeServer]. The compatibility gate uses this to permit
+  /// the "use a different server" recovery (connecting to a new, supported
+  /// server) while still blocking re-authentication into the current,
+  /// unsupported server. Returns false when the target can't be determined, so
+  /// the gate enforces by default.
+  bool _isConnectFlowToDifferentServer(
+    GoRouterState state,
+    ServerConfig? activeServer,
+  ) {
+    if (activeServer == null) return false;
+    final extra = state.extra;
+    final String? targetUrl;
+    if (extra is AuthFlowConfig) {
+      targetUrl = extra.serverConfig.url;
+    } else if (extra is ProxyAuthConfig) {
+      targetUrl = extra.serverConfig.url;
+    } else if (extra is ServerConfig) {
+      targetUrl = extra.url;
+    } else {
+      targetUrl = null;
+    }
+    return targetUrl != null && targetUrl != activeServer.url;
   }
 
   @override

--- a/lib/core/router/app_router.dart
+++ b/lib/core/router/app_router.dart
@@ -117,12 +117,13 @@ class RouterNotifier extends ChangeNotifier {
 
     // Compatibility gate: when the connected server runs a version newer than
     // this app build supports, block every in-app route and surface the
-    // incompatibility page. The server-connection route stays reachable so the
-    // user can point the app at a different (supported) server.
+    // incompatibility page. The auth/connection flow stays reachable so the
+    // user can recover by pointing the app at a different (supported) server —
+    // the connect-time gate prevents authenticating into another unsupported
+    // server, so opening those pages here is safe.
     final serverIncompatible = ref.read(serverIncompatibleProvider);
     if (serverIncompatible) {
-      if (location == Routes.serverIncompatible ||
-          location == Routes.serverConnection) {
+      if (location == Routes.serverIncompatible || _isAuthLocation(location)) {
         return null;
       }
       return Routes.serverIncompatible;

--- a/lib/core/services/navigation_service.dart
+++ b/lib/core/services/navigation_service.dart
@@ -123,6 +123,7 @@ class Routes {
   static const String login = '/login';
   static const String serverConnection = '/server-connection';
   static const String connectionIssue = '/connection-issue';
+  static const String serverIncompatible = '/server-incompatible';
   static const String authentication = '/authentication';
   static const String ssoAuth = '/sso-auth';
   static const String proxyAuth = '/proxy-auth';
@@ -148,6 +149,7 @@ class RouteNames {
   static const String login = 'login';
   static const String serverConnection = 'server-connection';
   static const String connectionIssue = 'connection-issue';
+  static const String serverIncompatible = 'server-incompatible';
   static const String authentication = 'authentication';
   static const String ssoAuth = 'sso-auth';
   static const String proxyAuth = 'proxy-auth';

--- a/lib/core/utils/server_version_compat.dart
+++ b/lib/core/utils/server_version_compat.dart
@@ -1,0 +1,75 @@
+/// Compatibility gate for the Open WebUI server this app talks to.
+///
+/// Conduit tracks the Open WebUI API surface via the vendored `openwebui-src/`
+/// submodule. When the upstream server jumps ahead of what this build has been
+/// validated against, endpoints and payloads can drift in ways that silently
+/// break the app. Rather than fail in confusing ways deep in a feature, the app
+/// refuses to operate against servers newer than [maxSupportedVersion] and
+/// surfaces a clear "downgrade or wait for an update" message.
+///
+/// This is a pure leaf utility with no Flutter dependencies so it can be unit
+/// tested in isolation and reused from models, providers, and views alike.
+class ServerVersionCompat {
+  ServerVersionCompat._();
+
+  /// The newest Open WebUI server version this app build is known to support.
+  ///
+  /// Servers reporting a `/api/config` `version` strictly greater than this are
+  /// gated off. Bump this (and re-verify against `openwebui-src/`) whenever a
+  /// newer server release is validated.
+  static const String maxSupportedVersion = '0.10.1';
+
+  /// Parsed [maxSupportedVersion] components: `[major, minor, patch]`.
+  static const List<int> _maxSupported = [0, 10, 1];
+
+  /// Whether [rawVersion] is within the supported range (<= [maxSupportedVersion]).
+  ///
+  /// Fails open: a `null`, empty, or unparseable version is treated as
+  /// supported so the gate never locks users out of a server whose version
+  /// string we simply don't understand. The gate only triggers when we can
+  /// confidently determine the server is newer than we support.
+  static bool isSupported(String? rawVersion) {
+    final parsed = _parse(rawVersion);
+    if (parsed == null) return true; // fail open on unknown versions
+    return _compare(parsed, _maxSupported) <= 0;
+  }
+
+  /// Convenience inverse of [isSupported] for readable call sites.
+  static bool isUnsupported(String? rawVersion) => !isSupported(rawVersion);
+
+  /// Parses a semantic-ish version string into up to three numeric components.
+  ///
+  /// Tolerates a leading `v`/`V` and drops any pre-release or build metadata
+  /// suffix (e.g. `0.10.1-dev`, `0.10.1+build.5`). Returns `null` when no
+  /// leading numeric component can be found.
+  static List<int>? _parse(String? raw) {
+    if (raw == null) return null;
+    var s = raw.trim();
+    if (s.isEmpty) return null;
+    if (s.startsWith('v') || s.startsWith('V')) {
+      s = s.substring(1);
+    }
+    // Strip pre-release / build metadata so `0.10.1-rc1` compares as `0.10.1`.
+    final cut = s.indexOf(RegExp(r'[-+ ]'));
+    if (cut != -1) {
+      s = s.substring(0, cut);
+    }
+    final match = RegExp(r'^(\d+)(?:\.(\d+))?(?:\.(\d+))?').firstMatch(s);
+    if (match == null) return null;
+    final major = int.tryParse(match.group(1) ?? '');
+    if (major == null) return null;
+    final minor = int.tryParse(match.group(2) ?? '0') ?? 0;
+    final patch = int.tryParse(match.group(3) ?? '0') ?? 0;
+    return [major, minor, patch];
+  }
+
+  /// Compares two `[major, minor, patch]` triples, returning -1/0/1.
+  static int _compare(List<int> a, List<int> b) {
+    for (var i = 0; i < 3; i++) {
+      final av = i < a.length ? a[i] : 0;
+      final bv = i < b.length ? b[i] : 0;
+      if (av != bv) return av < bv ? -1 : 1;
+    }
+    return 0;
+  }
+}

--- a/lib/features/auth/views/server_connection_page.dart
+++ b/lib/features/auth/views/server_connection_page.dart
@@ -22,8 +22,10 @@ import '../../../core/services/worker_manager.dart';
 import '../../../core/services/input_validation_service.dart';
 import '../../../core/services/navigation_service.dart';
 import '../../../core/utils/debug_logger.dart';
+import '../../../core/utils/server_version_compat.dart';
 import '../../../core/widgets/error_boundary.dart';
 import '../providers/unified_auth_providers.dart';
+import 'server_incompatible_page.dart';
 import '../../../shared/services/brand_service.dart';
 import '../../../shared/theme/theme_extensions.dart';
 import '../../../shared/widgets/adaptive_route_shell.dart';
@@ -203,6 +205,32 @@ class _ServerConnectionPageState extends ConsumerState<ServerConnectionPage> {
         throw Exception('This does not appear to be an Open-WebUI server.');
       }
 
+      // Compatibility gate: refuse to proceed when the server is newer than
+      // this app build supports. The server config is not saved, so the user
+      // stays on the connection form after acknowledging.
+      if (!backendConfig.isVersionSupported) {
+        DebugLogger.log(
+          'Server version ${backendConfig.version} unsupported '
+          '(max ${ServerVersionCompat.maxSupportedVersion}); blocking',
+          scope: 'auth/connection',
+        );
+        if (mounted) {
+          await showServerIncompatibleDialog(
+            context,
+            serverVersion: backendConfig.version,
+          );
+        }
+        if (mounted) {
+          setState(() {
+            _connectionError =
+                AppLocalizations.of(context)?.serverIncompatibleConnectBlocked(
+                  ServerVersionCompat.maxSupportedVersion,
+                );
+          });
+        }
+        return;
+      }
+
       DebugLogger.log(
         'Server validation passed, navigating to auth page',
         scope: 'auth/connection',
@@ -350,6 +378,31 @@ class _ServerConnectionPageState extends ConsumerState<ServerConnectionPage> {
           _connectionError =
               'Could not verify OpenWebUI server. The proxy cookies may '
               'have expired or be invalid. Please try again.';
+          _isConnecting = false;
+        });
+      }
+      return;
+    }
+
+    // Compatibility gate (proxy path): same block as the direct connection.
+    if (!backendConfig.isVersionSupported) {
+      DebugLogger.log(
+        'Server version ${backendConfig.version} unsupported '
+        '(max ${ServerVersionCompat.maxSupportedVersion}); blocking proxy flow',
+        scope: 'auth/connection',
+      );
+      if (mounted) {
+        await showServerIncompatibleDialog(
+          context,
+          serverVersion: backendConfig.version,
+        );
+      }
+      if (mounted) {
+        setState(() {
+          _connectionError =
+              AppLocalizations.of(context)?.serverIncompatibleConnectBlocked(
+                ServerVersionCompat.maxSupportedVersion,
+              );
           _isConnecting = false;
         });
       }

--- a/lib/features/auth/views/server_connection_page.dart
+++ b/lib/features/auth/views/server_connection_page.dart
@@ -15,6 +15,7 @@ import 'package:uuid/uuid.dart';
 import 'package:conduit/l10n/app_localizations.dart';
 
 import '../../../core/auth/webview_cookie_helper.dart';
+import '../../../core/models/backend_config.dart';
 import '../../../core/models/server_config.dart';
 import '../../../core/providers/app_providers.dart';
 import '../../../core/services/api_service.dart';
@@ -98,6 +99,36 @@ class _ServerConnectionPageState extends ConsumerState<ServerConnectionPage> {
     _mtlsPrivateKeyPasswordController.dispose();
     _headerValueFocusNode.dispose();
     super.dispose();
+  }
+
+  /// Refuses to proceed when [backendConfig] reports a server version newer
+  /// than this build supports: surfaces the blocking dialog plus an inline
+  /// error and returns `true` so the caller can abort. Shared by the direct
+  /// and reverse-proxy connection flows. `_isConnecting` is intentionally left
+  /// to each caller's `finally`, which always resets it.
+  Future<bool> _refuseIfServerIncompatible(BackendConfig backendConfig) async {
+    if (backendConfig.isVersionSupported) return false;
+    DebugLogger.log(
+      'Server version ${backendConfig.version} unsupported '
+      '(max ${ServerVersionCompat.maxSupportedVersion}); blocking',
+      scope: 'auth/connection',
+    );
+    if (mounted) {
+      await showServerIncompatibleDialog(
+        context,
+        serverVersion: backendConfig.version,
+      );
+    }
+    if (mounted) {
+      setState(() {
+        _connectionError = AppLocalizations.of(
+          context,
+        )?.serverIncompatibleConnectBlocked(
+          ServerVersionCompat.maxSupportedVersion,
+        );
+      });
+    }
+    return true;
   }
 
   Future<void> _connectToServer() async {
@@ -208,26 +239,7 @@ class _ServerConnectionPageState extends ConsumerState<ServerConnectionPage> {
       // Compatibility gate: refuse to proceed when the server is newer than
       // this app build supports. The server config is not saved, so the user
       // stays on the connection form after acknowledging.
-      if (!backendConfig.isVersionSupported) {
-        DebugLogger.log(
-          'Server version ${backendConfig.version} unsupported '
-          '(max ${ServerVersionCompat.maxSupportedVersion}); blocking',
-          scope: 'auth/connection',
-        );
-        if (mounted) {
-          await showServerIncompatibleDialog(
-            context,
-            serverVersion: backendConfig.version,
-          );
-        }
-        if (mounted) {
-          setState(() {
-            _connectionError =
-                AppLocalizations.of(context)?.serverIncompatibleConnectBlocked(
-                  ServerVersionCompat.maxSupportedVersion,
-                );
-          });
-        }
+      if (await _refuseIfServerIncompatible(backendConfig)) {
         return;
       }
 
@@ -384,28 +396,8 @@ class _ServerConnectionPageState extends ConsumerState<ServerConnectionPage> {
       return;
     }
 
-    // Compatibility gate (proxy path): same block as the direct connection.
-    if (!backendConfig.isVersionSupported) {
-      DebugLogger.log(
-        'Server version ${backendConfig.version} unsupported '
-        '(max ${ServerVersionCompat.maxSupportedVersion}); blocking proxy flow',
-        scope: 'auth/connection',
-      );
-      if (mounted) {
-        await showServerIncompatibleDialog(
-          context,
-          serverVersion: backendConfig.version,
-        );
-      }
-      if (mounted) {
-        setState(() {
-          _connectionError =
-              AppLocalizations.of(context)?.serverIncompatibleConnectBlocked(
-                ServerVersionCompat.maxSupportedVersion,
-              );
-          _isConnecting = false;
-        });
-      }
+    // Compatibility gate (proxy path): shares the direct flow's helper.
+    if (await _refuseIfServerIncompatible(backendConfig)) {
       return;
     }
 

--- a/lib/features/auth/views/server_incompatible_page.dart
+++ b/lib/features/auth/views/server_incompatible_page.dart
@@ -1,0 +1,323 @@
+import 'dart:io' show Platform;
+
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+
+import '../../../core/models/server_config.dart';
+import '../../../core/providers/app_providers.dart';
+import '../../../core/services/navigation_service.dart';
+import '../../../core/utils/server_version_compat.dart';
+import '../../../core/widgets/error_boundary.dart';
+import '../../../l10n/app_localizations.dart';
+import '../../../shared/theme/theme_extensions.dart';
+import '../../../shared/widgets/adaptive_route_shell.dart';
+import '../../../shared/widgets/conduit_components.dart';
+import '../../../shared/widgets/themed_dialogs.dart';
+
+/// Full-screen blocking gate shown when the connected Open WebUI server reports
+/// a version newer than this app build supports (see [ServerVersionCompat]).
+///
+/// The router redirects every in-app route here while the active server is
+/// incompatible, so the user genuinely cannot use the app. From here they can
+/// recheck (after downgrading the server) or point the app at a different
+/// server.
+class ServerIncompatiblePage extends ConsumerStatefulWidget {
+  const ServerIncompatiblePage({super.key});
+
+  @override
+  ConsumerState<ServerIncompatiblePage> createState() =>
+      _ServerIncompatiblePageState();
+}
+
+class _ServerIncompatiblePageState
+    extends ConsumerState<ServerIncompatiblePage> {
+  bool _isRechecking = false;
+  String? _statusMessage;
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context)!;
+    final activeServer = ref.watch(activeServerProvider).asData?.value;
+    final serverVersion = ref
+        .watch(backendConfigProvider)
+        .asData
+        ?.value
+        ?.version;
+    final maxVersion = ServerVersionCompat.maxSupportedVersion;
+
+    return ErrorBoundary(
+      child: AdaptiveRouteShell(
+        bodySafeArea: true,
+        body: Padding(
+          padding: const EdgeInsets.symmetric(
+            horizontal: Spacing.pagePadding,
+            vertical: Spacing.lg,
+          ),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              Expanded(
+                child: Center(
+                  child: SingleChildScrollView(
+                    child: ConstrainedBox(
+                      constraints: const BoxConstraints(maxWidth: 480),
+                      child: Column(
+                        mainAxisSize: MainAxisSize.min,
+                        crossAxisAlignment: CrossAxisAlignment.stretch,
+                        children: [
+                          _buildHeader(context, l10n),
+                          if (activeServer != null) ...[
+                            const SizedBox(height: Spacing.sm),
+                            _buildServerDetails(context, activeServer),
+                          ],
+                          const SizedBox(height: Spacing.lg),
+                          Text(
+                            l10n.serverIncompatibleMessage(
+                              _displayVersion(serverVersion),
+                              maxVersion,
+                            ),
+                            textAlign: TextAlign.center,
+                            style: context.conduitTheme.bodyMedium?.copyWith(
+                              color: context.conduitTheme.textSecondary,
+                              height: 1.4,
+                            ),
+                          ),
+                          const SizedBox(height: Spacing.sm),
+                          Text(
+                            l10n.serverIncompatibleResolution(maxVersion),
+                            textAlign: TextAlign.center,
+                            style: context.conduitTheme.bodyMedium?.copyWith(
+                              color: context.conduitTheme.textSecondary,
+                              height: 1.4,
+                            ),
+                          ),
+                        ],
+                      ),
+                    ),
+                  ),
+                ),
+              ),
+              _buildActions(context, l10n),
+              if (_statusMessage != null) ...[
+                const SizedBox(height: Spacing.sm),
+                _buildStatusMessage(context, _statusMessage!),
+              ],
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildHeader(BuildContext context, AppLocalizations l10n) {
+    final iconColor = context.conduitTheme.warning;
+
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      crossAxisAlignment: CrossAxisAlignment.center,
+      children: [
+        Container(
+          width: 64,
+          height: 64,
+          decoration: BoxDecoration(
+            color: iconColor.withValues(alpha: 0.1),
+            shape: BoxShape.circle,
+            border: Border.all(
+              color: iconColor.withValues(alpha: 0.2),
+              width: BorderWidth.thin,
+            ),
+          ),
+          child: Icon(
+            Platform.isIOS
+                ? CupertinoIcons.exclamationmark_triangle
+                : Icons.warning_amber_rounded,
+            color: iconColor,
+            size: 28,
+          ),
+        ),
+        const SizedBox(height: Spacing.lg),
+        Text(
+          l10n.serverIncompatibleTitle,
+          textAlign: TextAlign.center,
+          style: context.conduitTheme.headingMedium?.copyWith(
+            fontWeight: FontWeight.w600,
+            color: context.conduitTheme.textPrimary,
+          ),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildServerDetails(BuildContext context, ServerConfig server) {
+    final host = _resolveHost(server);
+
+    return Column(
+      children: [
+        Text(
+          host,
+          textAlign: TextAlign.center,
+          style: context.conduitTheme.bodyMedium?.copyWith(
+            color: context.conduitTheme.textPrimary,
+            fontFamily: AppTypography.monospaceFontFamily,
+          ),
+        ),
+        const SizedBox(height: Spacing.xs),
+        Text(
+          server.url,
+          textAlign: TextAlign.center,
+          style: context.conduitTheme.bodySmall?.copyWith(
+            color: context.conduitTheme.textSecondary,
+          ),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildActions(BuildContext context, AppLocalizations l10n) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: Spacing.md),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          ConduitButton(
+            text: l10n.serverIncompatibleRecheck,
+            onPressed: _isRechecking ? null : _recheck,
+            isLoading: _isRechecking,
+            icon: Platform.isIOS
+                ? CupertinoIcons.refresh
+                : Icons.refresh_rounded,
+            isFullWidth: true,
+          ),
+          const SizedBox(height: Spacing.sm),
+          ConduitButton(
+            text: l10n.serverIncompatibleSwitchServer,
+            onPressed: _isRechecking ? null : _switchServer,
+            isSecondary: true,
+            icon: Platform.isIOS
+                ? CupertinoIcons.arrow_2_circlepath
+                : Icons.swap_horiz_rounded,
+            isFullWidth: true,
+            isCompact: true,
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildStatusMessage(BuildContext context, String message) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: Spacing.md),
+      child: Text(
+        message,
+        textAlign: TextAlign.center,
+        style: context.conduitTheme.bodySmall?.copyWith(
+          color: context.conduitTheme.textSecondary,
+        ),
+      ),
+    );
+  }
+
+  Future<void> _recheck() async {
+    final l10n = AppLocalizations.of(context)!;
+    setState(() {
+      _isRechecking = true;
+      _statusMessage = null;
+    });
+
+    try {
+      // Re-fetch /api/config. If the server was downgraded to a supported
+      // version, serverIncompatibleProvider flips and the router redirects
+      // away from this page automatically.
+      await ref.read(backendConfigProvider.notifier).refresh();
+    } catch (_) {
+      // Ignore — handled by the still-incompatible message below.
+    }
+
+    if (!mounted) return;
+
+    final stillIncompatible = ref.read(serverIncompatibleProvider);
+    setState(() {
+      _isRechecking = false;
+      _statusMessage = stillIncompatible
+          ? l10n.serverIncompatibleStillUnsupported
+          : null;
+    });
+  }
+
+  void _switchServer() {
+    // The router permits the server-connection route even while the active
+    // server is incompatible, so the user can point the app at a different
+    // (supported) server from there.
+    context.goNamed(RouteNames.serverConnection);
+  }
+
+  String _displayVersion(String? version) {
+    final trimmed = version?.trim();
+    if (trimmed == null || trimmed.isEmpty) return '?';
+    return trimmed;
+  }
+
+  String _resolveHost(ServerConfig? config) {
+    final url = config?.url;
+    if (url == null || url.isEmpty) {
+      return 'Open WebUI';
+    }
+    try {
+      final uri = Uri.parse(url);
+      if (uri.host.isNotEmpty) {
+        return uri.host;
+      }
+      return url;
+    } catch (_) {
+      return url;
+    }
+  }
+}
+
+/// Shows a blocking dialog explaining that the just-probed server is newer than
+/// this app supports. Used at connection time (before a server is saved) so the
+/// user is told why the connection was refused.
+///
+/// The dialog cannot be dismissed by tapping outside; it has a single
+/// acknowledge action that returns the user to the connection form.
+Future<void> showServerIncompatibleDialog(
+  BuildContext context, {
+  required String? serverVersion,
+}) {
+  final l10n = AppLocalizations.of(context);
+  final maxVersion = ServerVersionCompat.maxSupportedVersion;
+  final trimmed = serverVersion?.trim();
+  final version = (trimmed == null || trimmed.isEmpty) ? '?' : trimmed;
+
+  return ThemedDialogs.show<void>(
+    context,
+    title: l10n?.serverIncompatibleTitle ?? 'Server not supported',
+    barrierDismissible: false,
+    content: Column(
+      mainAxisSize: MainAxisSize.min,
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          l10n?.serverIncompatibleMessage(version, maxVersion) ??
+              'This server runs Open WebUI $version, which is newer than '
+                  'this app supports (up to $maxVersion).',
+        ),
+        const SizedBox(height: Spacing.sm),
+        Text(
+          l10n?.serverIncompatibleResolution(maxVersion) ??
+              'Downgrade your server to $maxVersion or earlier, or wait for '
+                  'an app update that adds support.',
+        ),
+      ],
+    ),
+    actions: [
+      ConduitTextButton(
+        text: l10n?.ok ?? 'OK',
+        onPressed: () => Navigator.of(context).pop(),
+        isPrimary: true,
+      ),
+    ],
+  );
+}

--- a/lib/l10n/app_cs.arb
+++ b/lib/l10n/app_cs.arb
@@ -1,6 +1,13 @@
 {
   "@@locale": "cs",
   "appTitle": "Conduit",
+  "serverIncompatibleTitle": "Server není podporován",
+  "serverIncompatibleMessage": "Tento server používá Open WebUI {serverVersion}, což je novější verze, než tato aplikace podporuje (maximálně {maxVersion}).",
+  "serverIncompatibleResolution": "Chcete-li pokračovat, snižte verzi serveru na {maxVersion} nebo nižší, nebo počkejte na aktualizaci aplikace, která podporu doplní.",
+  "serverIncompatibleConnectBlocked": "Tento server je novější, než tato aplikace podporuje (maximálně {maxVersion}).",
+  "serverIncompatibleRecheck": "Zkontrolovat server znovu",
+  "serverIncompatibleSwitchServer": "Vybrat jiný server",
+  "serverIncompatibleStillUnsupported": "Tento server je stále novější, než tato aplikace podporuje.",
   "@appTitle": {
     "description": "Application name displayed in the app and OS UI."
   },

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -1,6 +1,13 @@
 {
   "@@locale": "de",
   "appTitle": "Conduit",
+  "serverIncompatibleTitle": "Server nicht unterstützt",
+  "serverIncompatibleMessage": "Auf diesem Server läuft Open WebUI {serverVersion}, was neuer ist, als diese App unterstützt (bis {maxVersion}).",
+  "serverIncompatibleResolution": "Um fortzufahren, stufe deinen Server auf {maxVersion} oder älter zurück oder warte auf ein App-Update, das diese Version unterstützt.",
+  "serverIncompatibleConnectBlocked": "Dieser Server ist neuer, als diese App unterstützt (bis {maxVersion}).",
+  "serverIncompatibleRecheck": "Server erneut prüfen",
+  "serverIncompatibleSwitchServer": "Anderen Server wählen",
+  "serverIncompatibleStillUnsupported": "Dieser Server ist weiterhin neuer, als diese App unterstützt.",
   "retry": "Erneut versuchen",
   "back": "Zurück",
   "you": "Du",

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -29,6 +29,56 @@
   "@connectionIssueSubtitle": {
     "description": "Subtitle explaining available actions when the server cannot be reached"
   },
+  "serverIncompatibleTitle": "Server not supported",
+  "@serverIncompatibleTitle": {
+    "description": "Title shown when the connected Open WebUI server is newer than the app supports"
+  },
+  "serverIncompatibleMessage": "This server runs Open WebUI {serverVersion}, which is newer than this app supports (up to {maxVersion}).",
+  "@serverIncompatibleMessage": {
+    "description": "Explains that the server version is too new for the current app build",
+    "placeholders": {
+      "serverVersion": {
+        "type": "String",
+        "example": "0.11.0"
+      },
+      "maxVersion": {
+        "type": "String",
+        "example": "0.10.1"
+      }
+    }
+  },
+  "serverIncompatibleResolution": "To continue, downgrade your server to {maxVersion} or earlier, or wait for an app update that adds support.",
+  "@serverIncompatibleResolution": {
+    "description": "Tells the user how to resolve an unsupported server version",
+    "placeholders": {
+      "maxVersion": {
+        "type": "String",
+        "example": "0.10.1"
+      }
+    }
+  },
+  "serverIncompatibleConnectBlocked": "This server is newer than this app supports (up to {maxVersion}).",
+  "@serverIncompatibleConnectBlocked": {
+    "description": "Inline error on the connection form when the probed server version is too new",
+    "placeholders": {
+      "maxVersion": {
+        "type": "String",
+        "example": "0.10.1"
+      }
+    }
+  },
+  "serverIncompatibleRecheck": "Recheck server",
+  "@serverIncompatibleRecheck": {
+    "description": "Button that re-fetches the server version after a downgrade"
+  },
+  "serverIncompatibleSwitchServer": "Use a different server",
+  "@serverIncompatibleSwitchServer": {
+    "description": "Button that lets the user connect to a different server from the incompatibility gate"
+  },
+  "serverIncompatibleStillUnsupported": "This server is still newer than this app supports.",
+  "@serverIncompatibleStillUnsupported": {
+    "description": "Status shown after a recheck when the server version is still too new"
+  },
   "@pleaseCheckConnection": {
     "description": "Generic connectivity hint after an error."
   },

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -1,6 +1,13 @@
 {
   "@@locale": "es",
   "appTitle": "Conduit",
+  "serverIncompatibleTitle": "Servidor no compatible",
+  "serverIncompatibleMessage": "Este servidor ejecuta Open WebUI {serverVersion}, que es más reciente de lo que admite esta app (hasta {maxVersion}).",
+  "serverIncompatibleResolution": "Para continuar, baja la versión de tu servidor a {maxVersion} o anterior, o espera a una actualización de la app que añada compatibilidad.",
+  "serverIncompatibleConnectBlocked": "Este servidor es más reciente de lo que admite esta app (hasta {maxVersion}).",
+  "serverIncompatibleRecheck": "Volver a comprobar",
+  "serverIncompatibleSwitchServer": "Usar otro servidor",
+  "serverIncompatibleStillUnsupported": "Este servidor sigue siendo más reciente de lo que admite esta app.",
   "retry": "Reintentar",
   "back": "Atrás",
   "you": "Tú",

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -1,6 +1,13 @@
 {
   "@@locale": "fr",
   "appTitle": "Conduit",
+  "serverIncompatibleTitle": "Serveur non pris en charge",
+  "serverIncompatibleMessage": "Ce serveur exécute Open WebUI {serverVersion}, une version plus récente que celle prise en charge par cette application (jusqu'à {maxVersion}).",
+  "serverIncompatibleResolution": "Pour continuer, rétrogradez votre serveur vers la version {maxVersion} ou une version antérieure, ou attendez une mise à jour de l'application qui ajoute la prise en charge.",
+  "serverIncompatibleConnectBlocked": "Ce serveur est plus récent que ce que cette application prend en charge (jusqu'à {maxVersion}).",
+  "serverIncompatibleRecheck": "Revérifier le serveur",
+  "serverIncompatibleSwitchServer": "Utiliser un autre serveur",
+  "serverIncompatibleStillUnsupported": "Ce serveur est toujours plus récent que ce que cette application prend en charge.",
   "retry": "Réessayer",
   "back": "Retour",
   "you": "Vous",

--- a/lib/l10n/app_it.arb
+++ b/lib/l10n/app_it.arb
@@ -1,6 +1,13 @@
 {
   "@@locale": "it",
   "appTitle": "Conduit",
+  "serverIncompatibleTitle": "Server non supportato",
+  "serverIncompatibleMessage": "Questo server esegue Open WebUI {serverVersion}, una versione più recente di quella supportata da questa app (fino alla {maxVersion}).",
+  "serverIncompatibleResolution": "Per continuare, riporta il server alla versione {maxVersion} o precedente, oppure attendi un aggiornamento dell'app che ne aggiunga il supporto.",
+  "serverIncompatibleConnectBlocked": "Questo server è più recente di quanto supportato da questa app (fino alla {maxVersion}).",
+  "serverIncompatibleRecheck": "Ricontrolla il server",
+  "serverIncompatibleSwitchServer": "Usa un server diverso",
+  "serverIncompatibleStillUnsupported": "Questo server è ancora più recente di quanto supportato da questa app.",
   "retry": "Riprova",
   "back": "Indietro",
   "you": "Tu",

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -1,6 +1,13 @@
 {
   "@@locale": "ja",
   "appTitle": "Conduit",
+  "serverIncompatibleTitle": "サーバーは未対応です",
+  "serverIncompatibleMessage": "このサーバーは Open WebUI {serverVersion} を実行しており、このアプリが対応するバージョン（{maxVersion} まで）よりも新しいバージョンです。",
+  "serverIncompatibleResolution": "続行するには、サーバーを {maxVersion} 以前にダウングレードするか、対応を追加するアプリの更新をお待ちください。",
+  "serverIncompatibleConnectBlocked": "このサーバーは、このアプリが対応するバージョン（{maxVersion} まで）よりも新しいバージョンです。",
+  "serverIncompatibleRecheck": "サーバーを再確認",
+  "serverIncompatibleSwitchServer": "別のサーバーを使用",
+  "serverIncompatibleStillUnsupported": "このサーバーは、まだこのアプリが対応するバージョンよりも新しいバージョンです。",
   "@appTitle": {
     "description": "Application name displayed in the app and OS UI."
   },

--- a/lib/l10n/app_ko.arb
+++ b/lib/l10n/app_ko.arb
@@ -1,6 +1,13 @@
 {
   "@@locale": "ko",
   "appTitle": "Conduit",
+  "serverIncompatibleTitle": "지원되지 않는 서버",
+  "serverIncompatibleMessage": "이 서버는 Open WebUI {serverVersion} 버전을 사용 중이며, 이는 이 앱이 지원하는 버전({maxVersion} 이하)보다 최신입니다.",
+  "serverIncompatibleResolution": "계속하려면 서버를 {maxVersion} 이하 버전으로 다운그레이드하거나, 해당 버전을 지원하는 앱 업데이트를 기다리세요.",
+  "serverIncompatibleConnectBlocked": "이 서버는 이 앱이 지원하는 버전({maxVersion} 이하)보다 최신입니다.",
+  "serverIncompatibleRecheck": "서버 다시 확인",
+  "serverIncompatibleSwitchServer": "다른 서버 사용",
+  "serverIncompatibleStillUnsupported": "이 서버는 여전히 이 앱이 지원하는 버전보다 최신입니다.",
   "retry": "다시 시도",
   "back": "뒤로",
   "you": "프로필",

--- a/lib/l10n/app_nl.arb
+++ b/lib/l10n/app_nl.arb
@@ -1,6 +1,13 @@
 {
   "@@locale": "nl",
   "appTitle": "Conduit",
+  "serverIncompatibleTitle": "Server niet ondersteund",
+  "serverIncompatibleMessage": "Deze server draait Open WebUI {serverVersion}, wat nieuwer is dan deze app ondersteunt (tot {maxVersion}).",
+  "serverIncompatibleResolution": "Om door te gaan, zet je je server terug naar {maxVersion} of eerder, of wacht je op een app-update die ondersteuning toevoegt.",
+  "serverIncompatibleConnectBlocked": "Deze server is nieuwer dan deze app ondersteunt (tot {maxVersion}).",
+  "serverIncompatibleRecheck": "Server opnieuw controleren",
+  "serverIncompatibleSwitchServer": "Andere server gebruiken",
+  "serverIncompatibleStillUnsupported": "Deze server is nog steeds nieuwer dan deze app ondersteunt.",
   "retry": "Opnieuw proberen",
   "back": "Terug",
   "you": "Jij",

--- a/lib/l10n/app_ru.arb
+++ b/lib/l10n/app_ru.arb
@@ -1,6 +1,13 @@
 {
   "@@locale": "ru",
   "appTitle": "Conduit",
+  "serverIncompatibleTitle": "Сервер не поддерживается",
+  "serverIncompatibleMessage": "На этом сервере установлена версия Open WebUI {serverVersion}, которая новее, чем поддерживает это приложение (до {maxVersion}).",
+  "serverIncompatibleResolution": "Чтобы продолжить, понизьте версию сервера до {maxVersion} или более ранней либо дождитесь обновления приложения с поддержкой новой версии.",
+  "serverIncompatibleConnectBlocked": "Этот сервер новее, чем поддерживает это приложение (до {maxVersion}).",
+  "serverIncompatibleRecheck": "Проверить сервер",
+  "serverIncompatibleSwitchServer": "Выбрать другой сервер",
+  "serverIncompatibleStillUnsupported": "Этот сервер по-прежнему новее, чем поддерживает это приложение.",
   "retry": "Повторить",
   "back": "Назад",
   "you": "Вы",

--- a/lib/l10n/app_sk.arb
+++ b/lib/l10n/app_sk.arb
@@ -1,6 +1,13 @@
 {
   "@@locale": "sk",
   "appTitle": "Conduit",
+  "serverIncompatibleTitle": "Server nie je podporovaný",
+  "serverIncompatibleMessage": "Tento server používa Open WebUI {serverVersion}, čo je novšia verzia, než akú táto aplikácia podporuje (maximálne {maxVersion}).",
+  "serverIncompatibleResolution": "Ak chcete pokračovať, znížte verziu servera na {maxVersion} alebo staršiu, alebo počkajte na aktualizáciu aplikácie, ktorá pridá podporu.",
+  "serverIncompatibleConnectBlocked": "Tento server je novší, než akú verziu táto aplikácia podporuje (maximálne {maxVersion}).",
+  "serverIncompatibleRecheck": "Skontrolovať server znova",
+  "serverIncompatibleSwitchServer": "Použiť iný server",
+  "serverIncompatibleStillUnsupported": "Tento server je stále novší, než akú verziu táto aplikácia podporuje.",
   "@appTitle": {
     "description": "Application name displayed in the app and OS UI."
   },

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -1,6 +1,13 @@
 {
   "@@locale": "zh",
   "appTitle": "Conduit",
+  "serverIncompatibleTitle": "不支持该服务器",
+  "serverIncompatibleMessage": "此服务器运行的 Open WebUI 版本为 {serverVersion}，高于本应用支持的版本（最高 {maxVersion}）。",
+  "serverIncompatibleResolution": "若要继续，请将服务器降级到 {maxVersion} 或更早版本，或等待新增支持的应用更新。",
+  "serverIncompatibleConnectBlocked": "此服务器的版本高于本应用支持的版本（最高 {maxVersion}）。",
+  "serverIncompatibleRecheck": "重新检查服务器",
+  "serverIncompatibleSwitchServer": "使用其他服务器",
+  "serverIncompatibleStillUnsupported": "此服务器的版本仍高于本应用支持的版本。",
   "retry": "重试",
   "back": "返回",
   "you": "你",

--- a/lib/l10n/app_zh_Hant.arb
+++ b/lib/l10n/app_zh_Hant.arb
@@ -1,6 +1,13 @@
 {
   "@@locale": "zh_Hant",
   "appTitle": "Conduit",
+  "serverIncompatibleTitle": "不支援此伺服器",
+  "serverIncompatibleMessage": "此伺服器執行的 Open WebUI 版本為 {serverVersion}，比此應用程式所支援的版本（最高 {maxVersion}）還要新。",
+  "serverIncompatibleResolution": "若要繼續，請將您的伺服器降級至 {maxVersion} 或更舊的版本，或等待應用程式更新以新增支援。",
+  "serverIncompatibleConnectBlocked": "此伺服器比此應用程式所支援的版本（最高 {maxVersion}）還要新。",
+  "serverIncompatibleRecheck": "重新檢查伺服器",
+  "serverIncompatibleSwitchServer": "使用其他伺服器",
+  "serverIncompatibleStillUnsupported": "此伺服器仍比此應用程式所支援的版本還要新。",
   "retry": "重試",
   "back": "返回",
   "you": "你",

--- a/test/core/providers/server_incompatible_provider_test.dart
+++ b/test/core/providers/server_incompatible_provider_test.dart
@@ -1,0 +1,103 @@
+import 'package:conduit/core/models/backend_config.dart';
+import 'package:conduit/core/models/server_config.dart';
+import 'package:conduit/core/providers/app_providers.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+/// Pins [backendConfigProvider] to a fixed config for the test.
+class _FixedBackendConfigNotifier extends BackendConfigNotifier {
+  _FixedBackendConfigNotifier(this._config);
+
+  final BackendConfig? _config;
+
+  @override
+  Future<BackendConfig?> build() async => _config;
+}
+
+ServerConfig _server(String id) =>
+    ServerConfig(id: id, name: id, url: 'https://$id.example');
+
+Future<ProviderContainer> _container({
+  ServerConfig? activeServer,
+  BackendConfig? config,
+}) async {
+  final container = ProviderContainer(
+    overrides: [
+      activeServerProvider.overrideWith((ref) async => activeServer),
+      backendConfigProvider.overrideWith(
+        () => _FixedBackendConfigNotifier(config),
+      ),
+    ],
+  );
+  // Resolve the async dependencies so the synchronous gate provider can read
+  // their data values.
+  await container.read(activeServerProvider.future);
+  await container.read(backendConfigProvider.future);
+  return container;
+}
+
+void main() {
+  group('serverIncompatibleProvider', () {
+    test('gates when the active server\'s config is unsupported', () async {
+      final container = await _container(
+        activeServer: _server('A'),
+        config: const BackendConfig(version: '0.11.0', serverId: 'A'),
+      );
+      addTearDown(container.dispose);
+
+      expect(container.read(serverIncompatibleProvider), isTrue);
+    });
+
+    test('does not gate when the active server is supported', () async {
+      final container = await _container(
+        activeServer: _server('A'),
+        config: const BackendConfig(version: '0.10.1', serverId: 'A'),
+      );
+      addTearDown(container.dispose);
+
+      expect(container.read(serverIncompatibleProvider), isFalse);
+    });
+
+    test(
+      'fails open when the cached config belongs to a different server',
+      () async {
+        // The crux fix: after switching from unsupported server A to supported
+        // server B, the still-cached A config must not gate B.
+        final container = await _container(
+          activeServer: _server('B'),
+          config: const BackendConfig(version: '0.11.0', serverId: 'A'),
+        );
+        addTearDown(container.dispose);
+
+        expect(container.read(serverIncompatibleProvider), isFalse);
+      },
+    );
+
+    test('fails open for an untagged (legacy) cached config', () async {
+      final container = await _container(
+        activeServer: _server('A'),
+        config: const BackendConfig(version: '0.11.0'),
+      );
+      addTearDown(container.dispose);
+
+      expect(container.read(serverIncompatibleProvider), isFalse);
+    });
+
+    test('fails open when there is no active server', () async {
+      final container = await _container(
+        activeServer: null,
+        config: const BackendConfig(version: '0.11.0', serverId: 'A'),
+      );
+      addTearDown(container.dispose);
+
+      expect(container.read(serverIncompatibleProvider), isFalse);
+    });
+
+    test('fails open when the backend config is unknown', () async {
+      final container = await _container(activeServer: _server('A'));
+      addTearDown(container.dispose);
+
+      expect(container.read(serverIncompatibleProvider), isFalse);
+    });
+  });
+}

--- a/test/core/providers/server_incompatible_provider_test.dart
+++ b/test/core/providers/server_incompatible_provider_test.dart
@@ -73,10 +73,26 @@ void main() {
       },
     );
 
-    test('fails open for an untagged (legacy) cached config', () async {
+    test(
+      'gates an untagged (legacy) cached config against the active server',
+      () async {
+        // A cache written by a pre-tagging app version has a null serverId.
+        // On a cold start into an unsupported server it must still gate, not
+        // be treated as foreign and waved through.
+        final container = await _container(
+          activeServer: _server('A'),
+          config: const BackendConfig(version: '0.11.0'),
+        );
+        addTearDown(container.dispose);
+
+        expect(container.read(serverIncompatibleProvider), isTrue);
+      },
+    );
+
+    test('does not gate a supported untagged (legacy) cached config', () async {
       final container = await _container(
         activeServer: _server('A'),
-        config: const BackendConfig(version: '0.11.0'),
+        config: const BackendConfig(version: '0.10.0'),
       );
       addTearDown(container.dispose);
 

--- a/test/core/providers/server_incompatible_provider_test.dart
+++ b/test/core/providers/server_incompatible_provider_test.dart
@@ -73,26 +73,14 @@ void main() {
       },
     );
 
-    test(
-      'gates an untagged (legacy) cached config against the active server',
-      () async {
-        // A cache written by a pre-tagging app version has a null serverId.
-        // On a cold start into an unsupported server it must still gate, not
-        // be treated as foreign and waved through.
-        final container = await _container(
-          activeServer: _server('A'),
-          config: const BackendConfig(version: '0.11.0'),
-        );
-        addTearDown(container.dispose);
-
-        expect(container.read(serverIncompatibleProvider), isTrue);
-      },
-    );
-
-    test('does not gate a supported untagged (legacy) cached config', () async {
+    test('fails open for an untagged (legacy) cached config', () async {
+      // A cache written by a pre-tagging app version has a null serverId and
+      // can't be attributed to a server. The gate fails open and relies on the
+      // immediate refresh to produce a freshly-tagged config, rather than risk
+      // trapping a supported server on a stale unsupported cache.
       final container = await _container(
         activeServer: _server('A'),
-        config: const BackendConfig(version: '0.10.0'),
+        config: const BackendConfig(version: '0.11.0'),
       );
       addTearDown(container.dispose);
 

--- a/test/core/utils/server_version_compat_test.dart
+++ b/test/core/utils/server_version_compat_test.dart
@@ -1,0 +1,60 @@
+import 'package:checks/checks.dart';
+import 'package:conduit/core/utils/server_version_compat.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('ServerVersionCompat.isSupported', () {
+    test('the max supported version itself is supported', () {
+      check(ServerVersionCompat.isSupported('0.10.1')).isTrue();
+    });
+
+    test('older versions are supported', () {
+      for (final v in ['0.10.0', '0.9.9', '0.6.5', '0.1.0', '0.0.1']) {
+        check(because: v, ServerVersionCompat.isSupported(v)).isTrue();
+      }
+    });
+
+    test('newer patch / minor / major versions are unsupported', () {
+      for (final v in ['0.10.2', '0.11.0', '0.20.0', '1.0.0', '2.5.3']) {
+        check(because: v, ServerVersionCompat.isSupported(v)).isFalse();
+      }
+    });
+
+    test('tolerates a leading v prefix', () {
+      check(ServerVersionCompat.isSupported('v0.10.1')).isTrue();
+      check(ServerVersionCompat.isSupported('v0.11.0')).isFalse();
+    });
+
+    test('strips pre-release / build metadata before comparing', () {
+      // A pre-release of the max version is treated as the max version.
+      check(ServerVersionCompat.isSupported('0.10.1-dev')).isTrue();
+      check(ServerVersionCompat.isSupported('0.10.1+build.7')).isTrue();
+      // Metadata on a newer core still gates.
+      check(ServerVersionCompat.isSupported('0.11.0-rc1')).isFalse();
+    });
+
+    test('partial versions are padded with zeros', () {
+      check(ServerVersionCompat.isSupported('0.10')).isTrue();
+      check(ServerVersionCompat.isSupported('0')).isTrue();
+      check(ServerVersionCompat.isSupported('1')).isFalse();
+    });
+
+    test('fails open on null / empty / unparseable versions', () {
+      for (final v in [null, '', '   ', 'nightly', 'unknown', 'abc.def']) {
+        check(because: '$v', ServerVersionCompat.isSupported(v)).isTrue();
+      }
+    });
+
+    test('isUnsupported is the inverse of isSupported', () {
+      check(ServerVersionCompat.isUnsupported('0.11.0')).isTrue();
+      check(ServerVersionCompat.isUnsupported('0.10.1')).isFalse();
+      check(ServerVersionCompat.isUnsupported(null)).isFalse();
+    });
+
+    test('maxSupportedVersion constant parses as supported', () {
+      check(
+        ServerVersionCompat.isSupported(ServerVersionCompat.maxSupportedVersion),
+      ).isTrue();
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Blocks the app when the connected Open WebUI server reports a version **newer than `0.10.1`** (the newest version this build has been validated against), and shows a clear dialog telling the user to **downgrade the server to ≤ 0.10.1** or **wait for an app update** that adds support. This avoids confusing failures deep inside features when the upstream API drifts ahead of the vendored `openwebui-src/`.

## Two enforcement points

1. **Connect time** (`server_connection_page.dart`, both direct and reverse-proxy flows): after probing `/api/config`, if the version is unsupported it shows a non-dismissible dialog and **aborts without saving the server** — the user never gets in.
2. **Runtime / restored sessions** (`app_router.dart`): a `serverIncompatibleProvider`-driven redirect gate sends every in-app route to a blocking `ServerIncompatiblePage` while the active server is incompatible. This covers servers upgraded *after* connecting, or an app whose ceiling is lower than a previously-saved server. The `server-connection` route stays reachable so users can switch servers, and the gate **auto-clears** once a supported version is reported (e.g. after a downgrade + Recheck).

## Key pieces

- **`lib/core/utils/server_version_compat.dart`** — pure, unit-tested comparator. `maxSupportedVersion = '0.10.1'`; tolerates a `v` prefix and `-dev`/`+build` suffixes; **fails open** on null/unparseable versions so it never locks users out of a server whose version string it can't read.
- **`BackendConfig.version`** — captured from `/api/config` and round-tripped through the local cache.
- **`serverIncompatibleProvider`** — derives the gate state; `RouterNotifier` listens to it.
- **`ServerIncompatiblePage`** + shared `showServerIncompatibleDialog` helper.
- New strings localized across **all 12 supported locales**.

## Design decisions

- **Strictly greater** than `0.10.1` is blocked; `0.10.1` itself is allowed.
- **Reviewer/demo mode bypasses** the gate (it short-circuits to chat before the gate runs).
- **Fail-open** on unknown versions to avoid false lockouts.

To support a newer server later, bump `ServerVersionCompat.maxSupportedVersion` (one line) after validating against `openwebui-src/`.

## Verification

- `flutter analyze` (full project): **No issues found**
- `flutter test test/core/utils/server_version_compat_test.dart`: **9/9 pass**
- All 13 ARB files valid JSON; `flutter gen-l10n` clean with ICU placeholders preserved (untranslated count dropped by exactly 7 per locale)

## Test plan

- [ ] Connect to a server reporting > 0.10.1 → dialog appears, connection aborts, server not saved
- [ ] Connect to a server ≤ 0.10.1 → normal flow
- [ ] Already-authenticated session whose server reports > 0.10.1 → redirected to the gate page; **Use a different server** reaches the connection form; **Recheck server** clears the gate after a downgrade

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Block app access when the Open WebUI server version exceeds the supported maximum
> - Adds `ServerVersionCompat` utility with a `maxSupportedVersion` of `0.10.1` that parses and compares semantic version strings to determine compatibility.
> - Introduces `serverIncompatibleProvider` that evaluates whether the active server's reported version exceeds the supported maximum.
> - Blocks connection attempts to unsupported servers in `ServerConnectionPage`, showing a dialog and inline error without saving the server.
> - Redirects all routes to a new `ServerIncompatiblePage` when the active server is unsupported; restores navigation when compatibility is restored.
> - Behavioral Change: users connected to a server newer than `0.10.1` will be redirected to a blocking incompatibility screen until they switch servers or the server downgrades.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2084c93.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a server version compatibility gate using the backend-reported version to block access when newer than supported.
  * Introduced an “incompatible server” screen and route with actions to recheck compatibility or switch servers.
  * Added connection-time refusal messaging showing the detected server version/max supported version.
* **Bug Fixes**
  * Prevented navigation until compatibility is resolved, with safe “fails open” behavior when version is missing/unparseable.
* **Localization**
  * Added multi-language strings for the incompatibility flow (including version/max placeholders).
* **Tests**
  * Added/extended tests for version parsing and the incompatibility routing gate.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR blocks use of unsupported Open WebUI server versions. The main changes are:

- Adds server-version parsing and compatibility checks.
- Stores backend config version data with a server id.
- Blocks incompatible servers during connection and restored sessions.
- Adds a blocking incompatibility page with recheck and switch-server actions.
- Adds localized strings and tests for the new gate.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The version-gating changes look merge-safe.

No code issues were identified in the reviewed changes, and the described coverage exercises the comparator and routing behavior.
</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- The connect-gate contract test harness trex-artifacts/connect-gate-contract-test.dart was used for both runs.
- Before attempted execution, the base worktree was checked out and EXIT\_CODE 127 due to flutter: not found.
- After attempting execution, the head worktree was checked out with EXIT\_CODE 127 due to flutter: not found.
- A supplemental source probe trex-artifacts/connect-gate-source-probe.txt was run to inspect the head source and found direct and proxy gates after config verification, plus the source-equivalent version decisions.
- Base Flutter test attempted on the base worktree failed with EXIT\_CODE 127 due to missing Flutter.
- Head Flutter test attempted on the head worktree also failed with EXIT\_CODE 127 due to missing Flutter.
- No route behavior, UI surface, or before/after runtime comparison could be executed in this environment.
- Before artifact shows the generated test content and command failure in /tmp/version-compat-base with EXIT\_CODE 127 and /bin/sh: flutter: not found.
- After artifact shows the same generated test content and command failure in /tmp/version-compat-head with EXIT\_CODE 127 and /bin/sh: flutter: not found.
- Before log shows base ARB validation command, cwd, output, and exit code 0.
- After log shows head ARB validation output plus the attempted Flutter widget render command, which failed because flutter is unavailable.
- After ARB-only log reruns the head ARB validator successfully and records the Flutter availability blocker.

<a href="https://app.greptile.com/trex/runs/12811421/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=1"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=1" height="32"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (5): Last reviewed commit: ["fix: gate only on a config confirmed for..."](https://github.com/cogwheel0/conduit/commit/2084c93082ec69f2d0342b9f77fd1d200fc40089) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40876988)</sub>

<!-- /greptile_comment -->