### PR TITLE
fix: keep sidebar chat loads alive

### DIFF
--- a/lib/core/providers/app_providers.dart
+++ b/lib/core/providers/app_providers.dart
@@ -3425,7 +3425,15 @@ ActiveConversationRemapNamespace _activeConversationRemapNamespaceFor(
 
 // Provider to load full conversation with messages
 @riverpod
-Future<Conversation> loadConversation(Ref ref, String conversationId) async {
+Future<Conversation> loadConversation(Ref ref, String conversationId) {
+  final keepAliveLink = ref.keepAlive();
+  return _loadConversation(
+    ref,
+    conversationId,
+  ).whenComplete(keepAliveLink.close);
+}
+
+Future<Conversation> _loadConversation(Ref ref, String conversationId) async {
   final identity = ChatStorageIdentity.parse(conversationId);
   final rawConversationId = identity.rawId;
   // Preserve database provenance from the selected summary when possible.

--- a/test/core/providers/openwebui_account_storage_isolation_test.dart
+++ b/test/core/providers/openwebui_account_storage_isolation_test.dart
@@ -1463,6 +1463,57 @@ void main() {
   );
 
   test(
+    'unlistened conversation provider stays mounted during repository load',
+    () async {
+      final harness = await _harness();
+      final container = harness.container;
+      final transactionStarted = Completer<void>();
+      final releaseTransaction = Completer<void>();
+      final blockingTransaction = harness.serverA.transaction(() async {
+        transactionStarted.complete();
+        await releaseTransaction.future;
+      });
+      try {
+        await transactionStarted.future;
+
+        final scopedId = const ChatStorageIdentity(
+          rawId: 'account-a-chat',
+          storage: ChatStorageKind.openWebUi,
+        ).scopedId;
+        var completed = false;
+        final pending = container
+            .read(loadConversationProvider(scopedId).future)
+            .then(
+              (conversation) {
+                completed = true;
+                return conversation;
+              },
+              onError: (Object error, StackTrace stackTrace) {
+                completed = true;
+                Error.throwWithStackTrace(error, stackTrace);
+              },
+            );
+        await Future<void>.delayed(Duration.zero);
+        check(completed).isFalse();
+
+        releaseTransaction.complete();
+        await blockingTransaction;
+
+        final conversation = await pending;
+        check(conversation.id).equals('account-a-chat');
+        check(
+          chatStorageKindOf(conversation),
+        ).equals(ChatStorageKind.openWebUi);
+      } finally {
+        if (!releaseTransaction.isCompleted) {
+          releaseTransaction.complete();
+        }
+        await blockingTransaction;
+      }
+    },
+  );
+
+  test(
     'conversation provider drops a repository body when ownership changes mid-load',
     () async {
       final harness = await _harness();


### PR DESCRIPTION
## Summary
- keep the auto-disposed conversation loader alive only until its current async load settles
- preserve OpenWebUI account-ownership fences and normal provider-family disposal afterward
- add regression coverage for the unlistened provider read used by sidebar chat selection

## Root cause
The direct OpenAI/Ollama merge changed sidebar selection to read an auto-disposed FutureProvider without listening to it. Riverpod disposed the provider during the awaited repository load, so the post-load ownership check saw an unmounted ref and rejected the conversation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved conversation loading reliability by keeping the provider active until loading completes.
  * Prevented pending conversation requests from being disposed prematurely during database operations.

* **Tests**
  * Added coverage confirming conversations load successfully after a blocked storage transaction is released.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Keep `loadConversationProvider` alive until the conversation load Future completes
> Previously, the `loadConversation` Riverpod provider could be disposed before its async work finished if all listeners detached early. The provider is now restructured as a non-async wrapper that acquires a `keepAlive` link via `ref.keepAlive()`, delegates to a private `_loadConversation` helper, and releases the link in a `whenComplete` handler. A new test in [openwebui_account_storage_isolation_test.dart](https://github.com/cogwheel0/conduit/pull/575/files#diff-001004afca8850389f01883474315c354997f069bcee4452cbf56b6a457bf401) verifies that the provider stays mounted during a blocking transaction with no active listeners.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 31fc407.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR keeps sidebar conversation loads alive while their current async work finishes. The main changes are:

- Adds a temporary `keepAlive` link around `loadConversationProvider`.
- Closes the keep-alive link when the conversation load settles.
- Keeps the existing OpenWebUI ownership checks in the load path.
- Adds a test for an unlistened provider read during a blocked repository load.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge with minimal risk.

The change is narrow, keeps existing ownership checks, and closes the keep-alive link after the current future settles. The added test directly covers the unlistened read path described in the PR.

No files require special attention.
</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Reviewed the general-contract-validation-proof for the OpenWebUI lifecycle availability and noted the surrounding before-state evidence.
- Observed the initial before-state capture contains a shell portability error from /bin/sh, highlighting a portability mismatch in the availability proof.
- Observed the targeted regression block result, showing exit code 127 and the message flutter: command not found, indicating Flutter tooling was not available for the test run.
- Reviewed the after-state availability capture, which shows flutter\_exit=1 and dart\_exit=1, and noted that the corrected Bash capture is the authoritative availability proof used here.

<a href="https://app.greptile.com/trex/runs/14594657/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| lib/core/providers/app_providers.dart | Wraps `loadConversationProvider` with a temporary `keepAlive` link so unlistened reads remain mounted until the current async load settles. |
| test/core/providers/openwebui_account_storage_isolation_test.dart | Adds a test for an unlistened sidebar-style provider read blocked during repository load. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
participant Sidebar
participant Provider as loadConversationProvider
participant Repo as ChatDatabaseRepository
participant Fence as OpenWebUI ownership fence

Sidebar->>Provider: read(scopedId).future without listener
Provider->>Provider: ref.keepAlive()
Provider->>Fence: capture ownership before load
Provider->>Repo: loadConversation(rawId, preferred, locationIsCurrent)
Repo-->>Provider: LocatedConversation after async work
Provider->>Fence: verify ownership is still current
Provider-->>Sidebar: Conversation
Provider->>Provider: close keepAlive link after future settles
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
participant Sidebar
participant Provider as loadConversationProvider
participant Repo as ChatDatabaseRepository
participant Fence as OpenWebUI ownership fence

Sidebar->>Provider: read(scopedId).future without listener
Provider->>Provider: ref.keepAlive()
Provider->>Fence: capture ownership before load
Provider->>Repo: loadConversation(rawId, preferred, locationIsCurrent)
Repo-->>Provider: LocatedConversation after async work
Provider->>Fence: verify ownership is still current
Provider-->>Sidebar: Conversation
Provider->>Provider: close keepAlive link after future settles
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix: keep sidebar chat loads alive"](https://github.com/cogwheel0/conduit/commit/31fc407b9606113066e651ef42491da211352857) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44585469)</sub>

<!-- /greptile_comment -->