### PR TITLE
Fix chat title generation, copying, and note markdown styling

### DIFF
--- a/lib/features/chat/providers/chat_providers.dart
+++ b/lib/features/chat/providers/chat_providers.dart
@@ -5018,6 +5018,37 @@ Map<String, dynamic> _buildOpenWebUiBackgroundTasks({
   };
 }
 
+bool _shouldGenerateQueuedTitle(
+  List<ChatMessage> messages, {
+  required String assistantMessageId,
+  required bool isTemporary,
+}) {
+  if (isTemporary) return false;
+  final assistantIndex = messages.indexWhere(
+    (message) => message.id == assistantMessageId,
+  );
+  if (assistantIndex < 0) return false;
+  return messages
+          .take(assistantIndex)
+          .where((message) => message.role == 'user')
+          .length ==
+      1;
+}
+
+/// Exposes [_shouldGenerateQueuedTitle] for focused regression tests.
+@visibleForTesting
+bool shouldGenerateQueuedTitleForTest(
+  List<ChatMessage> messages, {
+  required String assistantMessageId,
+  required bool isTemporary,
+}) {
+  return _shouldGenerateQueuedTitle(
+    messages,
+    assistantMessageId: assistantMessageId,
+    isTemporary: isTemporary,
+  );
+}
+
 /// Exposes [_buildOpenWebUiBackgroundTasks] for focused unit tests.
 @visibleForTesting
 Map<String, dynamic> buildOpenWebUiBackgroundTasksForTest({
@@ -8133,7 +8164,11 @@ Future<void> runQueuedCompletion(
 
   final bgTasks = _buildOpenWebUiBackgroundTasks(
     userSettings: userSettingsData,
-    shouldGenerateTitle: false,
+    shouldGenerateTitle: _shouldGenerateQueuedTitle(
+      messages,
+      assistantMessageId: assistantMessageId,
+      isTemporary: isTemporary,
+    ),
     webSearchEnabled: enableWebSearch,
     imageGenerationEnabled: enableImageGeneration,
   );
@@ -8377,7 +8412,11 @@ Future<void> runHeadlessCompletion(
 
   final bgTasks = _buildOpenWebUiBackgroundTasks(
     userSettings: userSettingsData,
-    shouldGenerateTitle: false,
+    shouldGenerateTitle: _shouldGenerateQueuedTitle(
+      messages,
+      assistantMessageId: assistantMessageId,
+      isTemporary: false,
+    ),
     webSearchEnabled: enableWebSearch,
     imageGenerationEnabled: enableImageGeneration,
   );

--- a/lib/features/chat/views/chat_page.dart
+++ b/lib/features/chat/views/chat_page.dart
@@ -2541,8 +2541,9 @@ class _ChatPageState extends ConsumerState<ChatPage> {
   }
 
   void _copyMessage(String content) {
-    // Strip reasoning blocks and annotations from copied content
-    final cleanedContent = ConduitMarkdownPreprocessor.sanitize(content);
+    final cleanedContent = ConduitMarkdownPreprocessor.sanitizeForClipboard(
+      content,
+    );
     Clipboard.setData(ClipboardData(text: cleanedContent));
   }
 

--- a/lib/features/notes/views/note_editor_page.dart
+++ b/lib/features/notes/views/note_editor_page.dart
@@ -48,6 +48,104 @@ import '../widgets/audio_player_dialog.dart';
 import '../widgets/audio_recording_overlay.dart';
 import '../widgets/note_file_attachment.dart';
 
+/// Builds the rich-note editor theme from Conduit's semantic color tokens.
+///
+/// Fleather's fallback block styles derive their colors from a separate
+/// [DefaultTextStyle]. Every block type must therefore be mapped explicitly so
+/// headings and lists remain readable in both brightness modes.
+FleatherThemeData buildNoteEditorFleatherTheme(BuildContext context) {
+  final theme = context.conduitTheme;
+  final fallback = FleatherThemeData.fallback(context);
+  final base = AppTypography.bodyLargeStyle.copyWith(
+    color: theme.textPrimary,
+    height: 1.8,
+  );
+
+  TextStyle blockStyle(TextStyle source, {Color? color}) {
+    return base
+        .merge(source)
+        .copyWith(
+          color: color ?? theme.textPrimary,
+          fontFamily: AppTypography.fontFamily,
+        );
+  }
+
+  TextBlockTheme themedBlock(
+    TextBlockTheme source, {
+    TextStyle? style,
+    BoxDecoration? decoration,
+  }) {
+    return TextBlockTheme(
+      style: style ?? blockStyle(source.style),
+      spacing: source.spacing,
+      lineSpacing: source.lineSpacing,
+      decoration: decoration ?? source.decoration,
+    );
+  }
+
+  TextStyle inlineCodeStyle(TextStyle? source) {
+    return (source ?? fallback.inlineCode.style).copyWith(
+      color: theme.codeText,
+      fontFamily: AppTypography.monospaceFontFamily,
+    );
+  }
+
+  return fallback.copyWith(
+    paragraph: TextBlockTheme(
+      style: base,
+      spacing: const VerticalSpacing(top: 0, bottom: 6),
+    ),
+    heading1: themedBlock(fallback.heading1),
+    heading2: themedBlock(fallback.heading2),
+    heading3: themedBlock(fallback.heading3),
+    heading4: themedBlock(fallback.heading4),
+    heading5: themedBlock(fallback.heading5),
+    heading6: themedBlock(fallback.heading6),
+    lists: themedBlock(fallback.lists, style: base),
+    quote: themedBlock(
+      fallback.quote,
+      style: blockStyle(fallback.quote.style, color: theme.textSecondary),
+      decoration: BoxDecoration(
+        border: BorderDirectional(
+          start: BorderSide(width: 4, color: theme.dividerColor),
+        ),
+      ),
+    ),
+    code: themedBlock(
+      fallback.code,
+      style: fallback.code.style.copyWith(
+        color: theme.codeText,
+        fontFamily: AppTypography.monospaceFontFamily,
+      ),
+      decoration: BoxDecoration(
+        color: theme.codeBackground,
+        border: Border.all(color: theme.codeBorder),
+        borderRadius:
+            fallback.code.decoration?.borderRadius ?? BorderRadius.circular(2),
+      ),
+    ),
+    inlineCode: InlineCodeThemeData(
+      style: inlineCodeStyle(fallback.inlineCode.style),
+      heading1: inlineCodeStyle(fallback.inlineCode.heading1),
+      heading2: inlineCodeStyle(fallback.inlineCode.heading2),
+      heading3: inlineCodeStyle(fallback.inlineCode.heading3),
+      backgroundColor: theme.codeBackground,
+      radius: fallback.inlineCode.radius,
+    ),
+    horizontalRuleThemeData: HorizontalRuleThemeData(
+      height: fallback.horizontalRule.height,
+      thickness: fallback.horizontalRule.thickness,
+      color: theme.dividerColor,
+    ),
+    bold: const TextStyle(fontWeight: FontWeight.bold),
+    italic: const TextStyle(fontStyle: FontStyle.italic),
+    link: TextStyle(
+      color: theme.buttonPrimary,
+      decoration: TextDecoration.underline,
+    ),
+  );
+}
+
 /// Page for editing a note with OpenWebUI-style layout.
 class NoteEditorPage extends ConsumerStatefulWidget {
   final String noteId;
@@ -2264,24 +2362,7 @@ class _NoteEditorPageState extends ConsumerState<NoteEditorPage> {
   /// Builds a Fleather theme derived from the app's typography and colours so
   /// the rich-text editor matches the rest of the note UI.
   FleatherThemeData _buildFleatherTheme(BuildContext context) {
-    final theme = context.conduitTheme;
-    final base = AppTypography.bodyLargeStyle.copyWith(
-      color: theme.textPrimary,
-      height: 1.8,
-    );
-    final fallback = FleatherThemeData.fallback(context);
-    return fallback.copyWith(
-      paragraph: TextBlockTheme(
-        style: base,
-        spacing: const VerticalSpacing(top: 0, bottom: 6),
-      ),
-      bold: const TextStyle(fontWeight: FontWeight.bold),
-      italic: const TextStyle(fontStyle: FontStyle.italic),
-      link: TextStyle(
-        color: theme.buttonPrimary,
-        decoration: TextDecoration.underline,
-      ),
-    );
+    return buildNoteEditorFleatherTheme(context);
   }
 
   /// Play an audio file attachment.

--- a/lib/shared/widgets/markdown/markdown_preprocessor.dart
+++ b/lib/shared/widgets/markdown/markdown_preprocessor.dart
@@ -64,6 +64,7 @@ class ConduitMarkdownPreprocessor {
     multiLine: true,
     dotAll: true,
   );
+  static final _codeSpanOrFence = RegExp(r'```[\s\S]*?```|`[\s\S]*?`');
   static final _allDetailsBlocks = RegExp(
     r'<details[^>]*>[\s\S]*?</details>',
     multiLine: true,
@@ -193,9 +194,8 @@ class ConduitMarkdownPreprocessor {
     if (input.isEmpty) return input;
 
     final sanitized = sanitize(input);
-    return _replaceOutsideCode(
+    return _removeToolCallBlocksOutsideCode(
       sanitized,
-      (segment) => segment.replaceAll(_toolCallBlocks, ''),
     ).replaceAll(_multipleNewlines, '\n\n').trim();
   }
 
@@ -335,10 +335,32 @@ class ConduitMarkdownPreprocessor {
     String Function(String segment) replacer,
   ) {
     return input.splitMapJoin(
-      RegExp(r'```[\s\S]*?```|`[\s\S]*?`'),
+      _codeSpanOrFence,
       onMatch: (match) => match[0] ?? '',
       onNonMatch: replacer,
     );
+  }
+
+  static String _removeToolCallBlocksOutsideCode(String input) {
+    final codeSpans = <String>[];
+    var marker = '\u0000conduit-code-span-';
+    while (input.contains(marker)) {
+      marker = '\u0000$marker';
+    }
+
+    final masked = input.replaceAllMapped(_codeSpanOrFence, (match) {
+      final index = codeSpans.length;
+      codeSpans.add(match[0] ?? '');
+      return '$marker$index\u0000';
+    });
+    var output = masked.replaceAll(_toolCallBlocks, '');
+
+    // Placeholders inside removed tool calls no longer exist, so only code from
+    // the response itself is restored.
+    for (var index = 0; index < codeSpans.length; index++) {
+      output = output.replaceAll('$marker$index\u0000', codeSpans[index]);
+    }
+    return output;
   }
 
   static String _removeEmojis(String input) {

--- a/lib/shared/widgets/markdown/markdown_preprocessor.dart
+++ b/lib/shared/widgets/markdown/markdown_preprocessor.dart
@@ -64,7 +64,7 @@ class ConduitMarkdownPreprocessor {
     multiLine: true,
     dotAll: true,
   );
-  static final _codeSpanOrFence = RegExp(r'```[\s\S]*?```|`[\s\S]*?`');
+  static final _codeSpanOrFence = RegExp(r'(`+)([\s\S]*?)\1');
   static final _allDetailsBlocks = RegExp(
     r'<details[^>]*>[\s\S]*?</details>',
     multiLine: true,
@@ -180,7 +180,9 @@ class ConduitMarkdownPreprocessor {
     return input
         .replaceAll('\r\n', '\n')
         .transform(_stripLinkReferenceDefinitions)
-        .replaceAll(_reasoningBlocks, '')
+        .transform(
+          (content) => _removeMatchesOutsideCode(content, _reasoningBlocks),
+        )
         .replaceAll(_multipleNewlines, '\n\n')
         .trim();
   }
@@ -194,8 +196,9 @@ class ConduitMarkdownPreprocessor {
     if (input.isEmpty) return input;
 
     final sanitized = sanitize(input);
-    return _removeToolCallBlocksOutsideCode(
+    return _removeMatchesOutsideCode(
       sanitized,
+      _toolCallBlocks,
     ).replaceAll(_multipleNewlines, '\n\n').trim();
   }
 
@@ -243,10 +246,7 @@ class ConduitMarkdownPreprocessor {
   static String removeAllDetails(String input) {
     if (input.isEmpty) return input;
 
-    return _replaceOutsideCode(
-      input,
-      (segment) => segment.replaceAll(_allDetailsBlocks, ''),
-    );
+    return _removeMatchesOutsideCode(input, _allDetailsBlocks);
   }
 
   /// Breaks long inline code spans for better wrapping.
@@ -319,10 +319,7 @@ class ConduitMarkdownPreprocessor {
   static String _stripLinkReferenceDefinitions(String input) {
     if (!input.contains(']:')) return input;
 
-    final stripped = _replaceOutsideCode(
-      input,
-      (segment) => segment.replaceAll(_linkReferenceDefinition, ''),
-    );
+    final stripped = _removeMatchesOutsideCode(input, _linkReferenceDefinition);
     return stripped.replaceAll(_multipleNewlines, '\n\n').trim();
   }
 
@@ -330,18 +327,7 @@ class ConduitMarkdownPreprocessor {
     return _openWebUiRemoveFormattings(_removeEmojis(input.trim()));
   }
 
-  static String _replaceOutsideCode(
-    String input,
-    String Function(String segment) replacer,
-  ) {
-    return input.splitMapJoin(
-      _codeSpanOrFence,
-      onMatch: (match) => match[0] ?? '',
-      onNonMatch: replacer,
-    );
-  }
-
-  static String _removeToolCallBlocksOutsideCode(String input) {
+  static String _removeMatchesOutsideCode(String input, RegExp pattern) {
     final codeSpans = <String>[];
     var marker = '\u0000conduit-code-span-';
     while (input.contains(marker)) {
@@ -353,10 +339,10 @@ class ConduitMarkdownPreprocessor {
       codeSpans.add(match[0] ?? '');
       return '$marker$index\u0000';
     });
-    var output = masked.replaceAll(_toolCallBlocks, '');
+    var output = masked.replaceAll(pattern, '');
 
-    // Placeholders inside removed tool calls no longer exist, so only code from
-    // the response itself is restored.
+    // Placeholders inside removed matches no longer exist, so only code from
+    // the retained content is restored.
     for (var index = 0; index < codeSpans.length; index++) {
       output = output.replaceAll('$marker$index\u0000', codeSpans[index]);
     }

--- a/lib/shared/widgets/markdown/markdown_preprocessor.dart
+++ b/lib/shared/widgets/markdown/markdown_preprocessor.dart
@@ -184,6 +184,21 @@ class ConduitMarkdownPreprocessor {
         .trim();
   }
 
+  /// Sanitizes message content for copying while omitting internal tool calls.
+  ///
+  /// Tool-call markup inside code spans is preserved so documentation and
+  /// examples are copied faithfully. Ordinary `<details>` blocks are also left
+  /// untouched.
+  static String sanitizeForClipboard(String input) {
+    if (input.isEmpty) return input;
+
+    final sanitized = sanitize(input);
+    return _replaceOutsideCode(
+      sanitized,
+      (segment) => segment.replaceAll(_toolCallBlocks, ''),
+    ).replaceAll(_multipleNewlines, '\n\n').trim();
+  }
+
   /// Converts markdown to plain text for text-to-speech.
   static String toPlainText(String input) {
     if (input.trim().isEmpty) return '';

--- a/test/regressions/issues_511_576_577_test.dart
+++ b/test/regressions/issues_511_576_577_test.dart
@@ -1,3 +1,4 @@
+import 'package:checks/checks.dart';
 import 'package:conduit/core/models/chat_message.dart';
 import 'package:conduit/features/chat/providers/chat_providers.dart';
 import 'package:conduit/features/notes/views/note_editor_page.dart';
@@ -21,10 +22,9 @@ void main() {
 
 **After**''';
 
-      expect(
+      check(
         ConduitMarkdownPreprocessor.sanitizeForClipboard(input),
-        'Before\n\n**After**',
-      );
+      ).equals('Before\n\n**After**');
     });
 
     test('preserves ordinary details and literal tool-call examples', () {
@@ -36,7 +36,28 @@ void main() {
 <details type="tool_calls">example</details>
 ```''';
 
-      expect(ConduitMarkdownPreprocessor.sanitizeForClipboard(input), input);
+      check(
+        ConduitMarkdownPreprocessor.sanitizeForClipboard(input),
+      ).equals(input);
+    });
+
+    test('removes tool-call details that contain code spans', () {
+      const input = '''Before
+
+<details type="tool_calls" done="true">
+<summary>Tool call</summary>
+`private inline payload`
+
+```
+private fenced payload
+```
+</details>
+
+After''';
+
+      check(
+        ConduitMarkdownPreprocessor.sanitizeForClipboard(input),
+      ).equals('Before\n\nAfter');
     });
   });
 
@@ -56,21 +77,13 @@ void main() {
         isTemporary: false,
       );
 
-      expect(shouldGenerate, isTrue);
-      expect(
-        buildOpenWebUiBackgroundTasksForTest(
-          userSettings: null,
-          shouldGenerateTitle: shouldGenerate,
-        ),
-        containsPair('title_generation', true),
+      check(shouldGenerate).isTrue();
+      final backgroundTasks = buildOpenWebUiBackgroundTasksForTest(
+        userSettings: null,
+        shouldGenerateTitle: shouldGenerate,
       );
-      expect(
-        buildOpenWebUiBackgroundTasksForTest(
-          userSettings: null,
-          shouldGenerateTitle: shouldGenerate,
-        ),
-        containsPair('tags_generation', true),
-      );
+      check(backgroundTasks['title_generation']).equals(true);
+      check(backgroundTasks['tags_generation']).equals(true);
     });
 
     test('does not regenerate titles for later turns or temporary chats', () {
@@ -81,22 +94,20 @@ void main() {
         message('a-2', 'assistant'),
       ];
 
-      expect(
+      check(
         shouldGenerateQueuedTitleForTest(
           laterTurn,
           assistantMessageId: 'a-2',
           isTemporary: false,
         ),
-        isFalse,
-      );
-      expect(
+      ).isFalse();
+      check(
         shouldGenerateQueuedTitleForTest(
           [message('user-1', 'user'), message('a-1', 'assistant')],
           assistantMessageId: 'a-1',
           isTemporary: true,
         ),
-        isFalse,
-      );
+      ).isFalse();
     });
 
     test('anchors first-turn eligibility to the queued assistant', () {
@@ -107,14 +118,13 @@ void main() {
         message('a-2', 'assistant'),
       ];
 
-      expect(
+      check(
         shouldGenerateQueuedTitleForTest(
           queuedTurns,
           assistantMessageId: 'a-1',
           isTemporary: false,
         ),
-        isTrue,
-      );
+      ).isTrue();
     });
   });
 
@@ -144,19 +154,19 @@ void main() {
 
         final editor = fleatherTheme!;
         final colors = conduitTheme!;
-        expect(editor.paragraph.style.color, colors.textPrimary);
-        expect(editor.heading1.style.color, colors.textPrimary);
-        expect(editor.heading2.style.color, colors.textPrimary);
-        expect(editor.heading3.style.color, colors.textPrimary);
-        expect(editor.heading4.style.color, colors.textPrimary);
-        expect(editor.heading5.style.color, colors.textPrimary);
-        expect(editor.heading6.style.color, colors.textPrimary);
-        expect(editor.lists.style.color, colors.textPrimary);
-        expect(editor.lists.style.fontFamily, AppTypography.fontFamily);
-        expect(editor.code.style.color, colors.codeText);
-        expect(editor.code.decoration?.color, colors.codeBackground);
-        expect(editor.inlineCode.style.color, colors.codeText);
-        expect(editor.inlineCode.backgroundColor, colors.codeBackground);
+        check(editor.paragraph.style.color).equals(colors.textPrimary);
+        check(editor.heading1.style.color).equals(colors.textPrimary);
+        check(editor.heading2.style.color).equals(colors.textPrimary);
+        check(editor.heading3.style.color).equals(colors.textPrimary);
+        check(editor.heading4.style.color).equals(colors.textPrimary);
+        check(editor.heading5.style.color).equals(colors.textPrimary);
+        check(editor.heading6.style.color).equals(colors.textPrimary);
+        check(editor.lists.style.color).equals(colors.textPrimary);
+        check(editor.lists.style.fontFamily).equals(AppTypography.fontFamily);
+        check(editor.code.style.color).equals(colors.codeText);
+        check(editor.code.decoration?.color).equals(colors.codeBackground);
+        check(editor.inlineCode.style.color).equals(colors.codeText);
+        check(editor.inlineCode.backgroundColor).equals(colors.codeBackground);
       });
     }
   });

--- a/test/regressions/issues_511_576_577_test.dart
+++ b/test/regressions/issues_511_576_577_test.dart
@@ -1,0 +1,163 @@
+import 'package:conduit/core/models/chat_message.dart';
+import 'package:conduit/features/chat/providers/chat_providers.dart';
+import 'package:conduit/features/notes/views/note_editor_page.dart';
+import 'package:conduit/shared/theme/app_theme.dart';
+import 'package:conduit/shared/theme/theme_extensions.dart';
+import 'package:conduit/shared/theme/tweakcn_themes.dart';
+import 'package:conduit/shared/widgets/markdown/markdown_preprocessor.dart';
+import 'package:fleather/fleather.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('issue 577 - clipboard content', () {
+    test('removes tool-call details but preserves the response markdown', () {
+      const input = '''Before
+
+<details type="tool_calls" done="true">
+<summary>Tool call</summary>
+<div>private tool payload</div>
+</details>
+
+**After**''';
+
+      expect(
+        ConduitMarkdownPreprocessor.sanitizeForClipboard(input),
+        'Before\n\n**After**',
+      );
+    });
+
+    test('preserves ordinary details and literal tool-call examples', () {
+      const input = '''<details><summary>Keep me</summary>Body</details>
+
+`<details type="tool_calls">example</details>`
+
+```
+<details type="tool_calls">example</details>
+```''';
+
+      expect(ConduitMarkdownPreprocessor.sanitizeForClipboard(input), input);
+    });
+  });
+
+  group('issue 576 - queued title generation', () {
+    ChatMessage message(String id, String role) => ChatMessage(
+      id: id,
+      role: role,
+      content: role,
+      timestamp: DateTime(2026),
+    );
+
+    test('enables first-turn title and tag tasks', () {
+      final messages = [message('user-1', 'user'), message('a-1', 'assistant')];
+      final shouldGenerate = shouldGenerateQueuedTitleForTest(
+        messages,
+        assistantMessageId: 'a-1',
+        isTemporary: false,
+      );
+
+      expect(shouldGenerate, isTrue);
+      expect(
+        buildOpenWebUiBackgroundTasksForTest(
+          userSettings: null,
+          shouldGenerateTitle: shouldGenerate,
+        ),
+        containsPair('title_generation', true),
+      );
+      expect(
+        buildOpenWebUiBackgroundTasksForTest(
+          userSettings: null,
+          shouldGenerateTitle: shouldGenerate,
+        ),
+        containsPair('tags_generation', true),
+      );
+    });
+
+    test('does not regenerate titles for later turns or temporary chats', () {
+      final laterTurn = [
+        message('user-1', 'user'),
+        message('a-1', 'assistant'),
+        message('user-2', 'user'),
+        message('a-2', 'assistant'),
+      ];
+
+      expect(
+        shouldGenerateQueuedTitleForTest(
+          laterTurn,
+          assistantMessageId: 'a-2',
+          isTemporary: false,
+        ),
+        isFalse,
+      );
+      expect(
+        shouldGenerateQueuedTitleForTest(
+          [message('user-1', 'user'), message('a-1', 'assistant')],
+          assistantMessageId: 'a-1',
+          isTemporary: true,
+        ),
+        isFalse,
+      );
+    });
+
+    test('anchors first-turn eligibility to the queued assistant', () {
+      final queuedTurns = [
+        message('user-1', 'user'),
+        message('a-1', 'assistant'),
+        message('user-2', 'user'),
+        message('a-2', 'assistant'),
+      ];
+
+      expect(
+        shouldGenerateQueuedTitleForTest(
+          queuedTurns,
+          assistantMessageId: 'a-1',
+          isTemporary: false,
+        ),
+        isTrue,
+      );
+    });
+  });
+
+  group('issue 511 - rich note colors', () {
+    for (final brightness in Brightness.values) {
+      testWidgets('uses readable block colors in ${brightness.name} mode', (
+        tester,
+      ) async {
+        FleatherThemeData? fleatherTheme;
+        ConduitThemeExtension? conduitTheme;
+        final appTheme = brightness == Brightness.dark
+            ? AppTheme.dark(TweakcnThemes.conduit)
+            : AppTheme.light(TweakcnThemes.conduit);
+
+        await tester.pumpWidget(
+          MaterialApp(
+            theme: appTheme,
+            home: Builder(
+              builder: (context) {
+                conduitTheme = context.conduitTheme;
+                fleatherTheme = buildNoteEditorFleatherTheme(context);
+                return const SizedBox.shrink();
+              },
+            ),
+          ),
+        );
+
+        final editor = fleatherTheme!;
+        final colors = conduitTheme!;
+        expect(editor.paragraph.style.color, colors.textPrimary);
+        expect(editor.heading1.style.color, colors.textPrimary);
+        expect(editor.heading2.style.color, colors.textPrimary);
+        expect(editor.heading3.style.color, colors.textPrimary);
+        expect(editor.heading4.style.color, colors.textPrimary);
+        expect(editor.heading5.style.color, colors.textPrimary);
+        expect(editor.heading6.style.color, colors.textPrimary);
+        expect(editor.lists.style.color, colors.textPrimary);
+        expect(editor.lists.style.fontFamily, AppTypography.fontFamily);
+        expect(editor.code.style.color, colors.codeText);
+        expect(editor.code.decoration?.color, colors.codeBackground);
+        expect(editor.inlineCode.style.color, colors.codeText);
+        expect(editor.inlineCode.backgroundColor, colors.codeBackground);
+      });
+    }
+  });
+}

--- a/test/regressions/issues_511_576_577_test.dart
+++ b/test/regressions/issues_511_576_577_test.dart
@@ -30,11 +30,17 @@ void main() {
     test('preserves ordinary details and literal tool-call examples', () {
       const input = '''<details><summary>Keep me</summary>Body</details>
 
-`<details type="tool_calls">example</details>`
+`<details type="tool_calls">standard inline</details>`
 
 ```
+<details type="tool_calls">standard fence</details>
+```
+
+``<details type="tool_calls">`example`</details>``
+
+````
 <details type="tool_calls">example</details>
-```''';
+````''';
 
       check(
         ConduitMarkdownPreprocessor.sanitizeForClipboard(input),
@@ -46,11 +52,11 @@ void main() {
 
 <details type="tool_calls" done="true">
 <summary>Tool call</summary>
-`private inline payload`
+``private `inline` payload``
 
-```
+````
 private fenced payload
-```
+````
 </details>
 
 After''';

--- a/test/shared/widgets/markdown/markdown_preprocessor_test.dart
+++ b/test/shared/widgets/markdown/markdown_preprocessor_test.dart
@@ -91,9 +91,47 @@ void main() {
       check(result).contains('after');
     });
 
+    test('preserves literal reasoning blocks inside code spans and fences', () {
+      const input = '''before <think>remove me</think>
+
+``<think>`inline example`</think>``
+
+````
+<details type="reasoning">fenced example</details>
+````
+
+after''';
+
+      final result = ConduitMarkdownPreprocessor.sanitize(input);
+      check(result).not((value) => value.contains('remove me'));
+      check(result).contains('``<think>`inline example`</think>``');
+      check(result).contains(
+        '````\n<details type="reasoning">fenced example</details>\n````',
+      );
+    });
+
     test('collapses 3+ newlines to double newline', () {
       final result = ConduitMarkdownPreprocessor.sanitize('a\n\n\n\nb');
       check(result).equals('a\n\nb');
+    });
+  });
+
+  group('ConduitMarkdownPreprocessor.stripLinkReferenceDefinitions', () {
+    test('preserves definitions inside variable-length code delimiters', () {
+      const input = '''[remove]: https://example.com/remove
+
+``[inline]: `literal` ``
+
+````
+[fenced]: https://example.com/keep
+````''';
+
+      final result = ConduitMarkdownPreprocessor.stripLinkReferenceDefinitions(
+        input,
+      );
+      check(result).not((value) => value.contains('[remove]'));
+      check(result).contains('``[inline]: `literal` ``');
+      check(result).contains('````\n[fenced]: https://example.com/keep\n````');
     });
   });
 
@@ -270,6 +308,23 @@ void main() {
       );
       check(result).contains('```<details>code</details>```');
       check(result).not((s) => s.contains(' hide <details>x</details>'));
+    });
+
+    test('removes details containing code without splitting the block', () {
+      const input = '''before
+<details><summary>Hidden</summary>
+``inline `secret` ``
+````
+fenced secret
+````
+</details>
+after''';
+
+      final result = ConduitMarkdownPreprocessor.removeAllDetails(input);
+      check(result).not((value) => value.contains('Hidden'));
+      check(result).not((value) => value.contains('secret'));
+      check(result).contains('before');
+      check(result).contains('after');
     });
   });
 


