### PR TITLE
Fix full-width drawer gesture arbitration

### DIFF
--- a/lib/features/notes/views/note_editor_page.dart
+++ b/lib/features/notes/views/note_editor_page.dart
@@ -1546,16 +1546,18 @@ class _NoteEditorPageState extends ConsumerState<NoteEditorPage> {
       return const SizedBox.shrink();
     }
 
-    final editor = FleatherEditor(
-      controller: controller,
-      focusNode: _contentFocusNode,
-      // Lives inside the page's SingleChildScrollView; the editor must not
-      // scroll independently so the whole note grows with the content.
-      scrollable: false,
-      expands: false,
-      padding: EdgeInsets.zero,
-      minHeight: 20 * 1.8 * AppTypography.bodyLarge,
-      textCapitalization: TextCapitalization.sentences,
+    final editor = DrawerOpenGestureExclusion(
+      child: FleatherEditor(
+        controller: controller,
+        focusNode: _contentFocusNode,
+        // Lives inside the page's SingleChildScrollView; the editor must not
+        // scroll independently so the whole note grows with the content.
+        scrollable: false,
+        expands: false,
+        padding: EdgeInsets.zero,
+        minHeight: 20 * 1.8 * AppTypography.bodyLarge,
+        textCapitalization: TextCapitalization.sentences,
+      ),
     );
 
     // Fleather has no built-in placeholder, so overlay a hint while the

--- a/lib/shared/widgets/drawer_shell_page.dart
+++ b/lib/shared/widgets/drawer_shell_page.dart
@@ -32,7 +32,7 @@ class DrawerShellPage extends ConsumerWidget {
 
     return ResponsiveDrawerLayout(
       maxFraction: isTablet ? 0.42 : 1.0,
-      edgeFraction: isTablet ? 0.36 : 0.50,
+      edgeFraction: isTablet ? 0.36 : 1.0,
       settleFraction: 0.06,
       scrimColor: scrim,
       pushContent: true,

--- a/lib/shared/widgets/markdown/streaming_markdown_widget.dart
+++ b/lib/shared/widgets/markdown/streaming_markdown_widget.dart
@@ -4,6 +4,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../../core/models/chat_message.dart';
 import '../../utils/ask_conduit_context_menu.dart';
+import '../responsive_drawer_layout.dart';
 import 'compiled_markdown_document.dart';
 import 'markdown_config.dart';
 import 'markdown_compile_service.dart';
@@ -466,19 +467,21 @@ class _StreamingMarkdownWidgetState
       return result;
     }
 
-    return SelectionArea(
-      contextMenuBuilder: (context, selectableRegionState) {
-        return buildAskConduitSelectionAreaContextMenu(
-          selectableRegionState: selectableRegionState,
-          ref: ref,
-          selectedText: _selectedText,
-          composerTargetId: widget.askConduitComposerTargetId,
-        );
-      },
-      onSelectionChanged: (content) {
-        _selectedText = content?.plainText;
-      },
-      child: result,
+    return DrawerOpenGestureExclusion(
+      child: SelectionArea(
+        contextMenuBuilder: (context, selectableRegionState) {
+          return buildAskConduitSelectionAreaContextMenu(
+            selectableRegionState: selectableRegionState,
+            ref: ref,
+            selectedText: _selectedText,
+            composerTargetId: widget.askConduitComposerTargetId,
+          );
+        },
+        onSelectionChanged: (content) {
+          _selectedText = content?.plainText;
+        },
+        child: DrawerOpenGesturePriority(child: result),
+      ),
     );
   }
 

--- a/lib/shared/widgets/responsive_drawer_layout.dart
+++ b/lib/shared/widgets/responsive_drawer_layout.dart
@@ -3,6 +3,8 @@ import 'dart:async';
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/physics.dart';
+import 'package:flutter/rendering.dart'
+    show RenderBox, RenderEditable, RenderProxyBoxWithHitTestBehavior;
 import 'package:flutter/services.dart';
 
 import '../../shared/theme/theme_extensions.dart';
@@ -16,6 +18,119 @@ class _HorizontalScrollableHit {
   const _HorizontalScrollableHit({required this.isAtOpenGestureLeadingEdge});
 
   final bool isAtOpenGestureLeadingEdge;
+}
+
+class _DrawerOpenHorizontalDragGestureRecognizer
+    extends HorizontalDragGestureRecognizer {
+  _DrawerOpenHorizontalDragGestureRecognizer({super.debugOwner});
+
+  double minimumLocalX = 0.0;
+  double maximumLocalX = double.infinity;
+  double axisBias = 1.0;
+  bool Function(PointerEvent event)? isPositionAllowed;
+  int? _trackedPointer;
+  Offset? _pointerOrigin;
+  double _verticalDistance = 0.0;
+  bool _directionDisqualified = false;
+
+  @override
+  bool isPointerAllowed(PointerEvent event) {
+    final dx = event.localPosition.dx;
+    if (dx < minimumLocalX ||
+        dx >= maximumLocalX ||
+        (_trackedPointer != null && _trackedPointer != event.pointer) ||
+        isPositionAllowed?.call(event) == false) {
+      return false;
+    }
+    return super.isPointerAllowed(event);
+  }
+
+  @override
+  void addAllowedPointer(PointerDownEvent event) {
+    _trackedPointer = event.pointer;
+    _pointerOrigin = event.position;
+    _verticalDistance = 0.0;
+    _directionDisqualified = false;
+    super.addAllowedPointer(event);
+  }
+
+  @override
+  void handleEvent(PointerEvent event) {
+    if (event.pointer == _trackedPointer && event is PointerMoveEvent) {
+      final delta = event.position - _pointerOrigin!;
+      final dxAbs = delta.dx.abs();
+      _verticalDistance = delta.dy.abs();
+      final touchSlop = computeHitSlop(event.kind, gestureSettings);
+      if ((_verticalDistance > touchSlop && _verticalDistance > dxAbs) ||
+          (delta.dx < -touchSlop && dxAbs > _verticalDistance)) {
+        _directionDisqualified = true;
+      }
+    }
+    super.handleEvent(event);
+  }
+
+  @override
+  void didStopTrackingLastPointer(int pointer) {
+    super.didStopTrackingLastPointer(pointer);
+    _trackedPointer = null;
+    _pointerOrigin = null;
+    _verticalDistance = 0.0;
+    _directionDisqualified = false;
+  }
+
+  @override
+  bool isPointerPanZoomAllowed(PointerPanZoomStartEvent event) => false;
+
+  @override
+  bool hasSufficientGlobalDistanceToAccept(
+    PointerDeviceKind pointerDeviceKind,
+    double? deviceTouchSlop,
+  ) {
+    return !_directionDisqualified &&
+        globalDistanceMoved >
+            computeHitSlop(pointerDeviceKind, gestureSettings) &&
+        globalDistanceMoved > _verticalDistance * axisBias;
+  }
+
+  @override
+  String get debugDescription => 'drawer open horizontal drag';
+}
+
+/// Prevents the full-width drawer-open recognizer from competing with a
+/// descendant that owns non-scroll horizontal gestures, such as rich-text
+/// selection or a document editor.
+class DrawerOpenGestureExclusion extends SingleChildRenderObjectWidget {
+  const DrawerOpenGestureExclusion({super.key, required super.child});
+
+  @override
+  RenderObject createRenderObject(BuildContext context) =>
+      _RenderDrawerOpenGestureExclusion();
+}
+
+class _RenderDrawerOpenGestureExclusion
+    extends RenderProxyBoxWithHitTestBehavior {
+  _RenderDrawerOpenGestureExclusion()
+    : super(behavior: HitTestBehavior.translucent);
+}
+
+/// Gives a quick rightward drawer drag priority inside an otherwise excluded
+/// gesture owner while still allowing that owner to win gestures such as a
+/// stationary long press.
+///
+/// Place this below the owner's recognizer in the widget tree. For example,
+/// putting it around the child of a [SelectionArea] lets the drawer win an
+/// immediate horizontal drag on every platform, while the selection area's
+/// long-press recognizer still wins before any horizontal movement begins.
+class DrawerOpenGesturePriority extends StatelessWidget {
+  const DrawerOpenGesturePriority({super.key, required this.child});
+
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    final layout = ResponsiveDrawerLayout.of(context);
+    return layout?._buildPrioritizedDrawerGestureArena(child) ?? child;
+  }
 }
 
 bool _usesNativeSidebarChrome(BuildContext context) =>
@@ -119,6 +234,8 @@ class ResponsiveDrawerLayout extends StatefulWidget {
 
 class ResponsiveDrawerLayoutState extends State<ResponsiveDrawerLayout>
     with SingleTickerProviderStateMixin {
+  // Matches Flutter's default Material drawer edge width.
+  static const double _kDrawerEdgeDragWidth = 20.0;
   static const double _kEdgeOpenTouchSlop = kTouchSlop;
   static const double _kHorizontalScrollableOpenThreshold = 45.0;
   static const double _kEdgeOpenAxisBias = 1.0;
@@ -163,6 +280,41 @@ class ResponsiveDrawerLayoutState extends State<ResponsiveDrawerLayout>
 
   double get _edgeWidth =>
       MediaQuery.of(context).size.width * widget.edgeFraction;
+
+  double get _drawerEdgeDragWidth =>
+      _kDrawerEdgeDragWidth + MediaQuery.paddingOf(context).left;
+
+  double get _rawDrawerEdgeWidth =>
+      _drawerEdgeDragWidth.clamp(0.0, _edgeWidth).toDouble();
+
+  bool _contentDrawerGestureCanStart(PointerEvent event) {
+    if (_controller.value > 0.001) {
+      return false;
+    }
+
+    final result = HitTestResult();
+    WidgetsBinding.instance.hitTestInView(result, event.position, event.viewId);
+    return !result.path.any(
+      (entry) =>
+          entry.target is _RenderDrawerOpenGestureExclusion ||
+          entry.target is RenderEditable,
+    );
+  }
+
+  bool _prioritizedDrawerGestureCanStart(PointerEvent event) {
+    if (_isTablet(context) || _controller.value > 0.001) {
+      return false;
+    }
+
+    final renderObject = context.findRenderObject();
+    if (renderObject is! RenderBox || !renderObject.hasSize) {
+      return false;
+    }
+
+    final localPosition = renderObject.globalToLocal(event.position);
+    return localPosition.dx >= _rawDrawerEdgeWidth &&
+        localPosition.dx < _edgeWidth;
+  }
 
   /// Returns whether the drawer is currently open.
   /// Uses cached tablet state to avoid context access issues when unmounted.
@@ -405,9 +557,27 @@ class ResponsiveDrawerLayoutState extends State<ResponsiveDrawerLayout>
   ) {
     final result = HitTestResult();
     WidgetsBinding.instance.hitTestInView(result, globalPosition, viewId);
+    var foundHorizontalTarget = false;
 
     for (final entry in result.path) {
       final dynamic target = entry.target;
+
+      // Scrollable's opaque gesture handler remains in the hit-test path even
+      // when blank space inside its viewport has no hit-testable descendant.
+      // Its surrounding scroll-semantics render object exposes the position,
+      // which lets us recognize those otherwise invisible scrollable regions.
+      try {
+        final maybePosition = target.position;
+        if (maybePosition is ScrollPosition &&
+            _isHorizontalAxisDirection(maybePosition.axisDirection)) {
+          return _HorizontalScrollableHit(
+            isAtOpenGestureLeadingEdge: _isAtLeadingEdgeForOpenGesture(
+              maybePosition,
+              maybePosition.axisDirection,
+            ),
+          );
+        }
+      } catch (_) {}
 
       AxisDirection? axisDirection;
       try {
@@ -420,6 +590,7 @@ class ResponsiveDrawerLayoutState extends State<ResponsiveDrawerLayout>
       if (axisDirection == null || !_isHorizontalAxisDirection(axisDirection)) {
         continue;
       }
+      foundHorizontalTarget = true;
 
       try {
         final offset = target.offset;
@@ -432,11 +603,11 @@ class ResponsiveDrawerLayoutState extends State<ResponsiveDrawerLayout>
           );
         }
       } catch (_) {}
-
-      return const _HorizontalScrollableHit(isAtOpenGestureLeadingEdge: true);
     }
 
-    return null;
+    return foundHorizontalTarget
+        ? const _HorizontalScrollableHit(isAtOpenGestureLeadingEdge: true)
+        : null;
   }
 
   void _onEdgePointerDown(PointerDownEvent event) {
@@ -456,7 +627,8 @@ class ResponsiveDrawerLayoutState extends State<ResponsiveDrawerLayout>
       return;
     }
 
-    if (horizontalHit.isAtOpenGestureLeadingEdge) {
+    if (horizontalHit.isAtOpenGestureLeadingEdge &&
+        event.localPosition.dx <= _drawerEdgeDragWidth) {
       _edgePointerActivationThreshold = _kHorizontalScrollableOpenThreshold;
     } else {
       _edgePointerSuppressedByHorizontalScrollable = true;
@@ -545,6 +717,68 @@ class ResponsiveDrawerLayoutState extends State<ResponsiveDrawerLayout>
   void _onDragCancel() {
     if (_isTablet(context)) return;
     _resetDragState();
+  }
+
+  Widget _buildMobileContentGestureArena(Widget child) {
+    return RawGestureDetector(
+      behavior: HitTestBehavior.translucent,
+      excludeFromSemantics: true,
+      gestures: <Type, GestureRecognizerFactory>{
+        _DrawerOpenHorizontalDragGestureRecognizer:
+            GestureRecognizerFactoryWithHandlers<
+              _DrawerOpenHorizontalDragGestureRecognizer
+            >(
+              () =>
+                  _DrawerOpenHorizontalDragGestureRecognizer(debugOwner: this),
+              (recognizer) {
+                recognizer
+                  ..minimumLocalX = _rawDrawerEdgeWidth
+                  ..maximumLocalX = _edgeWidth
+                  ..axisBias = _kEdgeOpenAxisBias
+                  ..isPositionAllowed = _contentDrawerGestureCanStart
+                  ..onlyAcceptDragOnThreshold = true
+                  ..dragStartBehavior = DragStartBehavior.down
+                  ..gestureSettings = MediaQuery.maybeGestureSettingsOf(context)
+                  ..onStart = _onDragStart
+                  ..onUpdate = _onDragUpdate
+                  ..onEnd = _onDragEnd
+                  ..onCancel = _onDragCancel;
+              },
+            ),
+      },
+      child: child,
+    );
+  }
+
+  Widget _buildPrioritizedDrawerGestureArena(Widget child) {
+    return RawGestureDetector(
+      behavior: HitTestBehavior.translucent,
+      excludeFromSemantics: true,
+      gestures: <Type, GestureRecognizerFactory>{
+        _DrawerOpenHorizontalDragGestureRecognizer:
+            GestureRecognizerFactoryWithHandlers<
+              _DrawerOpenHorizontalDragGestureRecognizer
+            >(
+              () =>
+                  _DrawerOpenHorizontalDragGestureRecognizer(debugOwner: this),
+              (recognizer) {
+                recognizer
+                  ..minimumLocalX = -double.infinity
+                  ..maximumLocalX = double.infinity
+                  ..axisBias = _kEdgeOpenAxisBias
+                  ..isPositionAllowed = _prioritizedDrawerGestureCanStart
+                  ..onlyAcceptDragOnThreshold = true
+                  ..dragStartBehavior = DragStartBehavior.down
+                  ..gestureSettings = MediaQuery.maybeGestureSettingsOf(context)
+                  ..onStart = _onDragStart
+                  ..onUpdate = _onDragUpdate
+                  ..onEnd = _onDragEnd
+                  ..onCancel = _onDragCancel;
+              },
+            ),
+      },
+      child: child,
+    );
   }
 
   Widget _buildTabletDrawerSlot(ConduitThemeExtension theme, DrawerSlot slot) {
@@ -698,17 +932,20 @@ class ResponsiveDrawerLayoutState extends State<ResponsiveDrawerLayout>
                   child: child,
                 );
               },
-              child: widget.child,
+              child: _buildMobileContentGestureArena(widget.child),
             ),
           ),
         ),
 
