### PR TITLE
Bump max supported Open WebUI version to 0.10.2

### DIFF
--- a/lib/core/utils/server_version_compat.dart
+++ b/lib/core/utils/server_version_compat.dart
@@ -17,10 +17,10 @@ class ServerVersionCompat {
   /// Servers reporting a `/api/config` `version` strictly greater than this are
   /// gated off. Bump this (and re-verify against `openwebui-src/`) whenever a
   /// newer server release is validated.
-  static const String maxSupportedVersion = '0.10.1';
+  static const String maxSupportedVersion = '0.10.2';
 
   /// Parsed [maxSupportedVersion] components: `[major, minor, patch]`.
-  static const List<int> _maxSupported = [0, 10, 1];
+  static const List<int> _maxSupported = [0, 10, 2];
 
   /// Whether [rawVersion] is within the supported range (<= [maxSupportedVersion]).
   ///
@@ -40,7 +40,7 @@ class ServerVersionCompat {
   /// Parses a semantic-ish version string into up to three numeric components.
   ///
   /// Tolerates a leading `v`/`V` and drops any pre-release or build metadata
-  /// suffix (e.g. `0.10.1-dev`, `0.10.1+build.5`). Returns `null` when no
+  /// suffix (e.g. `0.10.2-dev`, `0.10.2+build.5`). Returns `null` when no
   /// leading numeric component can be found.
   static List<int>? _parse(String? raw) {
     if (raw == null) return null;
@@ -49,7 +49,7 @@ class ServerVersionCompat {
     if (s.startsWith('v') || s.startsWith('V')) {
       s = s.substring(1);
     }
-    // Strip pre-release / build metadata so `0.10.1-rc1` compares as `0.10.1`.
+    // Strip pre-release / build metadata so `0.10.2-rc1` compares as `0.10.2`.
     final cut = s.indexOf(RegExp(r'[-+ ]'));
     if (cut != -1) {
       s = s.substring(0, cut);

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -43,7 +43,7 @@
       },
       "maxVersion": {
         "type": "String",
-        "example": "0.10.1"
+        "example": "0.10.2"
       }
     }
   },
@@ -53,7 +53,7 @@
     "placeholders": {
       "maxVersion": {
         "type": "String",
-        "example": "0.10.1"
+        "example": "0.10.2"
       }
     }
   },
@@ -63,7 +63,7 @@
     "placeholders": {
       "maxVersion": {
         "type": "String",
-        "example": "0.10.1"
+        "example": "0.10.2"
       }
     }
   },

