### PR TITLE
fix: render slashes in assistant messages instead of &#47; (#549)

### DIFF
--- a/lib/core/services/semantic_message_builder.dart
+++ b/lib/core/services/semantic_message_builder.dart
@@ -193,18 +193,19 @@ String _escape(String value) => _semanticHtmlEscape.convert(value);
 
 // Matches fenced code blocks (``` or ~~~) and single-line inline code spans.
 // Fences must OPEN at the start of a line (0-3 spaces indent); the three
-// alternatives are (1) a fence closed by a matching run of fence characters,
-// (2) an unclosed fence that runs to end of input (as the block parser and
-// [ConduitMarkdownPreprocessor.normalize] treat it — e.g. mid-stream, or when a
-// model forgets the closing fence), and (3) a single-line inline span. Because
-// every fence is anchored to a line start, the matched regions are a strict
-// subset of what the markdown block parser treats as code, so escaping is only
-// ever SKIPPED where the parser would not begin a block — a line-leading
-// `<details>`/`<summary>` can never be smuggled past [_escapeText] via a
-// mid-line fence marker. Inline code is matched one line at a time for the same
-// reason.
+// alternatives are (1) a fence whose closing line repeats the same fence
+// character at least as many times as the opening run (`\1[`~]*`, matching
+// CommonMark's "closing fence may be longer"), (2) an unclosed fence that runs
+// to end of input (as the block parser and [ConduitMarkdownPreprocessor.
+// normalize] treat it — e.g. mid-stream, or when a model forgets the closing
+// fence), and (3) a single-line inline span. Because every fence is anchored to
+// a line start, the matched regions are a strict subset of what the markdown
+// block parser treats as code, so escaping is only ever SKIPPED where the
+// parser would not begin a block — a line-leading `<details>`/`<summary>` can
+// never be smuggled past [_escapeText] via a mid-line fence marker or a longer
+// closing fence. Inline code is matched one line at a time for the same reason.
 final _codeRegionPattern = RegExp(
-  r'(?:^|\n)[ ]{0,3}(`{3,}|~{3,})[^\n]*\n[\s\S]*?\n[ ]{0,3}\1[ \t]*(?=\n|$)'
+  r'(?:^|\n)[ ]{0,3}(`{3,}|~{3,})[^\n]*\n[\s\S]*?\n[ ]{0,3}\1[`~]*[ \t]*(?=\n|$)'
   r'|(?:^|\n)[ ]{0,3}(?:`{3,}|~{3,})[^\n]*\n[\s\S]*$'
   r'|`[^`\n]+?`',
   multiLine: true,

--- a/lib/core/services/semantic_message_builder.dart
+++ b/lib/core/services/semantic_message_builder.dart
@@ -1,6 +1,12 @@
 import 'dart:convert';
 
-const HtmlEscape _semanticHtmlEscape = HtmlEscape();
+// Escape only the characters needed to neutralize HTML tags (`&`, `<`, `>`)
+// and keep double-quoted `<details>` attributes intact (`"`). The default
+// `HtmlEscape()` (HtmlEscapeMode.unknown) additionally escapes `/` -> `&#47;`
+// and `'` -> `&#39;`. Those extra entities are unnecessary for tag safety and
+// are never decoded inside markdown code spans/blocks, so they leak into
+// rendered output (e.g. URLs showing `https:&#47;&#47;`). See issue #549.
+const HtmlEscape _semanticHtmlEscape = HtmlEscape(HtmlEscapeMode.attribute);
 
 /// Semantic assistant-message blocks that can be serialized into the markdown
 /// dialect consumed by Conduit's shared markdown renderer.
@@ -113,7 +119,7 @@ String renderSemanticMessageBlocks(List<SemanticMessageBlock> blocks) {
     switch (block) {
       case SemanticTextBlock(:final text):
         if (text.trim().isNotEmpty) {
-          parts.add(_escape(text));
+          parts.add(_escapeText(text));
         }
       case SemanticDetailsBlock():
         final rendered = _renderDetailsBlock(block);
@@ -184,3 +190,26 @@ String _markdownCodeFence(String code, String language) {
 }
 
 String _escape(String value) => _semanticHtmlEscape.convert(value);
+
+// Matches fenced code blocks (```...```) and single-line inline code spans.
+// Inline spans are intentionally matched one line at a time: a multi-line span
+// must never be able to hide a line-leading `<details>`/`<summary>` from the
+// block parser (see [_escapeText]).
+final _codeRegionPattern = RegExp(r'```[\s\S]*?```|`[^`\n]+?`');
+
+/// Escapes HTML-significant characters in plain answer text while leaving the
+/// contents of markdown code spans and fenced code blocks untouched.
+///
+/// Answer text is re-parsed by the markdown pipeline, which does not decode
+/// entity references inside code spans/fences. Escaping those regions leaks
+/// literal entities into the rendered output (e.g. `List&lt;int&gt;`,
+/// `https:&#47;&#47;`). Text outside code is still escaped so a model cannot
+/// emit a literal `<details>`/`<summary>` block that renders as a spoofed
+/// reasoning/tool section. Unlike [_escape], this is only safe for top-level
+/// answer text; `<details>` attributes/summaries/bodies are HTML-unescaped
+/// wholesale at parse time and must keep full escaping.
+String _escapeText(String value) => value.splitMapJoin(
+  _codeRegionPattern,
+  onMatch: (match) => match[0] ?? '',
+  onNonMatch: _escape,
+);

--- a/lib/core/services/semantic_message_builder.dart
+++ b/lib/core/services/semantic_message_builder.dart
@@ -191,39 +191,79 @@ String _markdownCodeFence(String code, String language) {
 
 String _escape(String value) => _semanticHtmlEscape.convert(value);
 
-// Matches fenced code blocks (``` or ~~~) and single-line inline code spans.
-// Fences must OPEN at the start of a line (0-3 spaces indent); the three
-// alternatives are (1) a fence whose closing line repeats the same fence
-// character at least as many times as the opening run (`\1[`~]*`, matching
-// CommonMark's "closing fence may be longer"), (2) an unclosed fence that runs
-// to end of input (as the block parser and [ConduitMarkdownPreprocessor.
-// normalize] treat it — e.g. mid-stream, or when a model forgets the closing
-// fence), and (3) a single-line inline span. Because every fence is anchored to
-// a line start, the matched regions are a strict subset of what the markdown
-// block parser treats as code, so escaping is only ever SKIPPED where the
-// parser would not begin a block — a line-leading `<details>`/`<summary>` can
-// never be smuggled past [_escapeText] via a mid-line fence marker or a longer
-// closing fence. Inline code is matched one line at a time for the same reason.
-final _codeRegionPattern = RegExp(
-  r'(?:^|\n)[ ]{0,3}(`{3,}|~{3,})[^\n]*\n[\s\S]*?\n[ ]{0,3}\1[`~]*[ \t]*(?=\n|$)'
-  r'|(?:^|\n)[ ]{0,3}(?:`{3,}|~{3,})[^\n]*\n[\s\S]*$'
-  r'|`[^`\n]+?`',
-  multiLine: true,
-);
+// Line-anchored fence patterns used by [_escapeText], mirroring the markdown
+// block parser (CommonMark fenced code blocks). A backtick fence opens on a
+// line of 3+ backticks (0-3 spaces indent) whose info string has no backtick; a
+// tilde fence opens on 3+ tildes. A fence closes on a line of the same fence
+// character repeated at least as many times as the opener, followed only by
+// whitespace. Because open/close detection matches the parser exactly, the code
+// regions [_escapeText] skips equal the parser's — a line-leading `<details>`/
+// `<summary>` can never be smuggled through unescaped (via a mid-line marker,
+// a longer/shorter closing fence, a backtick in the info string, etc.).
+final _openingBacktickFence = RegExp(r'^ {0,3}(`{3,})[^`]*$');
+final _openingTildeFence = RegExp(r'^ {0,3}(~{3,}).*$');
+final _closingFence = RegExp(r'^ {0,3}(`{3,}|~{3,})[ \t]*\r?$');
+final _inlineCodeSpan = RegExp(r'`[^`]+?`');
 
 /// Escapes HTML-significant characters in plain answer text while leaving the
-/// contents of markdown code spans and fenced code blocks untouched.
+/// contents of fenced code blocks and inline code spans untouched.
 ///
 /// Answer text is re-parsed by the markdown pipeline, which does not decode
-/// entity references inside code spans/fences. Escaping those regions leaks
-/// literal entities into the rendered output (e.g. `List&lt;int&gt;`,
-/// `https:&#47;&#47;`). Text outside code is still escaped so a model cannot
-/// emit a literal `<details>`/`<summary>` block that renders as a spoofed
-/// reasoning/tool section. Unlike [_escape], this is only safe for top-level
-/// answer text; `<details>` attributes/summaries/bodies are HTML-unescaped
-/// wholesale at parse time and must keep full escaping.
-String _escapeText(String value) => value.splitMapJoin(
-  _codeRegionPattern,
-  onMatch: (match) => match[0] ?? '',
-  onNonMatch: _escape,
-);
+/// entity references inside code spans/fences; escaping there would leak literal
+/// entities into rendered output (e.g. `List&lt;int&gt;`, `https:&#47;&#47;`).
+/// Text outside code is still escaped so a model cannot emit a literal
+/// `<details>`/`<summary>` that renders as a spoofed reasoning/tool section.
+///
+/// The scan is line-based and mirrors the block parser's fenced-code handling,
+/// including unclosed fences (which extend to end of input, e.g. mid-stream),
+/// so the skipped regions are exactly the parser's code and escaping is never
+/// skipped where the parser would begin a block. Inline code is matched a
+/// single line at a time so a multi-line span cannot hide a line-leading tag.
+///
+/// Unlike [_escape], this is only safe for top-level answer text; `<details>`
+/// attributes/summaries/bodies are HTML-unescaped wholesale at parse time and
+/// must keep full escaping.
+String _escapeText(String value) {
+  final lines = value.split('\n');
+  final result = <String>[];
+  String? openFenceChar;
+  var openFenceLength = 0;
+
+  for (final line in lines) {
+    if (openFenceChar != null) {
+      // Inside a fenced block: emit verbatim, closing on a matching fence line.
+      result.add(line);
+      final close = _closingFence.firstMatch(line);
+      if (close != null) {
+        final run = close.group(1)!;
+        if (run[0] == openFenceChar && run.length >= openFenceLength) {
+          openFenceChar = null;
+          openFenceLength = 0;
+        }
+      }
+      continue;
+    }
+
+    final open =
+        _openingBacktickFence.firstMatch(line) ??
+        _openingTildeFence.firstMatch(line);
+    if (open != null) {
+      final run = open.group(1)!;
+      openFenceChar = run[0];
+      openFenceLength = run.length;
+      result.add(line);
+      continue;
+    }
+
+    // Outside any code block: escape everything except inline code spans.
+    result.add(
+      line.splitMapJoin(
+        _inlineCodeSpan,
+        onMatch: (match) => match[0] ?? '',
+        onNonMatch: _escape,
+      ),
+    );
+  }
+
+  return result.join('\n');
+}

--- a/lib/core/services/semantic_message_builder.dart
+++ b/lib/core/services/semantic_message_builder.dart
@@ -191,11 +191,20 @@ String _markdownCodeFence(String code, String language) {
 
 String _escape(String value) => _semanticHtmlEscape.convert(value);
 
-// Matches fenced code blocks (```...```) and single-line inline code spans.
-// Inline spans are intentionally matched one line at a time: a multi-line span
-// must never be able to hide a line-leading `<details>`/`<summary>` from the
-// block parser (see [_escapeText]).
-final _codeRegionPattern = RegExp(r'```[\s\S]*?```|`[^`\n]+?`');
+// Matches fenced code blocks (``` or ~~~) and single-line inline code spans.
+// Fences must open and close at the start of a line (0-3 spaces indent) with a
+// matching run of fence characters, so the matched regions are a strict subset
+// of what the markdown block parser treats as code. Escaping is therefore only
+// ever SKIPPED where the parser would not begin a block, so a line-leading
+// `<details>`/`<summary>` can never be smuggled past [_escapeText] via a
+// mid-line fence marker. Inline code is matched one line at a time for the same
+// reason. Mismatched or unclosed fences fall back to being escaped as prose
+// (the safe direction — worst case is a rare cosmetic entity, never injection).
+final _codeRegionPattern = RegExp(
+  r'(?:^|\n)[ ]{0,3}(`{3,}|~{3,})[^\n]*\n[\s\S]*?\n[ ]{0,3}\1[ \t]*(?=\n|$)'
+  r'|`[^`\n]+?`',
+  multiLine: true,
+);
 
 /// Escapes HTML-significant characters in plain answer text while leaving the
 /// contents of markdown code spans and fenced code blocks untouched.

--- a/lib/core/services/semantic_message_builder.dart
+++ b/lib/core/services/semantic_message_builder.dart
@@ -202,7 +202,7 @@ String _escape(String value) => _semanticHtmlEscape.convert(value);
 // a longer/shorter closing fence, a backtick in the info string, etc.).
 final _openingBacktickFence = RegExp(r'^ {0,3}(`{3,})[^`]*$');
 final _openingTildeFence = RegExp(r'^ {0,3}(~{3,}).*$');
-final _closingFence = RegExp(r'^ {0,3}(`{3,}|~{3,})[ \t]*\r?$');
+final _closingFence = RegExp(r'^ {0,3}(`{3,}|~{3,})[ \t]*$');
 final _inlineCodeSpan = RegExp(r'`[^`]+?`');
 
 /// Escapes HTML-significant characters in plain answer text while leaving the
@@ -229,7 +229,12 @@ String _escapeText(String value) {
   String? openFenceChar;
   var openFenceLength = 0;
 
-  for (final line in lines) {
+  for (final rawLine in lines) {
+    // Normalize CRLF: split('\n') leaves a trailing '\r' the fence patterns
+    // (and the downstream renderer) would otherwise mishandle.
+    final line = rawLine.endsWith('\r')
+        ? rawLine.substring(0, rawLine.length - 1)
+        : rawLine;
     if (openFenceChar != null) {
       // Inside a fenced block: emit verbatim, closing on a matching fence line.
       result.add(line);

--- a/lib/core/services/semantic_message_builder.dart
+++ b/lib/core/services/semantic_message_builder.dart
@@ -192,16 +192,20 @@ String _markdownCodeFence(String code, String language) {
 String _escape(String value) => _semanticHtmlEscape.convert(value);
 
 // Matches fenced code blocks (``` or ~~~) and single-line inline code spans.
-// Fences must open and close at the start of a line (0-3 spaces indent) with a
-// matching run of fence characters, so the matched regions are a strict subset
-// of what the markdown block parser treats as code. Escaping is therefore only
-// ever SKIPPED where the parser would not begin a block, so a line-leading
+// Fences must OPEN at the start of a line (0-3 spaces indent); the three
+// alternatives are (1) a fence closed by a matching run of fence characters,
+// (2) an unclosed fence that runs to end of input (as the block parser and
+// [ConduitMarkdownPreprocessor.normalize] treat it — e.g. mid-stream, or when a
+// model forgets the closing fence), and (3) a single-line inline span. Because
+// every fence is anchored to a line start, the matched regions are a strict
+// subset of what the markdown block parser treats as code, so escaping is only
+// ever SKIPPED where the parser would not begin a block — a line-leading
 // `<details>`/`<summary>` can never be smuggled past [_escapeText] via a
 // mid-line fence marker. Inline code is matched one line at a time for the same
-// reason. Mismatched or unclosed fences fall back to being escaped as prose
-// (the safe direction — worst case is a rare cosmetic entity, never injection).
+// reason.
 final _codeRegionPattern = RegExp(
   r'(?:^|\n)[ ]{0,3}(`{3,}|~{3,})[^\n]*\n[\s\S]*?\n[ ]{0,3}\1[ \t]*(?=\n|$)'
+  r'|(?:^|\n)[ ]{0,3}(?:`{3,}|~{3,})[^\n]*\n[\s\S]*$'
   r'|`[^`\n]+?`',
   multiLine: true,
 );

--- a/test/core/services/openwebui_stream_parser_test.dart
+++ b/test/core/services/openwebui_stream_parser_test.dart
@@ -612,7 +612,7 @@ void main() {
         ]),
       );
 
-      check(serialized).contains('&lt;&#47;details&gt;');
+      check(serialized).contains('&lt;/details&gt;');
       check(serialized).contains('duration="1&quot; autofocus=&quot;true"');
       check(serialized).contains('id="call&quot; onmouseover=&quot;x"');
       check(serialized).contains('name="tool&lt;script&gt;"');

--- a/test/core/services/semantic_message_builder_test.dart
+++ b/test/core/services/semantic_message_builder_test.dart
@@ -1,0 +1,108 @@
+import 'package:checks/checks.dart';
+import 'package:conduit/core/services/semantic_message_builder.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('renderSemanticMessageBlocks', () {
+    // Regression for https://github.com/cogwheel0/conduit/issues/549: forward
+    // slashes were HTML-escaped to `&#47;` by the default HtmlEscape mode, which
+    // is never decoded inside markdown code spans/blocks and leaked into the UI
+    // (e.g. `https:&#47;&#47;`).
+    test('preserves forward slashes in text blocks', () {
+      final rendered = renderSemanticMessageBlocks([
+        const SemanticTextBlock('See https://example.com/path and `a/b`.'),
+      ]);
+
+      check(rendered).contains('https://example.com/path');
+      check(rendered).contains('`a/b`');
+      check(rendered).not((it) => it.contains('&#47;'));
+      check(rendered).not((it) => it.contains('&#x2F;'));
+    });
+
+    test('preserves apostrophes in text blocks', () {
+      final rendered = renderSemanticMessageBlocks([
+        const SemanticTextBlock("it's a `don't` case"),
+      ]);
+
+      check(rendered).contains("it's a `don't` case");
+      check(rendered).not((it) => it.contains('&#39;'));
+    });
+
+    test('still neutralizes literal HTML tags in text blocks', () {
+      final rendered = renderSemanticMessageBlocks([
+        const SemanticTextBlock('<details><summary>evil</summary></details>'),
+      ]);
+
+      check(rendered).contains('&lt;details&gt;');
+      check(rendered).contains('&lt;/details&gt;');
+      check(rendered).not((it) => it.contains('<details>'));
+    });
+
+    // The markdown renderer never decodes entity references inside code spans
+    // or fenced code blocks, so text-block escaping must leave those regions
+    // untouched (same failure class as #549, extended to `<` `>` `&` `"`).
+    test('leaves inline code spans unescaped', () {
+      final rendered = renderSemanticMessageBlocks([
+        const SemanticTextBlock('generic `List<int>` and url `https://x/a&b`'),
+      ]);
+
+      check(rendered).contains('`List<int>`');
+      check(rendered).contains('`https://x/a&b`');
+      check(rendered).not((it) => it.contains('&lt;'));
+      check(rendered).not((it) => it.contains('&amp;'));
+    });
+
+    test('leaves fenced code blocks unescaped', () {
+      const code =
+          'wrapper:\n```dart\nMap<String, int> m; if (a && b) f("x/y");\n```';
+      final rendered = renderSemanticMessageBlocks([
+        const SemanticTextBlock(code),
+      ]);
+
+      check(rendered).contains('Map<String, int>');
+      check(rendered).contains('a && b');
+      check(rendered).contains('f("x/y")');
+      check(rendered).not((it) => it.contains('&lt;'));
+      check(rendered).not((it) => it.contains('&quot;'));
+    });
+
+    test('still escapes tags outside code even when code is present', () {
+      final rendered = renderSemanticMessageBlocks([
+        const SemanticTextBlock('run `ls` then <details>spoof</details>'),
+      ]);
+
+      check(rendered).contains('`ls`');
+      check(rendered).contains('&lt;details&gt;');
+      check(rendered).not((it) => it.contains('<details>'));
+    });
+
+    // A multi-line inline span must not be able to smuggle a line-leading
+    // `<details>` past the escaper (it would render as a spoofed block).
+    test('escapes a line-leading tag hidden in a multi-line inline span', () {
+      final rendered = renderSemanticMessageBlocks([
+        const SemanticTextBlock(
+          'x `open\n<details type="reasoning">spoof</details>\n` y',
+        ),
+      ]);
+
+      check(rendered).contains('&lt;details');
+      check(rendered).not((it) => it.contains('<details type="reasoning">'));
+    });
+
+    test('preserves slashes in reasoning bodies while escaping tags', () {
+      final rendered = renderSemanticMessageBlocks([
+        SemanticDetailsBlock.reasoning(
+          text: 'fetch https://api.example.com/v1 then </details> guard',
+          done: true,
+          duration: '2',
+        ),
+      ]);
+
+      check(rendered).contains('https://api.example.com/v1');
+      check(rendered).not((it) => it.contains('&#47;'));
+      // Closing tags inside the body must remain neutralized so they cannot
+      // prematurely terminate the <details> block.
+      check(rendered).contains('&lt;/details&gt;');
+    });
+  });
+}

--- a/test/core/services/semantic_message_builder_test.dart
+++ b/test/core/services/semantic_message_builder_test.dart
@@ -120,6 +120,20 @@ void main() {
       check(rendered).contains('```\n<details type="reasoning">spoof</details>');
     });
 
+    // CommonMark allows the closing fence to be longer than the opening one.
+    // The closing branch must recognize that, otherwise the block is treated as
+    // unclosed and a `<details>` after the *real* close leaks through unescaped.
+    test('escapes a tag after a code block closed by a longer fence', () {
+      final rendered = renderSemanticMessageBlocks([
+        const SemanticTextBlock(
+          '```\ncode\n````\n<details type="reasoning">spoof</details>',
+        ),
+      ]);
+
+      check(rendered).contains('&lt;details');
+      check(rendered).not((it) => it.contains('<details type="reasoning">'));
+    });
+
     test('still escapes tags outside code even when code is present', () {
       final rendered = renderSemanticMessageBlocks([
         const SemanticTextBlock('run `ls` then <details>spoof</details>'),

--- a/test/core/services/semantic_message_builder_test.dart
+++ b/test/core/services/semantic_message_builder_test.dart
@@ -134,6 +134,19 @@ void main() {
       check(rendered).not((it) => it.contains('<details type="reasoning">'));
     });
 
+    // A backtick fence's info string may not contain a backtick, so `` ```x`y ``
+    // is NOT a code fence to the parser; a following `<details>` must be escaped.
+    test('escapes a tag after a non-fence line with backtick in info', () {
+      final rendered = renderSemanticMessageBlocks([
+        const SemanticTextBlock(
+          '```x`y\n<details type="reasoning">spoof</details>\nmore',
+        ),
+      ]);
+
+      check(rendered).contains('&lt;details');
+      check(rendered).not((it) => it.contains('<details type="reasoning">'));
+    });
+
     test('still escapes tags outside code even when code is present', () {
       final rendered = renderSemanticMessageBlocks([
         const SemanticTextBlock('run `ls` then <details>spoof</details>'),

--- a/test/core/services/semantic_message_builder_test.dart
+++ b/test/core/services/semantic_message_builder_test.dart
@@ -66,6 +66,33 @@ void main() {
       check(rendered).not((it) => it.contains('&quot;'));
     });
 
+    // `~~~` fences are code blocks too (GFM); their contents must be preserved.
+    test('leaves ~~~ fenced code blocks unescaped', () {
+      const code = 'wrapper:\n~~~dart\nMap<String, int> m; f("x/y") && g;\n~~~';
+      final rendered = renderSemanticMessageBlocks([
+        const SemanticTextBlock(code),
+      ]);
+
+      check(rendered).contains('Map<String, int>');
+      check(rendered).contains('f("x/y") && g');
+      check(rendered).not((it) => it.contains('&lt;'));
+      check(rendered).not((it) => it.contains('&quot;'));
+    });
+
+    // A fence marker that is NOT at the start of a line must not create a code
+    // region the block parser disagrees with; otherwise a line-leading
+    // `<details>` could slip through unescaped and render as a spoofed block.
+    test('escapes a line-leading tag after a mid-line fence marker', () {
+      final rendered = renderSemanticMessageBlocks([
+        const SemanticTextBlock(
+          'see ``` mid\n<details type="reasoning">spoof</details>\n``` end',
+        ),
+      ]);
+
+      check(rendered).contains('&lt;details');
+      check(rendered).not((it) => it.contains('<details type="reasoning">'));
+    });
+
     test('still escapes tags outside code even when code is present', () {
       final rendered = renderSemanticMessageBlocks([
         const SemanticTextBlock('run `ls` then <details>spoof</details>'),

--- a/test/core/services/semantic_message_builder_test.dart
+++ b/test/core/services/semantic_message_builder_test.dart
@@ -147,6 +147,20 @@ void main() {
       check(rendered).not((it) => it.contains('<details type="reasoning">'));
     });
 
+    // CRLF input must be recognized as fences too, otherwise code content
+    // (especially `~~~` blocks) is escaped and leaks entities.
+    test('recognizes fenced code blocks with CRLF line endings', () {
+      const body = 'a\n~~~\nMap<String, int> m = f("x/y");\n~~~\nb';
+      final rendered = renderSemanticMessageBlocks([
+        SemanticTextBlock(body.replaceAll('\n', '\r\n')),
+      ]);
+
+      check(rendered).contains('Map<String, int>');
+      check(rendered).contains('f("x/y")');
+      check(rendered).not((it) => it.contains('&lt;'));
+      check(rendered).not((it) => it.contains('&quot;'));
+    });
+
     test('still escapes tags outside code even when code is present', () {
       final rendered = renderSemanticMessageBlocks([
         const SemanticTextBlock('run `ls` then <details>spoof</details>'),

--- a/test/core/services/semantic_message_builder_test.dart
+++ b/test/core/services/semantic_message_builder_test.dart
@@ -93,6 +93,33 @@ void main() {
       check(rendered).not((it) => it.contains('<details type="reasoning">'));
     });
 
+    // Unclosed fences (mid-stream, or a model that forgets the closing fence)
+    // are still treated as code by the renderer, so their contents must not be
+    // escaped either.
+    test('leaves unclosed fenced code blocks unescaped', () {
+      final rendered = renderSemanticMessageBlocks([
+        const SemanticTextBlock('intro\n```dart\nMap<String, int> m = f("a/b");'),
+      ]);
+
+      check(rendered).contains('Map<String, int>');
+      check(rendered).contains('f("a/b")');
+      check(rendered).not((it) => it.contains('&lt;'));
+      check(rendered).not((it) => it.contains('&quot;'));
+    });
+
+    // A `<details>` after an unclosed fence is inside a code block, so it must
+    // not be smuggled out as a rendered block even though it is left unescaped.
+    test('unclosed fence keeps a following tag inside the code block', () {
+      final rendered = renderSemanticMessageBlocks([
+        const SemanticTextBlock(
+          'intro\n```\n<details type="reasoning">spoof</details>',
+        ),
+      ]);
+
+      // Left verbatim inside the (unclosed) code fence, not escaped as prose...
+      check(rendered).contains('```\n<details type="reasoning">spoof</details>');
+    });
+
     test('still escapes tags outside code even when code is present', () {
       final rendered = renderSemanticMessageBlocks([
         const SemanticTextBlock('run `ls` then <details>spoof</details>'),


### PR DESCRIPTION
## Summary

Fixes #549 — assistant messages rendered `/` as the literal HTML entity `&#47;` (e.g. `https:&#47;&#47;`), starting with 3.4.1/3.4.2.

**Root cause:** `semantic_message_builder.dart` reconstructs assistant content (answer text + reasoning/tool `<details>` blocks) and escaped text with Dart's **default** `HtmlEscape()` — `HtmlEscapeMode.unknown`, which encodes `/`→`&#47;` and `'`→`&#39;` in addition to `& < > "`. The markdown renderer decodes those entities in prose (via the `markdown` package's `DecodeHtmlSyntax`), but **never inside inline code, fenced code blocks, or link destinations** — so slashes there (URLs, paths, `a/b`) leaked to the screen. OpenWebUI's server uses Python `html.escape`, which does not escape `/`, so this over-escaping was Conduit-specific.

## Changes

- Switch the shared escaper to `HtmlEscapeMode.attribute` (`& < > "` only) — drops the leaky `/` and `'` while keeping everything needed to neutralize HTML tags and to keep double-quoted `<details>` attributes intact.
- Add `_escapeText`: plain answer text (`SemanticTextBlock`) is now escaped **only outside** code spans/fenced blocks, so `<`, `>`, `&`, `"` no longer leak inside code either (the same failure class, extended). `<details>` attributes/summaries/bodies keep full escaping — they're HTML-unescaped wholesale by `DetailsBlockSyntax._decode` at parse time and don't leak, and the body must keep escaping `</details>` for tag-counting.

## Safety

The one real risk was UI-spoofing: skipping escaping inside "code" could let a model inject a fake `<details type="reasoning">` block. Guard: inline-code matching is restricted to a **single line** (`` `[^`\n]+?` ``), a strict subset of real code spans, so a multi-line span can't hide a line-leading tag from the block parser. Validated adversarially against the real `DetailsBlockSyntax` — inline, fenced, multi-line-inline, double-backtick, and indented `<details>` spoofs all stay neutralized.

## Tests

- New `semantic_message_builder_test.dart` (8 cases): slashes, apostrophes, inline-code, fenced-code, tag neutralization, multi-line-inline injection — **8/8**.
- `openwebui_stream_parser_test.dart` — **36/36** (updated one assertion that hard-coded the `/`-escaping byproduct: `&lt;&#47;details&gt;` → `&lt;/details&gt;`).
- `conversation_parsing_test.dart` — **44/44** (incl. `<details>`-neutralization tests).
- `flutter analyze` — clean.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix slash rendering in assistant messages by switching HTML escape mode
> - Changes `_semanticHtmlEscape` from `HtmlEscape()` to `HtmlEscape(HtmlEscapeMode.attribute)` so `/` and apostrophes are no longer converted to `/` and `'` in assistant message output.
> - Adds `_escapeText`, which escapes HTML-significant characters only in prose regions, leaving fenced code blocks (backtick and tilde) and inline code spans untouched.
> - Updates `renderSemanticMessageBlocks` to use `_escapeText` instead of the raw `_escape` call for `SemanticTextBlock` content.
> - Behavioral Change: `</details>` and similar HTML tags in plain text are now neutralized via escaping, while the same tags inside code spans/blocks are emitted verbatim.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 76e787f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved HTML escaping for rendered semantic messages to remove unintended extra entities and better neutralize tag spoofing (including `</details>`/`<summary>`-style sequences).
  * Prose is now escaped while preserving URLs (e.g., forward slashes) and apostrophes; inline/backtick and fenced code blocks remain unmodified.

* **Tests**
  * Updated the stream parser test to expect `</details>` to render as `&lt;/details&gt;`.
  * Added a new regression suite covering escaping and code-region boundary/spoofing edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes assistant message rendering so slash and apostrophe characters no longer appear as HTML entities. The main changes are:

- Switch semantic HTML escaping to attribute mode for generated message markup.
- Escape plain answer text while preserving inline code and fenced code regions.
- Keep generated `<details>` attributes, summaries, and bodies escaped for tag safety.
- Add tests for slash rendering, code spans, fenced code, CRLF input, and details-block spoofing cases.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge with minimal risk.

The change is localized to semantic message serialization and tests. The implementation keeps generated details markup escaped while preserving markdown code regions. The tests cover the main rendering and spoofing edge cases reviewed.

No files require special attention.
</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- We confirmed that Flutter and Dart are not on PATH, based on the semantic-message-availability.log.
- The semantic message builder test invocation could not start because Flutter was not found on PATH, with /bin/sh: flutter: not found and exit code 127, as shown in the semantic-message-builder-test-blocker.log.

<a href="https://app.greptile.com/trex/runs/13892575/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| lib/core/services/semantic_message_builder.dart | Switches semantic HTML escaping to attribute mode and adds line-aware text escaping that preserves inline and fenced code while escaping prose and generated details content. |
| test/core/services/openwebui_stream_parser_test.dart | Updates the escaping expectation for generated details content now that closing slashes are no longer over-escaped. |
| test/core/services/semantic_message_builder_test.dart | Adds tests for entity rendering, code preservation, tag neutralization, CRLF handling, and prior spoofing edge cases. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
participant Parser as OpenWebUI stream parser
participant Builder as renderSemanticMessageBlocks
participant Escaper as _escapeText / _escape
participant Markdown as Markdown renderer

Parser->>Builder: SemanticTextBlock + SemanticDetailsBlock
Builder->>Escaper: Escape text blocks line-by-line
Escaper-->>Builder: Prose escaped, inline/fenced code preserved
Builder->>Escaper: Escape details attrs/summary/body
Escaper-->>Builder: Details content tag-safe
Builder->>Markdown: Serialized markdown/details markup
Markdown-->>Markdown: Decode prose/entities, preserve code text
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
participant Parser as OpenWebUI stream parser
participant Builder as renderSemanticMessageBlocks
participant Escaper as _escapeText / _escape
participant Markdown as Markdown renderer

Parser->>Builder: SemanticTextBlock + SemanticDetailsBlock
Builder->>Escaper: Escape text blocks line-by-line
Escaper-->>Builder: Prose escaped, inline/fenced code preserved
Builder->>Escaper: Escape details attrs/summary/body
Escaper-->>Builder: Details content tag-safe
Builder->>Markdown: Serialized markdown/details markup
Markdown-->>Markdown: Decode prose/entities, preserve code text
```

</a>
</details>

<sub>Reviews (6): Last reviewed commit: ["fix: normalize CRLF line endings in \_esc..."](https://github.com/cogwheel0/conduit/commit/76e787fab3c410b8c1309a62ba78daedd68153a4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43058852)</sub>

<!-- /greptile_comment -->