-        // Edge gesture region to open
+        // The true screen edge intentionally overrides a horizontal scroller
+        // only at its opening edge. Everywhere else, the ancestor recognizer
+        // above participates in the gesture arena so descendant interactions
+        // such as selection, editing, and platform views retain ownership.
         Positioned(
           left: 0,
           top: 0,
           bottom: 0,
-          width: _edgeWidth,
+          width: _rawDrawerEdgeWidth,
           child: Listener(
             behavior: HitTestBehavior.translucent,
             onPointerDown: _onEdgePointerDown,

--- a/test/shared/widgets/responsive_drawer_layout_test.dart
+++ b/test/shared/widgets/responsive_drawer_layout_test.dart
@@ -1,12 +1,22 @@
+import 'package:flutter/gestures.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart' show SelectedContent;
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 
+import 'package:conduit/shared/widgets/markdown/streaming_markdown_widget.dart';
 import 'package:conduit/shared/widgets/responsive_drawer_layout.dart';
 
 const _mobileSize = Size(390, 844);
 const _tabletSize = Size(1024, 1366);
 const _vibrateChannel = MethodChannel('vibrate');
+const _wideMarkdownTable = '''
+| Provider | Management experience | Deployment options | Access control |
+| --- | --- | --- | --- |
+| Example Identity Provider | Polished administrative interface | Docker Compose, Helm, and Kubernetes | OAuth, OIDC, SAML, and role-based access control |
+''';
 
 class _RecordedPlatformCall {
   const _RecordedPlatformCall(this.method, this.arguments);
@@ -82,12 +92,16 @@ Widget _buildHarness({
   GlobalKey<ResponsiveDrawerLayoutState>? layoutKey,
   Widget? child,
   Widget? drawer,
+  double edgeFraction = 0.5,
+  VoidCallback? onOpenStart,
 }) {
   return MaterialApp(
     home: MediaQuery(
       data: MediaQueryData(size: size),
       child: ResponsiveDrawerLayout(
         key: layoutKey,
+        edgeFraction: edgeFraction,
+        onOpenStart: onOpenStart,
         drawer:
             drawer ??
             const ColoredBox(
@@ -105,6 +119,49 @@ Widget _buildHarness({
       ),
     ),
   );
+}
+
+Widget _buildEagerGestureOwner() {
+  return RawGestureDetector(
+    behavior: HitTestBehavior.opaque,
+    gestures: <Type, GestureRecognizerFactory>{
+      EagerGestureRecognizer:
+          GestureRecognizerFactoryWithHandlers<EagerGestureRecognizer>(
+            EagerGestureRecognizer.new,
+            (_) {},
+          ),
+    },
+    child: const ColoredBox(
+      key: ValueKey('eager-gesture-owner'),
+      color: Colors.orange,
+      child: SizedBox.expand(),
+    ),
+  );
+}
+
+Future<void> _longPressDrag(
+  WidgetTester tester,
+  Offset start,
+  Offset delta,
+) async {
+  final gesture = await tester.startGesture(start);
+  await tester.pump(kLongPressTimeout + const Duration(milliseconds: 100));
+  await gesture.moveBy(delta);
+  await tester.pump();
+  await gesture.up();
+  await tester.pumpAndSettle();
+}
+
+Future<void> _withTargetPlatform(
+  TargetPlatform platform,
+  Future<void> Function() action,
+) async {
+  debugDefaultTargetPlatformOverride = platform;
+  try {
+    await action();
+  } finally {
+    debugDefaultTargetPlatformOverride = null;
+  }
 }
 
 Widget _buildHorizontalScrollableContent({
@@ -151,6 +208,364 @@ void main() {
     expect(_settleHapticCalls(calls), isEmpty);
   });
 
+  testWidgets('non-scrollable content retains the wide drawer drag region', (
+    tester,
+  ) async {
+    final layoutKey = GlobalKey<ResponsiveDrawerLayoutState>();
+
+    await tester.pumpWidget(
+      _buildHarness(size: _mobileSize, layoutKey: layoutKey),
+    );
+
+    await tester.dragFrom(const Offset(190, 200), const Offset(180, 0));
+    await tester.pumpAndSettle();
+
+    expect(layoutKey.currentState!.isOpen, isTrue);
+  });
+
+  testWidgets('full-width drawer drag opens from the right half of content', (
+    tester,
+  ) async {
+    final layoutKey = GlobalKey<ResponsiveDrawerLayoutState>();
+
+    await tester.pumpWidget(
+      _buildHarness(size: _mobileSize, layoutKey: layoutKey, edgeFraction: 1),
+    );
+
+    await tester.dragFrom(const Offset(300, 200), const Offset(80, 0));
+    await tester.pumpAndSettle();
+
+    expect(layoutKey.currentState!.isOpen, isTrue);
+  });
+
+  testWidgets('explicit gesture owner keeps ordinary full-width drags', (
+    tester,
+  ) async {
+    final layoutKey = GlobalKey<ResponsiveDrawerLayoutState>();
+
+    await tester.pumpWidget(
+      _buildHarness(
+        size: _mobileSize,
+        layoutKey: layoutKey,
+        edgeFraction: 1,
+        child: const DrawerOpenGestureExclusion(
+          child: ColoredBox(color: Colors.orange, child: SizedBox.expand()),
+        ),
+      ),
+    );
+
+    await tester.dragFrom(const Offset(300, 200), const Offset(80, 0));
+    await tester.pumpAndSettle();
+
+    expect(layoutKey.currentState!.isOpen, isFalse);
+  });
+
+  for (final platform in [TargetPlatform.iOS, TargetPlatform.android]) {
+    testWidgets(
+      'completed markdown allows an immediate full-width drawer drag on ${platform.name}',
+      (tester) async {
+        await _withTargetPlatform(platform, () async {
+          final layoutKey = GlobalKey<ResponsiveDrawerLayoutState>();
+
+          await tester.pumpWidget(
+            _buildHarness(
+              size: _mobileSize,
+              layoutKey: layoutKey,
+              edgeFraction: 1,
+              child: const ProviderScope(
+                child: Material(
+                  child: Padding(
+                    padding: EdgeInsets.only(top: 180),
+                    child: StreamingMarkdownWidget(
+                      content:
+                          'Completed assistant text still leaves a quick '
+                          'rightward swipe available to the navigation drawer.',
+                      isStreaming: false,
+                      debugTreatAsWidgetTest: true,
+                    ),
+                  ),
+                ),
+              ),
+            ),
+          );
+          await tester.pumpAndSettle();
+
+          final selectionArea = find.byType(SelectionArea);
+          expect(selectionArea, findsOneWidget);
+          final selectionRect = tester.getRect(selectionArea);
+          final dragStart = Offset(300, selectionRect.center.dy);
+          expect(selectionRect.contains(dragStart), isTrue);
+
+          await tester.dragFrom(dragStart, const Offset(80, 0));
+          await tester.pumpAndSettle();
+
+          expect(layoutKey.currentState!.isOpen, isTrue);
+        });
+      },
+    );
+  }
+
+  testWidgets('true screen edge retains drawer priority over exclusions', (
+    tester,
+  ) async {
+    final layoutKey = GlobalKey<ResponsiveDrawerLayoutState>();
+
+    await tester.pumpWidget(
+      _buildHarness(
+        size: _mobileSize,
+        layoutKey: layoutKey,
+        edgeFraction: 1,
+        child: const DrawerOpenGestureExclusion(
+          child: ColoredBox(color: Colors.orange, child: SizedBox.expand()),
+        ),
+      ),
+    );
+
+    await tester.dragFrom(const Offset(10, 200), const Offset(160, 0));
+    await tester.pumpAndSettle();
+
+    expect(layoutKey.currentState!.isOpen, isTrue);
+  });
+
+  testWidgets('full-width drawer recognizer is inert for an ordinary tap', (
+    tester,
+  ) async {
+    final layoutKey = GlobalKey<ResponsiveDrawerLayoutState>();
+    var openStartCount = 0;
+
+    await tester.pumpWidget(
+      _buildHarness(
+        size: _mobileSize,
+        layoutKey: layoutKey,
+        edgeFraction: 1,
+        onOpenStart: () => openStartCount++,
+      ),
+    );
+
+    await tester.tapAt(const Offset(300, 200));
+    await tester.pumpAndSettle();
+
+    expect(openStartCount, 0);
+    expect(layoutKey.currentState!.isOpen, isFalse);
+  });
+
+  testWidgets('a single physical move preserves the accepted drawer delta', (
+    tester,
+  ) async {
+    final layoutKey = GlobalKey<ResponsiveDrawerLayoutState>();
+
+    await tester.pumpWidget(
+      _buildHarness(size: _mobileSize, layoutKey: layoutKey, edgeFraction: 1),
+    );
+
+    await tester.dragFrom(
+      const Offset(300, 200),
+      const Offset(80, 0),
+      touchSlopX: 0,
+      touchSlopY: 0,
+    );
+    await tester.pumpAndSettle();
+
+    expect(layoutKey.currentState!.isOpen, isTrue);
+  });
+
+  testWidgets('non-opening drag directions leave full-width drawer inert', (
+    tester,
+  ) async {
+    final layoutKey = GlobalKey<ResponsiveDrawerLayoutState>();
+    var openStartCount = 0;
+
+    await tester.pumpWidget(
+      _buildHarness(
+        size: _mobileSize,
+        layoutKey: layoutKey,
+        edgeFraction: 1,
+        onOpenStart: () => openStartCount++,
+      ),
+    );
+
+    await tester.dragFrom(const Offset(300, 200), const Offset(30, 140));
+    await tester.pumpAndSettle();
+
+    expect(layoutKey.currentState!.isOpen, isFalse);
+    expect(openStartCount, 0);
+
+    await tester.dragFrom(const Offset(300, 200), const Offset(-100, 0));
+    await tester.pumpAndSettle();
+
+    expect(layoutKey.currentState!.isOpen, isFalse);
+    expect(openStartCount, 0);
+  });
+
+  testWidgets(
+    'right-half horizontal scroll drag wins over full-width drawer drag',
+    (tester) async {
+      final layoutKey = GlobalKey<ResponsiveDrawerLayoutState>();
+      final scrollController = ScrollController();
+
+      await tester.pumpWidget(
+        _buildHarness(
+          size: _mobileSize,
+          layoutKey: layoutKey,
+          edgeFraction: 1,
+          child: _buildHorizontalScrollableContent(
+            controller: scrollController,
+          ),
+        ),
+      );
+      await tester.pump();
+
+      await tester.dragFrom(const Offset(300, 200), const Offset(80, 0));
+      await tester.pumpAndSettle();
+
+      expect(scrollController.offset, 0);
+      expect(layoutKey.currentState!.isOpen, isFalse);
+
+      await tester.dragFrom(const Offset(300, 200), const Offset(-160, 0));
+      await tester.pumpAndSettle();
+
+      expect(scrollController.offset, greaterThan(0));
+      expect(layoutKey.currentState!.isOpen, isFalse);
+    },
+  );
+
+  for (final platform in [TargetPlatform.iOS, TargetPlatform.android]) {
+    testWidgets(
+      'SelectionArea long-press drag wins over the drawer on ${platform.name}',
+      (tester) async {
+        await _withTargetPlatform(platform, () async {
+          final layoutKey = GlobalKey<ResponsiveDrawerLayoutState>();
+          SelectedContent? selectedContent;
+
+          await tester.pumpWidget(
+            _buildHarness(
+              size: _mobileSize,
+              layoutKey: layoutKey,
+              edgeFraction: 1,
+              child: Material(
+                child: DrawerOpenGestureExclusion(
+                  child: SelectionArea(
+                    onSelectionChanged: (content) => selectedContent = content,
+                    contextMenuBuilder: (_, _) => const SizedBox.shrink(),
+                    magnifierConfiguration: TextMagnifierConfiguration.disabled,
+                    child: const DrawerOpenGesturePriority(
+                      child: Align(
+                        alignment: Alignment.topLeft,
+                        child: Padding(
+                          padding: EdgeInsets.only(top: 180),
+                          child: Text(
+                            key: ValueKey('selectable-copy'),
+                            'Selection gestures keep direct control of this text '
+                            'instead of opening the navigation drawer.',
+                            softWrap: false,
+                          ),
+                        ),
+                      ),
+                    ),
+                  ),
+                ),
+              ),
+            ),
+          );
+          await tester.pump();
+
+          final textRect = tester.getRect(
+            find.byKey(const ValueKey('selectable-copy')),
+          );
+          await _longPressDrag(
+            tester,
+            Offset(300, textRect.center.dy),
+            const Offset(70, 0),
+          );
+
+          expect(selectedContent?.plainText, isNotEmpty);
+          expect(layoutKey.currentState!.isOpen, isFalse);
+        });
+      },
+    );
+  }
+
+  testWidgets(
+    'text-field long-press selection wins over full-width drawer drag',
+    (tester) async {
+      await _withTargetPlatform(TargetPlatform.iOS, () async {
+        final layoutKey = GlobalKey<ResponsiveDrawerLayoutState>();
+        final textController = TextEditingController(
+          text:
+              'Editable text keeps cursor and selection gestures in the field',
+        );
+        addTearDown(textController.dispose);
+
+        await tester.pumpWidget(
+          _buildHarness(
+            size: _mobileSize,
+            layoutKey: layoutKey,
+            edgeFraction: 1,
+            child: Material(
+              child: Align(
+                alignment: Alignment.topLeft,
+                child: Padding(
+                  padding: const EdgeInsets.only(top: 180),
+                  child: TextField(
+                    key: const ValueKey('editable-copy'),
+                    controller: textController,
+                    maxLines: 1,
+                    contextMenuBuilder: (_, _) => const SizedBox.shrink(),
+                    magnifierConfiguration: TextMagnifierConfiguration.disabled,
+                  ),
+                ),
+              ),
+            ),
+          ),
+        );
+        await tester.pump();
+
+        final fieldRect = tester.getRect(
+          find.byKey(const ValueKey('editable-copy')),
+        );
+        await tester.dragFrom(
+          Offset(300, fieldRect.center.dy),
+          const Offset(70, 0),
+        );
+        await tester.pumpAndSettle();
+
+        expect(layoutKey.currentState!.isOpen, isFalse);
+
+        await _longPressDrag(
+          tester,
+          Offset(300, fieldRect.center.dy),
+          const Offset(70, 0),
+        );
+
+        expect(textController.selection.isCollapsed, isFalse);
+        expect(layoutKey.currentState!.isOpen, isFalse);
+      });
+    },
+  );
+
+  testWidgets(
+    'eager descendant gesture owner wins over full-width drawer drag',
+    (tester) async {
+      final layoutKey = GlobalKey<ResponsiveDrawerLayoutState>();
+
+      await tester.pumpWidget(
+        _buildHarness(
+          size: _mobileSize,
+          layoutKey: layoutKey,
+          edgeFraction: 1,
+          child: DrawerOpenGestureExclusion(
+            child: DrawerOpenGesturePriority(child: _buildEagerGestureOwner()),
+          ),
+        ),
+      );
+
+      await tester.dragFrom(const Offset(300, 200), const Offset(80, 0));
+      await tester.pumpAndSettle();
+
+      expect(layoutKey.currentState!.isOpen, isFalse);
+    },
+  );
+
   testWidgets(
     'horizontal scrollable away from the leading edge wins the edge drag',
     (tester) async {
@@ -178,6 +593,149 @@ void main() {
   );
 
   testWidgets(
+    'horizontal scrollable at the leading edge wins drags away from the screen edge',
+    (tester) async {
+      final layoutKey = GlobalKey<ResponsiveDrawerLayoutState>();
+      final scrollController = ScrollController();
+
+      await tester.pumpWidget(
+        _buildHarness(
+          size: _mobileSize,
+          layoutKey: layoutKey,
+          edgeFraction: 1,
+          child: _buildHorizontalScrollableContent(
+            controller: scrollController,
+          ),
+        ),
+      );
+      await tester.pump();
+
+      await tester.dragFrom(const Offset(21, 200), const Offset(-180, 0));
+      await tester.pumpAndSettle();
+
+      expect(layoutKey.currentState!.isOpen, isFalse);
+      expect(scrollController.offset, greaterThan(0));
+    },
+  );
+
+  testWidgets('wide markdown table keeps center-origin horizontal drags', (
+    tester,
+  ) async {
+    final layoutKey = GlobalKey<ResponsiveDrawerLayoutState>();
+
+    await tester.pumpWidget(
+      _buildHarness(
+        size: _mobileSize,
+        layoutKey: layoutKey,
+        child: const ProviderScope(
+          child: Material(
+            child: StreamingMarkdownWidget(
+              content: _wideMarkdownTable,
+              isStreaming: false,
+              debugTreatAsWidgetTest: true,
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    final table = find.byType(DataTable);
+    expect(table, findsOneWidget);
+    final horizontalScrollable = find.ancestor(
+      of: table,
+      matching: find.byType(Scrollable),
+    );
+    expect(horizontalScrollable, findsOneWidget);
+    final scrollableState = tester.state<ScrollableState>(horizontalScrollable);
+    expect(scrollableState.position.maxScrollExtent, greaterThan(0));
+
+    final tableRect = tester.getRect(table);
+    await tester.dragFrom(
+      Offset(190, tableRect.center.dy),
+      const Offset(180, 0),
+    );
+    await tester.pumpAndSettle();
+
+    expect(layoutKey.currentState!.isOpen, isFalse);
+
+    final initialScrollOffset = scrollableState.position.pixels;
+    await tester.dragFrom(
+      Offset(190, tableRect.center.dy),
+      const Offset(-180, 0),
+    );
+    await tester.pumpAndSettle();
+
+    expect(scrollableState.position.pixels, greaterThan(initialScrollOffset));
+    expect(layoutKey.currentState!.isOpen, isFalse);
+  });
+
+  testWidgets('wide markdown table keeps fresh drags from body-cell padding', (
+    tester,
+  ) async {
+    final layoutKey = GlobalKey<ResponsiveDrawerLayoutState>();
+
+    await tester.pumpWidget(
+      _buildHarness(
+        size: _mobileSize,
+        layoutKey: layoutKey,
+        child: const ProviderScope(
+          child: Material(
+            child: StreamingMarkdownWidget(
+              content: _wideMarkdownTable,
+              isStreaming: false,
+              debugTreatAsWidgetTest: true,
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    final table = find.byType(DataTable);
+    expect(table, findsOneWidget);
+    final horizontalScrollable = find.ancestor(
+      of: table,
+      matching: find.byType(Scrollable),
+    );
+    expect(horizontalScrollable, findsOneWidget);
+    final scrollableState = tester.state<ScrollableState>(horizontalScrollable);
+    expect(scrollableState.position.maxScrollExtent, greaterThan(0));
+
+    // With one header and one body row, DataTable's vertical center is still
+    // in the header's opaque InkWell. Exercise the non-interactive padding at
+    // the bottom of a body cell instead, matching a fresh drag on table chrome.
+    final tableRect = tester.getRect(table);
+    final bodyCellPaddingPoint = Offset(190, tableRect.bottom - 8);
+    expect(tableRect.contains(bodyCellPaddingPoint), isTrue);
+
+    final textRects = find
+        .descendant(of: table, matching: find.byType(Text))
+        .evaluate()
+        .map((element) {
+          final renderBox = element.renderObject! as RenderBox;
+          return renderBox.localToGlobal(Offset.zero) & renderBox.size;
+        });
+    expect(
+      textRects.any((rect) => rect.contains(bodyCellPaddingPoint)),
+      isFalse,
+    );
+
+    await tester.dragFrom(bodyCellPaddingPoint, const Offset(-180, 0));
+    await tester.pumpAndSettle();
+
+    final scrolledOffset = scrollableState.position.pixels;
+    expect(scrolledOffset, greaterThan(0));
+    expect(layoutKey.currentState!.isOpen, isFalse);
+
+    await tester.dragFrom(bodyCellPaddingPoint, const Offset(180, 0));
+    await tester.pumpAndSettle();
+
+    expect(scrollableState.position.pixels, lessThan(scrolledOffset));
+    expect(layoutKey.currentState!.isOpen, isFalse);
+  });
+
+  testWidgets(
     'horizontal scrollable at the leading edge can still open the drawer',
     (tester) async {
       final layoutKey = GlobalKey<ResponsiveDrawerLayoutState>();
@@ -187,6 +745,7 @@ void main() {
         _buildHarness(
           size: _mobileSize,
           layoutKey: layoutKey,
+          edgeFraction: 1,
           child: _buildHorizontalScrollableContent(
             controller: scrollController,
           ),


### PR DESCRIPTION
## Summary

- let wide Markdown tables, code blocks, LaTeX, and embedded WebViews retain horizontal gestures
- open the mobile drawer from ordinary content across the full screen
- arbitrate quick drawer swipes against long-press selection on iOS and Android
- retain the platform-style true-edge drawer gesture

## Verification

- dart run build_runner build
- flutter test: 2,750 tests passed
- flutter analyze: no issues
- clean detached-worktree gesture suite: 32 tests passed
- native iOS simulator: center swipe over completed assistant text opens; long-press selection remains functional

Fixes #556

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved drawer-opening gestures on mobile to avoid interfering with note editing, text selection, and horizontal scrolling.
  * Restricted drawer gestures to appropriate horizontal movements and edge interactions.
  * Improved behavior when interacting with wide markdown tables and other scrollable content.
  * Expanded drawer behavior across different screen sizes and platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix full-width drawer gesture arbitration on mobile to avoid conflicts with editors and scrollables
> - Expands the drawer-open drag recognition region to the full content width on phones (was 50%) in [drawer_shell_page.dart](https://github.com/cogwheel0/conduit/pull/568/files#diff-a35bf89b98924c2e936c552417951ed4ff7d2b24f5dd91f0c9c198ffe3a2a7f7), using a new custom `_DrawerOpenHorizontalDragGestureRecognizer` that only accepts sufficiently horizontal rightward drags.
> - Adds `DrawerOpenGestureExclusion` to suppress drawer-open recognition inside the rich-text editor ([note_editor_page.dart](https://github.com/cogwheel0/conduit/pull/568/files#diff-78854ea1159ecb3432e03346b97a0fe608a7e37275f5685601fc69ec944c11f4)) and selectable markdown areas, preventing the drawer from competing with text editing and selection gestures.
> - Adds `DrawerOpenGesturePriority` so that excluded regions (e.g. the markdown viewer) can still initiate a quick rightward drawer drag even when selection/scroll owns the gesture arena.
> - The true screen-edge override region is now confined to actual screen-edge insets; scrollables outside that region suppress edge drag instead of getting a higher threshold.
> - Behavioral Change: drawer drag now spans full content width on phones instead of the right 50%, which may affect users who rely on horizontal swipes anywhere in content for scrolling.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1afae9c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR changes how the mobile drawer competes with horizontal content gestures. The main changes are:

- Adds full-width drawer opening on mobile content.
- Adds exclusion and priority wrappers for markdown and editors.
- Narrows the true-edge listener to the platform-style edge strip.
- Expands drawer gesture tests for selection, editors, and horizontal scrollables.

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The streaming markdown gesture path needs a fix before merging.

Fresh completed markdown gets the new exclusion and priority wrappers, but streaming or stale markdown still returns the raw content tree. Wide streaming content can lose horizontal scroll gestures to the new full-width drawer recognizer.

lib/shared/widgets/markdown/streaming_markdown_widget.dart
</details>


<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- The Flutter/Dart tool availability check was performed, and neither flutter nor dart was found in the sandbox PATH, blocking the test and UI capture for the streaming markdown drawer gesture.
- T-Rex completed the requested verification, but the local artifact references were not uploaded.

<a href="https://app.greptile.com/trex/runs/14152672/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| lib/shared/widgets/responsive_drawer_layout.dart | Adds the custom drawer drag recognizer, exclusion render object, priority wrapper, content gesture arena, and refined true-edge handling. |
| lib/shared/widgets/markdown/streaming_markdown_widget.dart | Wraps fresh completed markdown in drawer gesture arbitration, but leaves streaming or stale markdown outside the new exclusion path. |
| lib/features/notes/views/note_editor_page.dart | Wraps the Fleather editor in drawer gesture exclusion so editor selection and editing gestures keep ownership. |
| lib/shared/widgets/drawer_shell_page.dart | Sets the mobile drawer edge fraction to full width while preserving the tablet value. |
| test/shared/widgets/responsive_drawer_layout_test.dart | Adds coverage for full-width drawer drags, excluded gesture owners, selection, editors, and horizontal scrollables. |

</details>


<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[Mobile pointer down] --> B{Inside true edge strip?}
  B -->|Yes| C[Edge listener checks horizontal scrollable]
  B -->|No| D[Content drawer recognizer checks start position]
  D --> E{Hit excluded editor or selection region?}
  E -->|Yes| F[Descendant gesture owns interaction]
  E -->|No| G[Drawer can open after horizontal threshold]
  F --> H{Priority drawer wrapper present?}
  H -->|Yes| G
  H -->|No| F
  C --> I{Scrollable at opening edge?}
  I -->|Yes| G
  I -->|No| F
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
  A[Mobile pointer down] --> B{Inside true edge strip?}
  B -->|Yes| C[Edge listener checks horizontal scrollable]
  B -->|No| D[Content drawer recognizer checks start position]
  D --> E{Hit excluded editor or selection region?}
  E -->|Yes| F[Descendant gesture owns interaction]
  E -->|No| G[Drawer can open after horizontal threshold]
  F --> H{Priority drawer wrapper present?}
  H -->|Yes| G
  H -->|No| F
  C --> I{Scrollable at opening edge?}
  I -->|Yes| G
  I -->|No| F
```

</a>
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `lib/shared/widgets/markdown/streaming_markdown_widget.dart`, line 466-467 ([link](https://github.com/cogwheel0/conduit/blob/1afae9cb17c75a8b02ddae1dbce0e9cc09f1c918/lib/shared/widgets/markdown/streaming_markdown_widget.dart#L466-L467)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Streaming Markdown Skips Exclusion**

   When `widget.isStreaming` is true or the compiled document is stale, this returns the raw markdown tree without `DrawerOpenGestureExclusion`. In the mobile drawer shell the new full-width content recognizer can then compete with wide code blocks, tables, or LaTeX while the response is still updating, so a horizontal scroll can open the drawer instead of scrolling the content.

   **Context Used:** AGENTS.md ([source](https://app.greptile.com/cogwheel/-/custom-context?memory=871e7f39-32ad-42bc-9cb3-4f44ae78faec))
   
   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (1): Last reviewed commit: ["fix(drawer): arbitrate full-width openin..."](https://github.com/cogwheel0/conduit/commit/1afae9cb17c75a8b02ddae1dbce0e9cc09f1c918) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43639965)</sub>

**Context used:**

- Context used - AGENTS.md ([source](https://app.greptile.com/cogwheel/-/custom-context?memory=871e7f39-32ad-42bc-9cb3-4f44ae78faec))

<!-- /greptile_comment -->