### PR DESCRIPTION
## Summary

- omit internal tool-call blocks when copying chat messages while preserving response markdown and literal code examples
- restore first-turn title and tag generation for queued and headless OpenWebUI completions, anchored to the target assistant placeholder so later queued turns do not suppress it
- apply Conduit semantic colors and typography to Fleather headings, lists, quotes, code blocks, and inline code in light and dark modes
- add regression coverage for all three issue paths

## Verification

- `dart run build_runner build`
- `flutter analyze`
- `flutter test` (4,008 passed, 2 existing skips)

Fixes #577
Fixes #576
Fixes #511

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix chat title generation, clipboard sanitization, and note editor markdown styling
> - Fixes queued chat title generation so `_shouldGenerateQueuedTitle` triggers title and tags background tasks only on the first user turn of non-temporary conversations, replacing a hardcoded `false`.
> - Adds `sanitizeForClipboard` to [`ConduitMarkdownPreprocessor`](https://github.com/cogwheel0/conduit/pull/579/files#diff-a6c03f1989d6f0e38d36c0fda375ff3adb3a983ed8a3f57d525ac60ce947b8af) which strips tool-call `<details>` blocks while preserving ordinary details and tool-call examples inside code spans/fences.
> - Refactors `sanitize`, `removeAllDetails`, and `_stripLinkReferenceDefinitions` to operate only outside code spans/fences via a new `_removeMatchesOutsideCode` helper, preventing accidental removal of literal examples in code.
> - Rebuilds the Fleather rich-text theme in [`note_editor_page.dart`](https://github.com/cogwheel0/conduit/pull/579/files#diff-78854ea1159ecb3432e03346b97a0fe608a7e37275f5685601fc69ec944c11f4) to apply consistent colors and typography for headings, lists, quotes, code, and links using the app's semantic color tokens.
> - Adds regression tests in [`issues_511_576_577_test.dart`](https://github.com/cogwheel0/conduit/pull/579/files#diff-242001f95a09117070deeeee499553d812899b68338bf28c605d5644b9195863) covering clipboard sanitization, queued title generation logic, and note editor theme colors in light and dark modes.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c810559.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Queued conversations can now generate titles and tags for eligible first assistant responses (with better handling of temporary chats).
  * Note editor styling is now more consistent and theme-aware across headings, lists, quotes, code blocks, inline code, links, and spacing.
* **Bug Fixes**
  * Clipboard copying now removes internal tool-call details while preserving the rest of the markdown, including inline code and fenced code.
* **Tests**
  * Added regression tests for clipboard sanitization, queued title/tag eligibility rules, and note editor theme styling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes chat title generation, message copying, and rich note markdown styling. The main changes are:

- Restores first-turn title and tag tasks for queued and headless OpenWebUI completions.
- Removes internal tool-call details when copying chat messages while preserving markdown and literal code examples.
- Applies Conduit semantic colors and typography to Fleather headings, lists, quotes, code blocks, inline code, and links.
- Adds tests for the affected title generation, clipboard sanitization, and note editor theme paths.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge with low risk.

The changes are targeted to the reported regressions and keep existing guards for temporary chats and later chat turns. Tests cover the updated markdown, queued-completion, and note-theme behavior. No blocking correctness or security issues were identified in the changed paths.

No files require special attention.
</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex executed the Flutter and Dart availability checks from the project workspace and captured the command outputs and exit codes.
- T-Rex reviewed the resulting logs and confirmed that both Flutter and Dart checks exited with code 1, indicating the tools are not available in the environment.
- T-Rex prepared two log artifacts that document the availability checks for Flutter and Dart for reviewer inspection.

<a href="https://app.greptile.com/trex/runs/14888244/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| lib/features/chat/providers/chat_providers.dart | Adds queued and headless title-generation eligibility anchored to the target assistant placeholder while preserving temporary-chat and later-turn suppression. |
| lib/features/chat/views/chat_page.dart | Switches message copying to clipboard-specific markdown sanitization so internal tool-call blocks are omitted without losing plain markdown. |
| lib/features/notes/views/note_editor_page.dart | Extracts and expands Fleather theme construction to apply semantic Conduit colors and typography across rich note blocks and inline styles. |
| lib/shared/widgets/markdown/markdown_preprocessor.dart | Adds clipboard sanitization and shared outside-code removal that masks variable-length code spans and fences before stripping hidden markdown blocks. |
| test/regressions/issues_511_576_577_test.dart | Adds tests for clipboard tool-call removal, queued title generation, and note editor theme color behavior. |
| test/shared/widgets/markdown/markdown_preprocessor_test.dart | Extends markdown preprocessor tests for preserving literal hidden-block syntax inside variable-length code delimiters and removing details containing code. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
participant User
participant ChatPage
participant Preprocessor
participant Queue as Queued/Headless Completion
participant OpenWebUI
participant Notes as Note Editor

User->>ChatPage: Copy assistant message
ChatPage->>Preprocessor: sanitizeForClipboard(content)
Preprocessor-->>ChatPage: Markdown without internal tool-call details
ChatPage-->>User: Clipboard text

Queue->>Queue: Locate target assistant placeholder
Queue->>Queue: Count prior user turns
alt first non-temporary turn
    Queue->>OpenWebUI: sendMessageSession(backgroundTasks: title/tags)
else later or temporary turn
    Queue->>OpenWebUI: sendMessageSession(without title/tags)
end

User->>Notes: Open rich note editor
Notes->>Notes: buildNoteEditorFleatherTheme(context)
Notes-->>User: Semantic colors for headings, lists, quotes, and code
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
participant User
participant ChatPage
participant Preprocessor
participant Queue as Queued/Headless Completion
participant OpenWebUI
participant Notes as Note Editor

User->>ChatPage: Copy assistant message
ChatPage->>Preprocessor: sanitizeForClipboard(content)
Preprocessor-->>ChatPage: Markdown without internal tool-call details
ChatPage-->>User: Clipboard text

Queue->>Queue: Locate target assistant placeholder
Queue->>Queue: Count prior user turns
alt first non-temporary turn
    Queue->>OpenWebUI: sendMessageSession(backgroundTasks: title/tags)
else later or temporary turn
    Queue->>OpenWebUI: sendMessageSession(without title/tags)
end

User->>Notes: Open rich note editor
Notes->>Notes: buildNoteEditorFleatherTheme(context)
Notes-->>User: Semantic colors for headings, lists, quotes, and code
```

</a>
</details>

<sub>Reviews (3): Last reviewed commit: ["fix: harden markdown code masking"](https://github.com/cogwheel0/conduit/commit/c810559aba9b16938cb58356e4587fb2ce293b6e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45173611)</sub>

<!-- /greptile_comment -->