### PR TITLE
fix: preserve note audio recordings across upload failures

### DIFF
--- a/lib/core/services/api_service.dart
+++ b/lib/core/services/api_service.dart
@@ -3261,8 +3261,9 @@ class ApiService {
     final files = <FileInfo>[];
     var page = 1;
     int? total;
+    const maxPages = 200;
 
-    while (true) {
+    while (page <= maxPages) {
       final pageResult = await getPage(page);
 
       files.addAll(pageResult.items);
@@ -3279,6 +3280,10 @@ class ApiService {
       }
 
       page += 1;
+    }
+
+    if (page > maxPages) {
+      _traceApi('Warning: Hit max user-files page limit ($maxPages)');
     }
 
     return List<FileInfo>.unmodifiable(files);
@@ -3315,11 +3320,34 @@ class ApiService {
     String? contentType,
     int? limit,
     int? offset,
+  }) async =>
+      await searchFilesForSession(
+        query: query,
+        contentType: contentType,
+        limit: limit,
+        offset: offset,
+      ) ??
+      const <FileInfo>[];
+
+  /// Searches the current user's files while keeping a long-running operation
+  /// pinned to its originating auth session.
+  ///
+  /// Returns null when the server does not expose the file-search endpoint, so
+  /// callers that require compatibility with older OpenWebUI releases can fall
+  /// back to paginated listing. A supported search with no matches returns an
+  /// empty list.
+  Future<List<FileInfo>?> searchFilesForSession({
+    String? query,
+    String? contentType,
+    int? limit,
+    int? offset,
+    ApiAuthSnapshot? authSnapshot,
+    CancelToken? cancelToken,
   }) async {
     _traceApi('Searching files with query: $query');
     final trimmedQuery = query?.trim();
     if (trimmedQuery == null || trimmedQuery.isEmpty) {
-      return const [];
+      return const <FileInfo>[];
     }
 
     final queryParams = <String, dynamic>{};
@@ -3334,6 +3362,8 @@ class ApiService {
       final response = await _dio.get(
         '/api/v1/files/search',
         queryParameters: queryParams,
+        options: _withAuthSnapshot(Options(), authSnapshot),
+        cancelToken: cancelToken,
       );
       final data = response.data;
       if (data is List) {
@@ -3349,10 +3379,15 @@ class ApiService {
         }
         return results;
       }
-      return const [];
+      return const <FileInfo>[];
     } on DioException catch (error) {
       if (error.response?.statusCode == 404) {
-        return const [];
+        final responseData = error.response?.data;
+        final detail = responseData is Map ? responseData['detail'] : null;
+        if (detail == 'No files found matching the pattern.') {
+          return const <FileInfo>[];
+        }
+        return null;
       }
       rethrow;
     }

--- a/lib/core/services/api_service.dart
+++ b/lib/core/services/api_service.dart
@@ -3237,14 +3237,33 @@ class ApiService {
     return response.data as Map<String, dynamic>;
   }
 
-  Future<List<FileInfo>> getUserFiles() async {
+  Future<List<FileInfo>> getUserFiles() =>
+      _getUserFilesWith((page) => getUserFilesPage(page: page));
+
+  Future<List<FileInfo>> getUserFilesForSession({
+    ApiAuthSnapshot? authSnapshot,
+    CancelToken? cancelToken,
+  }) => _getUserFilesWith(
+    (page) => getUserFilesPageForSession(
+      page: page,
+      authSnapshot: authSnapshot,
+      cancelToken: cancelToken,
+    ),
+  );
+
+  Future<List<FileInfo>> _getUserFilesWith(
+    Future<({List<FileInfo> items, int? total, bool isPaginated})> Function(
+      int page,
+    )
+    getPage,
+  ) async {
     _traceApi('Fetching user files');
     final files = <FileInfo>[];
     var page = 1;
     int? total;
 
     while (true) {
-      final pageResult = await getUserFilesPage(page: page);
+      final pageResult = await getPage(page);
 
       files.addAll(pageResult.items);
       total ??= pageResult.total;
@@ -3270,10 +3289,19 @@ class ApiService {
   /// Supports both the current paginated OpenWebUI response shape and the
   /// legacy plain-list payload used by older servers.
   Future<({List<FileInfo> items, int? total, bool isPaginated})>
-  getUserFilesPage({int page = 1}) async {
+  getUserFilesPage({int page = 1}) => getUserFilesPageForSession(page: page);
+
+  Future<({List<FileInfo> items, int? total, bool isPaginated})>
+  getUserFilesPageForSession({
+    int page = 1,
+    ApiAuthSnapshot? authSnapshot,
+    CancelToken? cancelToken,
+  }) async {
     final response = await _dio.get(
       '/api/v1/files/',
       queryParameters: {'page': page, 'content': false},
+      options: _withAuthSnapshot(Options(), authSnapshot),
+      cancelToken: cancelToken,
     );
     return _parseFileInfoCollection(
       response.data,
@@ -7348,6 +7376,7 @@ class ApiService {
     String? contentType,
     Map<String, dynamic>? metadata,
     CancelToken? cancelToken,
+    ApiAuthSnapshot? authSnapshot,
   }) async {
     _traceApi('Starting file upload: $fileName from $filePath');
 
@@ -7378,9 +7407,9 @@ class ApiService {
         '/api/v1/files/',
         data: formData,
         cancelToken: cancelToken,
-        options: Options(
-          sendTimeout: uploadTimeout,
-          receiveTimeout: uploadTimeout,
+        options: _withAuthSnapshot(
+          Options(sendTimeout: uploadTimeout, receiveTimeout: uploadTimeout),
+          authSnapshot,
         ),
       );
 
@@ -7810,6 +7839,22 @@ class ApiService {
     Map<String, dynamic>? data,
     Map<String, dynamic>? meta,
     Map<String, dynamic>? accessControl,
+  }) => updateNoteForSession(
+    id,
+    title: title,
+    data: data,
+    meta: meta,
+    accessControl: accessControl,
+  );
+
+  Future<Map<String, dynamic>> updateNoteForSession(
+    String id, {
+    String? title,
+    Map<String, dynamic>? data,
+    Map<String, dynamic>? meta,
+    Map<String, dynamic>? accessControl,
+    ApiAuthSnapshot? authSnapshot,
+    CancelToken? cancelToken,
   }) async {
     _traceApi('Updating note: $id');
     final response = await _dio.post(
@@ -7820,6 +7865,8 @@ class ApiService {
         'meta': ?meta,
         'access_control': ?accessControl,
       },
+      options: _withAuthSnapshot(Options(), authSnapshot),
+      cancelToken: cancelToken,
     );
     return response.data as Map<String, dynamic>;
   }

--- a/lib/features/notes/services/note_audio_upload_service.dart
+++ b/lib/features/notes/services/note_audio_upload_service.dart
@@ -1,0 +1,894 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:crypto/crypto.dart';
+import 'package:flutter/foundation.dart';
+import 'package:path/path.dart' as path;
+import 'package:path_provider/path_provider.dart';
+import 'package:uuid/uuid.dart';
+
+import '../../../core/utils/debug_logger.dart';
+
+const _manifestVersion = 1;
+const _storeDirectoryName = 'note_audio_uploads';
+const _manifestFileName = 'manifest.json';
+const _defaultAudioFileName = 'recording.m4a';
+
+enum NoteAudioUploadStatus { pending, uploading, attaching, failed }
+
+@immutable
+class PendingNoteAudioUpload {
+  const PendingNoteAudioUpload({
+    required this.id,
+    required this.serverScope,
+    required this.accountScope,
+    required this.noteId,
+    required this.localPath,
+    required this.fileName,
+    required this.fileSize,
+    required this.status,
+    required this.createdAt,
+    this.lastError,
+    this.serverFileId,
+    this.sourceCacheFileName,
+  });
+
+  final String id;
+  final String serverScope;
+  final String accountScope;
+  final String noteId;
+  final String localPath;
+  final String fileName;
+  final int fileSize;
+  final NoteAudioUploadStatus status;
+  final DateTime createdAt;
+  final String? lastError;
+  final String? serverFileId;
+  final String? sourceCacheFileName;
+
+  PendingNoteAudioUpload transition(
+    NoteAudioUploadStatus nextStatus, {
+    String? lastError,
+    String? serverFileId,
+  }) {
+    return PendingNoteAudioUpload(
+      id: id,
+      serverScope: serverScope,
+      accountScope: accountScope,
+      noteId: noteId,
+      localPath: localPath,
+      fileName: fileName,
+      fileSize: fileSize,
+      status: nextStatus,
+      createdAt: createdAt,
+      // A retrying/uploading transition intentionally clears a stale failure.
+      lastError: lastError,
+      serverFileId: serverFileId ?? this.serverFileId,
+      sourceCacheFileName: sourceCacheFileName,
+    );
+  }
+
+  Map<String, dynamic> toJson() => <String, dynamic>{
+    'version': _manifestVersion,
+    'id': id,
+    'serverScope': serverScope,
+    'accountScope': accountScope,
+    'noteId': noteId,
+    'localFileName': path.basename(localPath),
+    'fileName': fileName,
+    'fileSize': fileSize,
+    'status': status.name,
+    'createdAt': createdAt.toUtc().toIso8601String(),
+    'lastError': lastError,
+    'serverFileId': serverFileId,
+    // Only a basename is persisted. Recovery resolves it against the app's
+    // cache directory, so an absolute device path never enters the manifest.
+    'sourceCacheFileName': sourceCacheFileName,
+  };
+
+  static PendingNoteAudioUpload fromJson(
+    Map<String, dynamic> json, {
+    required Directory itemDirectory,
+  }) {
+    if (json['version'] != _manifestVersion) {
+      throw const FormatException('Unsupported note audio manifest version');
+    }
+
+    final id = json['id'] as String?;
+    final serverScope = json['serverScope'] as String?;
+    final accountScope = json['accountScope'] as String?;
+    final noteId = json['noteId'] as String?;
+    final localFileName = json['localFileName'] as String?;
+    final fileName = json['fileName'] as String?;
+    final fileSize = (json['fileSize'] as num?)?.toInt();
+    final statusName = json['status'] as String?;
+    final sourceCacheFileName = json['sourceCacheFileName'] as String?;
+    final createdAt = DateTime.tryParse(json['createdAt'] as String? ?? '');
+    if (id == null ||
+        serverScope == null ||
+        accountScope == null ||
+        noteId == null ||
+        localFileName == null ||
+        fileName == null ||
+        fileSize == null ||
+        statusName == null ||
+        createdAt == null ||
+        path.basename(localFileName) != localFileName ||
+        !RegExp(r'^recording\.[a-z0-9]{1,8}$').hasMatch(localFileName) ||
+        (sourceCacheFileName != null &&
+            (path.basename(sourceCacheFileName) != sourceCacheFileName ||
+                !RegExp(
+                  r'^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$',
+                ).hasMatch(sourceCacheFileName)))) {
+      throw const FormatException('Invalid note audio manifest');
+    }
+
+    final status = NoteAudioUploadStatus.values.firstWhere(
+      (candidate) => candidate.name == statusName,
+      orElse: () => NoteAudioUploadStatus.failed,
+    );
+    return PendingNoteAudioUpload(
+      id: id,
+      serverScope: serverScope,
+      accountScope: accountScope,
+      noteId: noteId,
+      localPath: path.join(itemDirectory.path, localFileName),
+      fileName: fileName,
+      fileSize: fileSize,
+      status: status,
+      createdAt: createdAt.toLocal(),
+      lastError: json['lastError'] as String?,
+      serverFileId: json['serverFileId'] as String?,
+      sourceCacheFileName: sourceCacheFileName,
+    );
+  }
+}
+
+typedef NoteAudioUploadCallback =
+    Future<String> Function(PendingNoteAudioUpload item, File file);
+typedef NoteAudioAttachCallback =
+    Future<void> Function(PendingNoteAudioUpload item, String fileId);
+typedef NoteAudioUploadChanged = void Function(PendingNoteAudioUpload? item);
+
+/// Durable, account-scoped storage for note recordings awaiting upload.
+///
+/// Each recording owns a small sidecar manifest in application-support storage.
+/// The manifest is written before the recorder's cache file is removed, and the
+/// returned server file id is written before note attachment begins. These two
+/// ordering guarantees make both network failure and process death recoverable.
+class NoteAudioUploadStore {
+  NoteAudioUploadStore({
+    Future<Directory> Function()? applicationSupportDirectory,
+    Future<Directory> Function()? temporaryDirectory,
+    String Function()? idGenerator,
+  }) : _applicationSupportDirectory =
+           applicationSupportDirectory ?? getApplicationSupportDirectory,
+       _temporaryDirectory = temporaryDirectory ?? getTemporaryDirectory,
+       _idGenerator = idGenerator ?? const Uuid().v4;
+
+  final Future<Directory> Function() _applicationSupportDirectory;
+  final Future<Directory> Function() _temporaryDirectory;
+  final String Function() _idGenerator;
+  static final Set<String> _activeStageDirectories = <String>{};
+  static final Map<String, Future<void>> _itemOperationTails =
+      <String, Future<void>>{};
+
+  Future<PendingNoteAudioUpload> stage({
+    required File source,
+    required String serverId,
+    String accountId = '',
+    required String noteId,
+    required String fileName,
+  }) async {
+    if (!await source.exists()) {
+      throw StateError('Recorded audio file is missing');
+    }
+
+    final id = _safeId(_idGenerator());
+    final serverScope = _scope(serverId);
+    final accountScope = _scope(accountId);
+    final noteDirectory = await _noteDirectory(
+      serverScope: serverScope,
+      accountScope: accountScope,
+      noteId: noteId,
+    );
+    final itemDirectory = Directory(path.join(noteDirectory.path, id));
+    await itemDirectory.create(recursive: true);
+    final activeStageKey = path.normalize(itemDirectory.path);
+
+    final extension = _safeExtension(fileName);
+    final durableFile = File(
+      path.join(itemDirectory.path, 'recording$extension'),
+    );
+    final stagingFile = File(
+      path.join(itemDirectory.path, '.staging$extension'),
+    );
+    final sourceSize = await source.length();
+    final item = PendingNoteAudioUpload(
+      id: id,
+      serverScope: serverScope,
+      accountScope: accountScope,
+      noteId: noteId,
+      localPath: durableFile.path,
+      fileName: fileName,
+      fileSize: sourceSize,
+      status: NoteAudioUploadStatus.pending,
+      createdAt: DateTime.now(),
+      sourceCacheFileName: path.basename(source.path),
+    );
+    _activeStageDirectories.add(activeStageKey);
+    var stageCompleted = false;
+    var sourceMoved = false;
+    try {
+      // Journal the owning note before copying. An account-wide recovery scan
+      // can therefore attribute and surface a process-interrupted stage.
+      if (!await save(item)) {
+        throw const FileSystemException(
+          'Recorded audio staging directory disappeared',
+        );
+      }
+      try {
+        // Cache and application-support directories normally share a volume on
+        // iOS/Android, making this an atomic relocation with no partial-copy
+        // window. Cross-volume/test environments fall back to a recoverable
+        // copy while the journal still points at the cache basename.
+        await source.rename(stagingFile.path);
+        sourceMoved = true;
+      } on FileSystemException {
+        await source.copy(stagingFile.path);
+      }
+      final durableSize = await stagingFile.length();
+      if (sourceSize != durableSize) {
+        throw const FileSystemException('Recorded audio copy was incomplete');
+      }
+      // Rename is atomic within this directory. Recovery only recognizes the
+      // final `recording.*` name, so it can never surface a partial copy.
+      await stagingFile.rename(durableFile.path);
+      stageCompleted = true;
+
+      // The application-support copy and its manifest are durable now. Losing
+      // the cache source after this point cannot lose the recording.
+      if (!sourceMoved) {
+        try {
+          await source.delete();
+        } catch (error, stackTrace) {
+          DebugLogger.error(
+            'note-audio-source-cleanup-failed',
+            scope: 'notes/audio',
+            error: error,
+            stackTrace: stackTrace,
+            data: {'id': id},
+          );
+        }
+      }
+      return item;
+    } catch (_) {
+      if (!stageCompleted) {
+        var sourceAvailable = !sourceMoved;
+        if (sourceMoved && await stagingFile.exists()) {
+          try {
+            await stagingFile.rename(source.path);
+            sourceAvailable = true;
+          } catch (restoreError, restoreStackTrace) {
+            // Keep the journaled staging directory when restoration fails;
+            // recovery can still finish it on the next app start.
+            DebugLogger.error(
+              'note-audio-source-restore-failed',
+              scope: 'notes/audio',
+              error: restoreError,
+              stackTrace: restoreStackTrace,
+              data: {'id': id},
+            );
+          }
+        }
+        try {
+          if (sourceAvailable) await itemDirectory.delete(recursive: true);
+        } catch (cleanupError, cleanupStackTrace) {
+          DebugLogger.error(
+            'note-audio-stage-cleanup-failed',
+            scope: 'notes/audio',
+            error: cleanupError,
+            stackTrace: cleanupStackTrace,
+            data: {'id': id},
+          );
+        }
+      }
+      rethrow;
+    } finally {
+      _activeStageDirectories.remove(activeStageKey);
+    }
+  }
+
+  Future<List<PendingNoteAudioUpload>> loadForNote({
+    required String serverId,
+    String accountId = '',
+    required String noteId,
+  }) async {
+    final serverScope = _scope(serverId);
+    final accountScope = _scope(accountId);
+    final noteDirectory = await _noteDirectory(
+      serverScope: serverScope,
+      accountScope: accountScope,
+      noteId: noteId,
+    );
+    if (!await noteDirectory.exists()) return <PendingNoteAudioUpload>[];
+
+    final items = <PendingNoteAudioUpload>[];
+    await for (final entity in noteDirectory.list(followLinks: false)) {
+      if (entity is! Directory) continue;
+      final item = await _withItemLock(
+        entity,
+        () async => await entity.exists()
+            ? _readOrRecover(
+                entity,
+                serverScope: serverScope,
+                accountScope: accountScope,
+                noteId: noteId,
+              )
+            : null,
+      );
+      if (item != null) items.add(item);
+    }
+    items.sort((a, b) => a.createdAt.compareTo(b.createdAt));
+    return items;
+  }
+
+  /// Reloads one caller-owned item from its durable manifest.
+  ///
+  /// Editors may retain an older in-memory snapshot after another editor has
+  /// uploaded or removed the same recording. Processing must therefore begin
+  /// from disk, and a missing item directory means that the operation already
+  /// completed rather than that the stale snapshot should be saved again.
+  Future<PendingNoteAudioUpload?> loadCurrent(
+    PendingNoteAudioUpload item,
+  ) async {
+    final itemDirectory = File(item.localPath).parent;
+    await _validateItemDirectory(item, itemDirectory);
+    return _withItemLock(
+      itemDirectory,
+      () async => await itemDirectory.exists()
+          ? _readOrRecover(
+              itemDirectory,
+              serverScope: item.serverScope,
+              accountScope: item.accountScope,
+              noteId: item.noteId,
+            )
+          : null,
+    );
+  }
+
+  /// Loads every recording owned by an account on a server.
+  ///
+  /// This account-level scan is needed when a note was recorded under a
+  /// temporary `local:` id which was remapped to its server id while the app
+  /// was closed. Callers still resolve and filter [PendingNoteAudioUpload.noteId]
+  /// before displaying or retrying an item.
+  Future<List<PendingNoteAudioUpload>> loadForAccount({
+    required String serverId,
+    String accountId = '',
+  }) async {
+    final serverScope = _scope(serverId);
+    final accountScope = _scope(accountId);
+    final accountDirectory = await _accountDirectory(
+      serverScope: serverScope,
+      accountScope: accountScope,
+    );
+    if (!await accountDirectory.exists()) {
+      return <PendingNoteAudioUpload>[];
+    }
+
+    final items = <PendingNoteAudioUpload>[];
+    await for (final noteEntity in accountDirectory.list(followLinks: false)) {
+      if (noteEntity is! Directory) continue;
+      final expectedNoteScope = path.basename(noteEntity.path);
+      await for (final itemEntity in noteEntity.list(followLinks: false)) {
+        if (itemEntity is! Directory) continue;
+        final item = await _withItemLock(
+          itemEntity,
+          () async => await itemEntity.exists()
+              ? _readAccountItem(
+                  itemEntity,
+                  serverScope: serverScope,
+                  accountScope: accountScope,
+                  expectedNoteScope: expectedNoteScope,
+                )
+              : null,
+        );
+        if (item != null) items.add(item);
+      }
+    }
+    items.sort((a, b) => a.createdAt.compareTo(b.createdAt));
+    return items;
+  }
+
+  /// Saves [item] only while its durable directory still exists.
+  ///
+  /// Returning false is a completion signal: another editor already attached
+  /// and removed this upload, so a stale writer must not recreate a ghost job.
+  Future<bool> save(PendingNoteAudioUpload item) async {
+    final itemDirectory = File(item.localPath).parent;
+    await _validateItemDirectory(item, itemDirectory);
+    return _withItemLock(
+      itemDirectory,
+      () => _saveUnlocked(item, itemDirectory),
+    );
+  }
+
+  Future<bool> _saveUnlocked(
+    PendingNoteAudioUpload item,
+    Directory itemDirectory,
+  ) async {
+    if (!await itemDirectory.exists()) return false;
+
+    final manifest = File(path.join(itemDirectory.path, _manifestFileName));
+    final temporary = File('${manifest.path}.tmp');
+    await temporary.writeAsString(jsonEncode(item.toJson()), flush: true);
+    await temporary.rename(manifest.path);
+    return true;
+  }
+
+  Future<void> remove(PendingNoteAudioUpload item) async {
+    final itemDirectory = File(item.localPath).parent;
+    await _validateItemDirectory(item, itemDirectory);
+    await _withItemLock(itemDirectory, () async {
+      if (await itemDirectory.exists()) {
+        await itemDirectory.delete(recursive: true);
+      }
+    });
+  }
+
+  Future<PendingNoteAudioUpload?> _readOrRecover(
+    Directory itemDirectory, {
+    required String serverScope,
+    required String accountScope,
+    required String noteId,
+  }) async {
+    if (_activeStageDirectories.contains(path.normalize(itemDirectory.path))) {
+      return null;
+    }
+    final manifest = File(path.join(itemDirectory.path, _manifestFileName));
+    try {
+      final decoded = jsonDecode(await manifest.readAsString());
+      if (decoded is! Map<String, dynamic>) {
+        throw const FormatException('Invalid note audio manifest root');
+      }
+      var item = PendingNoteAudioUpload.fromJson(
+        decoded,
+        itemDirectory: itemDirectory,
+      );
+      if (item.id != path.basename(itemDirectory.path) ||
+          item.serverScope != serverScope ||
+          item.accountScope != accountScope ||
+          item.noteId != noteId) {
+        throw const FormatException('Note audio manifest scope mismatch');
+      }
+      item = await _recoverInterruptedStage(item);
+      if (!await File(item.localPath).exists()) {
+        item = item.transition(
+          NoteAudioUploadStatus.failed,
+          lastError: 'The saved recording file is missing.',
+        );
+        if (!await _saveUnlocked(item, itemDirectory)) return null;
+      }
+      return item;
+    } catch (error, stackTrace) {
+      DebugLogger.error(
+        'note-audio-manifest-read-failed',
+        scope: 'notes/audio',
+        error: error,
+        stackTrace: stackTrace,
+        data: {'id': path.basename(itemDirectory.path)},
+      );
+      return _recoverItemDirectory(
+        itemDirectory,
+        serverScope: serverScope,
+        accountScope: accountScope,
+        noteId: noteId,
+      );
+    }
+  }
+
+  Future<PendingNoteAudioUpload?> _readAccountItem(
+    Directory itemDirectory, {
+    required String serverScope,
+    required String accountScope,
+    required String expectedNoteScope,
+  }) async {
+    if (_activeStageDirectories.contains(path.normalize(itemDirectory.path))) {
+      return null;
+    }
+    final manifest = File(path.join(itemDirectory.path, _manifestFileName));
+    try {
+      final decoded = jsonDecode(await manifest.readAsString());
+      if (decoded is! Map<String, dynamic>) {
+        throw const FormatException('Invalid note audio manifest root');
+      }
+      var item = PendingNoteAudioUpload.fromJson(
+        decoded,
+        itemDirectory: itemDirectory,
+      );
+      if (item.id != path.basename(itemDirectory.path) ||
+          item.serverScope != serverScope ||
+          item.accountScope != accountScope ||
+          _scope(item.noteId) != expectedNoteScope) {
+        throw const FormatException('Note audio manifest scope mismatch');
+      }
+      item = await _recoverInterruptedStage(item);
+      if (!await File(item.localPath).exists()) {
+        item = item.transition(
+          NoteAudioUploadStatus.failed,
+          lastError: 'The saved recording file is missing.',
+        );
+        if (!await _saveUnlocked(item, itemDirectory)) return null;
+      }
+      return item;
+    } catch (error, stackTrace) {
+      // The note id itself lives inside the manifest, so a corrupt manifest
+      // cannot be safely attributed during an account-wide scan. An exact
+      // [loadForNote] can still recover its recording directory.
+      DebugLogger.error(
+        'note-audio-account-manifest-read-failed',
+        scope: 'notes/audio',
+        error: error,
+        stackTrace: stackTrace,
+        data: {'id': path.basename(itemDirectory.path)},
+      );
+      return null;
+    }
+  }
+
+  Future<PendingNoteAudioUpload> _recoverInterruptedStage(
+    PendingNoteAudioUpload item,
+  ) async {
+    final recording = File(item.localPath);
+    if (await recording.exists()) return item;
+
+    final extension = path.extension(item.localPath);
+    final staging = File(
+      path.join(recording.parent.path, '.staging$extension'),
+    );
+    var stagingComplete =
+        await staging.exists() && await staging.length() == item.fileSize;
+    File? copiedSource;
+    if (!stagingComplete) {
+      final sourceCacheFileName = item.sourceCacheFileName;
+      if (sourceCacheFileName == null) return item;
+
+      final temporaryDirectory = await _temporaryDirectory();
+      final source = File(
+        path.join(temporaryDirectory.path, sourceCacheFileName),
+      );
+      if (!await source.exists() || await source.length() != item.fileSize) {
+        return item;
+      }
+      if (await staging.exists()) await staging.delete();
+      try {
+        await source.rename(staging.path);
+      } on FileSystemException {
+        await source.copy(staging.path);
+        copiedSource = source;
+      }
+      stagingComplete =
+          await staging.exists() && await staging.length() == item.fileSize;
+      if (!stagingComplete) return item;
+    }
+
+    await staging.rename(recording.path);
+    if (copiedSource != null) {
+      try {
+        await copiedSource.delete();
+      } catch (error, stackTrace) {
+        DebugLogger.error(
+          'note-audio-recovered-source-cleanup-failed',
+          scope: 'notes/audio',
+          error: error,
+          stackTrace: stackTrace,
+          data: {'id': item.id},
+        );
+      }
+    }
+    final recovered = item.transition(
+      NoteAudioUploadStatus.failed,
+      lastError: 'The recording copy was interrupted and needs to be retried.',
+    );
+    await _saveUnlocked(recovered, recording.parent);
+    return recovered;
+  }
+
+  Future<PendingNoteAudioUpload?> _recoverItemDirectory(
+    Directory itemDirectory, {
+    required String serverScope,
+    required String accountScope,
+    required String noteId,
+  }) async {
+    File? recording;
+    await for (final entity in itemDirectory.list(followLinks: false)) {
+      if (entity is File &&
+          path.basename(entity.path).startsWith('recording.')) {
+        recording = entity;
+        break;
+      }
+    }
+    if (recording == null || !await recording.exists()) return null;
+
+    final item = PendingNoteAudioUpload(
+      id: path.basename(itemDirectory.path),
+      serverScope: serverScope,
+      accountScope: accountScope,
+      noteId: noteId,
+      localPath: recording.path,
+      fileName: _defaultAudioFileName,
+      fileSize: await recording.length(),
+      status: NoteAudioUploadStatus.failed,
+      createdAt: await recording.lastModified(),
+      lastError: 'The upload state was interrupted and needs to be retried.',
+    );
+    return await _saveUnlocked(item, itemDirectory) ? item : null;
+  }
+
+  Future<Directory> _noteDirectory({
+    required String serverScope,
+    required String accountScope,
+    required String noteId,
+  }) async {
+    final accountDirectory = await _accountDirectory(
+      serverScope: serverScope,
+      accountScope: accountScope,
+    );
+    return Directory(path.join(accountDirectory.path, _scope(noteId)));
+  }
+
+  Future<Directory> _accountDirectory({
+    required String serverScope,
+    required String accountScope,
+  }) async {
+    final support = await _applicationSupportDirectory();
+    return Directory(
+      path.join(support.path, _storeDirectoryName, serverScope, accountScope),
+    );
+  }
+
+  Future<void> _validateItemDirectory(
+    PendingNoteAudioUpload item,
+    Directory itemDirectory,
+  ) async {
+    final expectedNoteDirectory = await _noteDirectory(
+      serverScope: item.serverScope,
+      accountScope: item.accountScope,
+      noteId: item.noteId,
+    );
+    final expected = path.normalize(
+      path.join(expectedNoteDirectory.path, _safeId(item.id)),
+    );
+    if (path.normalize(itemDirectory.path) != expected ||
+        path.normalize(File(item.localPath).parent.path) != expected) {
+      throw StateError('Refusing to access note audio outside its scope');
+    }
+  }
+
+  Future<T> _withItemLock<T>(
+    Directory itemDirectory,
+    Future<T> Function() operation,
+  ) async {
+    final key = path.normalize(path.absolute(itemDirectory.path));
+    final previous = _itemOperationTails[key] ?? Future<void>.value();
+    final release = Completer<void>();
+    final tail = release.future;
+    _itemOperationTails[key] = tail;
+
+    await previous;
+    try {
+      return await operation();
+    } finally {
+      if (identical(_itemOperationTails[key], tail)) {
+        _itemOperationTails.remove(key);
+      }
+      release.complete();
+    }
+  }
+
+  static String _scope(String value) =>
+      sha256.convert(utf8.encode(value)).toString();
+
+  static String _safeId(String value) {
+    final safe = value.replaceAll(RegExp(r'[^A-Za-z0-9_-]'), '_');
+    if (safe.isEmpty) {
+      throw ArgumentError.value(value, 'id', 'Invalid note audio upload id');
+    }
+    return safe;
+  }
+
+  static String _safeExtension(String fileName) {
+    final extension = path.extension(fileName).toLowerCase();
+    return RegExp(r'^\.[a-z0-9]{1,8}$').hasMatch(extension)
+        ? extension
+        : '.m4a';
+  }
+}
+
+/// Runs the two-phase upload/attach operation against durable store state.
+class NoteAudioUploadCoordinator {
+  NoteAudioUploadCoordinator({
+    required NoteAudioUploadStore store,
+    required NoteAudioUploadCallback upload,
+    required NoteAudioAttachCallback attach,
+    NoteAudioUploadChanged? onChanged,
+  }) : _store = store,
+       _upload = upload,
+       _attach = attach,
+       _onChanged = onChanged;
+
+  final NoteAudioUploadStore _store;
+  final NoteAudioUploadCallback _upload;
+  final NoteAudioAttachCallback _attach;
+  final NoteAudioUploadChanged? _onChanged;
+
+  static final Map<String, Future<PendingNoteAudioUpload?>> _inFlight =
+      <String, Future<PendingNoteAudioUpload?>>{};
+  static final Map<String, Completer<void>> _removalReservations =
+      <String, Completer<void>>{};
+
+  /// Atomically reserves an item for deletion across every editor instance.
+  /// Returns false while upload/attach work already owns the item.
+  static bool tryReserveRemoval(PendingNoteAudioUpload item) {
+    final key = _keyFor(item);
+    if (_inFlight.containsKey(key) || _removalReservations.containsKey(key)) {
+      return false;
+    }
+    _removalReservations[key] = Completer<void>();
+    return true;
+  }
+
+  static void releaseRemoval(PendingNoteAudioUpload item) {
+    final reservation = _removalReservations.remove(_keyFor(item));
+    if (reservation != null && !reservation.isCompleted) {
+      reservation.complete();
+    }
+  }
+
+  /// Lets another editor wait for a reserved deletion instead of interpreting
+  /// the coordinator's `null` completion sentinel as a successful attachment.
+  static Future<void>? removalCompletion(PendingNoteAudioUpload item) =>
+      _removalReservations[_keyFor(item)]?.future;
+
+  static String _keyFor(PendingNoteAudioUpload item) => jsonEncode(<String>[
+    item.serverScope,
+    item.accountScope,
+    item.noteId,
+    item.id,
+    path.normalize(item.localPath),
+  ]);
+
+  Future<PendingNoteAudioUpload?> process(PendingNoteAudioUpload item) {
+    final key = _keyFor(item);
+    final removal = _removalReservations[key]?.future;
+    if (removal != null) return _reloadAfterRemoval(item, removal);
+    final existing = _inFlight[key];
+    if (existing != null) return _continueAfter(existing);
+
+    late final Future<PendingNoteAudioUpload?> tracked;
+    tracked = _processCurrent(item).whenComplete(() {
+      if (identical(_inFlight[key], tracked)) {
+        _inFlight.remove(key);
+      }
+    });
+    _inFlight[key] = tracked;
+    return tracked;
+  }
+
+  Future<PendingNoteAudioUpload?> _reloadAfterRemoval(
+    PendingNoteAudioUpload item,
+    Future<void> removal,
+  ) async {
+    await removal;
+    final current = await _store.loadCurrent(item);
+    _notify(current);
+    return current;
+  }
+
+  Future<PendingNoteAudioUpload?> _continueAfter(
+    Future<PendingNoteAudioUpload?> existing,
+  ) async {
+    final result = await existing;
+    if (result == null || result.serverFileId == null) return result;
+
+    // A replacement editor may have joined while the original owner was being
+    // disposed during a local-id route remap. The upload itself is shared, but
+    // let the current owner take over the idempotent attachment phase.
+    return process(result);
+  }
+
+  Future<PendingNoteAudioUpload?> _processCurrent(
+    PendingNoteAudioUpload staleItem,
+  ) async {
+    final current = await _store.loadCurrent(staleItem);
+    if (current == null) {
+      _notify(null);
+      return null;
+    }
+    return _process(current);
+  }
+
+  Future<PendingNoteAudioUpload?> _process(PendingNoteAudioUpload item) async {
+    var current = item;
+    try {
+      var fileId = current.serverFileId;
+      if (fileId == null) {
+        final uploadItem = current;
+        current = current.transition(NoteAudioUploadStatus.uploading);
+        await _persistAndNotify(current);
+
+        final file = File(current.localPath);
+        if (!await file.exists()) {
+          throw StateError('Saved recording file is missing');
+        }
+        // Preserve the durable pre-attempt status for reconciliation. A
+        // restored `uploading`/`failed` job may already exist on the server,
+        // while a freshly staged `pending` job cannot.
+        fileId = await _upload(uploadItem, file);
+
+        // This write is the crash boundary: once it commits, subsequent retry
+        // attaches the known server file instead of uploading a duplicate.
+        current = current.transition(
+          NoteAudioUploadStatus.attaching,
+          serverFileId: fileId,
+        );
+        await _persistAndNotify(current);
+      } else {
+        current = current.transition(NoteAudioUploadStatus.attaching);
+        await _persistAndNotify(current);
+      }
+
+      await _attach(current, fileId);
+      await _store.remove(current);
+      _notify(null);
+      return null;
+    } catch (error, stackTrace) {
+      final safeError = current.serverFileId == null
+          ? 'The recording could not be uploaded. Retry when the connection is available.'
+          : 'The uploaded recording could not be attached to the note. Retry to finish saving it.';
+      current = current.transition(
+        NoteAudioUploadStatus.failed,
+        lastError: safeError,
+      );
+      if (!await _store.save(current)) {
+        _notify(null);
+        return null;
+      }
+      _notify(current);
+      DebugLogger.error(
+        'note-audio-upload-failed',
+        scope: 'notes/audio',
+        stackTrace: stackTrace,
+        data: {
+          'id': current.id,
+          'hasFileId': current.serverFileId != null,
+          'errorType': error.runtimeType.toString(),
+        },
+      );
+      return current;
+    }
+  }
+
+  Future<void> _persistAndNotify(PendingNoteAudioUpload item) async {
+    if (!await _store.save(item)) {
+      throw StateError('The note audio upload already completed');
+    }
+    _notify(item);
+  }
+
+  void _notify(PendingNoteAudioUpload? item) {
+    try {
+      _onChanged?.call(item);
+    } catch (error, stackTrace) {
+      DebugLogger.error(
+        'note-audio-upload-callback-failed',
+        scope: 'notes/audio',
+        error: error,
+        stackTrace: stackTrace,
+        data: {'id': item?.id},
+      );
+    }
+  }
+}

--- a/lib/features/notes/views/note_editor_page.dart
+++ b/lib/features/notes/views/note_editor_page.dart
@@ -982,7 +982,9 @@ class _NoteEditorPageState extends ConsumerState<NoteEditorPage> {
         error: error,
         stackTrace: stackTrace,
       );
-      _showError(AppLocalizations.of(context)!.failedToUploadAudio);
+      if (mounted) {
+        _showError(AppLocalizations.of(context)!.failedToUploadAudio);
+      }
       return false;
     }
   }
@@ -1147,10 +1149,18 @@ class _NoteEditorPageState extends ConsumerState<NoteEditorPage> {
           // retry so that uncertain requests do not create duplicate files.
           if (item.status != NoteAudioUploadStatus.pending &&
               item.serverFileId == null) {
-            final files = await api.getUserFilesForSession(
+            final targetedFiles = await api.searchFilesForSession(
+              query: item.fileName,
+              limit: 100,
               authSnapshot: authSnapshot,
               cancelToken: cancelToken,
             );
+            final files =
+                targetedFiles ??
+                await api.getUserFilesForSession(
+                  authSnapshot: authSnapshot,
+                  cancelToken: cancelToken,
+                );
             if (!mounted ||
                 !_isCurrentNoteSession(
                   api: api,

--- a/lib/features/notes/views/note_editor_page.dart
+++ b/lib/features/notes/views/note_editor_page.dart
@@ -1,7 +1,10 @@
 import 'dart:async';
+import 'dart:convert';
 import 'dart:io' show File, Platform;
 
 import 'package:adaptive_platform_ui/adaptive_platform_ui.dart';
+import 'package:dio/dio.dart';
+import 'package:drift/drift.dart' show Value;
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
@@ -10,14 +13,20 @@ import 'package:fleather/fleather.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:intl/intl.dart';
+import 'package:share_plus/share_plus.dart';
 
 import 'package:conduit/l10n/app_localizations.dart';
+import '../../../core/auth/api_auth_interceptor.dart';
 import '../../../core/database/app_database.dart';
 import '../../../core/database/database_provider.dart';
+import '../../../core/database/mappers/note_mapper.dart';
 import '../../../core/models/note.dart';
 import '../../../core/providers/app_providers.dart';
+import '../../../core/services/connectivity_service.dart';
 import '../../../core/services/ios_native_dropdown_bridge.dart';
 import '../../../core/sync/sync_engine.dart';
+import '../../../core/sync/chat_locks.dart';
+import '../../../core/utils/debug_logger.dart';
 import '../../../core/widgets/error_boundary.dart';
 import '../../../shared/theme/conduit_input_styles.dart';
 import '../../../shared/theme/theme_extensions.dart';
@@ -30,8 +39,10 @@ import '../../../shared/widgets/conduit_loading.dart';
 import '../../../shared/widgets/middle_ellipsis_text.dart';
 import '../../../shared/widgets/themed_dialogs.dart';
 import '../../../shared/widgets/themed_sheets.dart';
+import '../../auth/providers/unified_auth_providers.dart';
 import '../../chat/services/voice_input_service.dart';
 import '../providers/notes_providers.dart';
+import '../services/note_audio_upload_service.dart';
 import '../utils/note_document_codec.dart';
 import '../widgets/audio_player_dialog.dart';
 import '../widgets/audio_recording_overlay.dart';
@@ -63,6 +74,18 @@ class _NoteEditorPageState extends ConsumerState<NoteEditorPage> {
   bool _isRecording = false;
   bool _isUploadingAudio = false;
   Note? _note;
+
+  final NoteAudioUploadStore _noteAudioUploadStore = NoteAudioUploadStore();
+  final List<PendingNoteAudioUpload> _pendingAudioUploads = [];
+  final Set<String> _audioUploadsInFlight = <String>{};
+  final Set<String> _queuedAudioUploadIds = <String>{};
+  final Set<String> _audioUploadFeedbackIds = <String>{};
+  final Set<String> _hiddenAudioUploadIds = <String>{};
+  int _pendingAudioMutationGeneration = 0;
+  bool _isDrainingAudioUploads = false;
+  ProviderSubscription<ConnectivityStatus>? _audioConnectivitySubscription;
+  ProviderSubscription<Object>? _audioAuthEpochSubscription;
+  CancelToken? _activeAudioCancelToken;
 
   // Voice input
   VoiceInputService? _voiceService;
@@ -108,6 +131,31 @@ class _NoteEditorPageState extends ConsumerState<NoteEditorPage> {
   void initState() {
     super.initState();
     _loadNote();
+    _audioConnectivitySubscription = ref.listenManual<ConnectivityStatus>(
+      connectivityStatusProvider,
+      (previous, next) {
+        if (previous == ConnectivityStatus.offline &&
+            next == ConnectivityStatus.online) {
+          unawaited(_retryPendingAudioUploads());
+        }
+      },
+    );
+    _audioAuthEpochSubscription = ref.listenManual<Object>(
+      openWebUiAuthSessionEpochProvider,
+      (previous, next) {
+        _activeAudioCancelToken?.cancel('Authentication session changed.');
+        _activeAudioCancelToken = null;
+        _queuedAudioUploadIds.clear();
+        _audioUploadFeedbackIds.clear();
+        _audioUploadsInFlight.clear();
+        _hiddenAudioUploadIds.clear();
+        _pendingAudioMutationGeneration++;
+        if (mounted) {
+          setState(_pendingAudioUploads.clear);
+          if (_note != null) unawaited(_loadPendingAudioUploads());
+        }
+      },
+    );
     _titleController.addListener(_onContentChanged);
     // The content controller is created once the note is loaded; its listener
     // is wired up in [_installContentDocument].
@@ -160,6 +208,9 @@ class _NoteEditorPageState extends ConsumerState<NoteEditorPage> {
   void dispose() {
     _saveDebounce?.cancel();
     _voiceSub?.cancel();
+    _audioConnectivitySubscription?.close();
+    _audioAuthEpochSubscription?.close();
+    _activeAudioCancelToken?.cancel('Note editor disposed.');
     _voiceService?.stopListening();
     _titleController.dispose();
     _contentController?.dispose();
@@ -171,8 +222,17 @@ class _NoteEditorPageState extends ConsumerState<NoteEditorPage> {
     super.dispose();
   }
 
-  bool _isCurrentNoteSession({required Object? api, required Object? db}) {
+  bool _isCurrentNoteSession({
+    required Object? api,
+    required Object? db,
+    Object? authEpoch,
+  }) {
+    if (!ref.read(isAuthenticatedProvider2)) return false;
     if (!identical(ref.read(apiServiceProvider), api)) return false;
+    if (authEpoch != null &&
+        !identical(ref.read(openWebUiAuthSessionEpochProvider), authEpoch)) {
+      return false;
+    }
     final currentDb = ref.read(appDatabaseProvider);
     return db == null ? currentDb == null : identical(currentDb, db);
   }
@@ -197,6 +257,7 @@ class _NoteEditorPageState extends ConsumerState<NoteEditorPage> {
           _isLoading = false;
           _hasChanges = false;
         });
+        unawaited(_loadPendingAudioUploads());
       }
     } catch (e) {
       if (mounted) {
@@ -290,8 +351,8 @@ class _NoteEditorPageState extends ConsumerState<NoteEditorPage> {
     await _saveNote(showFeedback: false);
   }
 
-  /// Builds the note `data` PATCH for an update: only the fields the editor
-  /// actually changes — `content`, plus `files` when [files] is provided. It
+  /// Builds the note `data` PATCH for an update: `content` when
+  /// [includeContent] is true, plus `files` when [files] is provided. It
   /// deliberately does NOT spread the (possibly stale) in-memory `_note.data`:
   /// `durableUpdateNote` merges this patch onto the CURRENT DB row, which
   /// preserves server-managed fields like `versions` (a pull may have added
@@ -299,15 +360,22 @@ class _NoteEditorPageState extends ConsumerState<NoteEditorPage> {
   /// would revert them on the next save).
   Map<String, dynamic> _composeUpdatedNoteData({
     List<Map<String, dynamic>>? files,
+    bool includeContent = true,
   }) {
-    final document = _contentController?.document;
-    final markdown = document != null ? markdownFromDocument(document) : '';
-    final html = document != null ? htmlFromDocument(document) : '';
-    // `json` (TipTap) is intentionally left null: markdown stays the canonical
-    // interchange format so notes remain editable on the Open WebUI web client.
-    final data = <String, dynamic>{
-      'content': <String, dynamic>{'json': null, 'html': html, 'md': markdown},
-    };
+    final data = <String, dynamic>{};
+    if (includeContent) {
+      final document = _contentController?.document;
+      final markdown = document != null ? markdownFromDocument(document) : '';
+      final html = document != null ? htmlFromDocument(document) : '';
+      // `json` (TipTap) is intentionally left null: markdown stays the
+      // canonical interchange format so notes remain editable on the Open
+      // WebUI web client.
+      data['content'] = <String, dynamic>{
+        'json': null,
+        'html': html,
+        'md': markdown,
+      };
+    }
     if (files != null) {
       data['files'] = files;
     }
@@ -328,8 +396,13 @@ class _NoteEditorPageState extends ConsumerState<NoteEditorPage> {
     required AppDatabase? db,
     required String title,
     required Map<String, dynamic> data,
+    Object? authEpoch,
+    ApiAuthSnapshot? authSnapshot,
+    CancelToken? cancelToken,
   }) async {
-    if (!_isCurrentNoteSession(api: api, db: db)) return null;
+    if (!_isCurrentNoteSession(api: api, db: db, authEpoch: authEpoch)) {
+      return null;
+    }
     Note? note;
     if (db != null) {
       note = await durableUpdateNote(
@@ -344,9 +417,16 @@ class _NoteEditorPageState extends ConsumerState<NoteEditorPage> {
       final currentApi = ref.read(apiServiceProvider);
       if (currentApi == null) return null;
       note = Note.fromJson(
-        await currentApi.updateNote(widget.noteId, title: title, data: data),
+        await currentApi.updateNoteForSession(
+          widget.noteId,
+          title: title,
+          data: data,
+          authSnapshot: authSnapshot,
+          cancelToken: cancelToken,
+        ),
       );
-      if (mounted && _isCurrentNoteSession(api: api, db: db)) {
+      if (mounted &&
+          _isCurrentNoteSession(api: api, db: db, authEpoch: authEpoch)) {
         ref.read(notesListProvider.notifier).updateNote(note, sourceDb: db);
       }
     }
@@ -355,7 +435,8 @@ class _NoteEditorPageState extends ConsumerState<NoteEditorPage> {
     // and reopening the note in the same app session shows stale/empty content
     // until a full restart. Invalidate so the next open re-reads what we just
     // saved. Cover the remapped server id too, in case a `local:` id resolved.
-    if (note != null) {
+    if (note != null &&
+        _isCurrentNoteSession(api: api, db: db, authEpoch: authEpoch)) {
       ref.invalidate(noteByIdProvider(widget.noteId));
       if (note.id != widget.noteId) {
         ref.invalidate(noteByIdProvider(note.id));
@@ -826,8 +907,9 @@ class _NoteEditorPageState extends ConsumerState<NoteEditorPage> {
             child: AudioRecordingOverlay(
               onCancel: () => Navigator.pop(context),
               onConfirm: (file) async {
-                Navigator.pop(context);
-                await _uploadAudioFile(file);
+                final staged = await _stageAudioFile(file);
+                if (staged && context.mounted) Navigator.pop(context);
+                return staged;
               },
             ),
           );
@@ -838,110 +920,500 @@ class _NoteEditorPageState extends ConsumerState<NoteEditorPage> {
     );
   }
 
-  /// Uploads an audio file to the server and attaches it to the note.
-  Future<void> _uploadAudioFile(File audioFile) async {
+  ({String serverId, String accountId})? _noteAudioScope() {
+    if (!ref.read(isAuthenticatedProvider2)) return null;
+    final api = ref.read(apiServiceProvider);
+    if (api == null) return null;
+
+    final userId = ref.read(currentUserProvider2)?.id.trim();
+    if (userId == null || userId.isEmpty) return null;
+
+    return (serverId: api.serverConfig.id, accountId: 'user:$userId');
+  }
+
+  /// Moves a recorder cache file into account-scoped application support
+  /// before any network request. Once this returns, closing the page or losing
+  /// connectivity cannot discard the recording.
+  Future<bool> _stageAudioFile(File audioFile) async {
+    final note = _note;
+    final scope = _noteAudioScope();
     final api = ref.read(apiServiceProvider);
     final db = ref.read(appDatabaseProvider);
-    final l10n = AppLocalizations.of(context)!;
+    final authEpoch = ref.read(openWebUiAuthSessionEpochProvider);
+    if (note == null || scope == null) {
+      _showError(AppLocalizations.of(context)!.failedToUploadAudio);
+      return false;
+    }
 
-    if (api == null || _note == null) {
-      _showError(l10n.failedToUploadAudio);
+    final fileName = 'recording_${DateTime.now().millisecondsSinceEpoch}.m4a';
+    try {
+      final item = await _noteAudioUploadStore.stage(
+        source: audioFile,
+        serverId: scope.serverId,
+        accountId: scope.accountId,
+        noteId: note.id,
+        fileName: fileName,
+      );
+      if (!mounted ||
+          !_isCurrentNoteSession(api: api, db: db, authEpoch: authEpoch)) {
+        return true;
+      }
+      setState(() {
+        _pendingAudioMutationGeneration++;
+        _hiddenAudioUploadIds.remove(item.id);
+        final index = _pendingAudioUploads.indexWhere(
+          (candidate) => candidate.id == item.id,
+        );
+        if (index < 0) {
+          _pendingAudioUploads.add(item);
+        } else {
+          _pendingAudioUploads[index] = item;
+        }
+        _pendingAudioUploads.sort((a, b) => a.createdAt.compareTo(b.createdAt));
+      });
+      unawaited(
+        _retryPendingAudioUploads(ids: <String>[item.id], showFeedback: true),
+      );
+      return true;
+    } catch (error, stackTrace) {
+      DebugLogger.error(
+        'note-audio-stage-failed',
+        scope: 'notes/audio',
+        error: error,
+        stackTrace: stackTrace,
+      );
+      _showError(AppLocalizations.of(context)!.failedToUploadAudio);
+      return false;
+    }
+  }
+
+  Future<void> _loadPendingAudioUploads() async {
+    final note = _note;
+    final scope = _noteAudioScope();
+    final api = ref.read(apiServiceProvider);
+    final db = ref.read(appDatabaseProvider);
+    final authEpoch = ref.read(openWebUiAuthSessionEpochProvider);
+    if (note == null || scope == null) return;
+    final mutationGeneration = _pendingAudioMutationGeneration;
+
+    try {
+      final currentIds = <String>{widget.noteId, note.id};
+      if (db != null) {
+        currentIds.add(await db.notesDao.resolveNoteRemapTarget(widget.noteId));
+        currentIds.add(await db.notesDao.resolveNoteRemapTarget(note.id));
+      }
+      if (!mounted ||
+          !_isCurrentNoteSession(api: api, db: db, authEpoch: authEpoch)) {
+        return;
+      }
+
+      final accountItems = await _noteAudioUploadStore.loadForAccount(
+        serverId: scope.serverId,
+        accountId: scope.accountId,
+      );
+      final exactItems = await Future.wait(
+        currentIds.map(
+          (noteId) => _noteAudioUploadStore.loadForNote(
+            serverId: scope.serverId,
+            accountId: scope.accountId,
+            noteId: noteId,
+          ),
+        ),
+      );
+      if (!mounted ||
+          !_isCurrentNoteSession(api: api, db: db, authEpoch: authEpoch)) {
+        return;
+      }
+
+      final matchingById = <String, PendingNoteAudioUpload>{};
+      for (final batch in exactItems) {
+        for (final item in batch) {
+          matchingById[item.id] = item;
+        }
+      }
+      for (final item in accountItems) {
+        if (currentIds.contains(item.noteId)) {
+          matchingById[item.id] = item;
+          continue;
+        }
+        if (db != null) {
+          final resolvedId = await db.notesDao.resolveNoteRemapTarget(
+            item.noteId,
+          );
+          if (currentIds.contains(resolvedId)) matchingById[item.id] = item;
+        }
+      }
+      if (!mounted ||
+          !_isCurrentNoteSession(api: api, db: db, authEpoch: authEpoch)) {
+        return;
+      }
+
+      setState(() {
+        final changedWhileLoading =
+            mutationGeneration != _pendingAudioMutationGeneration;
+        if (changedWhileLoading) {
+          // A stage, completion, or removal won the race with this disk scan.
+          // Preserve the newer UI state while still merging other recovered
+          // recordings, always deduplicated by their durable id.
+          for (final existing in _pendingAudioUploads) {
+            matchingById[existing.id] = existing;
+          }
+        }
+        for (final hiddenId in _hiddenAudioUploadIds) {
+          matchingById.remove(hiddenId);
+        }
+        _pendingAudioUploads
+          ..clear()
+          ..addAll(matchingById.values)
+          ..sort((a, b) => a.createdAt.compareTo(b.createdAt));
+      });
+      if (ref.read(connectivityStatusProvider) == ConnectivityStatus.online) {
+        unawaited(_retryPendingAudioUploads());
+      }
+    } catch (error, stackTrace) {
+      DebugLogger.error(
+        'note-audio-recovery-failed',
+        scope: 'notes/audio',
+        error: error,
+        stackTrace: stackTrace,
+      );
+    }
+  }
+
+  Future<void> _retryPendingAudioUploads({
+    Iterable<String>? ids,
+    bool showFeedback = false,
+  }) async {
+    if (!mounted || _noteAudioScope() == null) return;
+    final requestedIds = ids ?? _pendingAudioUploads.map((item) => item.id);
+    _queuedAudioUploadIds.addAll(requestedIds);
+    if (showFeedback) {
+      _audioUploadFeedbackIds.addAll(requestedIds);
+    }
+    if (_isDrainingAudioUploads) return;
+
+    _isDrainingAudioUploads = true;
+    setState(() => _isUploadingAudio = true);
+    try {
+      while (mounted && _queuedAudioUploadIds.isNotEmpty) {
+        final id = _queuedAudioUploadIds.first;
+        _queuedAudioUploadIds.remove(id);
+        final showItemFeedback = _audioUploadFeedbackIds.remove(id);
+        await _processPendingAudioUpload(id, showFeedback: showItemFeedback);
+      }
+    } finally {
+      _isDrainingAudioUploads = false;
+      if (mounted) setState(() => _isUploadingAudio = false);
+    }
+  }
+
+  Future<void> _processPendingAudioUpload(
+    String id, {
+    required bool showFeedback,
+  }) async {
+    final index = _pendingAudioUploads.indexWhere((item) => item.id == id);
+    if (index < 0) return;
+    final pendingItem = _pendingAudioUploads[index];
+    final removalCompletion = NoteAudioUploadCoordinator.removalCompletion(
+      pendingItem,
+    );
+    if (removalCompletion != null) {
+      await removalCompletion;
+      if (mounted) await _loadPendingAudioUploads();
       return;
     }
 
-    setState(() => _isUploadingAudio = true);
+    final api = ref.read(apiServiceProvider);
+    final db = ref.read(appDatabaseProvider);
+    if (api == null || _noteAudioScope() == null) return;
+    final authEpoch = ref.read(openWebUiAuthSessionEpochProvider);
+    final authSnapshot = api.captureAuthSnapshot();
+    final cancelToken = CancelToken();
+    _activeAudioCancelToken = cancelToken;
 
+    _audioUploadsInFlight.add(id);
+    if (mounted) setState(() {});
     try {
-      // Get file info
-      final fileSize = await audioFile.length();
-      final fileName = 'recording_${DateTime.now().millisecondsSinceEpoch}.m4a';
+      final coordinator = NoteAudioUploadCoordinator(
+        store: _noteAudioUploadStore,
+        upload: (item, file) async {
+          if (!mounted ||
+              !_isCurrentNoteSession(api: api, db: db, authEpoch: authEpoch)) {
+            throw StateError('The active note session changed');
+          }
 
-      // Upload file to Open WebUI with proper content type
-      final fileId = await api.uploadFile(
-        audioFile.path,
-        fileName,
-        contentType: 'audio/mp4',
-      );
+          // A prior process may have committed the POST but lost its response.
+          // OpenWebUI stores this marker under `meta.data`; reconcile before a
+          // retry so that uncertain requests do not create duplicate files.
+          if (item.status != NoteAudioUploadStatus.pending &&
+              item.serverFileId == null) {
+            final files = await api.getUserFilesForSession(
+              authSnapshot: authSnapshot,
+              cancelToken: cancelToken,
+            );
+            if (!mounted ||
+                !_isCurrentNoteSession(
+                  api: api,
+                  db: db,
+                  authEpoch: authEpoch,
+                )) {
+              throw StateError('The active note session changed');
+            }
+            final matches =
+                files
+                    .where((candidate) {
+                      final metadata = candidate.metadata;
+                      final nested = metadata?['data'];
+                      final marker = nested is Map
+                          ? nested['conduit_upload_id']
+                          : metadata?['conduit_upload_id'];
+                      return marker?.toString() == item.id &&
+                          candidate.displayName == item.fileName &&
+                          candidate.size == item.fileSize;
+                    })
+                    .toList(growable: false)
+                  ..sort((a, b) => b.createdAt.compareTo(a.createdAt));
+            if (matches.isNotEmpty) return matches.first.id;
+          }
 
-      // Get current note files
-      final currentFiles = _note!.data.files ?? [];
-
-      // Generate a local item ID (for OpenWebUI compatibility)
-      final itemId = DateTime.now().millisecondsSinceEpoch.toString();
-
-      // Add the new file in OpenWebUI's expected format
-      // Must match the structure in NoteEditor.svelte uploadFileHandler
-      final updatedFiles = [
-        ...currentFiles,
-        {
-          'type': 'file',
-          'file': '',
-          'id': fileId,
-          'url': fileId,
-          'name': fileName,
-          'collection_name': '',
-          'status': 'uploaded',
-          'size': fileSize,
-          'error': '',
-          'itemId': itemId,
+          return api.uploadFile(
+            file.path,
+            item.fileName,
+            contentType: 'audio/mp4',
+            metadata: <String, dynamic>{'conduit_upload_id': item.id},
+            cancelToken: cancelToken,
+            authSnapshot: authSnapshot,
+          );
         },
-      ];
-
-      // Update note with the file attachment. Snapshot the markdown that gets
-      // persisted so the dirty baseline stays in sync with what was saved.
-      final savedMarkdown = _contentMarkdown;
-      final data = _composeUpdatedNoteData(files: updatedFiles);
-
-      final resolvedTitle = _titleController.text.isEmpty
-          ? l10n.untitled
-          : _titleController.text;
-      final updatedNote = await _persistNoteUpdate(
-        api: api,
-        db: db,
-        title: resolvedTitle,
-        data: data,
+        attach: (item, fileId) => _attachUploadedAudio(
+          item,
+          fileId,
+          api: api,
+          db: db,
+          authEpoch: authEpoch,
+          authSnapshot: authSnapshot,
+          cancelToken: cancelToken,
+        ),
+        onChanged: (item) {
+          if (mounted &&
+              _isCurrentNoteSession(api: api, db: db, authEpoch: authEpoch)) {
+            _onPendingAudioChanged(id, item);
+          }
+        },
       );
+      final result = await coordinator.process(pendingItem);
+      if (!mounted ||
+          !_isCurrentNoteSession(api: api, db: db, authEpoch: authEpoch)) {
+        return;
+      }
 
-      if (mounted) {
-        if (!_isCurrentNoteSession(api: api, db: db)) {
-          setState(() => _isUploadingAudio = false);
-          return;
-        }
+      // A shared in-flight operation may have been owned by a different
+      // editor instance, whose change callback does not target this page.
+      _onPendingAudioChanged(id, result);
 
-        if (updatedNote != null) {
-          setState(() {
-            _note = updatedNote;
-            _savedMarkdown = savedMarkdown;
-            _isUploadingAudio = false;
-            _hasChanges = false;
-          });
-
-          ConduitHaptics.mediumImpact();
+      if (result == null) {
+        ConduitHaptics.mediumImpact();
+        if (showFeedback) {
           AdaptiveSnackBar.show(
             context,
-            message: l10n.audioRecordingSaved,
+            message: AppLocalizations.of(context)!.audioRecordingSaved,
             type: AdaptiveSnackBarType.success,
             duration: const Duration(seconds: 2),
           );
-        } else {
-          setState(() => _isUploadingAudio = false);
         }
+      } else if (showFeedback) {
+        _showError(AppLocalizations.of(context)!.failedToUploadAudio);
       }
-
-      // Clean up temp file
-      try {
-        await audioFile.delete();
-      } catch (_) {
-        // Ignore cleanup errors
+    } catch (error, stackTrace) {
+      DebugLogger.error(
+        'note-audio-coordinator-failed',
+        scope: 'notes/audio',
+        stackTrace: stackTrace,
+        data: {'id': id, 'errorType': error.runtimeType.toString()},
+      );
+      if (mounted &&
+          showFeedback &&
+          _isCurrentNoteSession(api: api, db: db, authEpoch: authEpoch)) {
+        _showError(AppLocalizations.of(context)!.failedToUploadAudio);
       }
-    } catch (e) {
-      if (mounted) {
-        setState(() => _isUploadingAudio = false);
-        _showError(
-          AppLocalizations.of(context)!.audioUploadError(e.toString()),
-        );
+    } finally {
+      if (identical(_activeAudioCancelToken, cancelToken)) {
+        _activeAudioCancelToken = null;
       }
+      _audioUploadsInFlight.remove(id);
+      if (mounted) setState(() {});
     }
+  }
+
+  /// Idempotently appends one attachment using the newest local note row.
+  ///
+  /// The read, duplicate check, and write share the same note lock as sync, so
+  /// an upload finishing from an older editor cannot replace files added by a
+  /// concurrent pull or recording.
+  Future<Note?> _durableAttachNoteAudioFile(
+    AppDatabase db, {
+    required String id,
+    required Map<String, dynamic> attachment,
+    required bool Function() canCommit,
+  }) async {
+    final resolvedId = await db.notesDao.resolveNoteRemapTarget(id);
+    if (!canCommit()) return null;
+
+    final noteLocks = ref.read(noteLocksProvider);
+    var noteAvailable = false;
+    await noteLocks.runExclusive(resolvedId, () async {
+      if (!canCommit()) return;
+      final existingRow = await db.notesDao.getNote(resolvedId);
+      if (existingRow == null || existingRow.deleted || !canCommit()) return;
+      noteAvailable = true;
+
+      final existingData = decodeNoteData(existingRow.data);
+      final rawFiles = existingData['files'];
+      final files = rawFiles is List
+          ? rawFiles
+                .whereType<Map>()
+                .map((file) => Map<String, dynamic>.from(file))
+                .toList(growable: true)
+          : <Map<String, dynamic>>[];
+      final fileId = attachment['id']?.toString();
+      final itemId = attachment['itemId']?.toString();
+      final alreadyAttached = files.any(
+        (file) =>
+            (fileId != null && file['id']?.toString() == fileId) ||
+            (itemId != null && file['itemId']?.toString() == itemId),
+      );
+      if (alreadyAttached || !canCommit()) return;
+
+      await db.notesDao.updateNoteWithOutbox(
+        resolvedId,
+        data: Value(
+          jsonEncode(<String, dynamic>{
+            ...existingData,
+            'files': <Map<String, dynamic>>[
+              ...files,
+              Map<String, dynamic>.from(attachment),
+            ],
+          }),
+        ),
+        localUpdatedAtNs: DateTime.now().microsecondsSinceEpoch * 1000,
+        enqueue: true,
+      );
+    });
+    if (!noteAvailable || !canCommit()) return null;
+
+    final row = await db.notesDao.getNote(resolvedId);
+    if (row == null || row.deleted || !canCommit()) return null;
+    unawaited(_drainPendingAudioAttachment());
+    return Note.fromJson(noteRowToServer(row));
+  }
+
+  Future<void> _drainPendingAudioAttachment() async {
+    try {
+      await ref.read(syncEngineProvider.notifier).drainNow();
+    } catch (error) {
+      DebugLogger.warning(
+        'note-audio-attachment-drain-failed',
+        scope: 'notes/audio',
+        data: {'errorType': error.runtimeType.toString()},
+      );
+    }
+  }
+
+  Future<void> _attachUploadedAudio(
+    PendingNoteAudioUpload item,
+    String fileId, {
+    required Object? api,
+    required AppDatabase? db,
+    required Object authEpoch,
+    required ApiAuthSnapshot authSnapshot,
+    required CancelToken cancelToken,
+  }) async {
+    if (!mounted ||
+        !_isCurrentNoteSession(api: api, db: db, authEpoch: authEpoch)) {
+      throw StateError('The active note session changed');
+    }
+    final note = _note;
+    if (note == null) throw StateError('The note is no longer available');
+
+    // Device-local paths never enter NoteData. Only the server attachment
+    // descriptor is synced, keyed by the durable upload id for replay dedupe.
+    final attachment = <String, dynamic>{
+      'type': 'file',
+      'file': '',
+      'id': fileId,
+      'url': fileId,
+      'name': item.fileName,
+      'collection_name': '',
+      'status': 'uploaded',
+      'size': item.fileSize,
+      'error': '',
+      'itemId': item.id,
+    };
+
+    Note? updatedNote;
+    if (db != null) {
+      updatedNote = await _durableAttachNoteAudioFile(
+        db,
+        id: widget.noteId,
+        attachment: attachment,
+        canCommit: () =>
+            mounted &&
+            _isCurrentNoteSession(api: api, db: db, authEpoch: authEpoch),
+      );
+    } else {
+      final currentFiles = note.data.files ?? <Map<String, dynamic>>[];
+      final alreadyAttached = currentFiles.any(
+        (file) =>
+            file['id']?.toString() == fileId ||
+            file['itemId']?.toString() == item.id,
+      );
+      if (alreadyAttached) return;
+      final data = _composeUpdatedNoteData(
+        files: <Map<String, dynamic>>[...currentFiles, attachment],
+        includeContent: false,
+      );
+      final title = _titleController.text.trim();
+      updatedNote = await _persistNoteUpdate(
+        api: api,
+        db: db,
+        title: title.isEmpty ? AppLocalizations.of(context)!.untitled : title,
+        data: data,
+        authEpoch: authEpoch,
+        authSnapshot: authSnapshot,
+        cancelToken: cancelToken,
+      );
+    }
+    if (updatedNote == null) {
+      throw StateError('The recording could not be attached to the note');
+    }
+    if (!mounted ||
+        !_isCurrentNoteSession(api: api, db: db, authEpoch: authEpoch)) {
+      throw StateError('The active note session changed');
+    }
+    ref.invalidate(noteByIdProvider(widget.noteId));
+    if (updatedNote.id != widget.noteId) {
+      ref.invalidate(noteByIdProvider(updatedNote.id));
+    }
+    setState(() => _note = updatedNote);
+  }
+
+  void _onPendingAudioChanged(String id, PendingNoteAudioUpload? updated) {
+    if (!mounted) return;
+    setState(() {
+      _pendingAudioMutationGeneration++;
+      final index = _pendingAudioUploads.indexWhere((item) => item.id == id);
+      if (updated == null) {
+        _hiddenAudioUploadIds.add(id);
+        if (index >= 0) _pendingAudioUploads.removeAt(index);
+      } else if (index >= 0) {
+        _hiddenAudioUploadIds.remove(id);
+        _pendingAudioUploads[index] = updated;
+      } else {
+        _hiddenAudioUploadIds.remove(id);
+        _pendingAudioUploads.add(updated);
+      }
+      _pendingAudioUploads.sort((a, b) => a.createdAt.compareTo(b.createdAt));
+    });
   }
 
   void _copyToClipboard() {
@@ -1463,13 +1935,9 @@ class _NoteEditorPageState extends ConsumerState<NoteEditorPage> {
           child: Column(
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
-              // File attachments section (if any)
-              if (files.isNotEmpty) ...[
-                NoteFilesSection(
-                  files: files,
-                  onPlayFile: _playAudioFile,
-                  onDeleteFile: _removeFile,
-                ),
+              // File attachments section (including durable pending audio).
+              if (files.isNotEmpty || _pendingAudioUploads.isNotEmpty) ...[
+                _buildAttachmentsSection(context, files),
                 const SizedBox(height: Spacing.lg),
               ],
               // Content editor
@@ -1479,6 +1947,201 @@ class _NoteEditorPageState extends ConsumerState<NoteEditorPage> {
         ),
       ),
     );
+  }
+
+  Widget _buildAttachmentsSection(
+    BuildContext context,
+    List<Map<String, dynamic>> files,
+  ) {
+    final theme = context.conduitTheme;
+    final l10n = AppLocalizations.of(context)!;
+    final total = files.length + _pendingAudioUploads.length;
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Padding(
+          padding: const EdgeInsets.only(left: Spacing.xs, bottom: Spacing.xs),
+          child: Row(
+            children: [
+              Icon(
+                Platform.isIOS
+                    ? CupertinoIcons.paperclip
+                    : Icons.attach_file_rounded,
+                size: IconSize.sm,
+                color: theme.textSecondary,
+              ),
+              const SizedBox(width: Spacing.xs),
+              Text(
+                l10n.attachments,
+                style: AppTypography.labelStyle.copyWith(
+                  color: theme.textSecondary,
+                  fontWeight: FontWeight.w600,
+                ),
+              ),
+              const SizedBox(width: Spacing.xs),
+              Container(
+                padding: const EdgeInsets.symmetric(
+                  horizontal: Spacing.xs,
+                  vertical: 2,
+                ),
+                decoration: BoxDecoration(
+                  color: theme.surfaceContainerHighest.withValues(alpha: 0.5),
+                  borderRadius: BorderRadius.circular(AppBorderRadius.xs),
+                ),
+                child: Text(
+                  '$total',
+                  style: AppTypography.captionStyle.copyWith(
+                    color: theme.textSecondary,
+                    fontWeight: FontWeight.w600,
+                  ),
+                ),
+              ),
+            ],
+          ),
+        ),
+        ..._pendingAudioUploads.map(
+          (item) => _buildPendingAudioAttachment(context, item),
+        ),
+        ...files.map(
+          (file) => Padding(
+            padding: const EdgeInsets.only(bottom: Spacing.xs),
+            child: NoteFileAttachment(
+              file: file,
+              onTap: () => _playAudioFile(file),
+              onDelete: () => _removeFile(file),
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildPendingAudioAttachment(
+    BuildContext context,
+    PendingNoteAudioUpload item,
+  ) {
+    final theme = context.conduitTheme;
+    final l10n = AppLocalizations.of(context)!;
+    final inFlight = _audioUploadsInFlight.contains(item.id);
+    final failed = item.status == NoteAudioUploadStatus.failed && !inFlight;
+    final retryable = !inFlight;
+    final localFile = <String, dynamic>{
+      'type': 'audio',
+      'name': item.fileName,
+      'size': item.fileSize,
+      '_localPath': item.localPath,
+      '_localAudioUploadId': item.id,
+    };
+
+    return Padding(
+      padding: const EdgeInsets.only(bottom: Spacing.xs),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          NoteFileAttachment(
+            file: localFile,
+            showDelete: !inFlight && item.serverFileId == null,
+            onTap: inFlight ? null : () => _playAudioFile(localFile),
+            onDelete: () => _removeFile(localFile),
+          ),
+          Padding(
+            padding: const EdgeInsets.only(left: Spacing.sm),
+            child: Row(
+              children: [
+                if (failed)
+                  Icon(
+                    Platform.isIOS
+                        ? CupertinoIcons.exclamationmark_circle_fill
+                        : Icons.error_rounded,
+                    size: IconSize.sm,
+                    color: theme.error,
+                  )
+                else
+                  ConduitLoading.inline(
+                    size: IconSize.sm,
+                    color: theme.loadingIndicator,
+                    context: context,
+                  ),
+                const SizedBox(width: Spacing.xs),
+                Expanded(
+                  child: Text(
+                    failed
+                        ? l10n.failedToUploadAudio
+                        : l10n.processingRecording,
+                    style: AppTypography.captionStyle.copyWith(
+                      color: failed ? theme.error : theme.textSecondary,
+                    ),
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                  ),
+                ),
+                IconButton(
+                  visualDensity: VisualDensity.compact,
+                  icon: Icon(
+                    Platform.isIOS ? CupertinoIcons.share : Icons.ios_share,
+                    size: IconSize.sm,
+                    color: theme.textSecondary,
+                  ),
+                  tooltip: l10n.shareSystemSheet,
+                  onPressed: inFlight ? null : () => _sharePendingAudio(item),
+                ),
+                if (retryable)
+                  IconButton(
+                    visualDensity: VisualDensity.compact,
+                    icon: Icon(
+                      Platform.isIOS
+                          ? CupertinoIcons.arrow_clockwise
+                          : Icons.refresh_rounded,
+                      size: IconSize.sm,
+                      color: theme.buttonPrimary,
+                    ),
+                    tooltip: l10n.retry,
+                    onPressed: () => unawaited(
+                      _retryPendingAudioUploads(
+                        ids: <String>[item.id],
+                        showFeedback: true,
+                      ),
+                    ),
+                  ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Future<void> _sharePendingAudio(PendingNoteAudioUpload item) async {
+    final l10n = AppLocalizations.of(context)!;
+    final renderObject = context.findRenderObject();
+    final shareOrigin = renderObject is RenderBox && renderObject.hasSize
+        ? renderObject.localToGlobal(Offset.zero) & renderObject.size
+        : null;
+    try {
+      if (!await File(item.localPath).exists()) {
+        throw StateError('The saved recording file is missing');
+      }
+      if (!mounted) return;
+      await SharePlus.instance.share(
+        ShareParams(
+          files: <XFile>[
+            XFile(item.localPath, mimeType: 'audio/mp4', name: item.fileName),
+          ],
+          fileNameOverrides: <String>[item.fileName],
+          sharePositionOrigin: shareOrigin,
+        ),
+      );
+    } catch (error, stackTrace) {
+      DebugLogger.error(
+        'note-audio-share-failed',
+        scope: 'notes/audio',
+        error: error,
+        stackTrace: stackTrace,
+        data: {'id': item.id},
+      );
+      if (mounted) _showError(l10n.errorMessage);
+    }
   }
 
   /// Pull-to-refresh handler: syncs the note with the server, then reloads it
@@ -1613,6 +2276,22 @@ class _NoteEditorPageState extends ConsumerState<NoteEditorPage> {
 
   /// Play an audio file attachment.
   Future<void> _playAudioFile(Map<String, dynamic> file) async {
+    final localPath = file['_localPath']?.toString();
+    if (localPath != null && localPath.isNotEmpty) {
+      final l10n = AppLocalizations.of(context)!;
+      if (!await File(localPath).exists()) {
+        if (mounted) _showError(l10n.fileNotFound);
+        return;
+      }
+      if (!mounted) return;
+      await AudioPlayerDialog.showLocal(
+        context,
+        filePath: localPath,
+        fileName: file['name']?.toString() ?? 'Audio Recording',
+      );
+      return;
+    }
+
     final fileId = file['id']?.toString();
     if (fileId == null) return;
 
@@ -1644,6 +2323,55 @@ class _NoteEditorPageState extends ConsumerState<NoteEditorPage> {
 
     if (confirmed != true || _note == null) return;
 
+    final localUploadId = file['_localAudioUploadId']?.toString();
+    if (localUploadId != null && localUploadId.isNotEmpty) {
+      if (_audioUploadsInFlight.contains(localUploadId)) return;
+      final index = _pendingAudioUploads.indexWhere(
+        (item) => item.id == localUploadId,
+      );
+      if (index < 0) return;
+      final item = _pendingAudioUploads[index];
+      // Once the server owns the bytes, deleting only this local retry record
+      // would misleadingly leave a private orphan on the server. Keep it
+      // available for the idempotent attach retry instead.
+      if (item.serverFileId != null) return;
+      if (!NoteAudioUploadCoordinator.tryReserveRemoval(item)) return;
+      _queuedAudioUploadIds.remove(localUploadId);
+      _audioUploadFeedbackIds.remove(localUploadId);
+      _audioUploadsInFlight.add(localUploadId);
+      _hiddenAudioUploadIds.add(localUploadId);
+      _pendingAudioMutationGeneration++;
+      if (mounted) setState(() {});
+      try {
+        await _noteAudioUploadStore.remove(item);
+        _onPendingAudioChanged(localUploadId, null);
+        if (mounted) {
+          ConduitHaptics.lightImpact();
+          AdaptiveSnackBar.show(
+            context,
+            message: l10n.fileRemoved,
+            type: AdaptiveSnackBarType.success,
+            duration: const Duration(seconds: 2),
+          );
+        }
+      } catch (error, stackTrace) {
+        DebugLogger.error(
+          'note-audio-remove-failed',
+          scope: 'notes/audio',
+          error: error,
+          stackTrace: stackTrace,
+          data: {'id': localUploadId},
+        );
+        _hiddenAudioUploadIds.remove(localUploadId);
+        _showError(l10n.errorMessage);
+      } finally {
+        NoteAudioUploadCoordinator.releaseRemoval(item);
+        _audioUploadsInFlight.remove(localUploadId);
+        if (mounted) setState(() {});
+      }
+      return;
+    }
+
     final api = ref.read(apiServiceProvider);
     final db = ref.read(appDatabaseProvider);
     if (api == null && db == null) return;
@@ -1657,10 +2385,10 @@ class _NoteEditorPageState extends ConsumerState<NoteEditorPage> {
           .where((f) => f['id']?.toString() != fileId)
           .toList();
 
-      // Snapshot the markdown that gets persisted so the dirty baseline stays
-      // in sync with what was saved.
-      final savedMarkdown = _contentMarkdown;
-      final data = _composeUpdatedNoteData(files: updatedFiles);
+      final data = _composeUpdatedNoteData(
+        files: updatedFiles,
+        includeContent: false,
+      );
 
       final resolvedTitle = _titleController.text.isEmpty
           ? l10n.untitled
@@ -1681,9 +2409,7 @@ class _NoteEditorPageState extends ConsumerState<NoteEditorPage> {
         if (updatedNote != null) {
           setState(() {
             _note = updatedNote;
-            _savedMarkdown = savedMarkdown;
             _isSaving = false;
-            _hasChanges = false;
           });
 
           ConduitHaptics.lightImpact();

--- a/lib/features/notes/widgets/audio_player_dialog.dart
+++ b/lib/features/notes/widgets/audio_player_dialog.dart
@@ -187,6 +187,8 @@ class _AudioPlayerDialogState extends State<AudioPlayerDialog> {
 
       await _player.play();
     } catch (error, stackTrace) {
+      // dispose() owns remote-temp cleanup once native teardown has started.
+      if (_isDisposed) return;
       await _deleteOwnedTempFile();
       if (_isDisposed) return;
       DebugLogger.error(
@@ -284,6 +286,21 @@ class _AudioPlayerDialogState extends State<AudioPlayerDialog> {
     }
   }
 
+  Future<void> _disposePlayerAndOwnedTempFile() async {
+    try {
+      await _player.dispose();
+    } catch (error, stackTrace) {
+      DebugLogger.error(
+        'audio-player-dispose-failed',
+        scope: 'notes/audio/player',
+        error: error,
+        stackTrace: stackTrace,
+      );
+    } finally {
+      await _deleteOwnedTempFile();
+    }
+  }
+
   Future<void> _togglePlayPause() async {
     if (_isPlaying) {
       await _player.pause();
@@ -321,11 +338,9 @@ class _AudioPlayerDialogState extends State<AudioPlayerDialog> {
     _positionSub?.cancel();
     _durationSub?.cancel();
     // AudioPlayer.dispose() is async but Flutter's dispose() is sync.
-    // Fire-and-forget is acceptable here as just_audio handles cleanup internally.
-    unawaited(_player.dispose());
-    // Only remote downloads are owned by this dialog. A durable local pending
-    // recording remains available for playback, retry, and export.
-    unawaited(_deleteOwnedTempFile());
+    // Wait for its native file handle to close before deleting an owned remote
+    // download. Durable local pending recordings are never owned or deleted.
+    unawaited(_disposePlayerAndOwnedTempFile());
     super.dispose();
   }
 

--- a/lib/features/notes/widgets/audio_player_dialog.dart
+++ b/lib/features/notes/widgets/audio_player_dialog.dart
@@ -9,6 +9,7 @@ import 'package:just_audio/just_audio.dart';
 import 'package:path_provider/path_provider.dart';
 
 import '../../../core/services/api_service.dart';
+import '../../../core/utils/debug_logger.dart';
 import '../../../l10n/app_localizations.dart';
 import '../../../shared/theme/theme_extensions.dart';
 import '../../../shared/widgets/themed_dialogs.dart';
@@ -16,20 +17,28 @@ import '../../../shared/widgets/themed_dialogs.dart';
 /// A dialog for playing audio files.
 class AudioPlayerDialog extends StatefulWidget {
   /// The file ID for downloading.
-  final String fileId;
+  final String? fileId;
 
   /// The API service for authenticated requests.
-  final ApiService api;
+  final ApiService? api;
+
+  /// Durable local source. Unlike a downloaded [_tempFile], this is never
+  /// deleted by the player dialog.
+  final String? localFilePath;
 
   /// The file name to display.
   final String fileName;
 
   const AudioPlayerDialog({
     super.key,
-    required this.fileId,
-    required this.api,
+    this.fileId,
+    this.api,
+    this.localFilePath,
     required this.fileName,
-  });
+  }) : assert(
+         localFilePath != null || (fileId != null && api != null),
+         'A local path or a server file id and API service is required',
+       );
 
   /// Shows the audio player dialog.
   static Future<void> show(
@@ -45,6 +54,19 @@ class AudioPlayerDialog extends StatefulWidget {
     );
   }
 
+  /// Plays a durable local recording without taking ownership of the file.
+  static Future<void> showLocal(
+    BuildContext context, {
+    required String filePath,
+    required String fileName,
+  }) {
+    return ThemedDialogs.showCustom<void>(
+      context: context,
+      builder: (context) =>
+          AudioPlayerDialog(localFilePath: filePath, fileName: fileName),
+    );
+  }
+
   @override
   State<AudioPlayerDialog> createState() => _AudioPlayerDialogState();
 }
@@ -55,6 +77,7 @@ class _AudioPlayerDialogState extends State<AudioPlayerDialog> {
   bool _isPlaying = false;
   bool _isLoading = true;
   bool _hasError = false;
+  bool _isDisposed = false;
   Duration _position = Duration.zero;
   Duration _duration = Duration.zero;
   File? _tempFile;
@@ -71,54 +94,18 @@ class _AudioPlayerDialogState extends State<AudioPlayerDialog> {
 
   Future<void> _setupPlayer() async {
     try {
-      // Get file info first to determine the correct extension
-      final fileInfo = await widget.api.getFileInfo(widget.fileId);
-      final filename = fileInfo['filename'] as String? ?? 'audio.m4a';
-      final contentType =
-          (fileInfo['meta'] as Map<String, dynamic>?)?['content_type']
-              as String?;
-
-      debugPrint(
-        'AudioPlayerDialog: filename=$filename, contentType=$contentType',
-      );
-      debugPrint('AudioPlayerDialog: fileInfo=$fileInfo');
-
-      // Extract extension from filename
-      final extension = filename.contains('.')
-          ? filename.substring(filename.lastIndexOf('.'))
-          : '.m4a';
-
-      // Download the file (requires authentication)
-      // Use timestamp suffix to prevent conflicts if same file opened multiple times
-      final tempDir = await getTemporaryDirectory();
-      final timestamp = DateTime.now().millisecondsSinceEpoch;
-      final tempPath =
-          '${tempDir.path}/audio_${widget.fileId}_$timestamp$extension';
-      _tempFile = File(tempPath);
-
-      // Fetch file content through API (authenticated)
-      final response = await widget.api.dio.get(
-        '/api/v1/files/${widget.fileId}/content',
-        options: Options(responseType: ResponseType.bytes),
-      );
-
-      final responseData = response.data;
-      if (responseData is! List<int>) {
-        throw Exception(
-          'Unexpected response type: ${responseData.runtimeType}',
-        );
+      final playablePath = widget.localFilePath ?? await _downloadRemoteFile();
+      if (_isDisposed) {
+        await _deleteOwnedTempFile();
+        return;
       }
-      final bytes = responseData;
-      debugPrint('AudioPlayerDialog: Downloaded ${bytes.length} bytes');
-      debugPrint(
-        'AudioPlayerDialog: First 20 bytes: ${bytes.take(20).toList()}',
-      );
-      debugPrint(
-        'AudioPlayerDialog: Response content-type: ${response.headers.value('content-type')}',
-      );
-
-      await _tempFile!.writeAsBytes(bytes);
-      debugPrint('AudioPlayerDialog: Saved to $tempPath');
+      if (!await File(playablePath).exists()) {
+        throw StateError('Audio file is missing');
+      }
+      if (_isDisposed) {
+        await _deleteOwnedTempFile();
+        return;
+      }
 
       // Setup player state listeners
       _stateSub = _player.playerStateStream.listen((state) {
@@ -148,32 +135,97 @@ class _AudioPlayerDialogState extends State<AudioPlayerDialog> {
       });
 
       // Load and play the file
-      await _player.setFilePath(_tempFile!.path);
+      await _player.setFilePath(playablePath);
+      if (_isDisposed) return;
 
       if (mounted) {
         setState(() => _isLoading = false);
       }
 
       await _player.play();
-    } catch (e) {
-      debugPrint('AudioPlayerDialog: Error loading audio: $e');
-      // Clean up temp file on error to avoid orphaned files
-      _tempFile
-          ?.delete()
-          .then((_) {
-            debugPrint('AudioPlayerDialog: Cleaned up temp file after error');
-          })
-          .catchError((e) {
-            debugPrint(
-              'AudioPlayerDialog: Failed to clean up temp file after error: $e',
-            );
-          });
-      _tempFile = null;
+    } catch (error, stackTrace) {
+      await _deleteOwnedTempFile();
+      if (_isDisposed) return;
+      DebugLogger.error(
+        'audio-load-failed',
+        scope: 'notes/audio/player',
+        error: error,
+        stackTrace: stackTrace,
+        data: {'local': widget.localFilePath != null},
+      );
       if (!mounted) return;
       setState(() {
         _hasError = true;
         _isLoading = false;
       });
+    }
+  }
+
+  Future<String> _downloadRemoteFile() async {
+    final api = widget.api;
+    final fileId = widget.fileId;
+    if (api == null || fileId == null) {
+      throw StateError('Server audio source is unavailable');
+    }
+
+    final fileInfo = await api.getFileInfo(fileId);
+    if (_isDisposed) throw StateError('Audio player was disposed');
+    final filename = fileInfo['filename'] as String? ?? 'audio.m4a';
+    final extension = filename.contains('.')
+        ? filename.substring(filename.lastIndexOf('.'))
+        : '.m4a';
+
+    final tempDir = await getTemporaryDirectory();
+    if (_isDisposed) throw StateError('Audio player was disposed');
+    final timestamp = DateTime.now().millisecondsSinceEpoch;
+    final tempPath = '${tempDir.path}/audio_${fileId}_$timestamp$extension';
+    final tempFile = File(tempPath);
+    _tempFile = tempFile;
+
+    final response = await api.dio.get(
+      '/api/v1/files/$fileId/content',
+      options: Options(responseType: ResponseType.bytes),
+    );
+    final responseData = response.data;
+    if (responseData is! List<int>) {
+      throw StateError(
+        'Unexpected audio response type: ${responseData.runtimeType}',
+      );
+    }
+    if (_isDisposed) {
+      await _deleteTemporaryFile(tempFile);
+      throw StateError('Audio player was disposed');
+    }
+    await tempFile.writeAsBytes(responseData, flush: true);
+    if (_isDisposed) {
+      await _deleteTemporaryFile(tempFile);
+      throw StateError('Audio player was disposed');
+    }
+    DebugLogger.log(
+      'audio-download-ready',
+      scope: 'notes/audio/player',
+      data: {'bytes': responseData.length},
+    );
+    return tempPath;
+  }
+
+  Future<void> _deleteOwnedTempFile() async {
+    final tempFile = _tempFile;
+    _tempFile = null;
+    if (tempFile == null) return;
+    await _deleteTemporaryFile(tempFile);
+  }
+
+  Future<void> _deleteTemporaryFile(File tempFile) async {
+    try {
+      if (await tempFile.exists()) await tempFile.delete();
+    } catch (error, stackTrace) {
+      DebugLogger.error(
+        'audio-temp-cleanup-failed',
+        scope: 'notes/audio/player',
+        error: error,
+        stackTrace: stackTrace,
+      );
     }
   }
 
@@ -204,21 +256,16 @@ class _AudioPlayerDialogState extends State<AudioPlayerDialog> {
 
   @override
   void dispose() {
+    _isDisposed = true;
     _stateSub?.cancel();
     _positionSub?.cancel();
     _durationSub?.cancel();
     // AudioPlayer.dispose() is async but Flutter's dispose() is sync.
     // Fire-and-forget is acceptable here as just_audio handles cleanup internally.
     unawaited(_player.dispose());
-    // Clean up temp file (fire and forget, log errors for debugging)
-    _tempFile
-        ?.delete()
-        .then((_) {
-          debugPrint('AudioPlayerDialog: Cleaned up temp file');
-        })
-        .catchError((e) {
-          debugPrint('AudioPlayerDialog: Failed to clean up temp file: $e');
-        });
+    // Only remote downloads are owned by this dialog. A durable local pending
+    // recording remains available for playback, retry, and export.
+    unawaited(_deleteOwnedTempFile());
     super.dispose();
   }
 

--- a/lib/features/notes/widgets/audio_player_dialog.dart
+++ b/lib/features/notes/widgets/audio_player_dialog.dart
@@ -81,6 +81,7 @@ class _AudioPlayerDialogState extends State<AudioPlayerDialog> {
   Duration _position = Duration.zero;
   Duration _duration = Duration.zero;
   File? _tempFile;
+  CancelToken? _downloadCancelToken;
 
   StreamSubscription<PlayerState>? _stateSub;
   StreamSubscription<Duration>? _positionSub;
@@ -168,45 +169,55 @@ class _AudioPlayerDialogState extends State<AudioPlayerDialog> {
       throw StateError('Server audio source is unavailable');
     }
 
-    final fileInfo = await api.getFileInfo(fileId);
-    if (_isDisposed) throw StateError('Audio player was disposed');
-    final filename = fileInfo['filename'] as String? ?? 'audio.m4a';
-    final extension = filename.contains('.')
-        ? filename.substring(filename.lastIndexOf('.'))
-        : '.m4a';
+    _downloadCancelToken?.cancel('Audio download superseded');
+    final cancelToken = CancelToken();
+    _downloadCancelToken = cancelToken;
+    try {
+      final fileInfo = await api.getFileInfo(fileId, cancelToken: cancelToken);
+      if (_isDisposed) throw StateError('Audio player was disposed');
+      final filename = fileInfo['filename'] as String? ?? 'audio.m4a';
+      final extension = filename.contains('.')
+          ? filename.substring(filename.lastIndexOf('.'))
+          : '.m4a';
 
-    final tempDir = await getTemporaryDirectory();
-    if (_isDisposed) throw StateError('Audio player was disposed');
-    final timestamp = DateTime.now().millisecondsSinceEpoch;
-    final tempPath = '${tempDir.path}/audio_${fileId}_$timestamp$extension';
-    final tempFile = File(tempPath);
-    _tempFile = tempFile;
+      final tempDir = await getTemporaryDirectory();
+      if (_isDisposed) throw StateError('Audio player was disposed');
+      final timestamp = DateTime.now().millisecondsSinceEpoch;
+      final tempPath = '${tempDir.path}/audio_${fileId}_$timestamp$extension';
+      final tempFile = File(tempPath);
+      _tempFile = tempFile;
 
-    final response = await api.dio.get(
-      '/api/v1/files/$fileId/content',
-      options: Options(responseType: ResponseType.bytes),
-    );
-    final responseData = response.data;
-    if (responseData is! List<int>) {
-      throw StateError(
-        'Unexpected audio response type: ${responseData.runtimeType}',
+      final response = await api.dio.get(
+        '/api/v1/files/$fileId/content',
+        options: Options(responseType: ResponseType.bytes),
+        cancelToken: cancelToken,
       );
+      final responseData = response.data;
+      if (responseData is! List<int>) {
+        throw StateError(
+          'Unexpected audio response type: ${responseData.runtimeType}',
+        );
+      }
+      if (_isDisposed) {
+        await _deleteTemporaryFile(tempFile);
+        throw StateError('Audio player was disposed');
+      }
+      await tempFile.writeAsBytes(responseData, flush: true);
+      if (_isDisposed) {
+        await _deleteTemporaryFile(tempFile);
+        throw StateError('Audio player was disposed');
+      }
+      DebugLogger.log(
+        'audio-download-ready',
+        scope: 'notes/audio/player',
+        data: {'bytes': responseData.length},
+      );
+      return tempPath;
+    } finally {
+      if (identical(_downloadCancelToken, cancelToken)) {
+        _downloadCancelToken = null;
+      }
     }
-    if (_isDisposed) {
-      await _deleteTemporaryFile(tempFile);
-      throw StateError('Audio player was disposed');
-    }
-    await tempFile.writeAsBytes(responseData, flush: true);
-    if (_isDisposed) {
-      await _deleteTemporaryFile(tempFile);
-      throw StateError('Audio player was disposed');
-    }
-    DebugLogger.log(
-      'audio-download-ready',
-      scope: 'notes/audio/player',
-      data: {'bytes': responseData.length},
-    );
-    return tempPath;
   }
 
   Future<void> _deleteOwnedTempFile() async {
@@ -257,6 +268,11 @@ class _AudioPlayerDialogState extends State<AudioPlayerDialog> {
   @override
   void dispose() {
     _isDisposed = true;
+    final downloadCancelToken = _downloadCancelToken;
+    _downloadCancelToken = null;
+    if (downloadCancelToken != null && !downloadCancelToken.isCancelled) {
+      downloadCancelToken.cancel('Audio player dialog disposed');
+    }
     _stateSub?.cancel();
     _positionSub?.cancel();
     _durationSub?.cancel();

--- a/lib/features/notes/widgets/audio_player_dialog.dart
+++ b/lib/features/notes/widgets/audio_player_dialog.dart
@@ -6,6 +6,7 @@ import 'package:dio/dio.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:just_audio/just_audio.dart';
+import 'package:path/path.dart' as path;
 import 'package:path_provider/path_provider.dart';
 
 import '../../../core/services/api_service.dart';
@@ -13,6 +14,47 @@ import '../../../core/utils/debug_logger.dart';
 import '../../../l10n/app_localizations.dart';
 import '../../../shared/theme/theme_extensions.dart';
 import '../../../shared/widgets/themed_dialogs.dart';
+
+const _defaultAudioExtension = '.m4a';
+const _maxAudioTempFileIdLength = 64;
+final _safeAudioExtension = RegExp(r'^\.[A-Za-z0-9]{1,10}$');
+final _unsafeAudioTempFileIdCharacter = RegExp(r'[^A-Za-z0-9_-]');
+
+String _audioDownloadTempFileName({
+  required String fileId,
+  required String serverFileName,
+  required int timestamp,
+}) {
+  final basename = serverFileName.replaceAll(r'\', '/').split('/').last;
+  final extensionStart = basename.lastIndexOf('.');
+  final candidateExtension = extensionStart > 0
+      ? basename.substring(extensionStart)
+      : _defaultAudioExtension;
+  final extension = _safeAudioExtension.hasMatch(candidateExtension)
+      ? candidateExtension
+      : _defaultAudioExtension;
+
+  final sanitizedFileId = fileId.replaceAll(
+    _unsafeAudioTempFileIdCharacter,
+    '_',
+  );
+  final nonEmptyFileId = sanitizedFileId.isEmpty ? 'file' : sanitizedFileId;
+  final boundedFileId = nonEmptyFileId.length > _maxAudioTempFileIdLength
+      ? nonEmptyFileId.substring(0, _maxAudioTempFileIdLength)
+      : nonEmptyFileId;
+  return 'audio_${boundedFileId}_$timestamp$extension';
+}
+
+@visibleForTesting
+String audioDownloadTempFileNameForTesting({
+  required String fileId,
+  required String serverFileName,
+  required int timestamp,
+}) => _audioDownloadTempFileName(
+  fileId: fileId,
+  serverFileName: serverFileName,
+  timestamp: timestamp,
+);
 
 /// A dialog for playing audio files.
 class AudioPlayerDialog extends StatefulWidget {
@@ -176,14 +218,16 @@ class _AudioPlayerDialogState extends State<AudioPlayerDialog> {
       final fileInfo = await api.getFileInfo(fileId, cancelToken: cancelToken);
       if (_isDisposed) throw StateError('Audio player was disposed');
       final filename = fileInfo['filename'] as String? ?? 'audio.m4a';
-      final extension = filename.contains('.')
-          ? filename.substring(filename.lastIndexOf('.'))
-          : '.m4a';
 
       final tempDir = await getTemporaryDirectory();
       if (_isDisposed) throw StateError('Audio player was disposed');
       final timestamp = DateTime.now().millisecondsSinceEpoch;
-      final tempPath = '${tempDir.path}/audio_${fileId}_$timestamp$extension';
+      final tempFileName = _audioDownloadTempFileName(
+        fileId: fileId,
+        serverFileName: filename,
+        timestamp: timestamp,
+      );
+      final tempPath = path.join(tempDir.path, tempFileName);
       final tempFile = File(tempPath);
       _tempFile = tempFile;
 

--- a/lib/features/notes/widgets/audio_recording_overlay.dart
+++ b/lib/features/notes/widgets/audio_recording_overlay.dart
@@ -20,8 +20,9 @@ class AudioRecordingOverlay extends StatefulWidget {
   /// Called when the user cancels recording.
   final VoidCallback onCancel;
 
-  /// Called when the user confirms the recording with the audio file.
-  final void Function(File audioFile) onConfirm;
+  /// Durably saves a confirmed recording. Returning false keeps the stopped
+  /// file in this overlay and re-enables the button so the user can retry.
+  final Future<bool> Function(File audioFile) onConfirm;
 
   const AudioRecordingOverlay({
     super.key,
@@ -40,6 +41,7 @@ class _AudioRecordingOverlayState extends State<AudioRecordingOverlay>
   bool _isRecording = false;
   bool _isProcessing = false;
   bool _hasError = false;
+  File? _stoppedRecording;
   Duration _duration = Duration.zero;
   double _amplitude = 0.0;
 
@@ -91,7 +93,7 @@ class _AudioRecordingOverlayState extends State<AudioRecordingOverlay>
           setState(() => _amplitude = normalized);
         }
       });
-    } catch (e) {
+    } catch (_) {
       if (!mounted) return;
       setState(() => _hasError = true);
       final l10n = AppLocalizations.of(context)!;
@@ -107,16 +109,20 @@ class _AudioRecordingOverlayState extends State<AudioRecordingOverlay>
   }
 
   Future<void> _confirmRecording() async {
-    if (_isProcessing || !_isRecording || !mounted) return;
+    if (_isProcessing || (!_isRecording && _stoppedRecording == null)) return;
+    if (!mounted) return;
 
     setState(() => _isProcessing = true);
     ConduitHaptics.mediumImpact();
 
     try {
-      final file = await _recordingService.stopRecording();
+      final file = _stoppedRecording ?? await _recordingService.stopRecording();
 
       if (file != null && mounted) {
-        widget.onConfirm(file);
+        _stoppedRecording = file;
+        setState(() => _isRecording = false);
+        final saved = await widget.onConfirm(file);
+        if (mounted && !saved) setState(() => _isProcessing = false);
       } else if (mounted) {
         final l10n = AppLocalizations.of(context)!;
         AdaptiveSnackBar.show(
@@ -130,11 +136,11 @@ class _AudioRecordingOverlayState extends State<AudioRecordingOverlay>
       if (mounted) {
         AdaptiveSnackBar.show(
           context,
-          message: e.toString(),
+          message: AppLocalizations.of(context)!.recordingFailed,
           type: AdaptiveSnackBarType.error,
           duration: const Duration(seconds: 4),
         );
-        widget.onCancel();
+        setState(() => _isProcessing = false);
       }
     }
   }
@@ -142,7 +148,20 @@ class _AudioRecordingOverlayState extends State<AudioRecordingOverlay>
   Future<void> _cancelRecording() async {
     ConduitHaptics.lightImpact();
     await _recordingService.cancelRecording();
+    await _deleteStoppedRecording();
     if (mounted) widget.onCancel();
+  }
+
+  Future<void> _deleteStoppedRecording() async {
+    final file = _stoppedRecording;
+    _stoppedRecording = null;
+    if (file != null && await file.exists()) {
+      try {
+        await file.delete();
+      } catch (_) {
+        // Cache cleanup is best effort after the user explicitly discards it.
+      }
+    }
   }
 
   String _formatDuration(Duration duration) {
@@ -159,6 +178,7 @@ class _AudioRecordingOverlayState extends State<AudioRecordingOverlay>
     // Recording service dispose is async but Flutter's dispose() is sync.
     // Fire-and-forget is acceptable here as the service handles its own cleanup.
     unawaited(_recordingService.dispose());
+    if (!_isProcessing) unawaited(_deleteStoppedRecording());
     super.dispose();
   }
 
@@ -188,7 +208,7 @@ class _AudioRecordingOverlayState extends State<AudioRecordingOverlay>
                   child: Row(
                     children: [
                       AdaptiveButton.child(
-                        onPressed: _cancelRecording,
+                        onPressed: _isProcessing ? null : _cancelRecording,
                         style: AdaptiveButtonStyle.plain,
                         child: Row(
                           mainAxisSize: MainAxisSize.min,
@@ -333,7 +353,10 @@ class _AudioRecordingOverlayState extends State<AudioRecordingOverlay>
                     width: double.infinity,
                     height: 56,
                     child: AdaptiveButton.child(
-                      onPressed: _isProcessing || !_isRecording || _hasError
+                      onPressed:
+                          _isProcessing ||
+                              (!_isRecording && _stoppedRecording == null) ||
+                              _hasError
                           ? null
                           : _confirmRecording,
                       color: Colors.red,

--- a/test/core/services/api_service_user_files_test.dart
+++ b/test/core/services/api_service_user_files_test.dart
@@ -47,6 +47,102 @@ void main() {
         check(adapter.requestedPages).deepEquals([1, 2]);
       },
     );
+
+    test('caps pagination when the server total never converges', () async {
+      final adapter = _QueuedJsonAdapter({
+        for (var page = 1; page <= 201; page++)
+          page: {
+            'items': [_fileJson('file-$page')],
+            'total': 1000,
+          },
+      });
+      final api = _buildApiService(adapter);
+
+      final files = await api.getUserFiles();
+
+      check(files).has((it) => it.length, 'length').equals(200);
+      check(
+        adapter.requestedPages,
+      ).has((it) => it.length, 'length').equals(200);
+      check(adapter.requestedPages.first).equals(1);
+      check(adapter.requestedPages.last).equals(200);
+      check(adapter.requestedPages.contains(201)).isFalse();
+    });
+  });
+
+  group('ApiService.searchFilesForSession', () {
+    test('distinguishes no matches from an unavailable endpoint', () async {
+      final noMatchesApi = _buildApiService(
+        _FileSearchAdapter(
+          statusCode: 404,
+          response: const {'detail': 'No files found matching the pattern.'},
+        ),
+      );
+      final unavailableApi = _buildApiService(
+        _FileSearchAdapter(
+          statusCode: 404,
+          response: const {'detail': 'Not Found'},
+        ),
+      );
+
+      final noMatches = await noMatchesApi.searchFilesForSession(
+        query: 'recording.m4a',
+      );
+      check(noMatches).isNotNull();
+      check(noMatches!).isEmpty();
+      check(
+        await unavailableApi.searchFilesForSession(query: 'recording.m4a'),
+      ).isNull();
+    });
+
+    test('uses a targeted query and forwards cancellation', () async {
+      final adapter = _FileSearchAdapter(response: [_fileJson('recording-1')]);
+      final api = _buildApiService(adapter);
+      final cancelToken = CancelToken();
+
+      final files = await api.searchFilesForSession(
+        query: 'recording_123.m4a',
+        limit: 100,
+        cancelToken: cancelToken,
+      );
+
+      check(files).isNotNull().has((it) => it.length, 'length').equals(1);
+      check(adapter.requestedPath).equals('/api/v1/files/search');
+      check(adapter.queryParameters).isNotNull();
+      check(adapter.queryParameters!).deepEquals({
+        'filename': '*recording_123.m4a*',
+        'content': false,
+        'limit': 100,
+      });
+      check(adapter.receivedCancelFuture).isNotNull();
+      cancelToken.cancel('test complete');
+      await adapter.requestCancelled.future.timeout(const Duration(seconds: 1));
+    });
+
+    test('rejects a stale auth snapshot before transport', () async {
+      final adapter = _FileSearchAdapter(response: const <Object?>[]);
+      final api = _buildAuthenticatedApiService(
+        adapter,
+        authToken: 'account-a',
+      );
+      final snapshot = api.captureAuthSnapshot();
+      api.updateAuthToken('account-b');
+
+      await expectLater(
+        api.searchFilesForSession(
+          query: 'recording.m4a',
+          authSnapshot: snapshot,
+        ),
+        throwsA(
+          isA<DioException>().having(
+            (error) => error.type,
+            'type',
+            DioExceptionType.cancel,
+          ),
+        ),
+      );
+      check(adapter.requestCount).equals(0);
+    });
   });
 
   group('ApiService.getFileContent', () {
@@ -372,6 +468,47 @@ class _QueuedJsonAdapter implements HttpClientAdapter {
   void close({bool force = false}) {}
 }
 
+class _FileSearchAdapter implements HttpClientAdapter {
+  _FileSearchAdapter({required this.response, this.statusCode = 200});
+
+  final Object? response;
+  final int statusCode;
+  String? requestedPath;
+  Map<String, dynamic>? queryParameters;
+  Future<void>? receivedCancelFuture;
+  final requestCancelled = Completer<void>();
+  int requestCount = 0;
+
+  @override
+  Future<ResponseBody> fetch(
+    RequestOptions options,
+    Stream<Uint8List>? requestStream,
+    Future<void>? cancelFuture,
+  ) async {
+    requestCount++;
+    requestedPath = options.path;
+    queryParameters = Map<String, dynamic>.from(options.queryParameters);
+    receivedCancelFuture = cancelFuture;
+    if (cancelFuture != null) {
+      unawaited(
+        cancelFuture.then<void>((_) {
+          if (!requestCancelled.isCompleted) requestCancelled.complete();
+        }),
+      );
+    }
+    return ResponseBody(
+      Stream.value(Uint8List.fromList(utf8.encode(jsonEncode(response)))),
+      statusCode,
+      headers: const {
+        'content-type': ['application/json'],
+      },
+    );
+  }
+
+  @override
+  void close({bool force = false}) {}
+}
+
 ApiService _buildApiService(HttpClientAdapter adapter) {
   final service = ApiService(
     serverConfig: const ServerConfig(
@@ -383,6 +520,23 @@ ApiService _buildApiService(HttpClientAdapter adapter) {
   );
   service.dio.httpClientAdapter = adapter;
   service.dio.interceptors.clear();
+  return service;
+}
+
+ApiService _buildAuthenticatedApiService(
+  HttpClientAdapter adapter, {
+  required String authToken,
+}) {
+  final service = ApiService(
+    serverConfig: const ServerConfig(
+      id: 'test',
+      name: 'Test',
+      url: 'http://localhost:0',
+    ),
+    workerManager: WorkerManager(),
+    authToken: authToken,
+  );
+  service.dio.httpClientAdapter = adapter;
   return service;
 }
 

--- a/test/features/notes/services/note_audio_upload_service_test.dart
+++ b/test/features/notes/services/note_audio_upload_service_test.dart
@@ -1,0 +1,522 @@
+import 'dart:async';
+import 'dart:io';
+
+import 'package:checks/checks.dart';
+import 'package:dio/dio.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:conduit/features/notes/services/note_audio_upload_service.dart';
+
+void main() {
+  group('NoteAudioUploadCoordinator', () {
+    test(
+      'keeps a durable recording and retry state when upload fails',
+      () async {
+        final root = await Directory.systemTemp.createTemp(
+          'conduit_note_audio_upload_test_',
+        );
+        addTearDown(() => _deleteDirectory(root));
+
+        final source = await _recordingFile(root, 'source.m4a');
+        final store = NoteAudioUploadStore(
+          applicationSupportDirectory: () async => root,
+          idGenerator: () => 'upload-1',
+        );
+        final staged = await store.stage(
+          source: source,
+          serverId: 'server-1',
+          accountId: 'user-1',
+          noteId: 'note-1',
+          fileName: 'recording.m4a',
+        );
+
+        var attachCalls = 0;
+        final coordinator = NoteAudioUploadCoordinator(
+          store: store,
+          upload: (_, _) async => throw DioException(
+            requestOptions: RequestOptions(path: '/api/v1/files/'),
+            type: DioExceptionType.connectionError,
+            message: 'offline',
+          ),
+          attach: (_, _) async => attachCalls++,
+        );
+
+        final failed = await coordinator.process(staged);
+
+        check(failed).isNotNull();
+        check(failed!.status).equals(NoteAudioUploadStatus.failed);
+        check(failed.serverFileId).isNull();
+        check(await source.exists()).isFalse();
+        check(await File(failed.localPath).exists()).isTrue();
+        check(attachCalls).equals(0);
+
+        final reloaded = await store.loadForNote(
+          serverId: 'server-1',
+          accountId: 'user-1',
+          noteId: 'note-1',
+        );
+        check(reloaded).length.equals(1);
+        check(reloaded.single.id).equals('upload-1');
+        check(reloaded.single.status).equals(NoteAudioUploadStatus.failed);
+
+        final accountItems = await store.loadForAccount(
+          serverId: 'server-1',
+          accountId: 'user-1',
+        );
+        check(accountItems.single.noteId).equals('note-1');
+        check(
+          await store.loadForAccount(
+            serverId: 'server-1',
+            accountId: 'another-user',
+          ),
+        ).isEmpty();
+      },
+    );
+
+    test(
+      'retries after reconstruction and deletes only after attach',
+      () async {
+        final root = await Directory.systemTemp.createTemp(
+          'conduit_note_audio_upload_test_',
+        );
+        addTearDown(() => _deleteDirectory(root));
+
+        final source = await _recordingFile(root, 'source.m4a');
+        final store = NoteAudioUploadStore(
+          applicationSupportDirectory: () async => root,
+          idGenerator: () => 'upload-2',
+        );
+        final staged = await store.stage(
+          source: source,
+          serverId: 'server-1',
+          noteId: 'note-1',
+          fileName: 'recording.m4a',
+        );
+
+        final failed = await NoteAudioUploadCoordinator(
+          store: store,
+          upload: (_, _) async => throw StateError('offline'),
+          attach: (_, _) async => fail('attach must not run'),
+        ).process(staged);
+        check(failed).isNotNull();
+
+        final durablePath = failed!.localPath;
+        final reconstructedStore = NoteAudioUploadStore(
+          applicationSupportDirectory: () async => root,
+        );
+        final reloaded = await reconstructedStore.loadForNote(
+          serverId: 'server-1',
+          noteId: 'note-1',
+        );
+        check(reloaded).length.equals(1);
+
+        var uploadCalls = 0;
+        String? attachedFileId;
+        final completed = await NoteAudioUploadCoordinator(
+          store: reconstructedStore,
+          upload: (_, file) async {
+            uploadCalls++;
+            check(await file.exists()).isTrue();
+            return 'file-1';
+          },
+          attach: (_, fileId) async => attachedFileId = fileId,
+        ).process(reloaded.single);
+
+        check(completed).isNull();
+        check(uploadCalls).equals(1);
+        check(attachedFileId).equals('file-1');
+        check(await File(durablePath).exists()).isFalse();
+        check(
+          await reconstructedStore.loadForNote(
+            serverId: 'server-1',
+            noteId: 'note-1',
+          ),
+        ).isEmpty();
+      },
+    );
+
+    test(
+      'persists file id before attach and does not re-upload on retry',
+      () async {
+        final root = await Directory.systemTemp.createTemp(
+          'conduit_note_audio_upload_test_',
+        );
+        addTearDown(() => _deleteDirectory(root));
+
+        final source = await _recordingFile(root, 'source.m4a');
+        final store = NoteAudioUploadStore(
+          applicationSupportDirectory: () async => root,
+          idGenerator: () => 'upload-3',
+        );
+        final staged = await store.stage(
+          source: source,
+          serverId: 'server-1',
+          noteId: 'note-1',
+          fileName: 'recording.m4a',
+        );
+
+        var uploadCalls = 0;
+        var attachCalls = 0;
+        final interrupted = await NoteAudioUploadCoordinator(
+          store: store,
+          upload: (_, _) async {
+            uploadCalls++;
+            return 'file-2';
+          },
+          attach: (_, _) async {
+            attachCalls++;
+            throw StateError('interrupted before note update');
+          },
+        ).process(staged);
+
+        check(interrupted).isNotNull();
+        check(interrupted!.status).equals(NoteAudioUploadStatus.failed);
+        check(interrupted.serverFileId).equals('file-2');
+        check(uploadCalls).equals(1);
+        check(attachCalls).equals(1);
+        check(await File(interrupted.localPath).exists()).isTrue();
+
+        final reconstructedStore = NoteAudioUploadStore(
+          applicationSupportDirectory: () async => root,
+        );
+        final reloaded = await reconstructedStore.loadForNote(
+          serverId: 'server-1',
+          noteId: 'note-1',
+        );
+        check(reloaded.single.serverFileId).equals('file-2');
+
+        final completed = await NoteAudioUploadCoordinator(
+          store: reconstructedStore,
+          upload: (_, _) async {
+            uploadCalls++;
+            return 'unexpected-file-id';
+          },
+          attach: (_, fileId) async {
+            attachCalls++;
+            check(fileId).equals('file-2');
+          },
+        ).process(reloaded.single);
+
+        check(completed).isNull();
+        check(uploadCalls).equals(1);
+        check(attachCalls).equals(2);
+      },
+    );
+
+    test(
+      'recovers a journaled copy interrupted before its final rename',
+      () async {
+        final root = await Directory.systemTemp.createTemp(
+          'conduit_note_audio_upload_test_',
+        );
+        addTearDown(() => _deleteDirectory(root));
+
+        final store = NoteAudioUploadStore(
+          applicationSupportDirectory: () async => root,
+          idGenerator: () => 'upload-4',
+        );
+        final staged = await store.stage(
+          source: await _recordingFile(root, 'source.m4a'),
+          serverId: 'server-1',
+          accountId: 'user-1',
+          noteId: 'note-1',
+          fileName: 'recording.m4a',
+        );
+        final recording = File(staged.localPath);
+        final interruptedCopy = File('${recording.parent.path}/.staging.m4a');
+        await recording.rename(interruptedCopy.path);
+
+        final recovered = await NoteAudioUploadStore(
+          applicationSupportDirectory: () async => root,
+        ).loadForAccount(serverId: 'server-1', accountId: 'user-1');
+
+        check(recovered).length.equals(1);
+        check(recovered.single.status).equals(NoteAudioUploadStatus.failed);
+        check(await File(recovered.single.localPath).exists()).isTrue();
+        check(await interruptedCopy.exists()).isFalse();
+      },
+    );
+
+    test(
+      'recovers an interrupted copy from its journaled cache name',
+      () async {
+        final root = await Directory.systemTemp.createTemp(
+          'conduit_note_audio_upload_test_',
+        );
+        addTearDown(() => _deleteDirectory(root));
+        final cache = await Directory('${root.path}/cache').create();
+
+        final store = NoteAudioUploadStore(
+          applicationSupportDirectory: () async => root,
+          temporaryDirectory: () async => cache,
+          idGenerator: () => 'upload-8',
+        );
+        final source = await _recordingFile(cache, 'source.m4a');
+        final staged = await store.stage(
+          source: source,
+          serverId: 'server-1',
+          accountId: 'user-1',
+          noteId: 'note-1',
+          fileName: 'recording.m4a',
+        );
+
+        final durable = File(staged.localPath);
+        final completeBytes = await durable.readAsBytes();
+        await durable.delete();
+        final interrupted = File('${durable.parent.path}/.staging.m4a');
+        await interrupted.writeAsBytes(completeBytes.take(512).toList());
+        await File(
+          '${cache.path}/source.m4a',
+        ).writeAsBytes(completeBytes, flush: true);
+
+        final recovered = await NoteAudioUploadStore(
+          applicationSupportDirectory: () async => root,
+          temporaryDirectory: () async => cache,
+        ).loadForAccount(serverId: 'server-1', accountId: 'user-1');
+
+        check(recovered).length.equals(1);
+        check(recovered.single.status).equals(NoteAudioUploadStatus.failed);
+        check(await File(recovered.single.localPath).length()).equals(2048);
+        check(await interrupted.exists()).isFalse();
+        check(await File('${cache.path}/source.m4a').exists()).isFalse();
+      },
+    );
+
+    test(
+      'shares upload work and lets a current editor take over attach',
+      () async {
+        final root = await Directory.systemTemp.createTemp(
+          'conduit_note_audio_upload_test_',
+        );
+        addTearDown(() => _deleteDirectory(root));
+
+        final store = NoteAudioUploadStore(
+          applicationSupportDirectory: () async => root,
+          idGenerator: () => 'upload-5',
+        );
+        final staged = await store.stage(
+          source: await _recordingFile(root, 'source.m4a'),
+          serverId: 'server-1',
+          noteId: 'note-1',
+          fileName: 'recording.m4a',
+        );
+
+        final uploadStarted = Completer<void>();
+        final finishUpload = Completer<String>();
+        var uploadCalls = 0;
+        var firstAttachCalls = 0;
+        var replacementAttachCalls = 0;
+        final first = NoteAudioUploadCoordinator(
+          store: store,
+          upload: (_, _) {
+            uploadCalls++;
+            uploadStarted.complete();
+            return finishUpload.future;
+          },
+          attach: (_, _) async {
+            firstAttachCalls++;
+            throw StateError('original editor was disposed');
+          },
+        ).process(staged);
+        await uploadStarted.future;
+        check(NoteAudioUploadCoordinator.tryReserveRemoval(staged)).isFalse();
+
+        final replacement = NoteAudioUploadCoordinator(
+          store: store,
+          upload: (_, _) async {
+            uploadCalls++;
+            return 'duplicate-file';
+          },
+          attach: (_, fileId) async {
+            replacementAttachCalls++;
+            check(fileId).equals('file-3');
+          },
+        ).process(staged);
+        finishUpload.complete('file-3');
+
+        check(await first).isNotNull();
+        check(await replacement).isNull();
+        check(uploadCalls).equals(1);
+        check(firstAttachCalls).equals(1);
+        check(replacementAttachCalls).equals(1);
+        check(
+          await store.loadForNote(serverId: 'server-1', noteId: 'note-1'),
+        ).isEmpty();
+      },
+    );
+
+    test(
+      'reloads newer durable state before processing a stale editor item',
+      () async {
+        final root = await Directory.systemTemp.createTemp(
+          'conduit_note_audio_upload_test_',
+        );
+        addTearDown(() => _deleteDirectory(root));
+
+        final store = NoteAudioUploadStore(
+          applicationSupportDirectory: () async => root,
+          idGenerator: () => 'upload-6',
+        );
+        final staged = await store.stage(
+          source: await _recordingFile(root, 'source.m4a'),
+          serverId: 'server-1',
+          noteId: 'note-1',
+          fileName: 'recording.m4a',
+        );
+
+        var uploadCalls = 0;
+        final failedAttach = await NoteAudioUploadCoordinator(
+          store: store,
+          upload: (_, _) async {
+            uploadCalls++;
+            return 'file-6';
+          },
+          attach: (_, _) async => throw StateError('attach interrupted'),
+        ).process(staged);
+        check(failedAttach?.serverFileId).equals('file-6');
+
+        var attachCalls = 0;
+        final completed = await NoteAudioUploadCoordinator(
+          store: store,
+          upload: (_, _) async {
+            uploadCalls++;
+            return 'duplicate-file';
+          },
+          attach: (_, fileId) async {
+            attachCalls++;
+            check(fileId).equals('file-6');
+          },
+        ).process(staged);
+
+        check(completed).isNull();
+        check(uploadCalls).equals(1);
+        check(attachCalls).equals(1);
+
+        // A still-mounted stale editor may retry after another owner removed
+        // the completed job. Missing durable state is terminal and must not be
+        // recreated from its old in-memory snapshot.
+        final repeated = await NoteAudioUploadCoordinator(
+          store: store,
+          upload: (_, _) async => fail('must not upload a completed job'),
+          attach: (_, _) async => fail('must not attach a completed job'),
+        ).process(staged);
+        check(repeated).isNull();
+        check(
+          await store.loadForNote(serverId: 'server-1', noteId: 'note-1'),
+        ).isEmpty();
+      },
+    );
+
+    test('a removal reservation excludes processing across editors', () async {
+      final root = await Directory.systemTemp.createTemp(
+        'conduit_note_audio_upload_test_',
+      );
+      addTearDown(() => _deleteDirectory(root));
+
+      final store = NoteAudioUploadStore(
+        applicationSupportDirectory: () async => root,
+        idGenerator: () => 'upload-7',
+      );
+      final staged = await store.stage(
+        source: await _recordingFile(root, 'source.m4a'),
+        serverId: 'server-1',
+        noteId: 'note-1',
+        fileName: 'recording.m4a',
+      );
+
+      check(NoteAudioUploadCoordinator.tryReserveRemoval(staged)).isTrue();
+      late final Future<PendingNoteAudioUpload?> processing;
+      try {
+        processing = NoteAudioUploadCoordinator(
+          store: store,
+          upload: (_, _) async => fail('reserved item must not upload'),
+          attach: (_, _) async => fail('reserved item must not attach'),
+        ).process(staged);
+        await store.remove(staged);
+      } finally {
+        NoteAudioUploadCoordinator.releaseRemoval(staged);
+      }
+      check(await processing).isNull();
+
+      check(
+        await store.loadForNote(serverId: 'server-1', noteId: 'note-1'),
+      ).isEmpty();
+    });
+
+    test(
+      'an account scan cannot resurrect an item removed while reading',
+      () async {
+        final root = await Directory.systemTemp.createTemp(
+          'conduit_note_audio_upload_test_',
+        );
+        addTearDown(() => _deleteDirectory(root));
+
+        final stagingStore = NoteAudioUploadStore(
+          applicationSupportDirectory: () async => root,
+          idGenerator: () => 'upload-9',
+        );
+        final staged = await stagingStore.stage(
+          source: await _recordingFile(root, 'source.m4a'),
+          serverId: 'server-1',
+          accountId: 'user-1',
+          noteId: 'note-1',
+          fileName: 'recording.m4a',
+        );
+        await File(staged.localPath).delete();
+
+        final recoveryStarted = Completer<void>();
+        final allowRecovery = Completer<Directory>();
+        final scanningStore = NoteAudioUploadStore(
+          applicationSupportDirectory: () async => root,
+          temporaryDirectory: () {
+            recoveryStarted.complete();
+            return allowRecovery.future;
+          },
+        );
+
+        final scan = scanningStore.loadForAccount(
+          serverId: 'server-1',
+          accountId: 'user-1',
+        );
+        await recoveryStarted.future;
+
+        var removalCompleted = false;
+        final removal = stagingStore
+            .remove(staged)
+            .then((_) => removalCompleted = true);
+        await Future<void>.delayed(Duration.zero);
+        check(removalCompleted).isFalse();
+
+        allowRecovery.complete(
+          await Directory.systemTemp.createTemp(
+            'conduit_note_audio_empty_cache_',
+          ),
+        );
+        final cache = await allowRecovery.future;
+        addTearDown(() => _deleteDirectory(cache));
+        await scan;
+        await removal;
+
+        check(await File(staged.localPath).parent.exists()).isFalse();
+        check(
+          await scanningStore.loadForAccount(
+            serverId: 'server-1',
+            accountId: 'user-1',
+          ),
+        ).isEmpty();
+      },
+    );
+  });
+}
+
+Future<File> _recordingFile(Directory root, String name) async {
+  final file = File('${root.path}/$name');
+  await file.writeAsBytes(List<int>.filled(2048, 7), flush: true);
+  return file;
+}
+
+Future<void> _deleteDirectory(Directory directory) async {
+  if (await directory.exists()) {
+    await directory.delete(recursive: true);
+  }
+}

--- a/test/features/notes/widgets/audio_player_dialog_test.dart
+++ b/test/features/notes/widgets/audio_player_dialog_test.dart
@@ -1,0 +1,55 @@
+import 'package:checks/checks.dart';
+import 'package:conduit/features/notes/widgets/audio_player_dialog.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:path/path.dart' as path;
+
+void main() {
+  group('audioDownloadTempFileNameForTesting', () {
+    test('removes path traversal from server-controlled components', () {
+      final fileName = audioDownloadTempFileNameForTesting(
+        fileId: r'../folder\audio:id',
+        serverFileName: r'voice.m4a\..\..\payload',
+        timestamp: 42,
+      );
+
+      check(fileName).equals('audio____folder_audio_id_42.m4a');
+      check(path.posix.basename(fileName)).equals(fileName);
+      check(path.windows.basename(fileName)).equals(fileName);
+      check(fileName.contains('..')).isFalse();
+    });
+
+    test('keeps only short alphanumeric extensions', () {
+      check(
+        audioDownloadTempFileNameForTesting(
+          fileId: 'file-1',
+          serverFileName: 'recording.opus',
+          timestamp: 7,
+        ),
+      ).equals('audio_file-1_7.opus');
+      check(
+        audioDownloadTempFileNameForTesting(
+          fileId: 'file-1',
+          serverFileName: 'recording.m4a/../../escape.bad-extension',
+          timestamp: 7,
+        ),
+      ).equals('audio_file-1_7.m4a');
+    });
+
+    test('bounds the file id and handles an empty id', () {
+      final bounded = audioDownloadTempFileNameForTesting(
+        fileId: 'a' * 1000,
+        serverFileName: 'recording.wav',
+        timestamp: 9,
+      );
+
+      check(bounded).equals('audio_${'a' * 64}_9.wav');
+      check(
+        audioDownloadTempFileNameForTesting(
+          fileId: '',
+          serverFileName: 'recording',
+          timestamp: 9,
+        ),
+      ).equals('audio_file_9.m4a');
+    });
+  });
+}


### PR DESCRIPTION
## Summary

- stage note recordings in account-scoped application-support storage before upload
- keep failed recordings visible with local playback, sharing, manual retry, and automatic retry after reconnect or note reopen
- make upload and attachment recovery idempotent across lost responses, auth changes, note remaps, and concurrent editors
- remove the durable local copy only after the uploaded file is attached to the note

## Verification

- `dart run build_runner build`
- `flutter analyze` — no issues
- `flutter test` — 3,913 passed, 2 skipped
- 9 focused durable-upload and concurrency regression tests
- clean detached-worktree verification on commit `60a74059`

Fixes #513

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Preserve note audio recordings across upload failures with durable staging and retry
> - Replaces the immediate-upload flow with a two-phase durable pipeline: recordings are staged to app storage first, shown as pending in the attachments list, then uploaded and attached with idempotent retry on reconnect or app restart.
> - Introduces `NoteAudioUploadStore` and `NoteAudioUploadCoordinator` in [note_audio_upload_service.dart](https://github.com/cogwheel0/conduit/pull/573/files#diff-43476ebcf76c7b8385c8500af453af3e67dea63305e94529d64fdfc2b195d96f) for crash-safe staging, manifest persistence, recovery of interrupted transfers, and single-flight deduplication.
> - Extends `AudioPlayerDialog` to support local file playback and adds cancellable, sanitized remote audio downloads with safe temp-file cleanup.
> - Adds session-aware API methods (`updateNoteForSession`, `getUserFilesForSession`, `searchFilesForSession`, `uploadFile` with auth snapshot) to pin in-flight operations to the current auth session and support cancellation on session change.
> - Pending recordings can be played, shared, retried, or deleted before upload completes; the attachments section shows a unified pending + server-file list with status indicators.
> - Risk: the staging flow moves recorded files into app support storage on confirm — a failure during staging keeps the overlay open rather than discarding the recording.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b1ea3af.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added durable, offline-friendly note audio uploads with automatic retry, crash recovery, and multi-editor coordination.
  - Pending recordings now show in note attachments with local playback, sharing, retry, and durable deletion.
  - Audio playback now supports durable local files (in addition to remote files).
- **Bug Fixes**
  - Confirm/cancel flow is now async, preserves cached recordings on refusal, and cleans up staged files correctly.
  - Session-aware API requests for file listing/search/uploads and note updates; attachment-only saves can omit content.
- **Tests**
  - Expanded coverage for durable upload recovery, concurrency/reservation behavior, and session-aware file/search cancellation semantics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR makes note audio recordings survive upload failures. The main changes are:

- Stages recordings in account-scoped application-support storage before upload.
- Adds durable upload recovery, retry, and idempotent attach coordination.
- Shows pending recordings in the note attachments list with local playback, sharing, retry, and deletion.
- Adds session-pinned API helpers for file search/list/upload and note updates.
- Updates the recording overlay and audio player dialog for async confirmation and local playback.
- Adds tests for durable upload recovery, concurrency, auth-session cancellation, and temp filename sanitization.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge with low risk.

Durable-state ordering, session cancellation checks, idempotent attachment dedupe, and focused tests cover the main changed workflows. No blocking correctness or security issues were identified in the changed files.

No files require special attention.
</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex captured the tool-availability checks for flutter and dart and logged their exit codes in the tool-availability log.
- T-Rex produced before and after captures to verify the same tooling blocker is present across states.
- Artifacts were created and linked to the proof to support contract validation, including the tool-availability log and the before/after blocker captures.

<a href="https://app.greptile.com/trex/runs/14469214/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| lib/core/services/api_service.dart | Adds session-pinned file listing/search/upload and note update helpers with cancellation support for durable audio retry flows. |
| lib/features/notes/services/note_audio_upload_service.dart | Introduces durable account-scoped staging, recovery, upload/attach coordination, and cross-editor reservation logic for note audio recordings. |
| lib/features/notes/views/note_editor_page.dart | Integrates staged audio uploads into the note editor, including recovery, retry, local playback/share, session cancellation, and idempotent attachment updates. |
| lib/features/notes/widgets/audio_player_dialog.dart | Adds local-file playback while preserving remote download cancellation and owned-temp cleanup semantics. |
| lib/features/notes/widgets/audio_recording_overlay.dart | Makes confirmation asynchronous so failed staging keeps the stopped recording available for retry instead of discarding it. |
| test/core/services/api_service_user_files_test.dart | Covers paginated file listing bounds, search endpoint fallback semantics, cancellation forwarding, and stale auth snapshot rejection. |
| test/features/notes/services/note_audio_upload_service_test.dart | Adds tests for durable staging, retry/idempotency, interrupted recovery, shared in-flight uploads, and removal reservations. |
| test/features/notes/widgets/audio_player_dialog_test.dart | Covers sanitization and bounding of server-derived temporary audio download filenames. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
participant User
participant Overlay as AudioRecordingOverlay
participant Editor as NoteEditorPage
participant Store as NoteAudioUploadStore
participant Coord as NoteAudioUploadCoordinator
participant API as ApiService/OpenWebUI
participant NoteSvc as Note DB/API

User->>Overlay: Confirm recording
Overlay->>Editor: onConfirm(file)
Editor->>Store: Stage source under account note scope
Store-->>Editor: PendingNoteAudioUpload
Editor->>Coord: Process item
Coord->>Store: loadCurrent and save uploading
Coord->>API: uploadFile with auth snapshot and cancel token
API-->>Coord: Server file id
Coord->>Store: save attaching with serverFileId
Coord->>NoteSvc: Attach file id to current note data
NoteSvc-->>Coord: Updated note
Coord->>Store: Remove durable copy
Coord-->>Editor: Completed or failed pending item
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
participant User
participant Overlay as AudioRecordingOverlay
participant Editor as NoteEditorPage
participant Store as NoteAudioUploadStore
participant Coord as NoteAudioUploadCoordinator
participant API as ApiService/OpenWebUI
participant NoteSvc as Note DB/API

User->>Overlay: Confirm recording
Overlay->>Editor: onConfirm(file)
Editor->>Store: Stage source under account note scope
Store-->>Editor: PendingNoteAudioUpload
Editor->>Coord: Process item
Coord->>Store: loadCurrent and save uploading
Coord->>API: uploadFile with auth snapshot and cancel token
API-->>Coord: Server file id
Coord->>Store: save attaching with serverFileId
Coord->>NoteSvc: Attach file id to current note data
NoteSvc-->>Coord: Updated note
Coord->>Store: Remove durable copy
Coord-->>Editor: Completed or failed pending item
```

</a>
</details>

<sub>Reviews (4): Last reviewed commit: ["fix: sequence audio player cleanup"](https://github.com/cogwheel0/conduit/commit/b1ea3af473e9f7de8a5cfa7e4cad7dbd6bb184ae) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44282134)</sub>

<!-- /greptile_comment -->