### PR TITLE
Offload large-conversation assembly, fix attachment-queue logout behavior, refresh docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,7 +26,7 @@ Run `dart run build_runner build` after `flutter pub get` and after switching br
 
 Top-level Dart code is split into `lib/core/` for app-wide services, models, routing, auth, storage, networking, and platform glue; `lib/features/` for product areas; `lib/shared/` for reusable widgets and utilities; and `lib/l10n/` for localization ARB files and generated localization output configured by `l10n.yaml`. Do not hand-edit generated localization Dart; edit ARB inputs and regenerate.
 
-State management uses Riverpod 3 with generated providers. Navigation uses `go_router`. HTTP and realtime transport use Dio and `socket_io_client`. Local persistence uses Hive CE, `shared_preferences`, and `flutter_secure_storage`.
+State management uses Riverpod 3 with generated providers. Navigation uses `go_router`. HTTP and realtime transport use Dio and `socket_io_client`. Local persistence uses Drift for structured data (chats, notes, caches, outbox), `shared_preferences` for preferences, and `flutter_secure_storage` for credentials; residual Hive CE code is staged for removal.
 
 # Conventions
 

--- a/PRIVACY_POLICY.md
+++ b/PRIVACY_POLICY.md
@@ -1,6 +1,6 @@
 # Conduit Privacy Policy
 
-Effective date: 2025-08-09
+Effective date: 2026-07-03
 
 Conduit is an open‑source mobile client for Open‑WebUI. This app acts as a client to a server you choose and configure. This policy describes how the app itself handles data on your device. Your configured server may collect, process, and store data under its own policies; please review your server's privacy terms separately.
 
@@ -24,6 +24,12 @@ Depending on how you use Conduit, the app may request:
 - Microphone: to capture voice input when you opt in.
 - Photos/Files: to let you pick and upload attachments.
 - Network access: to connect to your configured server.
+- Location: to optionally attach your approximate location to chat requests
+  when you enable the location feature; requested only when you opt in and
+  sent only to your configured server.
+- Camera: to capture photos for attachments when you choose the camera option.
+- Speech recognition: to transcribe voice input on-device when you use voice
+  features; your speech is converted to text on your device when available.
 
 ## Third‑Party Services
 The app does not include third‑party analytics or advertising SDKs. Your configured server or extensions you use may rely on third‑party services subject to their own terms.

--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ enough for daily use.
 | Mobile UX | Voice input, full voice-call mode, home screen widgets, app quick actions, clipboard image paste, haptics, and adaptive Material/Cupertino UI |
 | Personalization | Light, dark, and system themes plus a localized interface across 13 supported locales |
 | Privacy | Native secure storage, no third-party analytics or ads, and no developer-operated backend relaying your data |
+| Terminal | Interactive terminal sessions over WebSocket with a file browser, shown only when your server exposes the terminal integration |
 
 ## Built for Self-Hosted Reality
 
@@ -179,7 +180,7 @@ filters appear when they are available on the connected server.
 ### Run locally
 
 ```bash
-git clone https://github.com/cogwheel0/conduit.git
+git clone --recursive https://github.com/cogwheel0/conduit.git
 cd conduit
 flutter pub get
 dart run build_runner build
@@ -187,6 +188,8 @@ flutter run -d ios
 # or
 flutter run -d android
 ```
+
+The `--recursive` flag pulls the `openwebui-src` submodule — a vendored Open WebUI checkout used as an API reference during development; the app builds without it.
 
 ### Developer checks
 
@@ -226,7 +229,7 @@ credential handling built into the core layer.
 - Riverpod 3 and `riverpod_generator` for state and dependency wiring
 - GoRouter for navigation
 - Dio plus socket transport for API and streaming
-- Hive and shared preferences for local persistence
+- Drift (SQLite) for structured local data, with shared preferences for settings
 - Flutter Secure Storage for credentials
 
 ### Project layout
@@ -249,10 +252,12 @@ lib/
 <details>
 <summary>Platform permissions</summary>
 
-- Android asks for internet, microphone, camera, and file access for chat,
-  voice input, attachments, and image capture.
-- iOS requests microphone, speech recognition, camera, and photo library access
-  for voice and attachment workflows.
+- Android asks for internet, microphone, camera, file access, and optional
+  location for chat, voice input, attachments, image capture, and location
+  sharing.
+- iOS requests microphone, speech recognition, camera, photo library, and
+  optional location-when-in-use access for voice, attachment, and location
+  sharing workflows.
 
 </details>
 

--- a/README.md
+++ b/README.md
@@ -252,9 +252,9 @@ lib/
 <details>
 <summary>Platform permissions</summary>
 
-- Android asks for internet, microphone, camera, file access, and optional
-  location for chat, voice input, attachments, image capture, and location
-  sharing.
+- Android requests microphone, camera, and optional location permissions for
+  voice input, image capture, and location sharing; attachments use the system
+  photo picker, so no broad storage permission is needed.
 - iOS requests microphone, speech recognition, camera, photo library, and
   optional location-when-in-use access for voice, attachment, and location
   sharing workflows.

--- a/lib/core/database/local_conversation_loader.dart
+++ b/lib/core/database/local_conversation_loader.dart
@@ -9,10 +9,10 @@ import '../utils/debug_logger.dart';
 import 'database_provider.dart';
 import 'mappers/conversation_assembler.dart';
 
-/// Message count above which assembly is offloaded to the worker isolate.
-/// (`ApiService` uses a separate payload byte-size heuristic for the same
-/// purpose.)
-const int kLocalConversationWorkerThreshold = 100;
+// kLocalConversationWorkerThreshold is defined in
+// mappers/conversation_assembler.dart and re-exported here for callers that
+// already import local_conversation_loader.dart. Do NOT redeclare it.
+export 'mappers/conversation_assembler.dart' show kLocalConversationWorkerThreshold;
 
 /// Fire-and-forget background pull for one chat. Best-effort freshening:
 /// swallows every failure (engine unavailable, network down) so DB-first

--- a/lib/core/database/mappers/conversation_assembler.dart
+++ b/lib/core/database/mappers/conversation_assembler.dart
@@ -16,6 +16,12 @@ import '../daos/chats_dao.dart';
 import '../daos/search_dao.dart';
 import 'chat_blob_mapper.dart';
 
+/// Message count above which assembly MUST be offloaded to a worker isolate.
+/// (`ApiService` uses a separate payload byte-size heuristic for the same
+/// purpose.) Single source of truth — `local_conversation_loader.dart`
+/// re-exports this constant for callers that already import from there.
+const int kLocalConversationWorkerThreshold = 100;
+
 /// Inverse of `ChatsDao.upsertServerChat`'s decomposition: rebuilds
 /// [ChatRows] from a [ChatRow] + its [MessageRow]s (payload jsonDecoded per
 /// row; bookkeeping from `blobMeta` per amendment A3; `'{}'` blobMeta -> all
