### PR TITLE
Add a versioned Conduit User-Agent

### DIFF
--- a/lib/core/auth/api_auth_interceptor.dart
+++ b/lib/core/auth/api_auth_interceptor.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 
 import 'package:dio/dio.dart';
+import '../network/conduit_user_agent.dart';
 import '../utils/debug_logger.dart';
 
 /// Immutable authorization value captured for work that must remain bound to
@@ -133,6 +134,12 @@ class ApiAuthInterceptor extends Interceptor {
       // Never forward credentials belonging to the selected Open WebUI server
       // to an absolute URL on another origin.
       _removeServerCredentials(options);
+      if (!options.headers.keys.any(ConduitUserAgent.isHeaderName)) {
+        final runtimeDefault = ConduitUserAgent.runtimeDefaultValue;
+        if (runtimeDefault != null) {
+          options.headers[ConduitUserAgent.headerName] = runtimeDefault;
+        }
+      }
       options.headers['Content-Type'] ??= 'application/json';
       options.headers['Accept'] ??= 'application/json';
       handler.next(options);
@@ -182,7 +189,8 @@ class ApiAuthInterceptor extends Interceptor {
     if (customHeaders.isNotEmpty) {
       customHeaders.forEach((key, value) {
         final lowerKey = key.toLowerCase();
-        if (lowerKey == 'authorization') {
+        if (lowerKey == 'authorization' ||
+            ConduitUserAgent.isHeaderName(lowerKey)) {
           DebugLogger.warning(
             'Skipping reserved header override attempt: $key',
           );
@@ -195,6 +203,7 @@ class ApiAuthInterceptor extends Interceptor {
     // Add other common headers for API consistency
     options.headers['Content-Type'] ??= 'application/json';
     options.headers['Accept'] ??= 'application/json';
+    ConduitUserAgent.applyTo(options.headers);
 
     handler.next(options);
   }

--- a/lib/core/network/conduit_user_agent.dart
+++ b/lib/core/network/conduit_user_agent.dart
@@ -1,0 +1,58 @@
+import 'conduit_user_agent_platform.dart' as platform;
+
+/// Public identity for requests initiated against the configured Open WebUI
+/// server.
+///
+/// Native clients retain User-Agent headers across redirects so server
+/// allowlists remain stable. A redirect can cross origins, therefore this value
+/// must stay product-specific and never contain device or account data.
+abstract final class ConduitUserAgent {
+  static const String productName = 'Conduit';
+  static const String headerName = 'User-Agent';
+
+  static String _value = productName;
+
+  /// The process-wide User-Agent, falling back to [productName] until startup
+  /// supplies the installed package version.
+  static String get value => _value;
+
+  /// The runtime's original identity, used when an Open WebUI-scoped client is
+  /// deliberately reused for an absolute request to another origin.
+  static String? get runtimeDefaultValue => platform.runtimeDefaultUserAgent;
+
+  /// Initializes the process-wide value from public package metadata.
+  static void configure({required String appVersion}) {
+    _value = build(appVersion: appVersion);
+  }
+
+  /// Builds an RFC-compatible product token from an app version.
+  static String build({required String appVersion}) {
+    final sanitizedVersion = appVersion.trim().replaceAll(
+      RegExp(r'[^A-Za-z0-9._+\-]'),
+      '-',
+    );
+    if (sanitizedVersion.isEmpty) {
+      return productName;
+    }
+    return '$productName/$sanitizedVersion';
+  }
+
+  /// Returns [headers] with exactly one canonical Conduit User-Agent.
+  static Map<String, String> mergeHeaders([
+    Map<String, String> headers = const {},
+  ]) {
+    final merged = Map<String, String>.from(headers)
+      ..removeWhere((name, _) => isHeaderName(name));
+    merged[headerName] = value;
+    return merged;
+  }
+
+  /// Replaces any case variant in a mutable request-header map.
+  static void applyTo(Map<String, dynamic> headers) {
+    headers.removeWhere((name, _) => isHeaderName(name));
+    headers[headerName] = value;
+  }
+
+  static bool isHeaderName(String name) =>
+      name.toLowerCase() == headerName.toLowerCase();
+}

--- a/lib/core/network/conduit_user_agent_platform.dart
+++ b/lib/core/network/conduit_user_agent_platform.dart
@@ -1,0 +1,5 @@
+import 'conduit_user_agent_platform_stub.dart'
+    if (dart.library.io) 'conduit_user_agent_platform_io.dart'
+    as impl;
+
+String? get runtimeDefaultUserAgent => impl.runtimeDefaultUserAgent;

--- a/lib/core/network/conduit_user_agent_platform_io.dart
+++ b/lib/core/network/conduit_user_agent_platform_io.dart
@@ -1,0 +1,12 @@
+import 'dart:io';
+
+final String? runtimeDefaultUserAgent = _readRuntimeDefaultUserAgent();
+
+String? _readRuntimeDefaultUserAgent() {
+  final client = HttpClient();
+  try {
+    return client.userAgent;
+  } finally {
+    client.close(force: true);
+  }
+}

--- a/lib/core/network/conduit_user_agent_platform_stub.dart
+++ b/lib/core/network/conduit_user_agent_platform_stub.dart
@@ -1,0 +1,1 @@
+String? get runtimeDefaultUserAgent => null;

--- a/lib/core/network/image_header_utils.dart
+++ b/lib/core/network/image_header_utils.dart
@@ -1,25 +1,14 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import 'package:conduit/core/network/conduit_user_agent.dart';
 import 'package:conduit/core/providers/app_providers.dart';
 import 'package:conduit/core/services/api_service.dart';
 import 'package:conduit/features/auth/providers/unified_auth_providers.dart';
 
 /// Builds HTTP headers for protected image requests.
 ///
-/// Includes Authorization (Bearer token or API key) and any server-configured
-/// custom headers. Returns `null` if no headers are needed.
-Map<String, String>? buildImageHeadersFromRef(Ref ref) {
-  final api = ref.watch(apiServiceProvider);
-  final token = ref.watch(authTokenProvider3);
-  return _build(api, token);
-}
-
-Map<String, String>? buildImageHeadersFromWidgetRef(WidgetRef ref) {
-  final api = ref.watch(apiServiceProvider);
-  final token = ref.watch(authTokenProvider3);
-  return _build(api, token);
-}
-
+/// Includes Authorization (Bearer token or API key), the Conduit User-Agent,
+/// and any server-configured custom headers. Returns `null` without an API.
 Map<String, String>? buildImageHeadersForUrlFromWidgetRef(
   WidgetRef ref,
   String url,
@@ -41,16 +30,6 @@ Map<String, String>? readImageHeadersForUrlFromWidgetRef(
     return null;
   }
   final token = ref.read(authTokenProvider3);
-  return _build(api, token);
-}
-
-/// Same as [buildImageHeadersFromRef] but using a [ProviderContainer], useful
-/// when you don't have a `Ref` (e.g., in non-Consumer widgets/utilities).
-Map<String, String>? buildImageHeadersFromContainer(
-  ProviderContainer container,
-) {
-  final api = container.read(apiServiceProvider);
-  final token = container.read(authTokenProvider3);
   return _build(api, token);
 }
 
@@ -116,5 +95,8 @@ Map<String, String>? _build(ApiService? api, String? token) {
     headers.addAll(customHeaders);
   }
 
-  return headers.isEmpty ? null : headers;
+  if (api == null) {
+    return headers.isEmpty ? null : headers;
+  }
+  return ConduitUserAgent.mergeHeaders(headers);
 }

--- a/lib/core/services/api_service.dart
+++ b/lib/core/services/api_service.dart
@@ -21,6 +21,7 @@ import '../models/server_config.dart';
 import '../models/server_memory.dart';
 import '../models/server_user_settings.dart';
 import '../models/user.dart';
+import '../network/conduit_user_agent.dart';
 import '../../features/workspace/models/workspace_common.dart';
 import '../../features/workspace/models/workspace_knowledge.dart';
 import '../../features/workspace/models/workspace_prompt_command.dart';
@@ -360,7 +361,11 @@ class ApiService {
        ),
        _workerManager = workerManager,
        _now = now ?? DateTime.now {
-    ServerTlsHttpClientFactory.configureDio(_dio, serverConfig);
+    ServerTlsHttpClientFactory.configureDio(
+      _dio,
+      serverConfig,
+      userAgent: ConduitUserAgent.value,
+    );
 
     // Use API key from server config if provided and no explicit auth token
     final effectiveAuthToken = authToken ?? serverConfig.apiKey;
@@ -500,9 +505,7 @@ class ApiService {
           receiveTimeout: const Duration(seconds: 15),
           followRedirects: false,
           validateStatus: (status) => true, // Accept all status codes
-          headers: serverConfig.customHeaders.isNotEmpty
-              ? Map<String, String>.from(serverConfig.customHeaders)
-              : null,
+          headers: ConduitUserAgent.mergeHeaders(serverConfig.customHeaders),
         ),
       );
 

--- a/lib/core/services/connectivity_service.dart
+++ b/lib/core/services/connectivity_service.dart
@@ -6,6 +6,7 @@ import 'package:flutter/widgets.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
+import '../network/conduit_user_agent.dart';
 import '../providers/app_providers.dart';
 import 'server_tls_http_client_factory.dart';
 
@@ -346,15 +347,15 @@ final connectivityServiceProvider = Provider<ConnectivityService>((ref) {
           followRedirects: true,
           maxRedirects: 5,
           validateStatus: (status) => status != null && status < 400,
-          headers: server.customHeaders.isNotEmpty
-              ? Map<String, String>.from(server.customHeaders)
-              : null,
+          headers: ConduitUserAgent.mergeHeaders(server.customHeaders),
         ),
       );
 
-      if (ServerTlsHttpClientFactory.requiresCustomHttpClient(server)) {
-        ServerTlsHttpClientFactory.configureDio(dio, server);
-      }
+      ServerTlsHttpClientFactory.configureDio(
+        dio,
+        server,
+        userAgent: ConduitUserAgent.value,
+      );
 
       final service = ConnectivityService(dio, ref);
       ref.onDispose(service.dispose);

--- a/lib/core/services/native_sheet_hydration_service.dart
+++ b/lib/core/services/native_sheet_hydration_service.dart
@@ -54,11 +54,7 @@ class NativeSheetHydrationService {
     bool rethrowErrors = true,
   }) async {
     final api = _ref.read(apiServiceProvider);
-    final avatarHeaders =
-        buildImageHeadersFromContainer(
-          ProviderScope.containerOf(context, listen: false),
-        ) ??
-        const <String, String>{};
+    final container = ProviderScope.containerOf(context, listen: false);
     final l10n = AppLocalizations.of(context);
     final pinnedModelIds = allowsPinning
         ? _ref.read(effectivePinnedModelIdsProvider)
@@ -73,15 +69,21 @@ class NativeSheetHydrationService {
 
     final modelOptions = [
       ...leadingOptions,
-      for (final model in orderedModels)
-        NativeSheetModelOption(
+      ...orderedModels.map((model) {
+        final avatarUrl = resolveModelIconUrlForModel(api, model);
+        final avatarHeaders = avatarUrl == null
+            ? const <String, String>{}
+            : buildImageHeadersForUrlFromContainer(container, avatarUrl) ??
+                  const <String, String>{};
+        return NativeSheetModelOption(
           id: model.id,
           name: model.name,
           subtitle: model.description,
-          avatarUrl: resolveModelIconUrlForModel(api, model),
+          avatarUrl: avatarUrl,
           avatarHeaders: avatarHeaders,
           tags: model.modelTags,
-        ),
+        );
+      }),
     ];
 
     final hydratedModelOptions = await _ref

--- a/lib/core/services/server_tls_http_client_factory.dart
+++ b/lib/core/services/server_tls_http_client_factory.dart
@@ -36,8 +36,13 @@ class ServerTlsHttpClientFactory {
       !kIsWeb && serverConfig.needsCustomTlsClient;
 
   /// Configures Dio to use the server's TLS settings for all requests.
-  static void configureDio(Dio dio, ServerConfig serverConfig) {
-    if (!requiresCustomHttpClient(serverConfig)) {
+  static void configureDio(
+    Dio dio,
+    ServerConfig serverConfig, {
+    String? userAgent,
+  }) {
+    if (kIsWeb ||
+        (!requiresCustomHttpClient(serverConfig) && userAgent == null)) {
       return;
     }
 
@@ -46,7 +51,15 @@ class ServerTlsHttpClientFactory {
       return;
     }
 
-    adapter.createHttpClient = () => createHttpClient(serverConfig);
+    adapter.createHttpClient = () {
+      final client = requiresCustomHttpClient(serverConfig)
+          ? createHttpClient(serverConfig)
+          : HttpClient();
+      if (userAgent != null) {
+        client.userAgent = userAgent;
+      }
+      return client;
+    };
   }
 
   /// Creates a server-scoped [HttpClient] with self-signed and mTLS support.

--- a/lib/core/services/socket_service.dart
+++ b/lib/core/services/socket_service.dart
@@ -5,6 +5,7 @@ import 'package:socket_io_client/socket_io_client.dart' as io;
 
 import '../models/server_config.dart';
 import '../models/socket_health.dart';
+import '../network/conduit_user_agent.dart';
 import '../utils/debug_logger.dart';
 import 'socket_tls_override.dart';
 
@@ -384,7 +385,9 @@ class SocketService with WidgetsBindingObserver {
 
     // Merge Authorization (if any) with user-defined custom headers for the
     // Socket.IO handshake. Avoid overriding reserved headers.
-    final Map<String, String> extraHeaders = {};
+    final Map<String, String> extraHeaders = {
+      ConduitUserAgent.headerName: ConduitUserAgent.value,
+    };
     if (_authToken != null && _authToken!.isNotEmpty) {
       extraHeaders['Authorization'] = 'Bearer $_authToken';
       builder.setAuth({'token': _authToken});
@@ -403,6 +406,7 @@ class SocketService with WidgetsBindingObserver {
         'sec-websocket-version',
         'sec-websocket-extensions',
         'sec-websocket-protocol',
+        'user-agent',
       };
       serverConfig.customHeaders.forEach((key, value) {
         final lower = key.toLowerCase();

--- a/lib/core/services/socket_tls_override_impl_io.dart
+++ b/lib/core/services/socket_tls_override_impl_io.dart
@@ -4,13 +4,21 @@ import 'package:web_socket/io_web_socket.dart' show IOWebSocket;
 import 'package:web_socket/web_socket.dart' as ws;
 
 import '../models/server_config.dart';
+import '../network/conduit_user_agent.dart';
 import 'server_tls_http_client_factory.dart';
+
+// Match dart:io WebSocket's shared-client lifecycle while replacing its
+// generic runtime identity with the public product identity.
+final _defaultWebSocketConnector = _ScopedWebSocketConnector(
+  HttpClient()..userAgent = ConduitUserAgent.value,
+);
 
 io.Socket createSocketWithOptionalBadCertOverride(
   String base,
   io.OptionBuilder builder,
   ServerConfig serverConfig,
 ) {
+  builder.setWebSocketConnector(_defaultWebSocketConnector.connect);
   if (!ServerTlsHttpClientFactory.requiresCustomHttpClient(serverConfig)) {
     return io.io(base, builder.build());
   }
@@ -36,26 +44,36 @@ Uri? _tryParseUri(String url) {
   return null;
 }
 
-class _CustomTlsWebSocketConnector {
-  _CustomTlsWebSocketConnector(ServerConfig serverConfig)
-    : _httpClient = ServerTlsHttpClientFactory.createHttpClient(serverConfig);
+class _ScopedWebSocketConnector {
+  _ScopedWebSocketConnector(this._httpClient);
 
   final HttpClient _httpClient;
 
   // socket_io_client's connector contract returns package:web_socket sockets.
-  // Keep the custom dart:io HttpClient so self-signed TLS policy is preserved;
-  // callers force WebSocket-only because HTTP polling cannot use this connector.
   Future<ws.WebSocket> connect(
     Uri uri, {
     Iterable<String>? protocols,
     Map<String, String>? headers,
   }) async {
+    Map<String, String>? forwardedHeaders;
+    if (headers != null) {
+      forwardedHeaders = Map<String, String>.from(headers)
+        ..removeWhere((name, _) => ConduitUserAgent.isHeaderName(name));
+    }
     final socket = await WebSocket.connect(
       uri.toString(),
       protocols: protocols,
-      headers: headers,
+      headers: forwardedHeaders,
       customClient: _httpClient,
     );
     return IOWebSocket.fromWebSocket(socket);
   }
+}
+
+class _CustomTlsWebSocketConnector extends _ScopedWebSocketConnector {
+  _CustomTlsWebSocketConnector(ServerConfig serverConfig)
+    : super(
+        ServerTlsHttpClientFactory.createHttpClient(serverConfig)
+          ..userAgent = ConduitUserAgent.value,
+      );
 }

--- a/lib/features/auth/views/server_connection_page.dart
+++ b/lib/features/auth/views/server_connection_page.dart
@@ -16,6 +16,7 @@ import 'package:conduit/l10n/app_localizations.dart';
 import '../../../core/auth/webview_cookie_helper.dart';
 import '../../../core/models/backend_config.dart';
 import '../../../core/models/server_config.dart';
+import '../../../core/network/conduit_user_agent.dart';
 import '../../../core/providers/app_providers.dart';
 import '../../../core/services/api_service.dart';
 import '../../../core/services/worker_manager.dart';
@@ -685,9 +686,7 @@ class _ServerConnectionPageState extends ConsumerState<ServerConnectionPage> {
           receiveTimeout: const Duration(seconds: 2),
           followRedirects: false,
           validateStatus: (status) => true,
-          headers: _customHeaders.isNotEmpty
-              ? Map<String, String>.from(_customHeaders)
-              : null,
+          headers: ConduitUserAgent.mergeHeaders(_customHeaders),
         ),
       );
 

--- a/lib/features/chat/widgets/enhanced_image_attachment.dart
+++ b/lib/features/chat/widgets/enhanced_image_attachment.dart
@@ -18,6 +18,7 @@ import 'package:conduit/l10n/app_localizations.dart';
 import '../../../core/providers/app_providers.dart';
 import '../../../shared/widgets/adaptive_route_shell.dart';
 import '../../../core/utils/debug_logger.dart';
+import '../../../core/network/conduit_user_agent.dart';
 import '../../../core/network/self_signed_image_cache_manager.dart';
 import '../../../core/network/image_header_utils.dart';
 import '../../../core/services/api_service.dart';
@@ -532,8 +533,18 @@ Map<String, String>? _mergeHeaders(
       (overrides == null || overrides.isEmpty)) {
     return null;
   }
-  return {...?defaults, ...?overrides};
+  final merged = <String, String>{...?defaults, ...?overrides};
+  if (defaults?.keys.any(ConduitUserAgent.isHeaderName) == true) {
+    ConduitUserAgent.applyTo(merged);
+  }
+  return merged;
 }
+
+@visibleForTesting
+Map<String, String>? debugMergeImageHeaders(
+  Map<String, String>? defaults,
+  Map<String, String>? overrides,
+) => _mergeHeaders(defaults, overrides);
 
 class EnhancedImageAttachment extends ConsumerStatefulWidget {
   final String attachmentId;

--- a/lib/features/navigation/widgets/sidebar_user_pill.dart
+++ b/lib/features/navigation/widgets/sidebar_user_pill.dart
@@ -275,7 +275,10 @@ class SidebarProfileAppBarLeading extends ConsumerWidget {
               initials: initials,
               avatarUrl: avatarBytes == null ? avatarUrl : null,
               avatarBytes: avatarBytes,
-              avatarHeaders: buildImageHeadersFromWidgetRef(ref) ?? const {},
+              avatarHeaders: avatarUrl == null
+                  ? const {}
+                  : buildImageHeadersForUrlFromWidgetRef(ref, avatarUrl) ??
+                        const {},
               bio: accountProfile?.bio,
               gender: accountProfile?.gender,
               dateOfBirth: accountProfile?.dateOfBirth,

--- a/lib/features/terminal/providers/terminal_providers.dart
+++ b/lib/features/terminal/providers/terminal_providers.dart
@@ -1,14 +1,18 @@
 import 'dart:async';
+import 'dart:io';
 
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:web_socket_channel/io.dart';
 import 'package:web_socket_channel/web_socket_channel.dart';
 
+import '../../../core/network/conduit_user_agent.dart';
 import '../../../core/providers/app_providers.dart';
 import '../../tools/providers/tools_providers.dart';
 import '../models/terminal_models.dart';
 import '../services/terminal_service.dart';
 
-typedef TerminalChannelConnector = WebSocketChannel Function(Uri uri);
+typedef TerminalChannelConnector =
+    WebSocketChannel Function(Uri uri, {required TerminalServerKind kind});
 
 final terminalServiceProvider = Provider<TerminalService?>((ref) {
   final api = ref.watch(apiServiceProvider);
@@ -120,7 +124,15 @@ final terminalBrowserRefreshTokenProvider =
 final terminalChannelConnectorProvider = Provider<TerminalChannelConnector>((
   ref,
 ) {
-  return (uri) => WebSocketChannel.connect(uri);
+  final systemClient = HttpClient()..userAgent = ConduitUserAgent.value;
+  ref.onDispose(() => systemClient.close(force: true));
+
+  return (uri, {required kind}) {
+    if (kind == TerminalServerKind.direct) {
+      return WebSocketChannel.connect(uri);
+    }
+    return IOWebSocketChannel.connect(uri, customClient: systemClient);
+  };
 });
 
 final terminalAutoConnectProvider = Provider<bool>((ref) => true);

--- a/lib/features/terminal/widgets/terminal_tab.dart
+++ b/lib/features/terminal/widgets/terminal_tab.dart
@@ -394,6 +394,7 @@ class _TerminalTabState extends ConsumerState<TerminalTab>
       }
       final channel = ref.read(terminalChannelConnectorProvider)(
         service.buildWebSocketUri(server, session.sessionId),
+        kind: server.kind,
       );
       await channel.ready;
 

--- a/lib/features/workspace/views/models/workspace_model_editor.dart
+++ b/lib/features/workspace/views/models/workspace_model_editor.dart
@@ -8,6 +8,8 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
+import 'package:conduit/core/network/image_header_utils.dart';
+import 'package:conduit/core/network/conduit_user_agent.dart';
 import 'package:conduit/core/providers/app_providers.dart';
 import 'package:conduit/core/utils/debug_logger.dart';
 import 'package:conduit/features/workspace/models/workspace_capabilities.dart';
@@ -1510,10 +1512,18 @@ class _ModelAvatarState extends ConsumerState<_ModelAvatar> {
       }
     }
     if (inline != null && inline.startsWith('http')) {
+      final api = ref.watch(apiServiceProvider);
+      // Draft URLs are user-controlled and can redirect off-origin. Send only
+      // the public product identity; server credentials and custom proxy
+      // headers must never follow them.
+      final headers = imageUrlIsServerOrigin(api?.serverConfig.url, inline)
+          ? ConduitUserAgent.mergeHeaders()
+          : null;
       return wrap(
         Image.network(
           inline,
           fit: BoxFit.cover,
+          headers: headers,
           errorBuilder: (_, _, _) => placeholder,
         ),
       );

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -7,12 +7,14 @@ import 'package:flutter_driver/driver_extension.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter/services.dart' show rootBundle;
+import 'package:package_info_plus/package_info_plus.dart';
 import 'package:pdfrx/pdfrx.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'core/widgets/error_boundary.dart';
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 
 import 'core/providers/app_providers.dart';
+import 'core/network/conduit_user_agent.dart';
 import 'core/persistence/hive_bootstrap.dart';
 import 'core/persistence/hive_prefs_migrator.dart';
 import 'core/persistence/persistence_migrator.dart';
@@ -89,6 +91,17 @@ void main() {
   runZonedGuarded(
     () async {
       WidgetsFlutterBinding.ensureInitialized();
+      try {
+        final packageInfo = await PackageInfo.fromPlatform();
+        ConduitUserAgent.configure(appVersion: packageInfo.version);
+      } catch (error, stackTrace) {
+        DebugLogger.error(
+          'user-agent-version-unavailable',
+          scope: 'app/startup',
+          error: error,
+          stackTrace: stackTrace,
+        );
+      }
       _registerBundledLicenses();
       unawaited(
         pdfrxFlutterInitialize().catchError((

--- a/lib/shared/widgets/user_avatar.dart
+++ b/lib/shared/widgets/user_avatar.dart
@@ -56,8 +56,9 @@ class AvatarImage extends ConsumerWidget {
       return fallbackBuilder(context, size);
     }
 
-    // Build auth/custom headers when loading from network
-    final headers = buildImageHeadersFromWidgetRef(ref);
+    // Credentials and the Conduit identity are scoped to the configured
+    // server; profile-image fields may contain external URLs.
+    final headers = buildImageHeadersForUrlFromWidgetRef(ref, url);
 
     final cacheManager = ref.watch(selfSignedImageCacheManagerProvider);
 

--- a/test/core/auth/api_auth_interceptor_test.dart
+++ b/test/core/auth/api_auth_interceptor_test.dart
@@ -1,4 +1,5 @@
 import 'package:conduit/core/auth/api_auth_interceptor.dart';
+import 'package:conduit/core/network/conduit_user_agent.dart';
 import 'package:dio/dio.dart';
 import 'package:flutter/foundation.dart' show debugPrint;
 import 'package:flutter_test/flutter_test.dart';
@@ -62,6 +63,14 @@ void main() {
           .toSet();
       expect(headerNames, isNot(contains('authorization')));
       expect(headerNames, isNot(contains('x-proxy-credential')));
+      expect(
+        forwarded.headers[ConduitUserAgent.headerName],
+        ConduitUserAgent.runtimeDefaultValue,
+      );
+      expect(
+        forwarded.headers[ConduitUserAgent.headerName],
+        isNot(ConduitUserAgent.value),
+      );
       expect(forwarded.headers['X-Request-Header'], 'preserved');
     });
 
@@ -107,7 +116,35 @@ void main() {
       expect(forwarded, isNotNull);
       expect(forwarded!.headers['Authorization'], 'Bearer server-token');
       expect(forwarded.headers['X-Proxy-Credential'], 'proxy-secret');
+      expect(
+        forwarded.headers[ConduitUserAgent.headerName],
+        ConduitUserAgent.value,
+      );
     });
+
+    test(
+      'configured User-Agent cannot override the Conduit identity',
+      () async {
+        final interceptor = ApiAuthInterceptor(
+          serverUrl: _serverUrl,
+          customHeaders: const {'uSeR-aGeNt': 'spoofed-agent'},
+        );
+        final handler = _TestRequestInterceptorHandler();
+        final options = RequestOptions(path: '/health');
+
+        interceptor.onRequest(options, handler);
+        final forwarded = await handler.forwardedRequest;
+
+        expect(forwarded, isNotNull);
+        expect(
+          forwarded!.headers[ConduitUserAgent.headerName],
+          ConduitUserAgent.value,
+        );
+        expect(forwarded.headers.keys.where(ConduitUserAgent.isHeaderName), [
+          ConduitUserAgent.headerName,
+        ]);
+      },
+    );
 
     test('current auth snapshot forwards its captured token', () async {
       final interceptor = ApiAuthInterceptor(

--- a/test/core/network/conduit_user_agent_test.dart
+++ b/test/core/network/conduit_user_agent_test.dart
@@ -1,0 +1,56 @@
+import 'dart:io';
+
+import 'package:checks/checks.dart';
+import 'package:conduit/core/network/conduit_user_agent.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('ConduitUserAgent', () {
+    test('builds a product and app-version token', () {
+      check(
+        ConduitUserAgent.build(appVersion: ' 3.4.3 '),
+      ).equals('Conduit/3.4.3');
+    });
+
+    test('sanitizes characters that are invalid in a product token', () {
+      check(
+        ConduitUserAgent.build(appVersion: '3.4 beta/1'),
+      ).equals('Conduit/3.4-beta-1');
+    });
+
+    test('falls back to the product name when the version is empty', () {
+      check(ConduitUserAgent.build(appVersion: '   ')).equals('Conduit');
+    });
+
+    test('configure updates the process-wide identity', () {
+      addTearDown(() => ConduitUserAgent.configure(appVersion: ''));
+
+      ConduitUserAgent.configure(appVersion: '9.8.7');
+
+      check(ConduitUserAgent.value).equals('Conduit/9.8.7');
+    });
+
+    test('runtime fallback matches dart:io', () {
+      final client = HttpClient();
+      addTearDown(() => client.close(force: true));
+
+      check(ConduitUserAgent.runtimeDefaultValue).equals(client.userAgent);
+    });
+
+    test('replaces case variants with one canonical header', () {
+      final original = <String, String>{
+        'user-agent': 'spoofed',
+        'X-Custom': 'value',
+      };
+
+      final merged = ConduitUserAgent.mergeHeaders(original);
+
+      check(merged[ConduitUserAgent.headerName]).equals(ConduitUserAgent.value);
+      check(
+        merged.keys.where(ConduitUserAgent.isHeaderName),
+      ).deepEquals([ConduitUserAgent.headerName]);
+      check(merged['X-Custom']).equals('value');
+      check(original['user-agent']).equals('spoofed');
+    });
+  });
+}

--- a/test/core/network/image_header_utils_test.dart
+++ b/test/core/network/image_header_utils_test.dart
@@ -1,5 +1,6 @@
 import 'package:checks/checks.dart';
 import 'package:conduit/core/models/server_config.dart';
+import 'package:conduit/core/network/conduit_user_agent.dart';
 import 'package:conduit/core/network/image_header_utils.dart';
 import 'package:conduit/core/providers/app_providers.dart';
 import 'package:conduit/core/services/api_service.dart';
@@ -123,6 +124,7 @@ void main() {
       check(headers).isNotNull().deepEquals({
         'Authorization': 'Bearer token',
         'X-Custom': 'value',
+        ConduitUserAgent.headerName: ConduitUserAgent.value,
       });
     });
 
@@ -148,6 +150,7 @@ void main() {
       check(headers).isNotNull().deepEquals({
         'Authorization': 'Bearer api-key',
         'X-Custom': 'value',
+        ConduitUserAgent.headerName: ConduitUserAgent.value,
       });
     });
   });

--- a/test/core/services/api_service_proxy_diagnostics_test.dart
+++ b/test/core/services/api_service_proxy_diagnostics_test.dart
@@ -3,6 +3,7 @@ import 'dart:io';
 
 import 'package:checks/checks.dart';
 import 'package:conduit/core/models/server_config.dart';
+import 'package:conduit/core/network/conduit_user_agent.dart';
 import 'package:conduit/core/services/api_service.dart';
 import 'package:conduit/core/services/worker_manager.dart';
 import 'package:flutter/foundation.dart' show debugPrint;
@@ -12,12 +13,112 @@ const _headerSecret = 'proxy-custom-header-secret';
 const _redirectSecret = 'proxy-reflected-location-secret';
 
 void main() {
+  test(
+    'health check preserves the Conduit User-Agent across redirects',
+    () async {
+      final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+      final receivedUserAgents = <String?>[];
+      server.listen((request) async {
+        receivedUserAgents.add(
+          request.headers.value(HttpHeaders.userAgentHeader),
+        );
+        if (request.uri.path == '/health') {
+          request.response
+            ..statusCode = HttpStatus.found
+            ..headers.set(HttpHeaders.locationHeader, '/ready');
+          await request.response.close();
+          return;
+        }
+        request.response
+          ..statusCode = HttpStatus.ok
+          ..headers.contentType = ContentType.json
+          ..write('{"status":true}');
+        await request.response.close();
+      });
+
+      final workerManager = WorkerManager();
+      final api = ApiService(
+        serverConfig: ServerConfig(
+          id: 'health-user-agent',
+          name: 'Health User-Agent',
+          url: 'http://${server.address.address}:${server.port}',
+        ),
+        workerManager: workerManager,
+      );
+
+      try {
+        check(await api.checkHealth()).isTrue();
+        check(
+          receivedUserAgents,
+        ).deepEquals([ConduitUserAgent.value, ConduitUserAgent.value]);
+      } finally {
+        workerManager.dispose();
+        await server.close(force: true);
+      }
+    },
+  );
+
+  test(
+    'health check keeps its public identity on a cross-origin redirect',
+    () async {
+      final target = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+      final targetUserAgent = Completer<String?>();
+      target.listen((request) async {
+        if (!targetUserAgent.isCompleted) {
+          targetUserAgent.complete(
+            request.headers.value(HttpHeaders.userAgentHeader),
+          );
+        }
+        request.response
+          ..statusCode = HttpStatus.ok
+          ..headers.contentType = ContentType.json
+          ..write('{"status":true}');
+        await request.response.close();
+      });
+
+      final redirect = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+      redirect.listen((request) async {
+        request.response
+          ..statusCode = HttpStatus.found
+          ..headers.set(
+            HttpHeaders.locationHeader,
+            'http://${target.address.address}:${target.port}/ready',
+          );
+        await request.response.close();
+      });
+
+      final workerManager = WorkerManager();
+      final api = ApiService(
+        serverConfig: ServerConfig(
+          id: 'cross-origin-user-agent',
+          name: 'Cross-origin User-Agent',
+          url: 'http://${redirect.address.address}:${redirect.port}',
+        ),
+        workerManager: workerManager,
+      );
+
+      try {
+        check(await api.checkHealth()).isTrue();
+        check(
+          await targetUserAgent.future.timeout(const Duration(seconds: 5)),
+        ).equals(ConduitUserAgent.value);
+      } finally {
+        workerManager.dispose();
+        await redirect.close(force: true);
+        await target.close(force: true);
+      }
+    },
+  );
+
   test('proxy health-check diagnostics never log redirect credentials', () async {
     final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
     final requestSeen = Completer<void>();
     server.listen((request) async {
       check(request.uri.path).equals('/health');
       check(request.headers.value('x-proxy-credential')).equals(_headerSecret);
+      check(
+        request.headers.value(HttpHeaders.userAgentHeader),
+      ).equals(ConduitUserAgent.value);
       if (!requestSeen.isCompleted) requestSeen.complete();
       request.response
         ..statusCode = HttpStatus.temporaryRedirect
@@ -33,7 +134,10 @@ void main() {
         id: 'proxy-diagnostics',
         name: 'Proxy diagnostics',
         url: 'http://${server.address.address}:${server.port}',
-        customHeaders: const {'x-proxy-credential': _headerSecret},
+        customHeaders: const {
+          'x-proxy-credential': _headerSecret,
+          'uSeR-aGeNt': 'spoofed-agent',
+        },
       ),
       workerManager: WorkerManager(),
     );

--- a/test/core/services/server_tls_http_client_factory_test.dart
+++ b/test/core/services/server_tls_http_client_factory_test.dart
@@ -65,6 +65,21 @@ void main() {
       check(ioAdapter.createHttpClient).isNotNull();
       check(() => ioAdapter.createHttpClient!()).throws<StateError>();
     });
+
+    test('configures a standard Dio client with a stable User-Agent', () {
+      final dio = Dio();
+
+      ServerTlsHttpClientFactory.configureDio(
+        dio,
+        _server(),
+        userAgent: 'Conduit/test',
+      );
+
+      final adapter = dio.httpClientAdapter as IOHttpClientAdapter;
+      final client = adapter.createHttpClient!();
+      addTearDown(() => client.close(force: true));
+      check(client.userAgent).equals('Conduit/test');
+    });
   });
 }
 

--- a/test/core/services/socket_service_test.dart
+++ b/test/core/services/socket_service_test.dart
@@ -1,6 +1,8 @@
 import 'dart:async';
+import 'dart:io';
 
 import 'package:conduit/core/models/server_config.dart';
+import 'package:conduit/core/network/conduit_user_agent.dart';
 import 'package:conduit/core/services/socket_service.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -106,6 +108,70 @@ void main() {
   );
 
   test(
+    'connect includes the Conduit User-Agent in handshake headers',
+    () async {
+      final socketFactory = _RecordingSocketFactory();
+      final service = SocketService(
+        serverConfig: _serverConfig.copyWith(
+          customHeaders: const {
+            'X-Proxy-Credential': 'proxy-secret',
+            'user-agent': 'spoofed-agent',
+          },
+        ),
+        authToken: 'auth-token',
+        socketFactory: socketFactory.create,
+      );
+      addTearDown(service.dispose);
+
+      await service.connect();
+
+      final headers = socketFactory.handshakeHeaders.single;
+      expect(headers[ConduitUserAgent.headerName], ConduitUserAgent.value);
+      expect(headers['Authorization'], 'Bearer auth-token');
+      expect(headers['X-Proxy-Credential'], 'proxy-secret');
+      expect(headers.keys.where(ConduitUserAgent.isHeaderName), [
+        ConduitUserAgent.headerName,
+      ]);
+    },
+  );
+
+  test('native handshake sends one Conduit User-Agent value', () async {
+    await HttpOverrides.runWithHttpOverrides(() async {
+      final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+      final receivedUserAgents = Completer<List<String>>();
+      server.listen((request) async {
+        if (!receivedUserAgents.isCompleted) {
+          receivedUserAgents.complete(
+            request.headers[HttpHeaders.userAgentHeader] ?? const [],
+          );
+        }
+        request.response.statusCode = HttpStatus.badRequest;
+        await request.response.close();
+      });
+
+      final service = SocketService(
+        serverConfig: ServerConfig(
+          id: 'wire-user-agent',
+          name: 'Wire User-Agent',
+          url: 'http://${server.address.address}:${server.port}',
+        ),
+        websocketOnly: true,
+      );
+
+      try {
+        await service.connect();
+        expect(
+          await receivedUserAgents.future.timeout(const Duration(seconds: 5)),
+          [ConduitUserAgent.value],
+        );
+      } finally {
+        service.dispose();
+        await server.close(force: true);
+      }
+    }, _RealHttpOverrides());
+  });
+
+  test(
     'resume reconnect emits onReconnect after the new socket connects',
     () async {
       final binding = TestWidgetsFlutterBinding.ensureInitialized();
@@ -204,12 +270,19 @@ class _RecordingSocketService extends SocketService {
 
 class _RecordingSocketFactory {
   final List<io.Socket> sockets = <io.Socket>[];
+  final List<Map<String, String>> handshakeHeaders = <Map<String, String>>[];
 
   io.Socket create(
     String base,
     io.OptionBuilder builder,
     ServerConfig serverConfig,
   ) {
+    final options = builder.build();
+    handshakeHeaders.add(
+      Map<String, String>.from(
+        options['extraHeaders'] as Map<dynamic, dynamic>? ?? const {},
+      ),
+    );
     final socket = io.io(
       'http://localhost:${19000 + sockets.length}',
       <String, dynamic>{
@@ -222,3 +295,5 @@ class _RecordingSocketFactory {
     return socket;
   }
 }
+
+class _RealHttpOverrides extends HttpOverrides {}

--- a/test/features/chat/widgets/enhanced_image_attachment_cache_test.dart
+++ b/test/features/chat/widgets/enhanced_image_attachment_cache_test.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 
+import 'package:conduit/core/network/conduit_user_agent.dart';
 import 'package:conduit/core/services/worker_manager.dart';
 import 'package:conduit/features/chat/widgets/enhanced_image_attachment.dart';
 import 'package:conduit/l10n/app_localizations.dart';
@@ -9,6 +10,22 @@ import 'package:flutter_test/flutter_test.dart';
 void main() {
   setUp(debugResetImageAttachmentCaches);
   tearDown(debugResetImageAttachmentCaches);
+
+  test('same-origin image metadata cannot override the Conduit identity', () {
+    final headers = debugMergeImageHeaders(
+      {
+        'Authorization': 'Bearer token',
+        ConduitUserAgent.headerName: ConduitUserAgent.value,
+      },
+      const {'uSeR-aGeNt': 'spoofed-agent', 'X-Image': 'value'},
+    );
+
+    expect(headers, {
+      'Authorization': 'Bearer token',
+      'X-Image': 'value',
+      ConduitUserAgent.headerName: ConduitUserAgent.value,
+    });
+  });
 
   test('resolved image cache evicts the least recently used entry', () {
     for (var index = 0; index < 80; index += 1) {

--- a/test/features/terminal/providers/terminal_channel_connector_test.dart
+++ b/test/features/terminal/providers/terminal_channel_connector_test.dart
@@ -1,0 +1,79 @@
+import 'dart:async';
+import 'dart:io';
+
+import 'package:conduit/core/network/conduit_user_agent.dart';
+import 'package:conduit/features/terminal/models/terminal_models.dart';
+import 'package:conduit/features/terminal/providers/terminal_providers.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('terminal connector brands only system-server handshakes', () async {
+    await HttpOverrides.runWithHttpOverrides(() async {
+      final container = ProviderContainer();
+      try {
+        final systemUserAgents = await _captureHandshakeUserAgents(
+          container,
+          TerminalServerKind.system,
+        );
+        final directUserAgents = await _captureHandshakeUserAgents(
+          container,
+          TerminalServerKind.direct,
+        );
+
+        expect(systemUserAgents, [ConduitUserAgent.value]);
+        expect(
+          directUserAgents.where((value) => value.contains('Conduit')),
+          isEmpty,
+        );
+      } finally {
+        container.dispose();
+      }
+    }, _RealHttpOverrides());
+  });
+}
+
+Future<List<String>> _captureHandshakeUserAgents(
+  ProviderContainer container,
+  TerminalServerKind kind,
+) async {
+  final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+  final captured = Completer<List<String>>();
+  server.listen((request) async {
+    if (!captured.isCompleted) {
+      captured.complete(
+        request.headers[HttpHeaders.userAgentHeader] ?? const <String>[],
+      );
+    }
+    request.response.statusCode = HttpStatus.badRequest;
+    await request.response.close();
+  });
+
+  try {
+    final channel = container.read(terminalChannelConnectorProvider)(
+      Uri.parse('ws://${server.address.address}:${server.port}/terminal'),
+      kind: kind,
+    );
+    final readyFinished = _ignoreFailure(channel.ready);
+    final streamFinished = _ignoreFailure(channel.stream.drain<void>());
+
+    final userAgents = await captured.future.timeout(
+      const Duration(seconds: 5),
+    );
+    await Future.wait([
+      readyFinished,
+      streamFinished,
+    ]).timeout(const Duration(seconds: 5));
+    return userAgents;
+  } finally {
+    await server.close(force: true);
+  }
+}
+
+Future<void> _ignoreFailure(Future<void> future) async {
+  try {
+    await future;
+  } catch (_) {}
+}
+
+class _RealHttpOverrides extends HttpOverrides {}

--- a/test/features/terminal/widgets/terminal_tab_test.dart
+++ b/test/features/terminal/widgets/terminal_tab_test.dart
@@ -142,7 +142,10 @@ void main() {
         _buildHarnessWithActivity(
           fakeService,
           isActive,
-          channelConnector: (_) => channels[channelConnectCount++].channel,
+          channelConnector: (_, {required kind}) {
+            expect(kind, TerminalServerKind.direct);
+            return channels[channelConnectCount++].channel;
+          },
         ),
       );
       await tester.pumpAndSettle();

--- a/test/features/workspace/views/workspace_model_editor_test.dart
+++ b/test/features/workspace/views/workspace_model_editor_test.dart
@@ -6,8 +6,13 @@ import 'package:flutter_riverpod/misc.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:go_router/go_router.dart';
 
+import 'package:conduit/core/models/server_config.dart';
 import 'package:conduit/core/models/model.dart';
+import 'package:conduit/core/network/conduit_user_agent.dart';
 import 'package:conduit/core/providers/app_providers.dart';
+import 'package:conduit/core/services/api_service.dart';
+import 'package:conduit/core/services/worker_manager.dart';
+import 'package:conduit/features/auth/providers/unified_auth_providers.dart';
 import 'package:conduit/features/workspace/models/workspace_capabilities.dart';
 import 'package:conduit/features/workspace/models/workspace_resources.dart';
 import 'package:conduit/features/workspace/providers/workspace_capabilities_provider.dart';
@@ -125,6 +130,52 @@ void main() {
 
     expect(find.byKey(const Key('workspace-editor-save')), findsNothing);
     expect(find.byKey(const Key('workspace-read-only-badge')), findsOneWidget);
+  });
+
+  testWidgets('same-origin draft avatar uses only the public product header', (
+    tester,
+  ) async {
+    final workerManager = WorkerManager(debugIsWebOverride: true);
+    addTearDown(workerManager.dispose);
+    final api = ApiService(
+      serverConfig: const ServerConfig(
+        id: 'server',
+        name: 'Server',
+        url: 'https://open-webui.example',
+        customHeaders: {'X-Proxy': 'value'},
+      ),
+      workerManager: workerManager,
+    );
+
+    await tester.pumpWidget(
+      _harness(
+        models: _FakeWorkspaceModels(),
+        mode: WorkspaceRouteMode.edit,
+        resourceId: 'model-1',
+        api: api,
+        detail: const WorkspaceModelSummary(
+          id: 'model-1',
+          name: 'Model 1',
+          userId: 'owner',
+          writeAccess: true,
+          meta: {
+            'profile_image_url':
+                'https://open-webui.example/api/v1/models/model/profile/image?id=model-1',
+          },
+        ),
+      ),
+    );
+    await tester.pump();
+    await tester.pump();
+
+    final networkImage = tester
+        .widgetList<Image>(find.byType(Image))
+        .map((widget) => widget.image)
+        .whereType<NetworkImage>()
+        .single;
+    expect(networkImage.headers, {
+      ConduitUserAgent.headerName: ConduitUserAgent.value,
+    });
   });
 
   testWidgets('detail overflow deletes after confirmation', (tester) async {
@@ -413,10 +464,11 @@ Widget _harness({
   String? resourceId,
   WorkspaceModelSummary? detail,
   List<WorkspaceToolSummary> tools = const [],
+  ApiService? api,
 }) {
   return ProviderScope(
     overrides: [
-      ..._baseOverrides(models, tools: tools),
+      ..._baseOverrides(models, tools: tools, api: api),
       if (resourceId != null && detail != null)
         workspaceModelDetailProvider(
           resourceId,
@@ -429,10 +481,12 @@ Widget _harness({
 List<Override> _baseOverrides(
   _FakeWorkspaceModels models, {
   List<WorkspaceToolSummary> tools = const [],
+  ApiService? api,
 }) {
   return [
     reviewerModeProvider.overrideWithValue(false),
-    apiServiceProvider.overrideWithValue(null),
+    apiServiceProvider.overrideWithValue(api),
+    authTokenProvider3.overrideWithValue(api == null ? null : 'token'),
     workspaceCapabilitiesProvider.overrideWith(
       (ref) async => WorkspaceCapabilities.all,
     ),


### PR DESCRIPTION
## Summary

- add a centralized `Conduit/<app-version>` identity initialized from installed package metadata, with a safe `Conduit` fallback
- apply it to Open WebUI REST and health requests, redirects, Socket.IO, system terminals, and protected same-origin media
- reserve the header against custom overrides and prevent duplicate Dart and Conduit identities on native WebSocket handshakes
- keep direct third-party backends and OAuth/proxy WebViews on their native identities, while avoiding server credential forwarding for user-controlled draft avatar URLs

## Verification

- `dart format --output=none --set-exit-if-changed` on all changed Dart files
- `flutter analyze` — no issues
- `flutter test` — 3,880 passed; 2 skipped

Addresses the distinctive User-Agent portion of #542. HTTP/2 support remains separate.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add a versioned Conduit User-Agent to all outgoing HTTP and WebSocket requests
> - Introduces [`ConduitUserAgent`](https://github.com/cogwheel0/conduit/pull/572/files#diff-f8f65a1ea41423ddfebec920573108adf9bc4afc4ac47b92781e9eaa71b02c8e), a utility that builds an RFC-compatible product token (e.g. `Conduit/1.2.3`) from the app version set at startup in [`main.dart`](https://github.com/cogwheel0/conduit/pull/572/files#diff-e61eb31d013d12616f5532636a88cfa63631dda8f7829e5424e68542214d1608).
> - Applies the Conduit User-Agent across all HTTP clients (Dio, `HttpClient`), Socket.IO handshakes, and WebSocket connections via [`ApiAuthInterceptor`](https://github.com/cogwheel0/conduit/pull/572/files#diff-cf168d90c59780215ff2872ecba395def8bb940e771674f47a2aa699601ed130), [`ServerTlsHttpClientFactory`](https://github.com/cogwheel0/conduit/pull/572/files#diff-e7fc26057f6482b2d8ad6be6fd928e6cbfe9297aeb14aa516b0c981ddb77263c), and [`SocketService`](https://github.com/cogwheel0/conduit/pull/572/files#diff-5772cbe762f5d947423935aac8e13e0e6ad56ec7ba7382081ef4b8a545eaac26).
> - Same-origin requests always carry the Conduit User-Agent; cross-origin (absolute URL) requests use the runtime platform default instead and do not receive server credentials.
> - Caller-supplied `User-Agent` headers (any case variant) are silently dropped and replaced with the canonical Conduit value for same-origin requests.
> - Behavioral Change: image header helpers (`buildImageHeadersFromRef` and related) are removed; URL-aware replacements return `null` for cross-origin URLs, so callers that previously received headers for any URL will now receive `null` for external URLs.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e3098b0.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a consistent Conduit User-Agent to network, image, socket, terminal, and health-check requests.
  * User-Agent values now include the app version when available.
  * Reserved identity headers are protected from custom-header overrides.
  * Image requests apply authentication headers only for trusted server-origin URLs.

* **Bug Fixes**
  * Improved avatar and terminal connection handling across supported platforms.
  * Preserved the correct User-Agent across redirects and TLS configurations.

* **Tests**
  * Added coverage for User-Agent handling, redirects, sockets, terminal connections, and protected image requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a versioned Conduit User-Agent across server-facing network paths. The main changes are:

- Centralized `Conduit/<app-version>` header construction.
- Reserved User-Agent from custom header overrides.
- Applied the identity to REST, health, Socket.IO, terminal, and protected media requests.
- Scoped image credentials to same-origin media URLs.

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The native app paths look mostly sound, but the terminal provider can break Flutter web builds.

User-Agent scoping and custom-header reservation are covered by the changed code and tests, and image credential scoping now avoids cross-origin media leaks.

The terminal connector needs a platform split so web builds do not import native-only APIs.
</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Verified that the sandbox blocks web-target imports by confirming Flutter and Dart tooling are unavailable.
- Attempted the Flutter setup path (flutter pub get) but received 'flutter: not found', so no web-target import/compile could run.
- Captured the verification script flutter\_user\_agent\_validation.sh and the before/after logs to document tooling detection results.
- Observed in the before/after logs that Dart/Flutter were not detected and the workflow skipped as a result.

<a href="https://app.greptile.com/trex/runs/14449507/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| lib/core/network/conduit_user_agent.dart | Adds centralized User-Agent building, sanitization, and header merge helpers. |
| lib/core/auth/api_auth_interceptor.dart | Applies Conduit identity to server-scoped API requests and blocks custom User-Agent overrides. |
| lib/core/network/image_header_utils.dart | Scopes protected image headers to same-origin URLs and adds the Conduit identity. |
| lib/core/services/socket_tls_override_impl_io.dart | Routes native Socket.IO WebSocket handshakes through HttpClients carrying the Conduit identity. |
| lib/features/terminal/providers/terminal_providers.dart | Brands system terminal WebSocket handshakes but introduces native-only imports into the shared provider file. |
| lib/features/workspace/views/models/workspace_model_editor.dart | Avoids forwarding credentials for draft avatar URLs while preserving the public product identity for same-origin previews. |
| lib/main.dart | Initializes the process-wide User-Agent from package metadata with a safe fallback. |

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(network): add versioned Conduit use..."](https://github.com/cogwheel0/conduit/commit/e3098b0527b5e077f248cb10d90f76c72230d0cd) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44265633)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Context used - AGENTS.md ([source](https://app.greptile.com/cogwheel/-/custom-context?memory=871e7f39-32ad-42bc-9cb3-4f44ae78faec))

<!-- /greptile_comment -->