### PR TITLE
Fix multi-attachment crash and speech-to-text regressions

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -75,6 +75,7 @@ dependencies {
     coreLibraryDesugaring("com.android.tools:desugar_jdk_libs:2.1.4")
     implementation("com.google.mlkit:genai-speech-recognition:1.0.0-alpha1")
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.7.3")
+    testImplementation("junit:junit:4.13.2")
 }
 
 flutter {

--- a/android/app/src/main/kotlin/app/cogwheel/conduit/NativeSttBridge.kt
+++ b/android/app/src/main/kotlin/app/cogwheel/conduit/NativeSttBridge.kt
@@ -140,7 +140,7 @@ class NativeSttBridge(private val activity: MainActivity) : MethodChannel.Method
             return mlKitAvailability
         }
 
-        return if (AndroidSpeechRecognizer.isRecognitionAvailable(activity.applicationContext)) {
+        return if (platformRecognizerAvailable(allowOnlineFallback)) {
             available("android_speech")
         } else {
             unavailable(mlKitAvailability["reason"] as? String ?: "Android speech recognition unavailable")
@@ -220,7 +220,7 @@ class NativeSttBridge(private val activity: MainActivity) : MethodChannel.Method
             return
         }
         if (prepared == null) {
-            if (AndroidSpeechRecognizer.isRecognitionAvailable(activity.applicationContext)) {
+            if (platformRecognizerAvailable(allowOnlineFallback)) {
                 try {
                     startPlatformRecognizer(
                         localeId,
@@ -455,7 +455,7 @@ class NativeSttBridge(private val activity: MainActivity) : MethodChannel.Method
             "android_speech_auto"
         }
         platformCommittedText = ""
-        val recognizer = if (languageSwitchLanguages != null && !allowOnlineFallback) {
+        val recognizer = if (!allowOnlineFallback) {
             AndroidSpeechRecognizer.createOnDeviceSpeechRecognizer(
                 activity.applicationContext
             )
@@ -467,6 +467,21 @@ class NativeSttBridge(private val activity: MainActivity) : MethodChannel.Method
             it.startListening(platformRecognizerIntent())
         }
         emitStatus("listening", platformEngineName)
+    }
+
+    private fun platformRecognizerAvailable(allowOnlineFallback: Boolean): Boolean {
+        val context = activity.applicationContext
+        val recognitionAvailable = allowOnlineFallback &&
+            AndroidSpeechRecognizer.isRecognitionAvailable(context)
+        val onDeviceRecognitionAvailable = !allowOnlineFallback &&
+            Build.VERSION.SDK_INT >= Build.VERSION_CODES.S &&
+            AndroidSpeechRecognizer.isOnDeviceRecognitionAvailable(context)
+        return NativeSttLanguagePolicy.platformRecognizerAvailable(
+            allowOnlineFallback = allowOnlineFallback,
+            sdkInt = Build.VERSION.SDK_INT,
+            recognitionAvailable = recognitionAvailable,
+            onDeviceRecognitionAvailable = onDeviceRecognitionAvailable
+        )
     }
 
     private val platformRecognitionListener = object : RecognitionListener {

--- a/android/app/src/main/kotlin/app/cogwheel/conduit/NativeSttBridge.kt
+++ b/android/app/src/main/kotlin/app/cogwheel/conduit/NativeSttBridge.kt
@@ -4,6 +4,8 @@ import android.content.Intent
 import android.os.Build
 import android.os.Bundle
 import android.speech.RecognitionListener
+import android.speech.RecognitionSupport
+import android.speech.RecognitionSupportCallback
 import android.speech.RecognizerIntent
 import android.speech.SpeechRecognizer as AndroidSpeechRecognizer
 import android.util.Log
@@ -22,6 +24,7 @@ import io.flutter.plugin.common.MethodCall
 import io.flutter.plugin.common.MethodChannel
 import java.util.Locale
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
@@ -47,6 +50,8 @@ class NativeSttBridge(private val activity: MainActivity) : MethodChannel.Method
     private var platformAccumulateResults = true
     private var platformAllowOnlineFallback = true
     private var platformLocaleId: String? = null
+    private var platformLanguageSwitchLanguages: List<String>? = null
+    private var platformEngineName = "android_speech"
     private var platformCommittedText = ""
     @Volatile
     private var recognitionGeneration = 0
@@ -66,8 +71,10 @@ class NativeSttBridge(private val activity: MainActivity) : MethodChannel.Method
         when (call.method) {
             "checkAvailability" -> {
                 val localeId = call.argument<String>("localeId")
+                val allowOnlineFallback =
+                    call.argument<Boolean>("allowOnlineFallback") ?: true
                 scope.launch {
-                    result.success(checkAvailability(localeId))
+                    result.success(checkAvailability(localeId, allowOnlineFallback))
                 }
             }
             "getLocales" -> {
@@ -120,8 +127,11 @@ class NativeSttBridge(private val activity: MainActivity) : MethodChannel.Method
         }
     }
 
-    private suspend fun checkAvailability(localeId: String?): Map<String, Any?> {
-        if (canUsePlatformLanguageSwitch(localeId)) {
+    private suspend fun checkAvailability(
+        localeId: String?,
+        allowOnlineFallback: Boolean
+    ): Map<String, Any?> {
+        if (platformLanguageSwitchLanguages(localeId, allowOnlineFallback) != null) {
             return available("android_speech_auto")
         }
 
@@ -181,7 +191,11 @@ class NativeSttBridge(private val activity: MainActivity) : MethodChannel.Method
         val generation = recognitionGeneration + 1
         recognitionGeneration = generation
         stopInternal(emitDone = false, awaitCompletion = false)
-        val usePlatformLanguageSwitch = canUsePlatformLanguageSwitch(localeId)
+        val languageSwitchLanguages = platformLanguageSwitchLanguages(
+            localeId,
+            allowOnlineFallback
+        )
+        val usePlatformLanguageSwitch = languageSwitchLanguages != null
         val prepared = if (usePlatformLanguageSwitch) {
             null
         } else {
@@ -207,18 +221,26 @@ class NativeSttBridge(private val activity: MainActivity) : MethodChannel.Method
         }
         if (prepared == null) {
             if (AndroidSpeechRecognizer.isRecognitionAvailable(activity.applicationContext)) {
-                startPlatformRecognizer(
-                    localeId,
-                    emitPartialResults,
-                    accumulateResults,
-                    allowOnlineFallback
-                )
-                val engineName = if (usePlatformLanguageSwitch) {
-                    "android_speech_auto"
-                } else {
-                    "android_speech"
+                try {
+                    startPlatformRecognizer(
+                        localeId,
+                        emitPartialResults,
+                        accumulateResults,
+                        allowOnlineFallback,
+                        languageSwitchLanguages
+                    )
+                    val engineName = if (usePlatformLanguageSwitch) {
+                        "android_speech_auto"
+                    } else {
+                        "android_speech"
+                    }
+                    result.success(available(engineName))
+                } catch (error: Throwable) {
+                    Log.w(TAG, "Android speech recognition startup failed", error)
+                    result.success(
+                        unavailable(error.message ?: "Speech recognition failed to start")
+                    )
                 }
-                result.success(available(engineName))
             } else {
                 result.success(unavailable("Speech recognition is not available"))
             }
@@ -418,26 +440,38 @@ class NativeSttBridge(private val activity: MainActivity) : MethodChannel.Method
         localeId: String?,
         emitPartialResults: Boolean,
         accumulateResults: Boolean,
-        allowOnlineFallback: Boolean
+        allowOnlineFallback: Boolean,
+        languageSwitchLanguages: List<String>?
     ) {
         platformStopRequested = false
         platformEmitPartialResults = emitPartialResults
         platformAccumulateResults = accumulateResults
         platformAllowOnlineFallback = allowOnlineFallback
         platformLocaleId = localeId
-        platformCommittedText = ""
-        activePlatformRecognizer = AndroidSpeechRecognizer.createSpeechRecognizer(
-            activity.applicationContext
-        ).also { recognizer ->
-            recognizer.setRecognitionListener(platformRecognitionListener)
-            recognizer.startListening(platformRecognizerIntent())
+        platformLanguageSwitchLanguages = languageSwitchLanguages
+        platformEngineName = if (languageSwitchLanguages == null) {
+            "android_speech"
+        } else {
+            "android_speech_auto"
         }
-        emitStatus("listening", "android_speech")
+        platformCommittedText = ""
+        val recognizer = if (languageSwitchLanguages != null && !allowOnlineFallback) {
+            AndroidSpeechRecognizer.createOnDeviceSpeechRecognizer(
+                activity.applicationContext
+            )
+        } else {
+            AndroidSpeechRecognizer.createSpeechRecognizer(activity.applicationContext)
+        }
+        activePlatformRecognizer = recognizer.also {
+            it.setRecognitionListener(platformRecognitionListener)
+            it.startListening(platformRecognizerIntent())
+        }
+        emitStatus("listening", platformEngineName)
     }
 
     private val platformRecognitionListener = object : RecognitionListener {
         override fun onReadyForSpeech(params: Bundle?) {
-            emitStatus("listening", "android_speech")
+            emitStatus("listening", platformEngineName)
         }
 
         override fun onBeginningOfSpeech() {}
@@ -456,7 +490,7 @@ class NativeSttBridge(private val activity: MainActivity) : MethodChannel.Method
             } else {
                 text.trim()
             }
-            emitResult(emitted, false, "android_speech")
+            emitResult(emitted, false, platformEngineName)
         }
 
         override fun onResults(results: Bundle?) {
@@ -468,14 +502,14 @@ class NativeSttBridge(private val activity: MainActivity) : MethodChannel.Method
                 } else {
                     text.trim()
                 }
-                emitResult(emitted, true, "android_speech")
+                emitResult(emitted, true, platformEngineName)
             }
             restartPlatformRecognizerIfActive()
         }
 
         override fun onError(error: Int) {
             if (platformStopRequested || activePlatformRecognizer == null) {
-                emitDone("android_speech")
+                emitDone(platformEngineName)
                 return
             }
             if (isRestartablePlatformError(error)) {
@@ -485,9 +519,9 @@ class NativeSttBridge(private val activity: MainActivity) : MethodChannel.Method
             emitError(
                 "ANDROID_SPEECH_$error",
                 platformSpeechErrorMessage(error),
-                "android_speech"
+                platformEngineName
             )
-            emitDone("android_speech")
+            emitDone(platformEngineName)
         }
 
         override fun onEvent(eventType: Int, params: Bundle?) {}
@@ -496,7 +530,7 @@ class NativeSttBridge(private val activity: MainActivity) : MethodChannel.Method
     private fun restartPlatformRecognizerIfActive(delayMs: Long = 200L) {
         val recognizer = activePlatformRecognizer ?: return
         if (platformStopRequested) {
-            emitDone("android_speech")
+            emitDone(platformEngineName)
             return
         }
 
@@ -513,27 +547,30 @@ class NativeSttBridge(private val activity: MainActivity) : MethodChannel.Method
     }
 
     private fun platformRecognizerIntent(): Intent {
+        val languageSwitchLanguages = platformLanguageSwitchLanguages
+        val requestedLocale = parseLocale(platformLocaleId).toLanguageTag()
+        val baseLocale = NativeSttLanguagePolicy.preferredBaseLocale(
+            requestedLocale,
+            languageSwitchLanguages.orEmpty()
+        )
         return Intent(RecognizerIntent.ACTION_RECOGNIZE_SPEECH).apply {
             putExtra(
                 RecognizerIntent.EXTRA_LANGUAGE_MODEL,
                 RecognizerIntent.LANGUAGE_MODEL_FREE_FORM
             )
-            if (
-                NativeSttLanguagePolicy.usesPlatformLanguageSwitch(
-                    platformLocaleId,
-                    Build.VERSION.SDK_INT
-                )
-            ) {
+            putExtra(RecognizerIntent.EXTRA_LANGUAGE, baseLocale)
+            putExtra(RecognizerIntent.EXTRA_LANGUAGE_PREFERENCE, baseLocale)
+            putExtra(RecognizerIntent.EXTRA_ONLY_RETURN_LANGUAGE_PREFERENCE, false)
+            if (languageSwitchLanguages != null) {
                 putExtra(RecognizerIntent.EXTRA_ENABLE_LANGUAGE_DETECTION, true)
                 putExtra(
                     RecognizerIntent.EXTRA_ENABLE_LANGUAGE_SWITCH,
                     RecognizerIntent.LANGUAGE_SWITCH_BALANCED
                 )
-            } else {
-                val locale = parseLocale(platformLocaleId)
-                putExtra(RecognizerIntent.EXTRA_LANGUAGE, locale.toLanguageTag())
-                putExtra(RecognizerIntent.EXTRA_LANGUAGE_PREFERENCE, locale.toLanguageTag())
-                putExtra(RecognizerIntent.EXTRA_ONLY_RETURN_LANGUAGE_PREFERENCE, false)
+                putStringArrayListExtra(
+                    RecognizerIntent.EXTRA_LANGUAGE_SWITCH_ALLOWED_LANGUAGES,
+                    ArrayList(languageSwitchLanguages)
+                )
             }
             putExtra(RecognizerIntent.EXTRA_PARTIAL_RESULTS, platformEmitPartialResults)
             putExtra(RecognizerIntent.EXTRA_MAX_RESULTS, 1)
@@ -541,11 +578,83 @@ class NativeSttBridge(private val activity: MainActivity) : MethodChannel.Method
         }
     }
 
-    private fun canUsePlatformLanguageSwitch(localeId: String?): Boolean {
-        return NativeSttLanguagePolicy.usesPlatformLanguageSwitch(
-            localeId,
-            Build.VERSION.SDK_INT
-        ) && AndroidSpeechRecognizer.isRecognitionAvailable(activity.applicationContext)
+    private suspend fun platformLanguageSwitchLanguages(
+        localeId: String?,
+        allowOnlineFallback: Boolean
+    ): List<String>? {
+        if (!NativeSttLanguagePolicy.usesPlatformLanguageSwitch(localeId, Build.VERSION.SDK_INT)) {
+            return null
+        }
+        val context = activity.applicationContext
+        val recognizerAvailable = if (allowOnlineFallback) {
+            AndroidSpeechRecognizer.isRecognitionAvailable(context)
+        } else {
+            AndroidSpeechRecognizer.isOnDeviceRecognitionAvailable(context)
+        }
+        if (!recognizerAvailable) {
+            return null
+        }
+
+        return withContext(Dispatchers.Main.immediate) {
+            val recognizer = try {
+                if (allowOnlineFallback) {
+                    AndroidSpeechRecognizer.createSpeechRecognizer(context)
+                } else {
+                    AndroidSpeechRecognizer.createOnDeviceSpeechRecognizer(context)
+                }
+            } catch (error: Throwable) {
+                Log.w(TAG, "Unable to create Android recognizer for language switching", error)
+                return@withContext null
+            }
+            try {
+                val supportResult = CompletableDeferred<RecognitionSupport?>()
+                val supportIntent = Intent(RecognizerIntent.ACTION_RECOGNIZE_SPEECH).apply {
+                    putExtra(
+                        RecognizerIntent.EXTRA_LANGUAGE_MODEL,
+                        RecognizerIntent.LANGUAGE_MODEL_FREE_FORM
+                    )
+                    putExtra(RecognizerIntent.EXTRA_ENABLE_LANGUAGE_DETECTION, true)
+                    putExtra(
+                        RecognizerIntent.EXTRA_ENABLE_LANGUAGE_SWITCH,
+                        RecognizerIntent.LANGUAGE_SWITCH_BALANCED
+                    )
+                    putExtra(RecognizerIntent.EXTRA_PREFER_OFFLINE, !allowOnlineFallback)
+                }
+                recognizer.checkRecognitionSupport(
+                    supportIntent,
+                    activity.mainExecutor,
+                    object : RecognitionSupportCallback {
+                        override fun onSupportResult(recognitionSupport: RecognitionSupport) {
+                            supportResult.complete(recognitionSupport)
+                        }
+
+                        override fun onError(error: Int) {
+                            Log.i(TAG, "Android language-switch support check failed: $error")
+                            supportResult.complete(null)
+                        }
+                    }
+                )
+                val support = withTimeoutOrNull(PLATFORM_SUPPORT_CHECK_TIMEOUT_MS) {
+                    supportResult.await()
+                } ?: return@withContext null
+                val usableLanguages = buildList {
+                    addAll(support.installedOnDeviceLanguages)
+                    if (allowOnlineFallback) {
+                        addAll(support.onlineLanguages)
+                    }
+                }.map { it.replace('_', '-') }
+                    .filter { it.isNotBlank() }
+                    .distinctBy { it.lowercase(Locale.ROOT) }
+                usableLanguages.takeIf {
+                    NativeSttLanguagePolicy.hasMultipleLanguages(it)
+                }
+            } catch (error: Throwable) {
+                Log.w(TAG, "Android language-switch support check failed", error)
+                null
+            } finally {
+                runCatching { recognizer.destroy() }
+            }
+        }
     }
 
     private fun firstRecognitionText(results: Bundle?): String? {
@@ -705,5 +814,6 @@ class NativeSttBridge(private val activity: MainActivity) : MethodChannel.Method
         private const val EVENT_CHANNEL = "app.cogwheel.conduit/native_stt/events"
         private const val STOP_GRACE_PERIOD_MS = 1500L
         private const val STALE_GENERATION_CHECK_MS = 50L
+        private const val PLATFORM_SUPPORT_CHECK_TIMEOUT_MS = 2000L
     }
 }

--- a/android/app/src/main/kotlin/app/cogwheel/conduit/NativeSttBridge.kt
+++ b/android/app/src/main/kotlin/app/cogwheel/conduit/NativeSttBridge.kt
@@ -121,6 +121,10 @@ class NativeSttBridge(private val activity: MainActivity) : MethodChannel.Method
     }
 
     private suspend fun checkAvailability(localeId: String?): Map<String, Any?> {
+        if (canUsePlatformLanguageSwitch(localeId)) {
+            return available("android_speech_auto")
+        }
+
         val mlKitAvailability = checkMlKitAvailability(localeId)
         if (mlKitAvailability["available"] == true) {
             return mlKitAvailability
@@ -177,19 +181,24 @@ class NativeSttBridge(private val activity: MainActivity) : MethodChannel.Method
         val generation = recognitionGeneration + 1
         recognitionGeneration = generation
         stopInternal(emitDone = false, awaitCompletion = false)
-        val prepared = try {
-            withContext(Dispatchers.IO) {
-                prepareRecognizer(localeId, generation)
-            }
-        } catch (error: CancellationException) {
-            throw error
-        } catch (error: Throwable) {
-            if (!isCurrentGeneration(generation)) {
-                result.success(unavailable("Speech recognition start was cancelled"))
-                return
-            }
-            Log.w(TAG, "ML Kit STT startup failed", error)
+        val usePlatformLanguageSwitch = canUsePlatformLanguageSwitch(localeId)
+        val prepared = if (usePlatformLanguageSwitch) {
             null
+        } else {
+            try {
+                withContext(Dispatchers.IO) {
+                    prepareRecognizer(localeId, generation)
+                }
+            } catch (error: CancellationException) {
+                throw error
+            } catch (error: Throwable) {
+                if (!isCurrentGeneration(generation)) {
+                    result.success(unavailable("Speech recognition start was cancelled"))
+                    return
+                }
+                Log.w(TAG, "ML Kit STT startup failed", error)
+                null
+            }
         }
         if (!isCurrentGeneration(generation)) {
             prepared?.first?.close()
@@ -204,7 +213,12 @@ class NativeSttBridge(private val activity: MainActivity) : MethodChannel.Method
                     accumulateResults,
                     allowOnlineFallback
                 )
-                result.success(available("android_speech"))
+                val engineName = if (usePlatformLanguageSwitch) {
+                    "android_speech_auto"
+                } else {
+                    "android_speech"
+                }
+                result.success(available(engineName))
             } else {
                 result.success(unavailable("Speech recognition is not available"))
             }
@@ -499,19 +513,39 @@ class NativeSttBridge(private val activity: MainActivity) : MethodChannel.Method
     }
 
     private fun platformRecognizerIntent(): Intent {
-        val locale = parseLocale(platformLocaleId)
         return Intent(RecognizerIntent.ACTION_RECOGNIZE_SPEECH).apply {
             putExtra(
                 RecognizerIntent.EXTRA_LANGUAGE_MODEL,
                 RecognizerIntent.LANGUAGE_MODEL_FREE_FORM
             )
-            putExtra(RecognizerIntent.EXTRA_LANGUAGE, locale.toLanguageTag())
-            putExtra(RecognizerIntent.EXTRA_LANGUAGE_PREFERENCE, locale.toLanguageTag())
-            putExtra(RecognizerIntent.EXTRA_ONLY_RETURN_LANGUAGE_PREFERENCE, false)
+            if (
+                NativeSttLanguagePolicy.usesPlatformLanguageSwitch(
+                    platformLocaleId,
+                    Build.VERSION.SDK_INT
+                )
+            ) {
+                putExtra(RecognizerIntent.EXTRA_ENABLE_LANGUAGE_DETECTION, true)
+                putExtra(
+                    RecognizerIntent.EXTRA_ENABLE_LANGUAGE_SWITCH,
+                    RecognizerIntent.LANGUAGE_SWITCH_BALANCED
+                )
+            } else {
+                val locale = parseLocale(platformLocaleId)
+                putExtra(RecognizerIntent.EXTRA_LANGUAGE, locale.toLanguageTag())
+                putExtra(RecognizerIntent.EXTRA_LANGUAGE_PREFERENCE, locale.toLanguageTag())
+                putExtra(RecognizerIntent.EXTRA_ONLY_RETURN_LANGUAGE_PREFERENCE, false)
+            }
             putExtra(RecognizerIntent.EXTRA_PARTIAL_RESULTS, platformEmitPartialResults)
             putExtra(RecognizerIntent.EXTRA_MAX_RESULTS, 1)
             putExtra(RecognizerIntent.EXTRA_PREFER_OFFLINE, !platformAllowOnlineFallback)
         }
+    }
+
+    private fun canUsePlatformLanguageSwitch(localeId: String?): Boolean {
+        return NativeSttLanguagePolicy.usesPlatformLanguageSwitch(
+            localeId,
+            Build.VERSION.SDK_INT
+        ) && AndroidSpeechRecognizer.isRecognitionAvailable(activity.applicationContext)
     }
 
     private fun firstRecognitionText(results: Bundle?): String? {

--- a/android/app/src/main/kotlin/app/cogwheel/conduit/NativeSttBridge.kt
+++ b/android/app/src/main/kotlin/app/cogwheel/conduit/NativeSttBridge.kt
@@ -548,19 +548,11 @@ class NativeSttBridge(private val activity: MainActivity) : MethodChannel.Method
 
     private fun platformRecognizerIntent(): Intent {
         val languageSwitchLanguages = platformLanguageSwitchLanguages
-        val requestedLocale = parseLocale(platformLocaleId).toLanguageTag()
-        val baseLocale = NativeSttLanguagePolicy.preferredBaseLocale(
-            requestedLocale,
-            languageSwitchLanguages.orEmpty()
-        )
         return Intent(RecognizerIntent.ACTION_RECOGNIZE_SPEECH).apply {
             putExtra(
                 RecognizerIntent.EXTRA_LANGUAGE_MODEL,
                 RecognizerIntent.LANGUAGE_MODEL_FREE_FORM
             )
-            putExtra(RecognizerIntent.EXTRA_LANGUAGE, baseLocale)
-            putExtra(RecognizerIntent.EXTRA_LANGUAGE_PREFERENCE, baseLocale)
-            putExtra(RecognizerIntent.EXTRA_ONLY_RETURN_LANGUAGE_PREFERENCE, false)
             if (languageSwitchLanguages != null) {
                 putExtra(RecognizerIntent.EXTRA_ENABLE_LANGUAGE_DETECTION, true)
                 putExtra(
@@ -571,6 +563,11 @@ class NativeSttBridge(private val activity: MainActivity) : MethodChannel.Method
                     RecognizerIntent.EXTRA_LANGUAGE_SWITCH_ALLOWED_LANGUAGES,
                     ArrayList(languageSwitchLanguages)
                 )
+            } else {
+                val locale = parseLocale(platformLocaleId).toLanguageTag()
+                putExtra(RecognizerIntent.EXTRA_LANGUAGE, locale)
+                putExtra(RecognizerIntent.EXTRA_LANGUAGE_PREFERENCE, locale)
+                putExtra(RecognizerIntent.EXTRA_ONLY_RETURN_LANGUAGE_PREFERENCE, false)
             }
             putExtra(RecognizerIntent.EXTRA_PARTIAL_RESULTS, platformEmitPartialResults)
             putExtra(RecognizerIntent.EXTRA_MAX_RESULTS, 1)

--- a/android/app/src/main/kotlin/app/cogwheel/conduit/NativeSttLanguagePolicy.kt
+++ b/android/app/src/main/kotlin/app/cogwheel/conduit/NativeSttLanguagePolicy.kt
@@ -1,0 +1,9 @@
+package app.cogwheel.conduit
+
+internal object NativeSttLanguagePolicy {
+    private const val LANGUAGE_SWITCH_MIN_SDK = 34
+
+    fun usesPlatformLanguageSwitch(localeId: String?, sdkInt: Int): Boolean {
+        return localeId.isNullOrBlank() && sdkInt >= LANGUAGE_SWITCH_MIN_SDK
+    }
+}

--- a/android/app/src/main/kotlin/app/cogwheel/conduit/NativeSttLanguagePolicy.kt
+++ b/android/app/src/main/kotlin/app/cogwheel/conduit/NativeSttLanguagePolicy.kt
@@ -14,21 +14,6 @@ internal object NativeSttLanguagePolicy {
             .size >= 2
     }
 
-    fun preferredBaseLocale(requestedLocaleId: String, localeIds: List<String>): String {
-        if (localeIds.isEmpty()) {
-            return requestedLocaleId
-        }
-        val exact = localeIds.firstOrNull {
-            it.equals(requestedLocaleId, ignoreCase = true)
-        }
-        if (exact != null) {
-            return exact
-        }
-        val requestedLanguage = primaryLanguage(requestedLocaleId)
-        return localeIds.firstOrNull { primaryLanguage(it) == requestedLanguage }
-            ?: localeIds.first()
-    }
-
     private fun primaryLanguage(localeId: String): String? {
         return localeId
             .trim()

--- a/android/app/src/main/kotlin/app/cogwheel/conduit/NativeSttLanguagePolicy.kt
+++ b/android/app/src/main/kotlin/app/cogwheel/conduit/NativeSttLanguagePolicy.kt
@@ -1,7 +1,21 @@
 package app.cogwheel.conduit
 
 internal object NativeSttLanguagePolicy {
+    private const val ON_DEVICE_RECOGNIZER_MIN_SDK = 31
     private const val LANGUAGE_SWITCH_MIN_SDK = 34
+
+    fun platformRecognizerAvailable(
+        allowOnlineFallback: Boolean,
+        sdkInt: Int,
+        recognitionAvailable: Boolean,
+        onDeviceRecognitionAvailable: Boolean
+    ): Boolean {
+        return if (allowOnlineFallback) {
+            recognitionAvailable
+        } else {
+            sdkInt >= ON_DEVICE_RECOGNIZER_MIN_SDK && onDeviceRecognitionAvailable
+        }
+    }
 
     fun usesPlatformLanguageSwitch(localeId: String?, sdkInt: Int): Boolean {
         return localeId.isNullOrBlank() && sdkInt >= LANGUAGE_SWITCH_MIN_SDK

--- a/android/app/src/main/kotlin/app/cogwheel/conduit/NativeSttLanguagePolicy.kt
+++ b/android/app/src/main/kotlin/app/cogwheel/conduit/NativeSttLanguagePolicy.kt
@@ -6,4 +6,35 @@ internal object NativeSttLanguagePolicy {
     fun usesPlatformLanguageSwitch(localeId: String?, sdkInt: Int): Boolean {
         return localeId.isNullOrBlank() && sdkInt >= LANGUAGE_SWITCH_MIN_SDK
     }
+
+    fun hasMultipleLanguages(localeIds: List<String>): Boolean {
+        return localeIds
+            .mapNotNull(::primaryLanguage)
+            .distinct()
+            .size >= 2
+    }
+
+    fun preferredBaseLocale(requestedLocaleId: String, localeIds: List<String>): String {
+        if (localeIds.isEmpty()) {
+            return requestedLocaleId
+        }
+        val exact = localeIds.firstOrNull {
+            it.equals(requestedLocaleId, ignoreCase = true)
+        }
+        if (exact != null) {
+            return exact
+        }
+        val requestedLanguage = primaryLanguage(requestedLocaleId)
+        return localeIds.firstOrNull { primaryLanguage(it) == requestedLanguage }
+            ?: localeIds.first()
+    }
+
+    private fun primaryLanguage(localeId: String): String? {
+        return localeId
+            .trim()
+            .replace('_', '-')
+            .substringBefore('-')
+            .lowercase()
+            .takeIf { it.isNotBlank() }
+    }
 }

--- a/android/app/src/test/kotlin/app/cogwheel/conduit/NativeSttLanguagePolicyTest.kt
+++ b/android/app/src/test/kotlin/app/cogwheel/conduit/NativeSttLanguagePolicyTest.kt
@@ -6,6 +6,54 @@ import org.junit.Test
 
 class NativeSttLanguagePolicyTest {
     @Test
+    fun offlinePlatformFallbackRequiresVerifiedOnDeviceRecognizer() {
+        assertTrue(
+            NativeSttLanguagePolicy.platformRecognizerAvailable(
+                allowOnlineFallback = false,
+                sdkInt = 31,
+                recognitionAvailable = true,
+                onDeviceRecognitionAvailable = true
+            )
+        )
+        assertFalse(
+            NativeSttLanguagePolicy.platformRecognizerAvailable(
+                allowOnlineFallback = false,
+                sdkInt = 31,
+                recognitionAvailable = true,
+                onDeviceRecognitionAvailable = false
+            )
+        )
+        assertFalse(
+            NativeSttLanguagePolicy.platformRecognizerAvailable(
+                allowOnlineFallback = false,
+                sdkInt = 30,
+                recognitionAvailable = true,
+                onDeviceRecognitionAvailable = true
+            )
+        )
+    }
+
+    @Test
+    fun onlinePlatformFallbackUsesGeneralRecognizerAvailability() {
+        assertTrue(
+            NativeSttLanguagePolicy.platformRecognizerAvailable(
+                allowOnlineFallback = true,
+                sdkInt = 31,
+                recognitionAvailable = true,
+                onDeviceRecognitionAvailable = false
+            )
+        )
+        assertFalse(
+            NativeSttLanguagePolicy.platformRecognizerAvailable(
+                allowOnlineFallback = true,
+                sdkInt = 31,
+                recognitionAvailable = false,
+                onDeviceRecognitionAvailable = true
+            )
+        )
+    }
+
+    @Test
     fun automaticSwitchRequiresAndroid14AndNoExplicitLocale() {
         assertTrue(NativeSttLanguagePolicy.usesPlatformLanguageSwitch(null, 34))
         assertFalse(NativeSttLanguagePolicy.usesPlatformLanguageSwitch("pl-PL", 34))

--- a/android/app/src/test/kotlin/app/cogwheel/conduit/NativeSttLanguagePolicyTest.kt
+++ b/android/app/src/test/kotlin/app/cogwheel/conduit/NativeSttLanguagePolicyTest.kt
@@ -1,0 +1,39 @@
+package app.cogwheel.conduit
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class NativeSttLanguagePolicyTest {
+    @Test
+    fun automaticSwitchRequiresAndroid14AndNoExplicitLocale() {
+        assertTrue(NativeSttLanguagePolicy.usesPlatformLanguageSwitch(null, 34))
+        assertFalse(NativeSttLanguagePolicy.usesPlatformLanguageSwitch("pl-PL", 34))
+        assertFalse(NativeSttLanguagePolicy.usesPlatformLanguageSwitch(null, 33))
+    }
+
+    @Test
+    fun automaticSwitchRequiresTwoDistinctLanguages() {
+        assertTrue(NativeSttLanguagePolicy.hasMultipleLanguages(listOf("en-US", "pl-PL")))
+        assertFalse(NativeSttLanguagePolicy.hasMultipleLanguages(listOf("en-US", "en-GB")))
+    }
+
+    @Test
+    fun preferredBaseLocaleUsesClosestInstalledLanguage() {
+        assertEquals(
+            "en-US",
+            NativeSttLanguagePolicy.preferredBaseLocale(
+                "en-IN",
+                listOf("pl-PL", "en-US")
+            )
+        )
+        assertEquals(
+            "pl-PL",
+            NativeSttLanguagePolicy.preferredBaseLocale(
+                "de-DE",
+                listOf("pl-PL", "en-US")
+            )
+        )
+    }
+}

--- a/android/app/src/test/kotlin/app/cogwheel/conduit/NativeSttLanguagePolicyTest.kt
+++ b/android/app/src/test/kotlin/app/cogwheel/conduit/NativeSttLanguagePolicyTest.kt
@@ -1,6 +1,5 @@
 package app.cogwheel.conduit
 
-import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -17,23 +16,5 @@ class NativeSttLanguagePolicyTest {
     fun automaticSwitchRequiresTwoDistinctLanguages() {
         assertTrue(NativeSttLanguagePolicy.hasMultipleLanguages(listOf("en-US", "pl-PL")))
         assertFalse(NativeSttLanguagePolicy.hasMultipleLanguages(listOf("en-US", "en-GB")))
-    }
-
-    @Test
-    fun preferredBaseLocaleUsesClosestInstalledLanguage() {
-        assertEquals(
-            "en-US",
-            NativeSttLanguagePolicy.preferredBaseLocale(
-                "en-IN",
-                listOf("pl-PL", "en-US")
-            )
-        )
-        assertEquals(
-            "pl-PL",
-            NativeSttLanguagePolicy.preferredBaseLocale(
-                "de-DE",
-                listOf("pl-PL", "en-US")
-            )
-        )
     }
 }

--- a/lib/features/chat/services/voice_input_service.dart
+++ b/lib/features/chat/services/voice_input_service.dart
@@ -140,6 +140,8 @@ class VoiceInputService {
   Timer? _nativeDictationSettleTimer;
 
   bool get isSupportedPlatform => Platform.isAndroid || Platform.isIOS;
+  @protected
+  bool get usesAutomaticNativeLanguage => Platform.isAndroid;
   bool get hasServerStt => _api != null;
   SttPreference get preference => _preference;
   bool get prefersServerOnly => _preference == SttPreference.serverOnly;
@@ -174,7 +176,7 @@ class VoiceInputService {
         forceLocalStt || _preference != SttPreference.serverOnly;
     if (shouldPrepareLocalStt && !_didAttemptLocalInitialization) {
       await _loadLocales(deviceTag);
-      await _initializeNativeLocalStt(deviceTag);
+      await _initializeNativeLocalStt();
       _localSttAvailable = _nativeLocalSttAvailable;
       _didAttemptLocalInitialization = true;
     }
@@ -183,7 +185,7 @@ class VoiceInputService {
     return true;
   }
 
-  Future<void> _initializeNativeLocalStt(String deviceTag) async {
+  Future<void> _initializeNativeLocalStt() async {
     if (!_nativeStt.isSupportedPlatform) {
       _nativeLocalSttAvailable = false;
       return;
@@ -191,9 +193,9 @@ class VoiceInputService {
 
     try {
       final availability = await _nativeStt.checkAvailability(
-        // A null locale asks supported native recognizers to detect/switch
-        // languages automatically instead of pinning recognition to the
-        // device UI language.
+        // Android treats null as an automatic-language request when the
+        // installed recognizer can prove that switching is supported. Other
+        // platforms use the closest supported system locale selected below.
         localeId: _selectedLocaleId,
         allowOnlineFallback: false,
       );
@@ -314,6 +316,16 @@ class VoiceInputService {
           .toList();
       _usingFallbackLocales = false;
 
+      if (usesAutomaticNativeLanguage) {
+        _selectedLocaleId = null;
+      } else {
+        final systemTag = nativeLocales.systemLocaleId;
+        final tagForMatch = (systemTag != null && systemTag.isNotEmpty)
+            ? systemTag
+            : deviceTag;
+        _selectedLocaleId = _matchLocale(tagForMatch).localeId;
+      }
+
       DebugLogger.info(
         'native-stt-locales-loaded',
         scope: 'voice/stt',
@@ -339,6 +351,29 @@ class VoiceInputService {
       return;
     }
     _locales = [LocaleName(deviceTag, deviceTag)];
+  }
+
+  LocaleName _matchLocale(String deviceTag) {
+    if (_locales.isEmpty) {
+      return const LocaleName('en_US', 'en_US');
+    }
+    final normalizedDevice = deviceTag.toLowerCase();
+    for (final locale in _locales) {
+      if (locale.localeId.toLowerCase() == normalizedDevice) {
+        return locale;
+      }
+    }
+    final parts = normalizedDevice.split(RegExp('[-_]'));
+    final primary = parts.isNotEmpty ? parts.first : normalizedDevice;
+    for (final locale in _locales) {
+      final normalizedLocale = locale.localeId.toLowerCase();
+      if (normalizedLocale == primary ||
+          normalizedLocale.startsWith('$primary-') ||
+          normalizedLocale.startsWith('${primary}_')) {
+        return locale;
+      }
+    }
+    return _locales.first;
   }
 
   void _handleLocalRecognizerError(Object? error) {

--- a/lib/features/chat/services/voice_input_service.dart
+++ b/lib/features/chat/services/voice_input_service.dart
@@ -388,8 +388,19 @@ class VoiceInputService {
           ? 'Speech recognition failed'
           : message,
     );
-    _textStreamController?.addError(exception);
+    _reportRecognitionError(exception);
     unawaited(_stopListening());
+  }
+
+  void _reportRecognitionError(Object error) {
+    final textController = _textStreamController;
+    if (textController != null && !textController.isClosed) {
+      textController.addError(error);
+    }
+    final transcriptController = _transcriptEventController;
+    if (transcriptController != null && !transcriptController.isClosed) {
+      transcriptController.addError(error);
+    }
   }
 
   Future<bool> _ensureMicrophonePermission() async {
@@ -651,7 +662,7 @@ class VoiceInputService {
         if (!_isListening) {
           return _textStreamController!.stream;
         }
-        _textStreamController?.addError(error);
+        _reportRecognitionError(error);
         await _stopListening();
       }
     } else if (shouldUseServer) {
@@ -669,7 +680,7 @@ class VoiceInputService {
           );
         } catch (error) {
           if (!_isListening) return;
-          _textStreamController?.addError(error);
+          _reportRecognitionError(error);
           await _stopListening();
         }
       });
@@ -685,7 +696,7 @@ class VoiceInputService {
         error = Exception('Speech recognition not available on this device');
       }
       Future.microtask(() {
-        _textStreamController?.addError(error);
+        _reportRecognitionError(error);
         unawaited(_stopListening());
       });
     }
@@ -908,12 +919,12 @@ class VoiceInputService {
           );
           return;
         } catch (fallbackError) {
-          _textStreamController?.addError(fallbackError);
+          _reportRecognitionError(fallbackError);
           rethrow;
         }
       }
 
-      _textStreamController?.addError(error);
+      _reportRecognitionError(error);
       rethrow;
     }
   }
@@ -941,7 +952,7 @@ class VoiceInputService {
 
     await _vadErrorSub?.cancel();
     _vadErrorSub = vad.onError.listen((message) {
-      _textStreamController?.addError(Exception(message));
+      _reportRecognitionError(Exception(message));
       if (_isListening) {
         unawaited(_stopListening());
       }
@@ -1004,7 +1015,7 @@ class VoiceInputService {
         throw StateError('Empty transcription result');
       }
     } catch (error) {
-      _textStreamController?.addError(error);
+      _reportRecognitionError(error);
     }
   }
 

--- a/lib/features/chat/services/voice_input_service.dart
+++ b/lib/features/chat/services/voice_input_service.dart
@@ -191,7 +191,10 @@ class VoiceInputService {
 
     try {
       final availability = await _nativeStt.checkAvailability(
-        localeId: _selectedLocaleId ?? deviceTag,
+        // A null locale asks supported native recognizers to detect/switch
+        // languages automatically instead of pinning recognition to the
+        // device UI language.
+        localeId: _selectedLocaleId,
         allowOnlineFallback: false,
       );
       _nativeLocalSttAvailable = availability.available;
@@ -311,18 +314,15 @@ class VoiceInputService {
           .toList();
       _usingFallbackLocales = false;
 
-      final systemTag = nativeLocales.systemLocaleId;
-      final tagForMatch = (systemTag != null && systemTag.isNotEmpty)
-          ? systemTag
-          : deviceTag;
-
-      final match = _matchLocale(tagForMatch);
-      _selectedLocaleId = match.localeId;
-
-      debugPrint(
-        'VoiceInputService: deviceTag=$deviceTag, '
-        'systemLocale=$systemTag, '
-        'selectedLocaleId=$_selectedLocaleId',
+      DebugLogger.info(
+        'native-stt-locales-loaded',
+        scope: 'voice/stt',
+        data: {
+          'deviceLocale': deviceTag,
+          'systemLocale': nativeLocales.systemLocaleId,
+          'localeCount': _locales.length,
+          'automaticLanguage': _selectedLocaleId == null,
+        },
       );
     } catch (_) {
       // Some engines may not support locale listing
@@ -330,37 +330,15 @@ class VoiceInputService {
   }
 
   void _ensureFallbackLocale(String deviceTag) {
-    if (_locales.isNotEmpty && _selectedLocaleId != null) {
+    if (_locales.isNotEmpty) {
       return;
     }
     _usingFallbackLocales = true;
     if (deviceTag.isEmpty) {
       _locales = const [LocaleName('en_US', 'en_US')];
-      _selectedLocaleId = 'en_US';
       return;
     }
     _locales = [LocaleName(deviceTag, deviceTag)];
-    _selectedLocaleId = deviceTag;
-  }
-
-  LocaleName _matchLocale(String deviceTag) {
-    if (_locales.isEmpty) {
-      return const LocaleName('en_US', 'en_US');
-    }
-    final normalizedDevice = deviceTag.toLowerCase();
-    for (final locale in _locales) {
-      if (locale.localeId.toLowerCase() == normalizedDevice) {
-        return locale;
-      }
-    }
-    final parts = normalizedDevice.split(RegExp('[-_]'));
-    final primary = parts.isNotEmpty ? parts.first : normalizedDevice;
-    for (final locale in _locales) {
-      if (locale.localeId.toLowerCase().startsWith('$primary-')) {
-        return locale;
-      }
-    }
-    return _locales.first;
   }
 
   void _handleLocalRecognizerError(Object? error) {

--- a/lib/features/chat/services/voice_input_service.dart
+++ b/lib/features/chat/services/voice_input_service.dart
@@ -911,20 +911,14 @@ class VoiceInputService {
         try {
           await _stopVadRecording();
         } catch (_) {}
-        try {
-          await _startLocalRecognition(
-            allowOnlineFallback: !prefersDeviceOnly,
-            iosAudioSessionManagedExternally: iosAudioSessionManagedExternally,
-            nativeAccumulateResults: _nativeAccumulateResultsForCurrentListen,
-          );
-          return;
-        } catch (fallbackError) {
-          _reportRecognitionError(fallbackError);
-          rethrow;
-        }
+        await _startLocalRecognition(
+          allowOnlineFallback: !prefersDeviceOnly,
+          iosAudioSessionManagedExternally: iosAudioSessionManagedExternally,
+          nativeAccumulateResults: _nativeAccumulateResultsForCurrentListen,
+        );
+        return;
       }
 
-      _reportRecognitionError(error);
       rethrow;
     }
   }

--- a/lib/features/chat/services/voice_input_service.dart
+++ b/lib/features/chat/services/voice_input_service.dart
@@ -734,8 +734,12 @@ class VoiceInputService {
       await _stopVadRecording();
       final samples = _vadPendingSamples;
       _vadPendingSamples = null;
-      final hasActiveTextConsumer = _textStreamController?.hasListener ?? false;
-      if (samples != null && samples.isNotEmpty && hasActiveTextConsumer) {
+      final shouldProcessSamples = _shouldProcessServerSamples(
+        hasTextConsumer: _textStreamController?.hasListener ?? false,
+        hasTranscriptEventConsumer:
+            _transcriptEventController?.hasListener ?? false,
+      );
+      if (samples != null && samples.isNotEmpty && shouldProcessSamples) {
         await _processVadSamples(samples);
       }
     } else {
@@ -1000,6 +1004,22 @@ class VoiceInputService {
     final frameDurationMs = (frameSamples / _vadSampleRate) * 1000;
     final frames = (milliseconds / frameDurationMs).ceil();
     return frames.clamp(_minVadRedemptionFrames, _maxVadRedemptionFrames);
+  }
+
+  static bool _shouldProcessServerSamples({
+    required bool hasTextConsumer,
+    required bool hasTranscriptEventConsumer,
+  }) => hasTextConsumer || hasTranscriptEventConsumer;
+
+  @visibleForTesting
+  static bool shouldProcessServerSamplesForTesting({
+    required bool hasTextConsumer,
+    required bool hasTranscriptEventConsumer,
+  }) {
+    return _shouldProcessServerSamples(
+      hasTextConsumer: hasTextConsumer,
+      hasTranscriptEventConsumer: hasTranscriptEventConsumer,
+    );
   }
 
   @visibleForTesting

--- a/lib/features/chat/widgets/user_message_bubble.dart
+++ b/lib/features/chat/widgets/user_message_bubble.dart
@@ -321,10 +321,17 @@ class _UserMessageBubbleState extends ConsumerState<UserMessageBubble> {
   }
 
   Widget _buildImageLayout(int imageCount) {
+    // [message] is dynamic for legacy hydration compatibility. Normalize the
+    // ids before iterating so collection transforms produce List<Widget>
+    // instead of a runtime List<dynamic>.
+    final attachmentIds = List<String>.from(
+      widget.message.attachmentIds as Iterable,
+    );
+
     if (imageCount == 1) {
       // Single image - larger display
       return Row(
-        key: ValueKey('user_single_${widget.message.attachmentIds![0]}'),
+        key: ValueKey('user_single_${attachmentIds[0]}'),
         mainAxisAlignment: MainAxisAlignment.end,
         children: [
           Container(
@@ -338,7 +345,7 @@ class _UserMessageBubbleState extends ConsumerState<UserMessageBubble> {
                 AppBorderRadius.messageBubble,
               ),
               child: EnhancedAttachment(
-                attachmentId: widget.message.attachmentIds![0],
+                attachmentId: attachmentIds[0],
                 isUserMessage: true,
                 constraints: const BoxConstraints(
                   maxWidth: 280,
@@ -353,16 +360,14 @@ class _UserMessageBubbleState extends ConsumerState<UserMessageBubble> {
     } else if (imageCount == 2) {
       // Two images side by side
       return Row(
-        key: ValueKey('user_double_${widget.message.attachmentIds!.join('_')}'),
+        key: ValueKey('user_double_${attachmentIds.join('_')}'),
         mainAxisAlignment: MainAxisAlignment.end,
         mainAxisSize: MainAxisSize.min,
         children: [
           Flexible(
             child: Row(
               mainAxisSize: MainAxisSize.min,
-              children: widget.message.attachmentIds!.asMap().entries.map((
-                entry,
-              ) {
+              children: attachmentIds.asMap().entries.map<Widget>((entry) {
                 final index = entry.key;
                 final attachmentId = entry.value;
                 return Padding(
@@ -398,7 +403,7 @@ class _UserMessageBubbleState extends ConsumerState<UserMessageBubble> {
     } else {
       // Grid layout for 3+ images
       return Row(
-        key: ValueKey('user_grid_${widget.message.attachmentIds!.join('_')}'),
+        key: ValueKey('user_grid_${attachmentIds.join('_')}'),
         mainAxisAlignment: MainAxisAlignment.end,
         children: [
           Flexible(
@@ -408,7 +413,7 @@ class _UserMessageBubbleState extends ConsumerState<UserMessageBubble> {
                 alignment: WrapAlignment.end,
                 spacing: Spacing.xs,
                 runSpacing: Spacing.xs,
-                children: widget.message.attachmentIds!.map((attachmentId) {
+                children: attachmentIds.map<Widget>((attachmentId) {
                   return Container(
                     decoration: BoxDecoration(
                       borderRadius: BorderRadius.circular(AppBorderRadius.md),

--- a/test/features/chat/services/voice_input_service_test.dart
+++ b/test/features/chat/services/voice_input_service_test.dart
@@ -1,4 +1,5 @@
 import 'package:checks/checks.dart';
+import 'package:conduit/features/chat/services/native_stt_service.dart';
 import 'package:conduit/features/chat/services/voice_input_service.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -36,9 +37,7 @@ void main() {
       when(
         () => mockPermissions.checkPermissionStatus(Permission.microphone),
       ).thenAnswer((_) async => PermissionStatus.denied);
-      when(
-        () => mockPermissions.requestPermissions(any()),
-      ).thenAnswer(
+      when(() => mockPermissions.requestPermissions(any())).thenAnswer(
         (_) async => {Permission.microphone: PermissionStatus.granted},
       );
 
@@ -66,9 +65,7 @@ void main() {
         when(
           () => mockPermissions.checkPermissionStatus(Permission.microphone),
         ).thenAnswer((_) async => PermissionStatus.denied);
-        when(
-          () => mockPermissions.requestPermissions(any()),
-        ).thenAnswer(
+        when(() => mockPermissions.requestPermissions(any())).thenAnswer(
           (_) async => {Permission.microphone: PermissionStatus.denied},
         );
 
@@ -114,6 +111,18 @@ void main() {
       );
 
       check(language).isNull();
+    });
+  });
+
+  group('VoiceInputService automatic on-device language', () {
+    test('leaves the native locale unset for automatic recognition', () async {
+      final nativeStt = _FakeNativeSttService();
+      final service = _SupportedVoiceInputService(nativeStt: nativeStt);
+
+      await service.initialize(forceLocalStt: true);
+
+      check(nativeStt.availabilityLocaleId).isNull();
+      check(service.selectedLocaleId).isNull();
     });
   });
 
@@ -252,3 +261,40 @@ class _FakeVoiceInputService extends VoiceInputService {
 class _MockPermissionHandlerPlatform extends Mock
     with MockPlatformInterfaceMixin
     implements PermissionHandlerPlatform {}
+
+class _SupportedVoiceInputService extends VoiceInputService {
+  _SupportedVoiceInputService({required super.nativeStt});
+
+  @override
+  bool get isSupportedPlatform => true;
+}
+
+class _FakeNativeSttService extends NativeSttService {
+  String? availabilityLocaleId;
+
+  @override
+  bool get isSupportedPlatform => true;
+
+  @override
+  Future<NativeSttLocales> getLocales({String? deviceLocaleId}) async {
+    return const NativeSttLocales(
+      systemLocaleId: 'en-US',
+      locales: [
+        NativeSttLocale(localeId: 'en-US', name: 'English'),
+        NativeSttLocale(localeId: 'pl-PL', name: 'Polish'),
+      ],
+    );
+  }
+
+  @override
+  Future<NativeSttAvailability> checkAvailability({
+    String? localeId,
+    bool allowOnlineFallback = true,
+  }) async {
+    availabilityLocaleId = localeId;
+    return const NativeSttAvailability(
+      available: true,
+      engine: 'automatic-test',
+    );
+  }
+}

--- a/test/features/chat/services/voice_input_service_test.dart
+++ b/test/features/chat/services/voice_input_service_test.dart
@@ -117,6 +117,35 @@ void main() {
     });
   });
 
+  group('VoiceInputService server STT consumers', () {
+    test('processes samples for a live-mode event-only consumer', () {
+      check(
+        VoiceInputService.shouldProcessServerSamplesForTesting(
+          hasTextConsumer: false,
+          hasTranscriptEventConsumer: true,
+        ),
+      ).isTrue();
+    });
+
+    test('processes samples for the normal text consumer', () {
+      check(
+        VoiceInputService.shouldProcessServerSamplesForTesting(
+          hasTextConsumer: true,
+          hasTranscriptEventConsumer: false,
+        ),
+      ).isTrue();
+    });
+
+    test('skips samples when every consumer has detached', () {
+      check(
+        VoiceInputService.shouldProcessServerSamplesForTesting(
+          hasTextConsumer: false,
+          hasTranscriptEventConsumer: false,
+        ),
+      ).isFalse();
+    });
+  });
+
   group('VoiceInputService.androidServerVadRecordConfig', () {
     test('uses speech recognition routing outside voice calls', () {
       final config = VoiceInputService.androidServerVadRecordConfigForTesting(

--- a/test/features/chat/services/voice_input_service_test.dart
+++ b/test/features/chat/services/voice_input_service_test.dart
@@ -124,6 +124,22 @@ void main() {
       check(nativeStt.availabilityLocaleId).isNull();
       check(service.selectedLocaleId).isNull();
     });
+
+    test(
+      'uses a supported system-language variant when auto is unavailable',
+      () async {
+        final nativeStt = _FakeNativeSttService(systemLocaleId: 'en-IN');
+        final service = _SupportedVoiceInputService(
+          nativeStt: nativeStt,
+          usesAutomaticNativeLanguage: false,
+        );
+
+        await service.initialize(forceLocalStt: true);
+
+        check(nativeStt.availabilityLocaleId).equals('en-US');
+        check(service.selectedLocaleId).equals('en-US');
+      },
+    );
   });
 
   group('VoiceInputService server STT consumers', () {
@@ -263,13 +279,22 @@ class _MockPermissionHandlerPlatform extends Mock
     implements PermissionHandlerPlatform {}
 
 class _SupportedVoiceInputService extends VoiceInputService {
-  _SupportedVoiceInputService({required super.nativeStt});
+  _SupportedVoiceInputService({
+    required super.nativeStt,
+    this.usesAutomaticNativeLanguage = true,
+  });
+
+  @override
+  final bool usesAutomaticNativeLanguage;
 
   @override
   bool get isSupportedPlatform => true;
 }
 
 class _FakeNativeSttService extends NativeSttService {
+  _FakeNativeSttService({this.systemLocaleId = 'en-US'});
+
+  final String systemLocaleId;
   String? availabilityLocaleId;
 
   @override
@@ -277,9 +302,9 @@ class _FakeNativeSttService extends NativeSttService {
 
   @override
   Future<NativeSttLocales> getLocales({String? deviceLocaleId}) async {
-    return const NativeSttLocales(
-      systemLocaleId: 'en-US',
-      locales: [
+    return NativeSttLocales(
+      systemLocaleId: systemLocaleId,
+      locales: const [
         NativeSttLocale(localeId: 'en-US', name: 'English'),
         NativeSttLocale(localeId: 'pl-PL', name: 'Polish'),
       ],

--- a/test/features/chat/services/voice_input_service_test.dart
+++ b/test/features/chat/services/voice_input_service_test.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:checks/checks.dart';
 import 'package:conduit/features/chat/services/native_stt_service.dart';
 import 'package:conduit/features/chat/services/voice_input_service.dart';
@@ -140,6 +142,40 @@ void main() {
         check(service.selectedLocaleId).equals('en-US');
       },
     );
+  });
+
+  test('forwards native failures to transcript-event listeners', () async {
+    final nativeStt = _FakeNativeSttService();
+    final service = _SupportedVoiceInputService(nativeStt: nativeStt);
+    await service.initialize(forceLocalStt: true);
+    await service.startListening();
+
+    final errorCompleter = Completer<Object>();
+    final subscription = service.transcriptEvents.listen(
+      (_) {},
+      onError: (Object error, StackTrace _) {
+        if (!errorCompleter.isCompleted) {
+          errorCompleter.complete(error);
+        }
+      },
+    );
+
+    nativeStt.emit(
+      const NativeSttEvent(
+        type: 'error',
+        code: 'TEST_FAILURE',
+        message: 'recognition failed',
+      ),
+    );
+
+    final error = await errorCompleter.future.timeout(
+      const Duration(seconds: 1),
+    );
+    check(error.toString()).contains('recognition failed');
+
+    await subscription.cancel();
+    await service.stopListening();
+    await nativeStt.dispose();
   });
 
   group('VoiceInputService server STT consumers', () {
@@ -295,7 +331,13 @@ class _FakeNativeSttService extends NativeSttService {
   _FakeNativeSttService({this.systemLocaleId = 'en-US'});
 
   final String systemLocaleId;
+  final StreamController<NativeSttEvent> _events =
+      StreamController<NativeSttEvent>.broadcast();
   String? availabilityLocaleId;
+
+  void emit(NativeSttEvent event) => _events.add(event);
+
+  Future<void> dispose() => _events.close();
 
   @override
   bool get isSupportedPlatform => true;
@@ -322,4 +364,18 @@ class _FakeNativeSttService extends NativeSttService {
       engine: 'automatic-test',
     );
   }
+
+  @override
+  Future<Stream<NativeSttEvent>> startListening({
+    String? localeId,
+    bool preserveAudioSession = false,
+    bool emitPartialResults = true,
+    bool accumulateResults = true,
+    bool allowOnlineFallback = true,
+  }) async {
+    return _events.stream;
+  }
+
+  @override
+  Future<void> stopListening() async {}
 }

--- a/test/features/chat/widgets/user_message_bubble_test.dart
+++ b/test/features/chat/widgets/user_message_bubble_test.dart
@@ -153,6 +153,29 @@ void main() {
     expect(find.text('brief.pdf'), findsOneWidget);
     expect(find.byType(EnhancedImageAttachment), findsNothing);
   });
+
+  for (final attachmentCount in <int>[2, 3]) {
+    testWidgets(
+      'renders $attachmentCount uploaded attachments without a type error',
+      (WidgetTester tester) async {
+        final message = ChatMessage(
+          id: 'user-images-$attachmentCount',
+          role: 'user',
+          content: "what's this",
+          timestamp: DateTime.utc(2026, 7, 3, 19, 29),
+          attachmentIds: List<String>.generate(
+            attachmentCount,
+            (index) => 'image-${index + 1}',
+          ),
+        );
+
+        await tester.pumpWidget(buildHarness(message));
+
+        expect(tester.takeException(), isNull);
+        expect(find.byType(EnhancedAttachment), findsNWidgets(attachmentCount));
+      },
+    );
+  }
 }
 
 class _FakeAttachmentInfoApiService extends ApiService {


### PR DESCRIPTION
## Summary

This PR addresses three separate regressions:

- **#552 — crash after sending multiple media attachments (Android and iOS):** normalizes dynamically hydrated attachment IDs to `List<String>` and produces explicitly typed widget collections before rendering two-item and grid layouts.
- **#554 — server STT live mode remains stuck on “Listening”:** processes completed VAD samples when either the text stream or the transcript-event stream has a listener, and forwards recognition failures to both consumers. Live mode uses transcript events, so its audio and errors were previously invisible when no legacy text listener was attached.
- **#551 — on-device STT follows the Android UI language:** leaves the Android native locale unset and requests platform language switching when the device can prove the required offline support. This is automatic; no recognition-language setting is added.

## Platform behavior for automatic on-device language handling

- **Android 14+:** automatic switching is enabled only when the on-device `SpeechRecognizer` support query reports at least two distinct installed languages. The automatic intent is allowlisted to those installed models and deliberately omits fixed-language extras so recognition is not pinned.
- **Android 13 and earlier, or Android recognizers without verified switching support:** falls back to fixed current-system-locale recognition. Offline-only fallback is advertised and started only through Android's verified on-device recognizer; online-capable-only services are rejected.
- **iOS:** does not auto-switch languages because Apple's public Speech APIs require a recognition locale. Conduit automatically uses the closest supported variant of the current system language; no setting is added.

## Root causes

- Attachment IDs can arrive through legacy dynamic message hydration. Mapping that dynamic collection produced `List<dynamic>`, which failed at runtime where Flutter expected `List<Widget>`.
- Server live mode listens to transcript events, but VAD sample processing and recognition errors were wired only to the legacy text stream.
- Conduit selected and passed the device/system locale before starting Android STT, preventing Android's platform language-switch mode from being used.
- The first auto-language implementation advertised availability from recognizer presence alone instead of verifying installed language support.

## Validation

- `flutter test` — **2,534 tests passed**
- `flutter analyze` — **no issues**
- Focused voice-input suite — **20 tests passed**
- Android native policy unit tests — **4 tests passed**
- Android `:app:compileDebugKotlin` — **BUILD SUCCESSFUL**
- Android `:app:assembleDebug` — **BUILD SUCCESSFUL**

Existing Android/Kotlin deprecation warnings remain. Android device/emulator and iOS simulator/device validation were not run.

Fixes #552
Fixes #554
Fixes #551

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic on-device language detection and switching for supported Android devices, using platform speech language-switch capabilities when available.
* **Bug Fixes**
  * Continued processing server speech/VAD samples whenever transcript events are being consumed (not only when text is).
  * Fixed user message image rendering by safely normalizing attachment IDs to prevent runtime type issues.
* **Reliability**
  * Improved speech availability handling, error reporting consistency, and Android speech engine selection for the new automatic mode.
* **Tests**
  * Added coverage for automatic language behavior and updated attachment rendering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix multi-attachment crash and speech-to-text regressions in Android and chat UI
> - Fixes a crash in [`UserMessageBubble._buildImageLayout`](https://github.com/cogwheel0/conduit/pull/563/files#diff-904aac85c802fc8c7223261ec8b9ea2ac967bf202cd61904b2c83e0b889d892c) when rendering multiple attachments by normalizing dynamic `attachmentIds` to `List<String>` before iteration.
> - Adds automatic language switching support to [`NativeSttBridge`](https://github.com/cogwheel0/conduit/pull/563/files#diff-cbe660d00a0affeaecdb5283221d27c842169e8e1b04830d581b2bac182297cb): when the platform supports it, recognition runs with language detection enabled and emits `android_speech_auto` as the engine name instead of `android_speech`.
> - Centralizes STT availability and language-switch policy into a new [`NativeSttLanguagePolicy`](https://github.com/cogwheel0/conduit/pull/563/files#diff-f83f07ae4eba93c13636829146a5a284d6c021a1c4ee0cd6fe0d284f402ebb4c) object, with unit tests covering offline/online and SDK-version cases.
> - Fixes error propagation in [`VoiceInputService`](https://github.com/cogwheel0/conduit/pull/563/files#diff-b9661a7340a22f822387716b3ff0f11c6fd8d1f9b66a56bfb6d36d091e574e2c) so recognition errors reach both text and transcript-event stream consumers via a new `_reportRecognitionError` helper.
> - Behavioral Change: on Android, `_selectedLocaleId` is now left `null` to enable automatic language selection, and the platform recognizer uses an on-device-only recognizer when `allowOnlineFallback=false`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 579fe9c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes several chat and speech-to-text regressions. The main changes are:

- Normalizes user attachment IDs before rendering image layouts.
- Adds verified Android automatic language switching for native speech recognition.
- Uses the on-device Android recognizer for offline native speech paths.
- Sends speech recognition errors to both text and transcript-event consumers.
- Processes server speech samples when live transcript events are being consumed.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

This looks safe to merge.

No blocking issues found in the changed code.
</details>


<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- The before-check log shows Flutter is not installed because the command -v flutter exited with code 127 in the repository.
- The focused Flutter widget test command could not run and failed immediately due to Flutter not being installed.
- A separate flutter --version check confirms Flutter is missing, as the shell reports Flutter not found.

<a href="https://app.greptile.com/trex/runs/14021954/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| android/app/src/main/kotlin/app/cogwheel/conduit/NativeSttBridge.kt | Updates Android speech availability, recognizer startup, and automatic language-switch intents. |
| android/app/src/main/kotlin/app/cogwheel/conduit/NativeSttLanguagePolicy.kt | Adds shared policy checks for platform recognizer availability and automatic language support. |
| lib/features/chat/services/voice_input_service.dart | Updates native locale selection, speech error routing, and server sample processing for live mode. |
| lib/features/chat/widgets/user_message_bubble.dart | Normalizes attachment IDs before building single, double, and grid image layouts. |

</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `android/app/src/main/kotlin/app/cogwheel/conduit/NativeSttBridge.kt`, line 143-144 ([link](https://github.com/cogwheel0/conduit/blob/cb85f90533b55ad9c039c552b54fbebaae90ee48/android/app/src/main/kotlin/app/cogwheel/conduit/NativeSttBridge.kt#L143-L144)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Offline Probe Uses Online Recognizer**

   When Dart checks local STT with `allowOnlineFallback: false`, the auto-language probe can correctly reject missing on-device support and then this fallback still returns available from `isRecognitionAvailable`. Devices with only online platform recognition can be cached as local-capable and later start an offline-only session that fails with a recognizer/network error instead of falling back to server STT.

   **Context Used:** AGENTS.md ([source](https://app.greptile.com/cogwheel/-/custom-context?memory=871e7f39-32ad-42bc-9cb3-4f44ae78faec))

2. `android/app/src/main/kotlin/app/cogwheel/conduit/NativeSttBridge.kt`, line 143-145 ([link](https://github.com/cogwheel0/conduit/blob/edd054defbf8cf52068da5518306763e083a0aff/android/app/src/main/kotlin/app/cogwheel/conduit/NativeSttBridge.kt#L143-L145)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Offline Probe Uses Online Fallback**

   When `allowOnlineFallback=false` and the auto-language support probe returns no usable on-device languages, this fallback still reports `android_speech` from `isRecognitionAvailable()`. A device with only online recognition can be cached as local-capable, then the offline dictation path starts the regular recognizer with `EXTRA_PREFER_OFFLINE` and fails instead of falling back to server STT.

   **Context Used:** AGENTS.md ([source](https://app.greptile.com/cogwheel/-/custom-context?memory=871e7f39-32ad-42bc-9cb3-4f44ae78faec))
   
   <details><summary><strong>Artifacts</strong></summary><br />
   
   **[Repro: focused executable harness for the offline availability fallback path](https://app.greptile.com/trex/artifacts/f316acbe-4d80-4b0b-b3ac-17638dafed8c)**
   
   - Contains supporting evidence from the run (text/x-python; charset=utf-8).
   
   **[Repro: harness execution log showing mocked inputs and observed android\_speech availability](https://app.greptile.com/trex/artifacts/f880cfac-92c7-4495-aabc-373f78745ab5)**
   
   - Keeps the command output available without making the summary code-heavy.
   
   <a href="https://app.greptile.com/trex/runs/14019780/artifacts?artifact=f316acbe-4d80-4b0b-b3ac-17638dafed8c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewArtifacts.svg?v=4"><img alt="View artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewArtifacts.svg?v=4"></picture></a>
   </details>
   
   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (7): Last reviewed commit: ["Require on-device recognizer for offline..."](https://github.com/cogwheel0/conduit/commit/579fe9cc1941c7c342a14e6059704eb09987a929) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43355328)</sub>

<!-- /greptile_comment -->