@@ -83,10 +89,36 @@ Map<String, dynamic> buildChatResponseEnvelope(
 /// `parseFullConversationModel(buildChatResponseEnvelope(...))` — the parse
 /// entry point in `conversation_parsing.dart`.
 ///
-/// Call sites MUST offload via the existing WorkerManager worker entrypoint
-/// (`parseFullConversationModelWorker`) when `messages.length > 100`.
+/// **New call sites MUST use [assembleConversationGuarded] instead.**
+/// Raw calls here violate the worker contract when `messages.length >
+/// [kLocalConversationWorkerThreshold]` and will block the UI isolate on large
+/// conversations.
 Conversation assembleConversation(ChatRow chat, List<MessageRow> messages) {
   return parseFullConversationModel(buildChatResponseEnvelope(chat, messages));
+}
+
+/// Closure type for offloading a pre-built envelope to a worker isolate.
+/// The caller is responsible for routing through [parseFullConversationModelWorker]
+/// via [WorkerManager.schedule].
+typedef ConversationParseOffload = Future<Conversation> Function(
+  Object? envelope,
+);
+
+/// Contract-enforcing wrapper around [assembleConversation]: offloads via
+/// [offload] when `messages.length` exceeds [kLocalConversationWorkerThreshold],
+/// otherwise parses synchronously inline.
+///
+/// Callers that cannot supply an offload pass `null` and accept the documented
+/// jank risk (equivalent to the old raw [assembleConversation] call).
+Future<Conversation> assembleConversationGuarded(
+  ChatRow chat,
+  List<MessageRow> messages, {
+  required ConversationParseOffload? offload,
+}) {
+  if (offload != null && messages.length > kLocalConversationWorkerThreshold) {
+    return offload(buildChatResponseEnvelope(chat, messages));
+  }
+  return Future.value(assembleConversation(chat, messages));
 }
 
 /// Shared body-less summary builder. Timestamps are epoch SECONDS (scaled to

--- a/lib/core/providers/app_providers.dart
+++ b/lib/core/providers/app_providers.dart
@@ -564,25 +564,28 @@ final socketServiceProvider = Provider<SocketService?>((ref) {
 
 // Attachment upload queue — one instance per active server.
 //
-// Constructs the queue and awaits its initialization against the active
-// server's API + Drift table, so consumers that `await .future` get a
-// fully-loaded queue (no enqueue-before-load race). When the active server
-// changes (server switch / logout), this keepAlive provider rebuilds and
-// `ref.onDispose` tears the previous instance down — cancelling in-flight
-// uploads and closing its stream so awaiting upload completers resolve — before
-// a fresh instance takes over the new server. Null in reviewer mode / when
-// there is no active server.
-final attachmentUploadQueueProvider =
-    FutureProvider<AttachmentUploadQueue?>((ref) async {
+// Constructs the queue and kicks off its (async) initialization against the
+// active server's API + Drift table. Consumers `await queue.ready` before
+// enqueueing so an upload never races the load; `ready` is owned by the queue
+// instance, so — unlike a `FutureProvider.future` — awaiting it cannot hang if
+// this provider rebuilds mid-initialization. When the active server changes
+// (server switch / logout), this keepAlive provider rebuilds and `ref.onDispose`
+// tears the previous instance down (cancelling in-flight uploads and closing its
+// stream so awaiting upload completers resolve via `onDone`) before a fresh
+// instance takes over. Null in reviewer mode / when there is no active server.
+final attachmentUploadQueueProvider = Provider<AttachmentUploadQueue?>((ref) {
   final api = ref.watch(apiServiceProvider);
   if (api == null) return null;
 
   final queue = AttachmentUploadQueue();
   ref.onDispose(queue.dispose);
-  await queue.initialize(
-    onUpload: (filePath, fileName, {cancelToken}) =>
-        api.uploadFile(filePath, fileName, cancelToken: cancelToken),
-    database: () => ref.read(appDatabaseProvider),
+  // Fire-and-forget: readiness is exposed via `queue.ready`, awaited by callers.
+  unawaited(
+    queue.initialize(
+      onUpload: (filePath, fileName, {cancelToken}) =>
+          api.uploadFile(filePath, fileName, cancelToken: cancelToken),
+      database: () => ref.read(appDatabaseProvider),
+    ),
   );
   return queue;
 });

--- a/lib/core/providers/app_providers.dart
+++ b/lib/core/providers/app_providers.dart
@@ -9,6 +9,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:package_info_plus/package_info_plus.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 import '../services/api_service.dart';
+import '../services/attachment_upload_queue.dart';
 import '../auth/auth_state_manager.dart';
 import '../../features/auth/providers/unified_auth_providers.dart';
 import '../models/server_config.dart';
@@ -559,6 +560,31 @@ final socketServiceProvider = Provider<SocketService?>((ref) {
     orElse: () =>
         ref.read(socketServiceManagerProvider.notifier).currentService,
   );
+});
+
+// Attachment upload queue — one instance per active server.
+//
+// Constructs the queue and awaits its initialization against the active
+// server's API + Drift table, so consumers that `await .future` get a
+// fully-loaded queue (no enqueue-before-load race). When the active server
+// changes (server switch / logout), this keepAlive provider rebuilds and
+// `ref.onDispose` tears the previous instance down — cancelling in-flight
+// uploads and closing its stream so awaiting upload completers resolve — before
+// a fresh instance takes over the new server. Null in reviewer mode / when
+// there is no active server.
+final attachmentUploadQueueProvider =
+    FutureProvider<AttachmentUploadQueue?>((ref) async {
+  final api = ref.watch(apiServiceProvider);
+  if (api == null) return null;
+
+  final queue = AttachmentUploadQueue();
+  ref.onDispose(queue.dispose);
+  await queue.initialize(
+    onUpload: (filePath, fileName, {cancelToken}) =>
+        api.uploadFile(filePath, fileName, cancelToken: cancelToken),
+    database: () => ref.read(appDatabaseProvider),
+  );
+  return queue;
 });
 
 // Auth providers

--- a/lib/core/providers/app_providers.dart
+++ b/lib/core/providers/app_providers.dart
@@ -568,25 +568,30 @@ final socketServiceProvider = Provider<SocketService?>((ref) {
 // active server's API + Drift table. Consumers `await queue.ready` before
 // enqueueing so an upload never races the load; `ready` is owned by the queue
 // instance, so — unlike a `FutureProvider.future` — awaiting it cannot hang if
-// this provider rebuilds mid-initialization. When the active server changes
-// (server switch / logout), this keepAlive provider rebuilds and `ref.onDispose`
-// tears the previous instance down (cancelling in-flight uploads and closing its
-// stream so awaiting upload completers resolve via `onDone`) before a fresh
-// instance takes over. Null in reviewer mode / when there is no active server.
+// this provider rebuilds mid-initialization. The provider is also gated on the
+// authenticated state: logout flips `isAuthenticatedProvider2` false before its
+// first await, disposing the previous queue immediately even though the active
+// server (and ApiService object) is deliberately preserved. On server switch or
+// logout, `ref.onDispose` cancels in-flight uploads and closes the stream so
+// awaiting upload completers resolve via `onDone`. Null while unauthenticated,
+// in reviewer mode, or when there is no active server.
 final attachmentUploadQueueProvider = Provider<AttachmentUploadQueue?>((ref) {
+  if (!ref.watch(isAuthenticatedProvider2)) return null;
   final api = ref.watch(apiServiceProvider);
   if (api == null) return null;
 
   final queue = AttachmentUploadQueue();
   ref.onDispose(queue.dispose);
-  // Fire-and-forget: readiness is exposed via `queue.ready`, awaited by callers.
-  unawaited(
-    queue.initialize(
-      onUpload: (filePath, fileName, {cancelToken}) =>
-          api.uploadFile(filePath, fileName, cancelToken: cancelToken),
-      database: () => ref.read(appDatabaseProvider),
-    ),
+  // Readiness is exposed via `queue.ready`, awaited by callers. Attach an
+  // immediate error-consuming branch so a Drift load failure cannot surface as
+  // an uncaught fire-and-forget error; `queue.ready` retains the ORIGINAL
+  // future and still rejects, aborting the upload before enqueue.
+  final initialization = queue.initialize(
+    onUpload: (filePath, fileName, {cancelToken}) =>
+        api.uploadFile(filePath, fileName, cancelToken: cancelToken),
+    database: () => ref.read(appDatabaseProvider),
   );
+  unawaited(initialization.catchError((Object _, StackTrace _) {}));
   return queue;
 });
 

--- a/lib/core/providers/app_providers.dart
+++ b/lib/core/providers/app_providers.dart
@@ -11,7 +11,6 @@ import 'package:riverpod_annotation/riverpod_annotation.dart';
 import '../services/api_service.dart';
 import '../auth/auth_state_manager.dart';
 import '../../features/auth/providers/unified_auth_providers.dart';
-import '../services/attachment_upload_queue.dart';
 import '../models/server_config.dart';
 import '../models/user.dart';
 import '../models/model.dart';
@@ -560,23 +559,6 @@ final socketServiceProvider = Provider<SocketService?>((ref) {
     orElse: () =>
         ref.read(socketServiceManagerProvider.notifier).currentService,
   );
-});
-
-// Attachment upload queue provider
-final attachmentUploadQueueProvider = Provider<AttachmentUploadQueue?>((ref) {
-  final api = ref.watch(apiServiceProvider);
-  if (api == null) return null;
-
-  final queue = AttachmentUploadQueue();
-  // Re-runs when the API (and thus active server) changes, reloading the queue
-  // from the active server's Drift table.
-  queue.initialize(
-    onUpload: (filePath, fileName, {cancelToken}) =>
-        api.uploadFile(filePath, fileName, cancelToken: cancelToken),
-    database: () => ref.read(appDatabaseProvider),
-  );
-
-  return queue;
 });
 
 // Auth providers

--- a/lib/core/services/attachment_upload_queue.dart
+++ b/lib/core/services/attachment_upload_queue.dart
@@ -172,16 +172,16 @@ class AttachmentUploadQueue {
         scope: 'attachments/queue',
       );
     } catch (error, stackTrace) {
-      // Swallow init failures (e.g. a Drift load error) so the fire-and-forget
-      // initialize() future never surfaces as an uncaught async error and
-      // `ready` always completes. The queue degrades to empty; the next
-      // server-scoped instance re-loads.
       DebugLogger.error(
         'attachment-queue-init-failed',
         scope: 'attachments/queue',
         error: error,
         stackTrace: stackTrace,
       );
+      // Preserve the failure on `ready`: callers must abort before enqueueing,
+      // otherwise a load failure followed by _save() could rewrite the Drift
+      // table from an incomplete in-memory snapshot.
+      rethrow;
     }
   }
 
@@ -446,21 +446,24 @@ class AttachmentUploadQueue {
 
   // Utilities
   Future<void> _load() async {
-    _queue.clear();
     final dao = _attachmentDao;
     if (dao == null) return;
     final rows = await dao.getAll();
-    // An item persisted as `uploading` means a prior session ended mid-upload
-    // (deactivate on server switch/logout, or an app crash). Reset it to
-    // `pending` on load so processQueue can retry it instead of leaving it
-    // stuck in a non-terminal status that is never reprocessed.
-    _queue.addAll(
-      rows.map(_rowToModel).map(
-            (item) => item.status == QueuedAttachmentStatus.uploading
-                ? item.copyWith(status: QueuedAttachmentStatus.pending)
-                : item,
-          ),
-    );
+    // Stage the full conversion before replacing the in-memory queue. If the
+    // read or JSON conversion fails, `ready` rejects and the existing snapshot
+    // remains intact — a later enqueue cannot mirror a partial/empty snapshot
+    // over the persisted table.
+    final loaded = rows
+        .map(_rowToModel)
+        .map(
+          (item) => item.status == QueuedAttachmentStatus.uploading
+              ? item.copyWith(status: QueuedAttachmentStatus.pending)
+              : item,
+        )
+        .toList(growable: false);
+    _queue
+      ..clear()
+      ..addAll(loaded);
   }
 
   Future<void> _save() async {

--- a/lib/core/services/attachment_upload_queue.dart
+++ b/lib/core/services/attachment_upload_queue.dart
@@ -323,10 +323,39 @@ class AttachmentUploadQueue {
   void deactivate() {
     _retryTimer?.cancel();
     _retryTimer = null;
+    // Cancel any in-flight upload bound to the previous server so it does not
+    // complete against the account we just left.
+    for (final token in _cancelTokens.values) {
+      token.cancel('attachment queue deactivated');
+    }
+    _cancelTokens.clear();
+    // Drive every still-active item to a terminal (cancelled) state and emit
+    // once. Otherwise a pending/uploading item never reaches a terminal status
+    // after processing stops, leaving any queueStream listener awaiting it
+    // (e.g. a MediaUploadController upload completer) hung forever. The
+    // broadcast controller stays open; the next initialize() reloads the active
+    // server's queue from Drift.
+    var changed = false;
+    for (var i = 0; i < _queue.length; i++) {
+      final item = _queue[i];
+      if (item.status == QueuedAttachmentStatus.pending ||
+          item.status == QueuedAttachmentStatus.uploading) {
+        _queue[i] = item.copyWith(
+          status: QueuedAttachmentStatus.cancelled,
+          nextRetryAt: null,
+          lastError: 'cancelled: server changed',
+        );
+        changed = true;
+      }
+    }
+    if (changed) _notify();
     _onUpload = null;
     _onQueueChanged = null;
     _databaseResolver = null;
-    DebugLogger.log('AttachmentUploadQueue deactivated', scope: 'attachments/queue');
+    DebugLogger.log(
+      'AttachmentUploadQueue deactivated',
+      scope: 'attachments/queue',
+    );
   }
 
   void _processSafe() {
@@ -402,7 +431,17 @@ class AttachmentUploadQueue {
     final dao = _attachmentDao;
     if (dao == null) return;
     final rows = await dao.getAll();
-    _queue.addAll(rows.map(_rowToModel));
+    // An item persisted as `uploading` means a prior session ended mid-upload
+    // (deactivate on server switch/logout, or an app crash). Reset it to
+    // `pending` on load so processQueue can retry it instead of leaving it
+    // stuck in a non-terminal status that is never reprocessed.
+    _queue.addAll(
+      rows.map(_rowToModel).map(
+            (item) => item.status == QueuedAttachmentStatus.uploading
+                ? item.copyWith(status: QueuedAttachmentStatus.pending)
+                : item,
+          ),
+    );
   }
 
   Future<void> _save() async {

--- a/lib/core/services/attachment_upload_queue.dart
+++ b/lib/core/services/attachment_upload_queue.dart
@@ -310,16 +310,19 @@ class AttachmentUploadQueue {
     Timer(const Duration(milliseconds: 500), _processSafe);
   }
 
-  /// Stops background processing and detaches the current server's callbacks.
+  /// Stops background processing and releases the previous server's session.
   ///
-  /// Called when the active [ApiService] changes (server switch / logout) so a
-  /// stale [_onUpload] closure bound to the previous server can no longer fire
-  /// on a retry tick. Deliberately minimal and reusable: it cancels the periodic
-  /// timer and nulls the callbacks/db resolver, but does NOT close [queueStream]
-  /// (a shared broadcast stream reused across uploads) and does NOT cancel
-  /// in-flight [_cancelTokens] (an upload already awaiting its network call is
-  /// allowed to finish). The next [initialize] re-arms the timer and callbacks
-  /// and reloads the queue from the (new) active server's Drift table.
+  /// Called when the active [ApiService] changes (server switch / logout).
+  /// Cancels the periodic timer, aborts in-flight uploads via their
+  /// [CancelToken]s (so nothing completes against the account just left), and
+  /// drives every still-active queue item to a terminal (`cancelled`) state
+  /// with a single [_notify] so `queueStream` listeners (e.g. a
+  /// `MediaUploadController` upload completer) resolve instead of hanging. The
+  /// cancelled statuses are persisted best-effort before the db resolver is
+  /// dropped, so they do not reappear as pending on reconnect. The broadcast
+  /// [queueStream] is intentionally NOT closed (it is reused across uploads);
+  /// the next [initialize] re-arms the timer and callbacks and reloads the
+  /// active server's queue from Drift.
   void deactivate() {
     _retryTimer?.cancel();
     _retryTimer = null;
@@ -348,7 +351,14 @@ class AttachmentUploadQueue {
         changed = true;
       }
     }
-    if (changed) _notify();
+    if (changed) {
+      _notify();
+      // Persist the cancelled statuses to the previous server's table before we
+      // drop the resolver, so they do not reappear as pending on reconnect.
+      // Best-effort: _save() captures the db synchronously (before the null
+      // below); swallow errors since the db may be closing on a server switch.
+      unawaited(_save().catchError((Object _) {}));
+    }
     _onUpload = null;
     _onQueueChanged = null;
     _databaseResolver = null;

--- a/lib/core/services/attachment_upload_queue.dart
+++ b/lib/core/services/attachment_upload_queue.dart
@@ -310,6 +310,25 @@ class AttachmentUploadQueue {
     Timer(const Duration(milliseconds: 500), _processSafe);
   }
 
+  /// Stops background processing and detaches the current server's callbacks.
+  ///
+  /// Called when the active [ApiService] changes (server switch / logout) so a
+  /// stale [_onUpload] closure bound to the previous server can no longer fire
+  /// on a retry tick. Deliberately minimal and reusable: it cancels the periodic
+  /// timer and nulls the callbacks/db resolver, but does NOT close [queueStream]
+  /// (a shared broadcast stream reused across uploads) and does NOT cancel
+  /// in-flight [_cancelTokens] (an upload already awaiting its network call is
+  /// allowed to finish). The next [initialize] re-arms the timer and callbacks
+  /// and reloads the queue from the (new) active server's Drift table.
+  void deactivate() {
+    _retryTimer?.cancel();
+    _retryTimer = null;
+    _onUpload = null;
+    _onQueueChanged = null;
+    _databaseResolver = null;
+    DebugLogger.log('AttachmentUploadQueue deactivated', scope: 'attachments/queue');
+  }
+
   void _processSafe() {
     // Fire and forget
     unawaited(processQueue());

--- a/lib/core/services/attachment_upload_queue.dart
+++ b/lib/core/services/attachment_upload_queue.dart
@@ -163,13 +163,26 @@ class AttachmentUploadQueue {
   }
 
   Future<void> _initInternal() async {
-    await _load();
-    if (_disposed) return;
-    _startPeriodicProcessing();
-    DebugLogger.log(
-      'AttachmentUploadQueue initialized with ${_queue.length} items',
-      scope: 'attachments/queue',
-    );
+    try {
+      await _load();
+      if (_disposed) return;
+      _startPeriodicProcessing();
+      DebugLogger.log(
+        'AttachmentUploadQueue initialized with ${_queue.length} items',
+        scope: 'attachments/queue',
+      );
+    } catch (error, stackTrace) {
+      // Swallow init failures (e.g. a Drift load error) so the fire-and-forget
+      // initialize() future never surfaces as an uncaught async error and
+      // `ready` always completes. The queue degrades to empty; the next
+      // server-scoped instance re-loads.
+      DebugLogger.error(
+        'attachment-queue-init-failed',
+        scope: 'attachments/queue',
+        error: error,
+        stackTrace: stackTrace,
+      );
+    }
   }
 
   AttachmentQueueDao? get _attachmentDao =>
@@ -182,6 +195,12 @@ class AttachmentUploadQueue {
     String? mimeType,
     String? checksum,
   }) async {
+    if (_disposed) {
+      // The queue was torn down (server switch / logout). Fail loudly rather
+      // than adding an item that _save/_notify/_processSafe all skip, which
+      // would look enqueued but silently never persist or upload.
+      throw StateError('Cannot enqueue on a disposed AttachmentUploadQueue');
+    }
     final id = DateTime.now().microsecondsSinceEpoch.toString();
     final item = QueuedAttachment(
       id: id,

--- a/lib/core/services/attachment_upload_queue.dart
+++ b/lib/core/services/attachment_upload_queue.dart
@@ -109,11 +109,12 @@ typedef UploadCallback =
 typedef AttachmentsEventCallback = void Function(List<QueuedAttachment> queue);
 
 /// A lightweight background queue to upload attachments when back online.
+///
+/// One instance per active server, owned by `attachmentUploadQueueProvider`,
+/// which constructs it, awaits [initialize], and [dispose]s it (closing the
+/// stream and cancelling in-flight uploads) when the server changes.
 class AttachmentUploadQueue {
-  static final AttachmentUploadQueue _instance =
-      AttachmentUploadQueue._internal();
-  factory AttachmentUploadQueue() => _instance;
-  AttachmentUploadQueue._internal();
+  AttachmentUploadQueue();
 
   static const int _maxRetries = 4;
   static const Duration _baseRetryDelay = Duration(seconds: 5);
@@ -135,6 +136,8 @@ class AttachmentUploadQueue {
   // Streams
   final _queueController = StreamController<List<QueuedAttachment>>.broadcast();
   Stream<List<QueuedAttachment>> get queueStream => _queueController.stream;
+
+  bool _disposed = false;
 
   List<QueuedAttachment> get queue => List.unmodifiable(_queue);
 
@@ -310,65 +313,37 @@ class AttachmentUploadQueue {
     Timer(const Duration(milliseconds: 500), _processSafe);
   }
 
-  /// Stops background processing and releases the previous server's session.
+  /// Tears down this per-server queue instance.
   ///
-  /// Called when the active [ApiService] changes (server switch / logout).
-  /// Cancels the periodic timer, aborts in-flight uploads via their
-  /// [CancelToken]s (so nothing completes against the account just left), and
-  /// drives every still-active queue item to a terminal (`cancelled`) state
-  /// with a single [_notify] so `queueStream` listeners (e.g. a
-  /// `MediaUploadController` upload completer) resolve instead of hanging. The
-  /// cancelled statuses are persisted best-effort before the db resolver is
-  /// dropped, so they do not reappear as pending on reconnect. The broadcast
-  /// [queueStream] is intentionally NOT closed (it is reused across uploads);
-  /// the next [initialize] re-arms the timer and callbacks and reloads the
-  /// active server's queue from Drift.
-  void deactivate() {
+  /// The owning `attachmentUploadQueueProvider` calls this via `ref.onDispose`
+  /// when the active server changes (server switch / logout). Cancels the
+  /// periodic timer, aborts in-flight uploads via their [CancelToken]s (so
+  /// nothing completes against the account just left), and closes [queueStream]
+  /// so any listener awaiting an upload (e.g. a `MediaUploadController`
+  /// completer) resolves via `onDone` instead of hanging. Persisted queue rows
+  /// are left untouched: the next server-scoped instance reloads and resumes
+  /// them from that server's Drift table. Idempotent.
+  void dispose() {
+    if (_disposed) return;
+    _disposed = true;
     _retryTimer?.cancel();
     _retryTimer = null;
-    // Cancel any in-flight upload bound to the previous server so it does not
-    // complete against the account we just left.
     for (final token in _cancelTokens.values) {
-      token.cancel('attachment queue deactivated');
+      token.cancel('attachment queue disposed');
     }
     _cancelTokens.clear();
-    // Drive every still-active item to a terminal (cancelled) state and emit
-    // once. Otherwise a pending/uploading item never reaches a terminal status
-    // after processing stops, leaving any queueStream listener awaiting it
-    // (e.g. a MediaUploadController upload completer) hung forever. The
-    // broadcast controller stays open; the next initialize() reloads the active
-    // server's queue from Drift.
-    var changed = false;
-    for (var i = 0; i < _queue.length; i++) {
-      final item = _queue[i];
-      if (item.status == QueuedAttachmentStatus.pending ||
-          item.status == QueuedAttachmentStatus.uploading) {
-        _queue[i] = item.copyWith(
-          status: QueuedAttachmentStatus.cancelled,
-          nextRetryAt: null,
-          lastError: 'cancelled: server changed',
-        );
-        changed = true;
-      }
-    }
-    if (changed) {
-      _notify();
-      // Persist the cancelled statuses to the previous server's table before we
-      // drop the resolver, so they do not reappear as pending on reconnect.
-      // Best-effort: _save() captures the db synchronously (before the null
-      // below); swallow errors since the db may be closing on a server switch.
-      unawaited(_save().catchError((Object _) {}));
-    }
     _onUpload = null;
     _onQueueChanged = null;
     _databaseResolver = null;
+    _queueController.close();
     DebugLogger.log(
-      'AttachmentUploadQueue deactivated',
+      'AttachmentUploadQueue disposed',
       scope: 'attachments/queue',
     );
   }
 
   void _processSafe() {
+    if (_disposed) return;
     // Fire and forget
     unawaited(processQueue());
   }
@@ -513,6 +488,7 @@ class AttachmentUploadQueue {
   }
 
   void _notify() {
+    if (_disposed) return;
     _onQueueChanged?.call(queue);
     _queueController.add(queue);
   }

--- a/lib/core/services/attachment_upload_queue.dart
+++ b/lib/core/services/attachment_upload_queue.dart
@@ -138,18 +138,33 @@ class AttachmentUploadQueue {
   Stream<List<QueuedAttachment>> get queueStream => _queueController.stream;
 
   bool _disposed = false;
+  Future<void>? _readyFuture;
 
   List<QueuedAttachment> get queue => List.unmodifiable(_queue);
+
+  /// Completes once the initial load from Drift has finished (or immediately if
+  /// [initialize] has not run). Callers `await` this before enqueueing so an
+  /// upload never races the load. It is owned by this instance (not the owning
+  /// provider), so it can never be orphaned by the provider rebuilding — unlike
+  /// a `FutureProvider.future`, awaiting it cannot hang across a server switch.
+  Future<void> get ready => _readyFuture ?? Future<void>.value();
 
   Future<void> initialize({
     required UploadCallback onUpload,
     required AppDatabase? Function() database,
     AttachmentsEventCallback? onQueueChanged,
-  }) async {
+  }) {
     _onUpload = onUpload;
     _onQueueChanged = onQueueChanged;
     _databaseResolver = database;
+    final future = _initInternal();
+    _readyFuture = future;
+    return future;
+  }
+
+  Future<void> _initInternal() async {
     await _load();
+    if (_disposed) return;
     _startPeriodicProcessing();
     DebugLogger.log(
       'AttachmentUploadQueue initialized with ${_queue.length} items',

--- a/lib/core/services/media_upload_controller.dart
+++ b/lib/core/services/media_upload_controller.dart
@@ -382,5 +382,13 @@ class _InflightUpload {
 /// rebuilds (an upload can outlive the widget that started it). Every former
 /// `enqueueUploadMedia` call site reads this instead.
 @Riverpod(keepAlive: true)
-MediaUploadController mediaUploadController(Ref ref) =>
-    MediaUploadController(ref);
+MediaUploadController mediaUploadController(Ref ref) {
+  // When the active server / ApiService changes (server switch or logout),
+  // stop the shared upload queue's timer and drop its stale onUpload closure.
+  // The next upload re-initializes it against the new server. `ref.listen`
+  // does not fire for the current value, so this is inert until a real change.
+  ref.listen(apiServiceProvider, (previous, next) {
+    AttachmentUploadQueue().deactivate();
+  });
+  return MediaUploadController(ref);
+}

--- a/lib/core/services/media_upload_controller.dart
+++ b/lib/core/services/media_upload_controller.dart
@@ -95,10 +95,14 @@ class MediaUploadController {
     // fully-initialized instance per active server); awaiting `.future` avoids
     // the enqueue-before-load race and gives a queue already wired to the
     // active server's API + Drift table.
-    final uploader = await _ref.read(attachmentUploadQueueProvider.future);
+    final uploader = _ref.read(attachmentUploadQueueProvider);
     if (uploader == null) {
       throw Exception('API not available');
     }
+    // Wait for the queue's initial Drift load before enqueueing. `ready` is
+    // owned by the queue instance, so awaiting it cannot hang if the owning
+    // provider rebuilds on a server switch (unlike a FutureProvider.future).
+    await uploader.ready;
 
     // For images: convert unsupported formats to JPEG for compatibility.
     String uploadPath = filePath;
@@ -258,8 +262,10 @@ class MediaUploadController {
       // The queue was disposed (server switch / logout) before this upload
       // reached a terminal status. Resolve the awaiting caller so it does not
       // hang; the item stays in the previous server's Drift table and resumes
-      // when that server is next active.
-      cleanupTemp();
+      // when that server is next active. Do NOT cleanupTemp() here: the kept
+      // row still points at the converted temp file, which must survive for the
+      // resume to succeed. (An interrupted-and-never-resumed upload leaks the
+      // temp dir until OS cleanup — preferable to losing the attachment.)
       removeInflight();
       if (!completer.isCompleted) completer.complete();
     });

--- a/lib/core/services/media_upload_controller.dart
+++ b/lib/core/services/media_upload_controller.dart
@@ -7,7 +7,6 @@ import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 import '../../features/chat/services/file_attachment_service.dart';
 import '../../features/chat/widgets/enhanced_image_attachment.dart';
-import '../database/database_provider.dart';
 import '../models/file_info.dart';
 import '../providers/app_providers.dart';
 import '../utils/debug_logger.dart';
@@ -92,17 +91,14 @@ class MediaUploadController {
 
     // Upload all files (including images) to the server — mirrors OpenWebUI:
     // images go to /api/v1/files/ and the server resolves them when sending to
-    // the LLM.
-    final uploader = AttachmentUploadQueue();
-    final api = _ref.read(apiServiceProvider);
-    if (api == null) {
+    // the LLM. The queue is owned by attachmentUploadQueueProvider (one
+    // fully-initialized instance per active server); awaiting `.future` avoids
+    // the enqueue-before-load race and gives a queue already wired to the
+    // active server's API + Drift table.
+    final uploader = await _ref.read(attachmentUploadQueueProvider.future);
+    if (uploader == null) {
       throw Exception('API not available');
     }
-    await uploader.initialize(
-      onUpload: (path, name, {cancelToken}) =>
-          api.uploadFile(path, name, cancelToken: cancelToken),
-      database: () => _ref.read(appDatabaseProvider),
-    );
 
     // For images: convert unsupported formats to JPEG for compatibility.
     String uploadPath = filePath;
@@ -258,6 +254,14 @@ class MediaUploadController {
         default:
           break;
       }
+    }, onDone: () {
+      // The queue was disposed (server switch / logout) before this upload
+      // reached a terminal status. Resolve the awaiting caller so it does not
+      // hang; the item stays in the previous server's Drift table and resumes
+      // when that server is next active.
+      cleanupTemp();
+      removeInflight();
+      if (!completer.isCompleted) completer.complete();
     });
 
     // Wire the cancel path: stop listening + temp cleanup, then complete so the
@@ -382,13 +386,5 @@ class _InflightUpload {
 /// rebuilds (an upload can outlive the widget that started it). Every former
 /// `enqueueUploadMedia` call site reads this instead.
 @Riverpod(keepAlive: true)
-MediaUploadController mediaUploadController(Ref ref) {
-  // When the active server / ApiService changes (server switch or logout),
-  // stop the shared upload queue's timer and drop its stale onUpload closure.
-  // The next upload re-initializes it against the new server. `ref.listen`
-  // does not fire for the current value, so this is inert until a real change.
-  ref.listen(apiServiceProvider, (previous, next) {
-    AttachmentUploadQueue().deactivate();
-  });
-  return MediaUploadController(ref);
-}
+MediaUploadController mediaUploadController(Ref ref) =>
+    MediaUploadController(ref);

--- a/lib/core/sync/pull_sync.dart
+++ b/lib/core/sync/pull_sync.dart
@@ -75,20 +75,28 @@ class PullSync {
   /// pull completes the remap (folding the `local:` row into the server row)
   /// instead of inserting a duplicate. When null (read-path-only tests) the
   /// heal is skipped and merges proceed verbatim.
+  ///
+  /// [parseOffload] enables worker-isolate offloading for large conversations
+  /// (see [assembleConversationGuarded]). When null, assembly runs synchronously
+  /// on the calling isolate — safe for tests, jank-risk for production pulls
+  /// with large message counts.
   PullSync({
     required SyncApiClient client,
     required AppDatabase db,
     required ConversationLocks locks,
     IdRemapper? remapper,
+    ConversationParseOffload? parseOffload,
   }) : _client = client,
        _db = db,
        _locks = locks,
-       _remapper = remapper;
+       _remapper = remapper,
+       _parseOffload = parseOffload;
 
   final SyncApiClient _client;
   final AppDatabase _db;
   final ConversationLocks _locks;
   final IdRemapper? _remapper;
+  final ConversationParseOffload? _parseOffload;
 
   /// Runs one pull cycle. The watermark advances only when every list page
   /// and every chat fetch succeeded (REQ 5); on any failure it stays frozen
@@ -348,7 +356,11 @@ class PullSync {
       final chat = await _db.chatsDao.getChat(id);
       if (chat == null) return null;
       final messages = await _db.messagesDao.getForChat(id);
-      return assembleConversation(chat, messages);
+      return assembleConversationGuarded(
+        chat,
+        messages,
+        offload: _parseOffload,
+      );
     });
   }
 

--- a/lib/core/sync/sync_engine.dart
+++ b/lib/core/sync/sync_engine.dart
@@ -11,6 +11,8 @@ import '../models/conversation.dart';
 import '../persistence/persistence_providers.dart';
 import '../providers/app_providers.dart';
 import '../services/connectivity_service.dart';
+import '../services/conversation_parsing.dart';
+import '../services/worker_manager.dart';
 import '../utils/debug_logger.dart';
 import 'backoff.dart';
 import 'chat_adapter.dart';
@@ -503,11 +505,17 @@ class SyncEngine extends _$SyncEngine {
     if (db == null || client == null || chatLocks == null) return null;
     final remapper = _ensureRemapper();
     if (remapper == null) return null;
+    final workerManager = ref.read(workerManagerProvider);
     return PullSync(
       client: client,
       db: db,
       locks: chatLocks,
       remapper: remapper,
+      parseOffload: (envelope) => workerManager.schedule(
+        parseFullConversationModelWorker,
+        envelope,
+        debugLabel: 'pull.assembleConversation',
+      ),
     );
   }
 

--- a/lib/features/chat/providers/chat_providers.dart
+++ b/lib/features/chat/providers/chat_providers.dart
@@ -33,6 +33,7 @@ import '../../../core/services/settings_service.dart';
 import '../../../core/services/socket_service.dart';
 import '../../../core/services/streaming_response_controller.dart';
 import '../../../core/services/performance_profiler.dart';
+import '../../../core/services/conversation_parsing.dart';
 import '../../../core/services/worker_manager.dart';
 import '../../../core/utils/debug_logger.dart';
 import '../../../core/utils/json_normalization.dart';
@@ -529,7 +530,17 @@ class ChatMessagesNotifier extends Notifier<List<ChatMessage>> {
       if (chat == null || !chat.bodySynced) {
         return;
       }
-      final conversation = assembleConversation(chat, rows);
+      final conversation = await assembleConversationGuarded(
+        chat,
+        rows,
+        offload: (envelope) => ref
+            .read(workerManagerProvider)
+            .schedule(
+              parseFullConversationModelWorker,
+              envelope,
+              debugLabel: 'chat.dbWatch.assembleConversation',
+            ),
+      );
       if (_disposed ||
           !ref.mounted ||
           generation != _dbMessagesGeneration ||

--- a/lib/features/chat/services/request_completion_runner.dart
+++ b/lib/features/chat/services/request_completion_runner.dart
@@ -7,6 +7,8 @@ import '../../../core/database/daos/outbox_dao.dart';
 import '../../../core/database/database_provider.dart';
 import '../../../core/database/mappers/conversation_assembler.dart';
 import '../../../core/providers/app_providers.dart';
+import '../../../core/services/conversation_parsing.dart';
+import '../../../core/services/worker_manager.dart';
 import '../../../core/sync/outbox_drainer.dart';
 import '../../../core/utils/debug_logger.dart';
 import '../providers/chat_providers.dart';
@@ -166,7 +168,17 @@ class ChatRequestCompletionRunner implements RequestCompletionRunner {
     // Headless drive — no active-conversation switch, no chatMessagesProvider
     // mutation. Builds the request from this chat's DB rows.
     final rows = await db.messagesDao.getForChat(chatId);
-    final conversation = assembleConversation(chatRow, rows);
+    final conversation = await assembleConversationGuarded(
+      chatRow,
+      rows,
+      offload: (envelope) => _ref
+          .read(workerManagerProvider)
+          .schedule(
+            parseFullConversationModelWorker,
+            envelope,
+            debugLabel: 'headless.assembleConversation',
+          ),
+    );
     await runHeadlessCompletion(
       _ref,
       chatId: chatId,

--- a/test/core/database/mappers/conversation_assembler_guarded_test.dart
+++ b/test/core/database/mappers/conversation_assembler_guarded_test.dart
@@ -1,0 +1,123 @@
+/// Tests for [assembleConversationGuarded] — the contract-enforcing wrapper
+/// that offloads large-conversation assembly off the UI isolate.
+library;
+
+import 'package:checks/checks.dart';
+import 'package:conduit/core/database/app_database.dart';
+import 'package:conduit/core/database/mappers/conversation_assembler.dart';
+import 'package:conduit/core/models/conversation.dart';
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import '../support/chat_blob_fixtures.dart';
+
+void main() {
+  late AppDatabase db;
+
+  setUp(() {
+    db = AppDatabase(NativeDatabase.memory());
+  });
+
+  tearDown(() async {
+    await db.close();
+  });
+
+  Future<(ChatRow, List<MessageRow>)> seedFixture() async {
+    final fixture = loadChatBlobFixtures()
+        .singleWhere((f) => f.name == '02_linear_multi_turn');
+    await db.chatsDao.upsertServerChat(rows: rowsFromFixture(fixture));
+    final chat = (await db.chatsDao.getChat(fixture.chatId))!;
+    final messages = await db.messagesDao.getForChat(fixture.chatId);
+    return (chat, messages);
+  }
+
+  group('assembleConversationGuarded', () {
+    test(
+      'messages.length <= threshold: offload NOT called; result matches sync parse',
+      () async {
+        final (chat, messages) = await seedFixture();
+
+        // The fixture has far fewer than kLocalConversationWorkerThreshold messages.
+        check(messages.length).isLessThan(kLocalConversationWorkerThreshold);
+
+        var offloadCallCount = 0;
+        // This branch must never be entered.
+        Future<Conversation> offload(Object? envelope) async {
+          offloadCallCount++;
+          return assembleConversation(chat, messages);
+        }
+
+        final result = await assembleConversationGuarded(
+          chat,
+          messages,
+          offload: offload,
+        );
+
+        check(offloadCallCount).equals(0);
+        final expected = assembleConversation(chat, messages);
+        check(result.id).equals(expected.id);
+        check(result.title).equals(expected.title);
+        check(result.messages.length).equals(expected.messages.length);
+      },
+    );
+
+    test(
+      'messages.length > threshold: offload IS called exactly once with non-null envelope',
+      () async {
+        final (chat, realMessages) = await seedFixture();
+
+        // Pad the list past the threshold; the guarded helper only checks length.
+        final padded = <MessageRow>[
+          ...realMessages,
+          for (var i = 0; i < kLocalConversationWorkerThreshold; i++)
+            realMessages.first,
+        ];
+        check(padded.length).isGreaterThan(kLocalConversationWorkerThreshold);
+
+        var offloadCallCount = 0;
+        Object? capturedEnvelope;
+        final syncResult = assembleConversation(chat, realMessages);
+        Future<Conversation> offload(Object? envelope) async {
+          offloadCallCount++;
+          capturedEnvelope = envelope;
+          return syncResult;
+        }
+
+        final result = await assembleConversationGuarded(
+          chat,
+          padded,
+          offload: offload,
+        );
+
+        check(offloadCallCount).equals(1);
+        check(capturedEnvelope).isNotNull();
+        check(identical(result, syncResult)).isTrue();
+      },
+    );
+
+    test(
+      'messages.length > threshold, offload null: falls back to synchronous parse without throwing',
+      () async {
+        final (chat, realMessages) = await seedFixture();
+
+        // Pad the list past the threshold.
+        final padded = <MessageRow>[
+          ...realMessages,
+          for (var i = 0; i < kLocalConversationWorkerThreshold; i++)
+            realMessages.first,
+        ];
+        check(padded.length).isGreaterThan(kLocalConversationWorkerThreshold);
+
+        // Must not throw even with offload == null.
+        final result = await assembleConversationGuarded(
+          chat,
+          padded,
+          offload: null,
+        );
+
+        check(result).isA<Conversation>();
+        check(result.id).equals(chat.id);
+      },
+    );
+  });
+}

--- a/test/core/services/attachment_upload_queue_test.dart
+++ b/test/core/services/attachment_upload_queue_test.dart
@@ -137,5 +137,27 @@ void main() {
       queue.dispose();
       await queue.ready.timeout(const Duration(seconds: 1));
     });
+
+    test('enqueue after dispose throws instead of silently dropping', () async {
+      final queue = AttachmentUploadQueue();
+      queue.initialize(
+        onUpload: (filePath, fileName, {cancelToken}) async => 'id',
+        database: () => null,
+      );
+      await queue.ready;
+      queue.dispose();
+
+      var threw = false;
+      try {
+        await queue.enqueue(
+          filePath: '/tmp/c.txt',
+          fileName: 'c.txt',
+          fileSize: 1,
+        );
+      } on StateError {
+        threw = true;
+      }
+      check(threw).isTrue();
+    });
   });
 }

--- a/test/core/services/attachment_upload_queue_test.dart
+++ b/test/core/services/attachment_upload_queue_test.dart
@@ -1,0 +1,122 @@
+import 'package:checks/checks.dart';
+import 'package:fake_async/fake_async.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:conduit/core/services/attachment_upload_queue.dart';
+
+void main() {
+  // The class is a singleton — obtain via factory and call deactivate()
+  // between tests so leftover callbacks/timers do not bleed across.
+  tearDown(() {
+    AttachmentUploadQueue().deactivate();
+  });
+
+  group('AttachmentUploadQueue', () {
+    test('timer stops after deactivate', () {
+      int callCount = 0;
+
+      fakeAsync((async) {
+        final queue = AttachmentUploadQueue();
+        queue.initialize(
+          onUpload: (filePath, fileName, {cancelToken}) async {
+            callCount++;
+            return 'fake-file-id';
+          },
+          database: () => null,
+        );
+
+        // Enqueue one item so the periodic tick has something to attempt.
+        queue.enqueue(
+          filePath: '/tmp/test.txt',
+          fileName: 'test.txt',
+          fileSize: 42,
+        );
+
+        // Advance past several periodic ticks (period = 10s) plus the 500ms
+        // one-shot kick. Drain microtasks after each tick so the async
+        // processQueue future can run.
+        async.elapse(const Duration(seconds: 25));
+        async.flushMicrotasks();
+
+        final countBeforeDeactivate = callCount;
+        check(countBeforeDeactivate).isGreaterThan(0);
+
+        queue.deactivate();
+
+        // Advance well past another set of ticks — timer must be cancelled.
+        async.elapse(const Duration(seconds: 60));
+        async.flushMicrotasks();
+
+        check(callCount).equals(countBeforeDeactivate);
+      });
+    });
+
+    test('deactivate nulls the upload path so processQueue is a no-op', () async {
+      int callCount = 0;
+
+      final queue = AttachmentUploadQueue();
+      queue.initialize(
+        onUpload: (filePath, fileName, {cancelToken}) async {
+          callCount++;
+          return 'fake-file-id';
+        },
+        database: () => null,
+      );
+
+      queue.enqueue(
+        filePath: '/tmp/test.txt',
+        fileName: 'test.txt',
+        fileSize: 42,
+      );
+
+      queue.deactivate();
+      await queue.processQueue();
+
+      check(callCount).equals(0);
+    });
+
+    test('queueStream stays usable after deactivate', () async {
+      final queue = AttachmentUploadQueue();
+      final received = <List<QueuedAttachment>>[];
+
+      final subscription = queue.queueStream.listen(received.add);
+      addTearDown(subscription.cancel);
+
+      queue.deactivate();
+
+      // Re-initialize and enqueue — the broadcast stream must still deliver
+      // events to the subscription opened before deactivate.
+      queue.initialize(
+        onUpload: (filePath, fileName, {cancelToken}) async {
+          return 'fake-file-id';
+        },
+        database: () => null,
+      );
+
+      await queue.enqueue(
+        filePath: '/tmp/test2.txt',
+        fileName: 'test2.txt',
+        fileSize: 10,
+      );
+
+      // Allow async work to settle.
+      await Future<void>.delayed(Duration.zero);
+
+      check(received).isNotEmpty();
+    });
+
+    test('deactivate is idempotent — calling twice does not throw', () {
+      final queue = AttachmentUploadQueue();
+      queue.initialize(
+        onUpload: (filePath, fileName, {cancelToken}) async {
+          return 'fake-file-id';
+        },
+        database: () => null,
+      );
+
+      queue.deactivate();
+      // Second call must not throw.
+      queue.deactivate();
+    });
+  });
+}

--- a/test/core/services/attachment_upload_queue_test.dart
+++ b/test/core/services/attachment_upload_queue_test.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:checks/checks.dart';
 import 'package:fake_async/fake_async.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -117,6 +119,51 @@ void main() {
       queue.deactivate();
       // Second call must not throw.
       queue.deactivate();
+    });
+
+    test('deactivate terminalizes non-terminal items so awaiting listeners '
+        'resolve instead of hanging', () async {
+      final queue = AttachmentUploadQueue();
+      // Upload that never resolves on its own, so the item stays non-terminal
+      // (uploading) until deactivate() drives it to a terminal state.
+      final hang = Completer<String>();
+      queue.initialize(
+        onUpload: (filePath, fileName, {cancelToken}) => hang.future,
+        database: () => null,
+      );
+
+      final id = await queue.enqueue(
+        filePath: '/tmp/x.txt',
+        fileName: 'x.txt',
+        fileSize: 1,
+      );
+      // Let processQueue flip the item to `uploading` (then it awaits `hang`).
+      await Future<void>.delayed(Duration.zero);
+
+      // Subscribe after enqueue so we only observe events from here on.
+      final terminalEvents = <QueuedAttachmentStatus>[];
+      final sub = queue.queueStream.listen((items) {
+        for (final e in items) {
+          if (e.id == id &&
+              e.status != QueuedAttachmentStatus.pending &&
+              e.status != QueuedAttachmentStatus.uploading) {
+            terminalEvents.add(e.status);
+          }
+        }
+      });
+      addTearDown(sub.cancel);
+
+      queue.deactivate();
+      await Future<void>.delayed(Duration.zero);
+
+      // A terminal event was emitted, so a MediaUploadController completer
+      // awaiting queueStream would resolve rather than hang forever.
+      check(terminalEvents).isNotEmpty();
+      check(terminalEvents.last).equals(QueuedAttachmentStatus.cancelled);
+      // And the in-memory item is terminal.
+      check(
+        queue.queue.where((e) => e.id == id).single.status,
+      ).equals(QueuedAttachmentStatus.cancelled);
     });
   });
 }

--- a/test/core/services/attachment_upload_queue_test.dart
+++ b/test/core/services/attachment_upload_queue_test.dart
@@ -1,23 +1,20 @@
 import 'dart:async';
 
 import 'package:checks/checks.dart';
+import 'package:dio/dio.dart';
 import 'package:fake_async/fake_async.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'package:conduit/core/services/attachment_upload_queue.dart';
 
+/// Lifecycle tests for the per-server [AttachmentUploadQueue]. Each test builds
+/// a fresh instance (the queue is no longer a singleton — it is owned and
+/// disposed by `attachmentUploadQueueProvider`).
 void main() {
-  // The class is a singleton — obtain via factory and call deactivate()
-  // between tests so leftover callbacks/timers do not bleed across.
-  tearDown(() {
-    AttachmentUploadQueue().deactivate();
-  });
-
-  group('AttachmentUploadQueue', () {
-    test('timer stops after deactivate', () {
-      int callCount = 0;
-
+  group('AttachmentUploadQueue lifecycle', () {
+    test('periodic processing stops after dispose', () {
       fakeAsync((async) {
+        var callCount = 0;
         final queue = AttachmentUploadQueue();
         queue.initialize(
           onUpload: (filePath, fileName, {cancelToken}) async {
@@ -26,114 +23,59 @@ void main() {
           },
           database: () => null,
         );
+        queue.enqueue(filePath: '/tmp/a.txt', fileName: 'a.txt', fileSize: 1);
 
-        // Enqueue one item so the periodic tick has something to attempt.
-        queue.enqueue(
-          filePath: '/tmp/test.txt',
-          fileName: 'test.txt',
-          fileSize: 42,
-        );
-
-        // Advance past several periodic ticks (period = 10s) plus the 500ms
-        // one-shot kick. Drain microtasks after each tick so the async
-        // processQueue future can run.
         async.elapse(const Duration(seconds: 25));
         async.flushMicrotasks();
+        final before = callCount;
+        check(before).isGreaterThan(0);
 
-        final countBeforeDeactivate = callCount;
-        check(countBeforeDeactivate).isGreaterThan(0);
-
-        queue.deactivate();
-
-        // Advance well past another set of ticks — timer must be cancelled.
+        queue.dispose();
         async.elapse(const Duration(seconds: 60));
         async.flushMicrotasks();
-
-        check(callCount).equals(countBeforeDeactivate);
+        check(callCount).equals(before);
       });
     });
 
-    test('deactivate nulls the upload path so processQueue is a no-op', () async {
-      int callCount = 0;
-
+    test('dispose closes queueStream so listeners receive onDone', () async {
       final queue = AttachmentUploadQueue();
       queue.initialize(
-        onUpload: (filePath, fileName, {cancelToken}) async {
-          callCount++;
-          return 'fake-file-id';
-        },
+        onUpload: (filePath, fileName, {cancelToken}) async => 'id',
         database: () => null,
       );
+      var done = false;
+      final sub = queue.queueStream.listen((_) {}, onDone: () => done = true);
+      addTearDown(sub.cancel);
 
-      queue.enqueue(
-        filePath: '/tmp/test.txt',
-        fileName: 'test.txt',
-        fileSize: 42,
-      );
-
-      queue.deactivate();
-      await queue.processQueue();
-
-      check(callCount).equals(0);
-    });
-
-    test('queueStream stays usable after deactivate', () async {
-      final queue = AttachmentUploadQueue();
-      final received = <List<QueuedAttachment>>[];
-
-      final subscription = queue.queueStream.listen(received.add);
-      addTearDown(subscription.cancel);
-
-      queue.deactivate();
-
-      // Re-initialize and enqueue — the broadcast stream must still deliver
-      // events to the subscription opened before deactivate.
-      queue.initialize(
-        onUpload: (filePath, fileName, {cancelToken}) async {
-          return 'fake-file-id';
-        },
-        database: () => null,
-      );
-
-      await queue.enqueue(
-        filePath: '/tmp/test2.txt',
-        fileName: 'test2.txt',
-        fileSize: 10,
-      );
-
-      // Allow async work to settle.
+      queue.dispose();
       await Future<void>.delayed(Duration.zero);
 
-      check(received).isNotEmpty();
+      check(done).isTrue();
     });
 
-    test('deactivate is idempotent — calling twice does not throw', () {
+    test('dispose is idempotent (does not double-close the controller)', () {
       final queue = AttachmentUploadQueue();
       queue.initialize(
-        onUpload: (filePath, fileName, {cancelToken}) async {
-          return 'fake-file-id';
-        },
+        onUpload: (filePath, fileName, {cancelToken}) async => 'id',
         database: () => null,
       );
-
-      queue.deactivate();
-      // Second call must not throw.
-      queue.deactivate();
+      queue.dispose();
+      queue.dispose();
     });
 
-    test('deactivate terminalizes non-terminal items so awaiting listeners '
-        'resolve instead of hanging', () async {
+    test('an upload awaiting a terminal event resolves via onDone, and its '
+        'token is cancelled, when the queue is disposed mid-upload', () async {
       final queue = AttachmentUploadQueue();
-      // Upload that never resolves on its own, so the item stays non-terminal
-      // (uploading) until deactivate() drives it to a terminal state.
       final uploadStarted = Completer<void>();
       final hang = Completer<String>();
+      CancelToken? capturedToken;
       // Release the hanging upload during cleanup so its future does not leak.
       addTearDown(() {
         if (!hang.isCompleted) hang.complete('teardown');
       });
       queue.initialize(
         onUpload: (filePath, fileName, {cancelToken}) {
+          capturedToken = cancelToken;
           if (!uploadStarted.isCompleted) uploadStarted.complete();
           return hang.future;
         },
@@ -141,38 +83,42 @@ void main() {
       );
 
       final id = await queue.enqueue(
-        filePath: '/tmp/x.txt',
-        fileName: 'x.txt',
+        filePath: '/tmp/b.txt',
+        fileName: 'b.txt',
         fileSize: 1,
       );
-      // Wait until the upload actually starts (the item is now `uploading`),
-      // rather than relying on a bare microtask having elapsed.
+      // Wait until the upload actually starts (item is now `uploading`).
       await uploadStarted.future;
 
-      // Subscribe after upload start so we only observe events from here on.
-      final terminalEvents = <QueuedAttachmentStatus>[];
-      final sub = queue.queueStream.listen((items) {
-        for (final e in items) {
-          if (e.id == id &&
-              e.status != QueuedAttachmentStatus.pending &&
-              e.status != QueuedAttachmentStatus.uploading) {
-            terminalEvents.add(e.status);
+      // Model a MediaUploadController completer that resolves on a terminal
+      // status OR when the stream closes (onDone).
+      final resolved = Completer<void>();
+      void tryResolve() {
+        if (!resolved.isCompleted) resolved.complete();
+      }
+
+      final sub = queue.queueStream.listen(
+        (items) {
+          for (final e in items) {
+            if (e.id == id &&
+                e.status != QueuedAttachmentStatus.pending &&
+                e.status != QueuedAttachmentStatus.uploading) {
+              tryResolve();
+            }
           }
-        }
-      });
+        },
+        onDone: tryResolve,
+      );
       addTearDown(sub.cancel);
 
-      queue.deactivate();
-      await Future<void>.delayed(Duration.zero);
+      queue.dispose();
 
-      // A terminal event was emitted, so a MediaUploadController completer
-      // awaiting queueStream would resolve rather than hang forever.
-      check(terminalEvents).isNotEmpty();
-      check(terminalEvents.last).equals(QueuedAttachmentStatus.cancelled);
-      // And the in-memory item is terminal.
-      check(
-        queue.queue.where((e) => e.id == id).single.status,
-      ).equals(QueuedAttachmentStatus.cancelled);
+      // Would hang forever before the provider-ownership refactor; now the
+      // stream closes on dispose and the awaiting completer resolves.
+      await resolved.future.timeout(const Duration(seconds: 1));
+      check(resolved.isCompleted).isTrue();
+      // Dispose aborts the in-flight upload so it cannot land on the old server.
+      check(capturedToken?.isCancelled ?? false).isTrue();
     });
   });
 }

--- a/test/core/services/attachment_upload_queue_test.dart
+++ b/test/core/services/attachment_upload_queue_test.dart
@@ -159,5 +159,38 @@ void main() {
       }
       check(threw).isTrue();
     });
+
+    test('ready rejects on load failure and preserves the existing snapshot',
+        () async {
+      final queue = AttachmentUploadQueue();
+      queue.initialize(
+        onUpload: (filePath, fileName, {cancelToken}) async => 'id',
+        database: () => null,
+      );
+      await queue.ready;
+      await queue.enqueue(
+        filePath: '/tmp/kept.txt',
+        fileName: 'kept.txt',
+        fileSize: 1,
+      );
+      final before = queue.queue.map((e) => e.id).toList();
+
+      // Re-initialize with a resolver that fails before the DAO read. The
+      // failure must remain visible through `ready`, and staging the load means
+      // the previous in-memory snapshot is not cleared on the failed attempt.
+      queue.initialize(
+        onUpload: (filePath, fileName, {cancelToken}) async => 'id',
+        database: () => throw StateError('load failed'),
+      );
+      var threw = false;
+      try {
+        await queue.ready;
+      } on StateError {
+        threw = true;
+      }
+      check(threw).isTrue();
+      check(queue.queue.map((e) => e.id).toList()).deepEquals(before);
+      queue.dispose();
+    });
   });
 }

--- a/test/core/services/attachment_upload_queue_test.dart
+++ b/test/core/services/attachment_upload_queue_test.dart
@@ -23,6 +23,8 @@ void main() {
           },
           database: () => null,
         );
+        // Let the initial (async) load settle before enqueueing.
+        async.flushMicrotasks();
         queue.enqueue(filePath: '/tmp/a.txt', fileName: 'a.txt', fileSize: 1);
 
         async.elapse(const Duration(seconds: 25));
@@ -81,6 +83,7 @@ void main() {
         },
         database: () => null,
       );
+      await queue.ready; // load settled before enqueue (no enqueue-vs-load race)
 
       final id = await queue.enqueue(
         filePath: '/tmp/b.txt',
@@ -119,6 +122,20 @@ void main() {
       check(resolved.isCompleted).isTrue();
       // Dispose aborts the in-flight upload so it cannot land on the old server.
       check(capturedToken?.isCancelled ?? false).isTrue();
+    });
+
+    test('ready resolves even when the queue is disposed mid-initialization',
+        () async {
+      final queue = AttachmentUploadQueue();
+      queue.initialize(
+        onUpload: (filePath, fileName, {cancelToken}) async => 'id',
+        database: () => null,
+      );
+      // Dispose before the initial load settles. `ready` is owned by the
+      // instance (not a provider future), so awaiting it must still resolve
+      // rather than hang — the guarantee the provider read relies on.
+      queue.dispose();
+      await queue.ready.timeout(const Duration(seconds: 1));
     });
   });
 }

--- a/test/core/services/attachment_upload_queue_test.dart
+++ b/test/core/services/attachment_upload_queue_test.dart
@@ -126,9 +126,17 @@ void main() {
       final queue = AttachmentUploadQueue();
       // Upload that never resolves on its own, so the item stays non-terminal
       // (uploading) until deactivate() drives it to a terminal state.
+      final uploadStarted = Completer<void>();
       final hang = Completer<String>();
+      // Release the hanging upload during cleanup so its future does not leak.
+      addTearDown(() {
+        if (!hang.isCompleted) hang.complete('teardown');
+      });
       queue.initialize(
-        onUpload: (filePath, fileName, {cancelToken}) => hang.future,
+        onUpload: (filePath, fileName, {cancelToken}) {
+          if (!uploadStarted.isCompleted) uploadStarted.complete();
+          return hang.future;
+        },
         database: () => null,
       );
 
@@ -137,10 +145,11 @@ void main() {
         fileName: 'x.txt',
         fileSize: 1,
       );
-      // Let processQueue flip the item to `uploading` (then it awaits `hang`).
-      await Future<void>.delayed(Duration.zero);
+      // Wait until the upload actually starts (the item is now `uploading`),
+      // rather than relying on a bare microtask having elapsed.
+      await uploadStarted.future;
 
-      // Subscribe after enqueue so we only observe events from here on.
+      // Subscribe after upload start so we only observe events from here on.
       final terminalEvents = <QueuedAttachmentStatus>[];
       final sub = queue.queueStream.listen((items) {
         for (final e in items) {


### PR DESCRIPTION
## Summary

Three independent improvements from an advisory audit. The changes touch disjoint files and rebase cleanly on current `main`.

- **perf(sync): offload large conversation assembly to a worker isolate** — three call sites (pull-sync, chat DB-watch, headless completion) ignored the documented `messages.length > 100` worker-offload contract and parsed whole conversations on the UI isolate, freezing frames when opening/syncing large chats. Adds a guarded `assembleConversationGuarded` helper + 3 unit tests.
- **fix(attachments): stop the upload queue timer/closure surviving logout; drop dead provider** — removes an orphaned `attachmentUploadQueueProvider` (zero readers) and adds a non-destructive `deactivate()` fired on `ApiService` change, so the singleton's retry timer and stale upload closure no longer outlive logout/server-switch. +4 unit tests.
- **docs: disclose location/camera/speech permissions; refresh stale stack docs** — PRIVACY_POLICY.md now discloses location/camera/speech (the app requests them); README/AGENTS corrected Hive→Drift; clone instructions get `--recursive`; the terminal feature is added to the feature table.

## Testing

- `flutter analyze`: clean on each change (verified individually before combining).
- `flutter test`: **NOT run, and this PR adds no CI test job.** The local Flutter test toolchain is hung at the environment level (reproduces on pre-existing tests, unrelated to these changes). The **7 new tests** (3 sync + 4 attachment) therefore run nowhere automatically — please run `flutter test` in a working environment before merging.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Offloaded large chat conversation assembly/parsing to background workers when available, with a defined size threshold.
* **Reliability**
  * Refactored attachment uploads to use per-instance queues with `ready` gating, idempotent disposal, safe cancellation on shutdown, and retryable handling for in-progress items.
  * Media upload now waits for queue readiness and avoids potential waits when the queue stops.
  * Guarded conversation parsing gracefully falls back when offloading isn’t available.
* **Documentation**
  * Updated architecture guidance for Drift, plus refreshed README setup details and expanded platform permission documentation; updated privacy policy effective date and location/speech wording.
* **Tests**
  * Added unit tests for guarded conversation assembly and expanded attachment queue lifecycle/disposal coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Offload large-conversation assembly to worker isolates and fix attachment queue logout behavior
> - Adds `assembleConversationGuarded` in [conversation_assembler.dart](https://github.com/cogwheel0/conduit/pull/565/files#diff-9ba693dd7c8717e71949a8424937f30dec13aefc4d2336027f89e27fde3a2b33) which parses synchronously below 100 messages and offloads to a worker isolate above that threshold, preventing UI jank on large conversations.
> - Refactors `AttachmentUploadQueue` from a singleton to a per-server instance owned by `attachmentUploadQueueProvider`, which returns `null` when unauthenticated, disposes the queue on logout or server switch, and cancels in-flight uploads on disposal.
> - `MediaUploadController` now awaits `queue.ready` before enqueueing to eliminate initialization race conditions, and handles queue disposal mid-upload gracefully.
> - Updates docs (README, AGENTS.md, PRIVACY_POLICY.md) to reflect the Drift/SQLite persistence stack, submodule setup, and expanded permissions details.
> - Behavioral Change: `enqueue` throws `StateError` after disposal instead of silently dropping uploads; consumers must await `queue.ready` before use.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 744e808.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR improves large-chat assembly and attachment upload lifecycle handling. The main changes are:

- Moves large local conversation assembly through a guarded worker-offload path.
- Scopes attachment upload queues to the active authenticated server lifecycle.
- Cancels and closes upload queue work on logout or server switch.
- Refreshes persistence, setup, feature, permission, and privacy documentation.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

This looks safe to merge.

No blocking issues found in the changed code.

No files need attention.
</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex determined that Flutter was unavailable, evidenced by the flutter\_command\_v\_exit=127 and /bin/sh: 1: flutter: not found messages in the Flutter tool availability log.
- T-Rex captured the targeted Flutter test selection and the pubspec.yaml SDK metadata used to choose the intended test command.
- Because Flutter was unavailable, the plan to run flutter pub get and flutter test was not executed, aligning with the blocker.

<a href="https://app.greptile.com/trex/runs/14078608/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| lib/core/providers/app_providers.dart | Creates the attachment queue only for an authenticated active API service and disposes it with the provider lifecycle. |
| lib/core/services/attachment_upload_queue.dart | Changes the upload queue to an owned instance with readiness tracking, cancel-token cleanup, stream closure, and disposed-state guards. |
| lib/core/services/media_upload_controller.dart | Uses the provider-owned upload queue, waits for readiness, and resolves waiting upload flows when the queue closes. |
| lib/core/database/mappers/conversation_assembler.dart | Adds a shared worker threshold and guarded assembly helper for large local conversations. |
| lib/core/sync/pull_sync.dart | Routes local pull-sync conversation assembly through the guarded helper. |
| lib/core/sync/sync_engine.dart | Supplies pull-sync assembly with WorkerManager scheduling. |
| lib/features/chat/providers/chat_providers.dart | Uses guarded assembly for chat database-watch reloads. |
| lib/features/chat/services/request_completion_runner.dart | Uses guarded assembly before headless completion requests. |

</details>

<sub>Reviews (7): Last reviewed commit: ["fix(attachments): propagate init failure..."](https://github.com/cogwheel0/conduit/commit/744e808d45f47ef4b75aa5d253de09ba6f147b2c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43409879)</sub>

<!-- /greptile_comment -->