--- a/test/core/providers/server_incompatible_provider_test.dart
+++ b/test/core/providers/server_incompatible_provider_test.dart
@@ -51,7 +51,7 @@ void main() {
     test('does not gate when the active server is supported', () async {
       final container = await _container(
         activeServer: _server('A'),
-        config: const BackendConfig(version: '0.10.1', serverId: 'A'),
+        config: const BackendConfig(version: '0.10.2', serverId: 'A'),
       );
       addTearDown(container.dispose);
 

--- a/test/core/utils/server_version_compat_test.dart
+++ b/test/core/utils/server_version_compat_test.dart
@@ -5,30 +5,30 @@ import 'package:flutter_test/flutter_test.dart';
 void main() {
   group('ServerVersionCompat.isSupported', () {
     test('the max supported version itself is supported', () {
-      check(ServerVersionCompat.isSupported('0.10.1')).isTrue();
+      check(ServerVersionCompat.isSupported('0.10.2')).isTrue();
     });
 
     test('older versions are supported', () {
-      for (final v in ['0.10.0', '0.9.9', '0.6.5', '0.1.0', '0.0.1']) {
+      for (final v in ['0.10.1', '0.10.0', '0.9.9', '0.6.5', '0.1.0', '0.0.1']) {
         check(because: v, ServerVersionCompat.isSupported(v)).isTrue();
       }
     });
 
     test('newer patch / minor / major versions are unsupported', () {
-      for (final v in ['0.10.2', '0.11.0', '0.20.0', '1.0.0', '2.5.3']) {
+      for (final v in ['0.10.3', '0.11.0', '0.20.0', '1.0.0', '2.5.3']) {
         check(because: v, ServerVersionCompat.isSupported(v)).isFalse();
       }
     });
 
     test('tolerates a leading v prefix', () {
-      check(ServerVersionCompat.isSupported('v0.10.1')).isTrue();
+      check(ServerVersionCompat.isSupported('v0.10.2')).isTrue();
       check(ServerVersionCompat.isSupported('v0.11.0')).isFalse();
     });
 
     test('strips pre-release / build metadata before comparing', () {
       // A pre-release of the max version is treated as the max version.
-      check(ServerVersionCompat.isSupported('0.10.1-dev')).isTrue();
-      check(ServerVersionCompat.isSupported('0.10.1+build.7')).isTrue();
+      check(ServerVersionCompat.isSupported('0.10.2-dev')).isTrue();
+      check(ServerVersionCompat.isSupported('0.10.2+build.7')).isTrue();
       // Metadata on a newer core still gates.
       check(ServerVersionCompat.isSupported('0.11.0-rc1')).isFalse();
     });
@@ -39,6 +39,10 @@ void main() {
       check(ServerVersionCompat.isSupported('1')).isFalse();
     });
 
+    test('the previous max (0.10.1) remains supported after the bump', () {
+      check(ServerVersionCompat.isSupported('0.10.1')).isTrue();
+    });
+
     test('fails open on null / empty / unparseable versions', () {
       for (final v in [null, '', '   ', 'nightly', 'unknown', 'abc.def']) {
         check(because: '$v', ServerVersionCompat.isSupported(v)).isTrue();
@@ -47,7 +51,7 @@ void main() {
 
     test('isUnsupported is the inverse of isSupported', () {
       check(ServerVersionCompat.isUnsupported('0.11.0')).isTrue();
-      check(ServerVersionCompat.isUnsupported('0.10.1')).isFalse();
+      check(ServerVersionCompat.isUnsupported('0.10.2')).isFalse();
       check(ServerVersionCompat.isUnsupported(null)).isFalse();
     });
 


### PR DESCRIPTION
Bumps `ServerVersionCompat.maxSupportedVersion` to `0.10.2` and updates the vendored `openwebui-src` submodule to the 0.10.2 release.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Bump max supported Open WebUI version to 0.10.2
> Updates `ServerVersionCompat.maxSupportedVersion` from `0.10.1` to `0.10.2` in [server_version_compat.dart](https://github.com/cogwheel0/conduit/pull/547/files#diff-26aba364aaae3f3a77898e609dfe7b2e3279a54ecdb3244d27ad38bec742a2fb). Tests and the English localization file are updated to match the new boundary, with `0.10.1` now verified as a still-supported older version and `0.10.3` becoming the new unsupported ceiling.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 445e4ca.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated server compatibility checks so the app now recognizes newer supported server versions.
  * Improved version handling for examples with prefixes and pre-release/build suffixes.
  * Refreshed the in-app server incompatibility messages to match the latest supported version.
* **Tests**
  * Adjusted version-compatibility checks to reflect the updated support range and added coverage for the previous maximum supported version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR updates the app's Open WebUI support range to 0.10.2. The main changes are:

- Bumps the supported server version constants.
- Updates localization placeholder examples.
- Advances the vendored Open WebUI submodule pointer.
- Refreshes compatibility tests for the new boundary.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

This looks safe to merge.

No blocking issues were found in the changed code. The version comparison logic is unchanged, and the tests keep coverage for the previous supported version and the new unsupported boundary.

No files need attention.
</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Observed the base checkout and a failing test command (exit code 127) in the before artifact.
- Observed the head checkout and the same failing test command (exit code 127) in the after artifact.
- Encountered a blocker when trying to run tests: /bin/bash reported flutter: command not found and neither dart nor flutter were found in the PATH.
- Compared the base openwebui-src state in the before artifact; the base commit is 02dc3e689ceac915a870b373318b99c029ddf603 and the exact tag lookup failed with version hints v0.9.6-37-g02dc3e689 and package.json version is 0.9.6.
- Compared the head openwebui-src state in the after artifact; the head points to ecd48e2f718220a6400ecf49eafd4867a38feb10, the tag lookup returns v0.10.2, 'git log --decorate' shows HEAD decorated with refs/tags/v0.10.2, and package.json version is 0.10.2.

<a href="https://app.greptile.com/trex/runs/12960576/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=2"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=2"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| lib/core/utils/server_version_compat.dart | Updates the maximum supported Open WebUI version and matching parsed components from 0.10.1 to 0.10.2. |
| lib/l10n/app_en.arb | Updates English localization placeholder examples to show 0.10.2. |
| openwebui-src | Moves the vendored Open WebUI submodule pointer to the newer release commit. |
| test/core/providers/server_incompatible_provider_test.dart | Updates the supported active-server fixture to 0.10.2. |
| test/core/utils/server_version_compat_test.dart | Updates the version boundary tests and keeps explicit coverage that 0.10.1 remains supported. |

</details>

<sub>Reviews (1): Last reviewed commit: ["Bump max supported Open WebUI version to..."](https://github.com/cogwheel0/conduit/commit/445e4caa43c9e59962d464f28f065273f23eb782) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41183668)</sub>

<!-- /greptile_comment -->