### PR TITLE
fix: request iOS microphone permission in voice preflight (#557)

### DIFF
--- a/lib/features/chat/services/voice_input_service.dart
+++ b/lib/features/chat/services/voice_input_service.dart
@@ -382,7 +382,14 @@ class VoiceInputService {
   Future<bool> _ensureMicrophonePermission() async {
     try {
       final status = await Permission.microphone.status;
-      return status.isGranted;
+      if (status.isGranted) {
+        return true;
+      }
+      // On a fresh install iOS reports the "not determined" state as denied.
+      // Actively request so the system permission dialog is surfaced instead
+      // of silently failing the voice flow. A permanently denied permission
+      // simply returns its current status without re-prompting.
+      return await requestMicrophonePermission();
     } catch (_) {
       return false;
     }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -118,6 +118,9 @@ dev_dependencies:
   pigeon: ^27.1.0
   drift_dev: ^2.34.0
   fake_async: ^1.3.3
+  # Used only in tests to mock the microphone permission platform channel.
+  permission_handler_platform_interface: ^4.3.0
+  plugin_platform_interface: ^2.1.8
 
 flutter:
   config:

--- a/test/features/chat/services/voice_input_service_test.dart
+++ b/test/features/chat/services/voice_input_service_test.dart
@@ -2,9 +2,83 @@ import 'package:checks/checks.dart';
 import 'package:conduit/features/chat/services/voice_input_service.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:permission_handler_platform_interface/permission_handler_platform_interface.dart';
+import 'package:plugin_platform_interface/plugin_platform_interface.dart';
 import 'package:vad/vad.dart';
 
 void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  // Regression guard for issue #557: on a fresh install iOS reports the mic
+  // permission as "denied" (not-determined). checkPermissions() must actively
+  // REQUEST the permission so the system dialog appears, rather than only
+  // reading the current status and silently failing the voice flow.
+  group('VoiceInputService.checkPermissions', () {
+    late _MockPermissionHandlerPlatform mockPermissions;
+    late PermissionHandlerPlatform originalPlatform;
+
+    setUpAll(() {
+      registerFallbackValue(<Permission>[Permission.microphone]);
+    });
+
+    setUp(() {
+      originalPlatform = PermissionHandlerPlatform.instance;
+      mockPermissions = _MockPermissionHandlerPlatform();
+      PermissionHandlerPlatform.instance = mockPermissions;
+    });
+
+    tearDown(() {
+      PermissionHandlerPlatform.instance = originalPlatform;
+    });
+
+    test('requests the microphone dialog when status is not granted', () async {
+      when(
+        () => mockPermissions.checkPermissionStatus(Permission.microphone),
+      ).thenAnswer((_) async => PermissionStatus.denied);
+      when(
+        () => mockPermissions.requestPermissions(any()),
+      ).thenAnswer(
+        (_) async => {Permission.microphone: PermissionStatus.granted},
+      );
+
+      final granted = await VoiceInputService().checkPermissions();
+
+      check(granted).isTrue();
+      // The core of the bug: it must call requestPermissions, not just read.
+      verify(() => mockPermissions.requestPermissions(any())).called(1);
+    });
+
+    test('does not re-prompt when permission is already granted', () async {
+      when(
+        () => mockPermissions.checkPermissionStatus(Permission.microphone),
+      ).thenAnswer((_) async => PermissionStatus.granted);
+
+      final granted = await VoiceInputService().checkPermissions();
+
+      check(granted).isTrue();
+      verifyNever(() => mockPermissions.requestPermissions(any()));
+    });
+
+    test(
+      'returns false without granting when the user denies the request',
+      () async {
+        when(
+          () => mockPermissions.checkPermissionStatus(Permission.microphone),
+        ).thenAnswer((_) async => PermissionStatus.denied);
+        when(
+          () => mockPermissions.requestPermissions(any()),
+        ).thenAnswer(
+          (_) async => {Permission.microphone: PermissionStatus.denied},
+        );
+
+        final granted = await VoiceInputService().checkPermissions();
+
+        check(granted).isFalse();
+        verify(() => mockPermissions.requestPermissions(any())).called(1);
+      },
+    );
+  });
   group('VoiceInputService.silenceDurationToVadFrames', () {
     test('does not shorten the requested pause window', () {
       check(VoiceInputService.silenceDurationToVadFrames(2000)).equals(63);
@@ -145,3 +219,7 @@ class _FakeVoiceInputService extends VoiceInputService {
   @override
   Future<void> dispose() async {}
 }
+
+class _MockPermissionHandlerPlatform extends Mock
+    with MockPlatformInterfaceMixin
+    implements PermissionHandlerPlatform {}


### PR DESCRIPTION
Fixes #557 — on iOS the app never asked for microphone permission and Voice mode failed immediately with `Exception: Microphone permission not granted`.

## Root cause

The voice preflight `beginListening()` → `checkPermissions()` → `_ensureMicrophonePermission()` only **read** the permission status and never **requested** it:

```dart
final status = await Permission.microphone.status; // only reads — never prompts
return status.isGranted;
```

On a fresh install iOS reports the mic permission as "not determined", which `permission_handler` maps to `PermissionStatus.denied`. So the method returned `false` and `beginListening()` threw without ever showing the system permission dialog. The method that actually prompts — `requestMicrophonePermission()` (calls `.request()`) — existed but was **dead code with zero call sites**.

This explains all three reported symptoms:
- **No permission prompt** — `.status` never triggers the iOS dialog.
- **Immediate "Microphone permission not granted" exception** — thrown by the preflight.
- **No microphone toggle under Settings → Conduit** — iOS only lists the toggle once an app has *requested* the permission at least once.

Regression introduced in `4cbb8a62` ("Implement voice call functionality"), which replaced the previous `record`-package probe — whose `hasPermission()` does prompt on iOS — with a status-only `permission_handler` read.

`Info.plist` (`NSMicrophoneUsageDescription`, `NSSpeechRecognitionUsageDescription`) and the Podfile permission macros (`PERMISSION_MICROPHONE=1`, `PERMISSION_SPEECH_RECOGNIZER=1`) were already correct — the defect was purely Dart-side.

## Fix

`_ensureMicrophonePermission()` now requests the permission when it isn't already granted, reusing the existing `requestMicrophonePermission()`:

```dart
final status = await Permission.microphone.status;
if (status.isGranted) return true;
// Fresh install reports "not determined" as denied; actively request so
// the iOS dialog is surfaced instead of silently failing. A permanently
// denied permission returns without re-prompting.
return await requestMicrophonePermission();
```

This is centralized in the single method reached by all three user-initiated voice entry points (Voice mode, composer hold-to-talk mic, notes dictation). The server-only STT path is unaffected (it already skips this preflight and lets the `record` pipeline request the mic). Double-requesting on the device-only path (permission_handler, then the native `SFSpeechRecognizer`/`AVAudioSession` request) is harmless — iOS shows each dialog once and returns the cached result thereafter.

## Tests

Adds a `VoiceInputService.checkPermissions` regression group that mocks `PermissionHandlerPlatform` and asserts the preflight calls `requestPermissions` (not just `checkPermissionStatus`) when the mic isn't granted, plus the already-granted (no re-prompt) and denied (returns false) paths. `permission_handler_platform_interface` and `plugin_platform_interface` are declared as dev-only deps for the mock.

> Note: the fix file passes `flutter analyze` and the new tests were verified against the `permission_handler` 12.0.3 API by inspection, but the local Flutter test runner was hitting an intermittent `flutter_tester` load hang in this environment — please let CI run the suite.

## Follow-up (out of scope, pre-existing)
- When a user permanently denies the mic, there's no "Open Settings" recovery path — voice input just fails with a generic error. Worth a future UX improvement (detect `isPermanentlyDenied` and offer `openAppSettings()`).

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix iOS microphone permission request in voice input preflight
> Previously, `VoiceInputService._ensureMicrophonePermission` only checked the current permission status and returned `false` if not granted, never surfacing the system dialog. It now calls `requestMicrophonePermission()` when permission is not already granted. Tests are added to cover the denied-then-granted, already-granted, and user-denies scenarios using a mocked `PermissionHandlerPlatform`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0c426e9.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved microphone permission handling by prompting users when access has not yet been decided.
  * Correctly recognizes already-granted microphone access without showing another prompt.
  * Accurately handles denied microphone requests.

* **Tests**
  * Added coverage for granted, denied, and newly requested microphone permission scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR makes the voice permission preflight actively request microphone access. The main changes are:

- Requests microphone permission when the current status is not granted.
- Adds tests for request, already-granted, and denied permission paths.
- Adds dev-only platform-interface dependencies for the permission mock.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

This looks safe to merge after a small cleanup to avoid permission prompts from automatic voice retries.

The iOS fresh-install path now reaches the system permission request, and the server-only voice path remains outside this preflight.

One automatic voice retry path can re-enter the new request call after a prior denial.
</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Validated the environment by running 'command -v flutter' and 'command -v dart'; both commands failed to locate the tools.
- Reviewed the voice permission inspection fallback path to understand how permission status is checked and when requestMicrophonePermission() is invoked.
- Confirmed the regression tests cover the scenarios: request-when-denied, no-request-when-granted, and false-after-denial.
- Verified that the implementation triggers a permission request when microphone permission is not granted.
- Linked and preserved the relevant logs as artifacts for reviewer inspection.

<a href="https://app.greptile.com/trex/runs/13946778/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| lib/features/chat/services/voice_input_service.dart | Updates microphone preflight to request permission instead of only reading status. |
| pubspec.yaml | Adds dev dependencies used by the new permission-handler mock tests. |
| test/features/chat/services/voice_input_service_test.dart | Adds tests for the microphone permission preflight behavior. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: request iOS microphone permission i..."](https://github.com/cogwheel0/conduit/commit/0c426e9414637b09a4124d74749b6a4e5ce9f335) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43227011)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Context used - AGENTS.md ([source](https://app.greptile.com/cogwheel/-/custom-context?memory=871e7f39-32ad-42bc-9cb3-4f44ae78faec))

<!-- /greptile_comment -->