### PR TITLE
Stabilize adaptive navigation and account sync

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -15,7 +15,6 @@ PODS:
     - Flutter
   - flutter_image_compress_common (1.0.0):
     - Flutter
-    - Mantle
     - SDWebImage
     - SDWebImageWebPCoder
   - flutter_inappwebview_ios (0.0.1):
@@ -56,9 +55,6 @@ PODS:
   - libwebp/sharpyuv (1.5.0)
   - libwebp/webp (1.5.0):
     - libwebp/sharpyuv
-  - Mantle (2.2.0):
-    - Mantle/extobjc (= 2.2.0)
-  - Mantle/extobjc (2.2.0)
   - onnxruntime-c (1.22.0)
   - onnxruntime-objc (1.22.0):
     - onnxruntime-objc/Core (= 1.22.0)
@@ -135,7 +131,6 @@ SPEC REPOS:
   trunk:
     - CryptoSwift
     - libwebp
-    - Mantle
     - onnxruntime-c
     - onnxruntime-objc
     - OrderedSet
@@ -201,14 +196,14 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/webview_flutter_wkwebview/darwin"
 
 SPEC CHECKSUMS:
-  adaptive_platform_ui: f54f620666d1797636f9ef06f49137ef2cc13611
+  adaptive_platform_ui: cd3c5a2997126f138a1e7f12e8376d3ca3fdbfad
   audio_session: 9bb7f6c970f21241b19f5a3658097ae459681ba0
   connectivity_plus: cb623214f4e1f6ef8fe7403d580fdad517d2f7dd
   CryptoSwift: e64e11850ede528a02a0f3e768cec8e9d92ecb90
   file_picker: 70164d9778c42c47218d6cd79ce435de0856b11a
   Flutter: cabc95a1d2626b1b06e7179b784ebcf0c0cde467
   flutter_callkit_incoming: a143995975818a3717524decd3566d5ca7a8c608
-  flutter_image_compress_common: 1697a328fd72bfb335507c6bca1a65fa5ad87df1
+  flutter_image_compress_common: 11d5dcfb36f4ded92320bfa896261813a073240e
   flutter_inappwebview_ios: b89ba3482b96fb25e00c967aae065701b66e9b99
   flutter_local_notifications: 643a3eda1ce1c0599413ca31672536d423dee214
   flutter_secure_storage_darwin: acdb3f316ed05a3e68f856e0353b133eec373a23
@@ -219,7 +214,6 @@ SPEC CHECKSUMS:
   image_picker_ios: e0ece4aa2a75771a7de3fa735d26d90817041326
   just_audio: 4e391f57b79cad2b0674030a00453ca5ce817eed
   libwebp: 02b23773aedb6ff1fd38cec7a77b81414c6842a8
-  Mantle: c5aa8794a29a022dfbbfc9799af95f477a69b62d
   onnxruntime-c: 7f778680e96145956c0a31945f260321eed2611a
   onnxruntime-objc: 83d28b87525bd971259a66e153ea32b5d023de19
   OrderedSet: e539b66b644ff081c73a262d24ad552a69be3a94

--- a/lib/core/auth/auth_state_manager.dart
+++ b/lib/core/auth/auth_state_manager.dart
@@ -372,8 +372,8 @@ class AuthStateManager extends _$AuthStateManager {
             attemptRevision: attemptRevision,
             candidateToken: token,
             publish: () {
-              _updateApiServiceToken(token);
               _setIncompleteLogoutFenceInMemory(false);
+              _updateApiServiceToken(token);
               if (invalidateServerProviders) {
                 ref.invalidate(activeServerProvider);
                 ref.invalidate(apiServiceProvider);
@@ -2326,8 +2326,8 @@ class AuthStateManager extends _$AuthStateManager {
         attemptRevision: commitRevision,
         candidateToken: token,
         publish: () {
-          _updateApiServiceToken(token);
           _setIncompleteLogoutFenceInMemory(false);
+          _updateApiServiceToken(token);
           ref.invalidate(activeServerProvider);
           ref.invalidate(apiServiceProvider);
           if (_authAttemptSuperseded(commitRevision)) {
@@ -3084,6 +3084,7 @@ class AuthStateManager extends _$AuthStateManager {
   /// Preload the default model as soon as authentication succeeds.
   /// Update API service with current token
   void _updateApiServiceToken(String? token) {
+    ref.read(apiAuthTokenMirrorProvider.notifier).set(token);
     final api = ref.read(apiServiceProvider);
     api?.updateAuthToken(token);
   }

--- a/lib/core/providers/app_providers.dart
+++ b/lib/core/providers/app_providers.dart
@@ -537,6 +537,26 @@ final class IncompleteLogoutFence extends _$IncompleteLogoutFence {
   }
 }
 
+/// In-memory bearer mirror used when [apiServiceProvider] is rebuilt.
+///
+/// The API client watches transport configuration such as the incomplete-logout
+/// Cookie fence and can therefore be replaced during authentication publication.
+/// Keeping the current bearer in an independent process-local provider prevents
+/// that replacement from reverting to an unauthenticated client. The token is
+/// never persisted or logged here; secure credential storage remains owned by
+/// [OptimizedStorageService].
+final apiAuthTokenMirrorProvider =
+    NotifierProvider<ApiAuthTokenMirror, String?>(ApiAuthTokenMirror.new);
+
+final class ApiAuthTokenMirror extends Notifier<String?> {
+  @override
+  String? build() => null;
+
+  void set(String? token) {
+    if (state != token) state = token;
+  }
+}
+
 // API Service provider with unified auth integration
 final apiServiceProvider = Provider<ApiService?>((ref) {
   // If reviewer mode is enabled, skip creating ApiService
@@ -544,6 +564,7 @@ final apiServiceProvider = Provider<ApiService?>((ref) {
   if (reviewerMode) {
     return null;
   }
+  final authToken = ref.watch(apiAuthTokenMirrorProvider);
   final activeServer = ref.watch(activeServerProvider);
   final workerManager = ref.watch(workerManagerProvider);
   final liveFence = ref.watch(incompleteLogoutFenceProvider);
@@ -558,7 +579,7 @@ final apiServiceProvider = Provider<ApiService?>((ref) {
       final apiService = ApiService(
         serverConfig: server,
         workerManager: workerManager,
-        authToken: null, // Will be set by auth state manager
+        authToken: authToken,
         suppressCookieCustomHeader: suppressCookieHeader,
       );
 
@@ -740,6 +761,47 @@ final class OpenWebUiConversationReadSnapshot {
   final String? apiServerId;
 }
 
+/// Logical account/server owner for a user-initiated conversation selection.
+///
+/// Exact database and API identities belong to [OpenWebUiConversationReadSnapshot]
+/// and may legitimately change while the same account finishes opening. This
+/// owner survives that replacement while still canceling on logout, account
+/// changes, or server changes.
+@immutable
+final class OpenWebUiConversationSelectionOwner {
+  const OpenWebUiConversationSelectionOwner._({
+    required this.serverId,
+    required this.userId,
+    required this.authToken,
+    required this.authSessionEpoch,
+  });
+
+  final String serverId;
+  final String? userId;
+  final String authToken;
+  final Object authSessionEpoch;
+}
+
+enum OpenWebUiConversationOwnershipFailureReason {
+  unavailable,
+  changedWhileLoading,
+  changedWhileFetching,
+}
+
+final class OpenWebUiConversationOwnershipException extends StateError {
+  OpenWebUiConversationOwnershipException(this.reason)
+    : super(switch (reason) {
+        OpenWebUiConversationOwnershipFailureReason.unavailable =>
+          'OpenWebUI conversation ownership is unavailable',
+        OpenWebUiConversationOwnershipFailureReason.changedWhileLoading =>
+          'OpenWebUI conversation ownership changed while loading',
+        OpenWebUiConversationOwnershipFailureReason.changedWhileFetching =>
+          'OpenWebUI conversation ownership changed while fetching',
+      });
+
+  final OpenWebUiConversationOwnershipFailureReason reason;
+}
+
 typedef _OpenWebUiConversationReadContext = ({
   AppDatabase? database,
   ApiService? api,
@@ -859,6 +921,111 @@ _OpenWebUiConversationReadContext? _readOpenWebUiConversationContext(
   );
 }
 
+String? _readOpenWebUiLogicalServerId(dynamic ref) {
+  if (!_openWebUiConversationReaderIsMounted(ref)) return null;
+
+  late final OpenWebUiDatabaseAccessPhase accessPhase;
+  try {
+    accessPhase =
+        ref.read(openWebUiDatabaseAccessProvider)
+            as OpenWebUiDatabaseAccessPhase;
+  } catch (_) {
+    return null;
+  }
+
+  final primaryIds = <String>{};
+  try {
+    final activeServer = ref.read(activeServerProvider);
+    if (activeServer is AsyncData<ServerConfig?>) {
+      final id = activeServer.value?.id;
+      if (id != null && id.isNotEmpty) primaryIds.add(id);
+    }
+  } catch (_) {}
+  try {
+    if (PreferencesStore.isReady) {
+      final id = PreferencesStore.getString(PreferenceKeys.activeServerId);
+      if (id != null && id.isNotEmpty) primaryIds.add(id);
+    }
+  } catch (_) {}
+  try {
+    final api = ref.read(apiServiceProvider) as ApiService?;
+    final id = api?.serverConfig.id;
+    if (id != null && id.isNotEmpty) primaryIds.add(id);
+  } catch (_) {}
+  if (primaryIds.length > 1) return null;
+
+  final storageIds = <String>{};
+  try {
+    final certified =
+        ref.read(openWebUiCertifiedDatabaseServerProvider) as String?;
+    if (certified != null && certified.isNotEmpty) storageIds.add(certified);
+  } catch (_) {}
+  try {
+    final database = ref.read(appDatabaseProvider) as AppDatabase?;
+    if (database != null) {
+      final managed = ref
+          .read(databaseManagerProvider)
+          .serverIdForDatabase(database);
+      if (managed != null && managed.isNotEmpty) storageIds.add(managed);
+    }
+  } catch (_) {}
+  if (storageIds.length > 1) return null;
+
+  final primary = primaryIds.isEmpty ? null : primaryIds.first;
+  final storage = storageIds.isEmpty ? null : storageIds.first;
+  if (accessPhase == OpenWebUiDatabaseAccessPhase.open &&
+      primary != null &&
+      storage != null &&
+      primary != storage) {
+    return null;
+  }
+  return primary ?? storage;
+}
+
+OpenWebUiConversationSelectionOwner? captureOpenWebUiConversationSelectionOwner(
+  dynamic ref,
+) {
+  if (!_openWebUiConversationReaderIsMounted(ref)) return null;
+  try {
+    final authenticated = ref.read(isAuthenticatedProvider2) as bool;
+    final authToken = ref.read(authTokenProvider3) as String?;
+    final userId = (ref.read(currentUserProvider2) as User?)?.id.trim();
+    final serverId = _readOpenWebUiLogicalServerId(ref);
+    if (!authenticated ||
+        authToken == null ||
+        authToken.isEmpty ||
+        serverId == null) {
+      return null;
+    }
+    return OpenWebUiConversationSelectionOwner._(
+      serverId: serverId,
+      userId: userId == null || userId.isEmpty ? null : userId,
+      authToken: authToken,
+      authSessionEpoch: ref.read(openWebUiAuthSessionEpochProvider) as Object,
+    );
+  } catch (_) {
+    return null;
+  }
+}
+
+bool openWebUiConversationSelectionOwnerIsCurrent(
+  dynamic ref,
+  OpenWebUiConversationSelectionOwner owner,
+) {
+  final current = captureOpenWebUiConversationSelectionOwner(ref);
+  if (current == null ||
+      current.serverId != owner.serverId ||
+      !identical(current.authSessionEpoch, owner.authSessionEpoch)) {
+    return false;
+  }
+  final ownerUserId = owner.userId;
+  final currentUserId = current.userId;
+  if (ownerUserId != null && currentUserId != null) {
+    return ownerUserId == currentUserId;
+  }
+  return owner.authToken == current.authToken;
+}
+
 /// Captures the single ownership token shared by all OpenWebUI conversation
 /// read and publication paths.
 ///
@@ -932,6 +1099,45 @@ bool openWebUiConversationReadIsCurrent(
       context.rawActiveServerId == snapshot.rawActiveServerId &&
       context.managedDatabaseServerId == snapshot.managedDatabaseServerId &&
       context.apiServerId == snapshot.apiServerId;
+}
+
+/// Whether account-scoped OpenWebUI storage is safe for active chat content.
+bool openWebUiAccountStorageIsCertified(dynamic ref) {
+  try {
+    if (ref.read(openWebUiDatabaseAccessProvider) !=
+        OpenWebUiDatabaseAccessPhase.open) {
+      return false;
+    }
+    final certifiedServerId = ref.read(
+      openWebUiCertifiedDatabaseServerProvider,
+    );
+    final activeServer = ref.read(activeServerProvider);
+    if (activeServer is AsyncData<ServerConfig?>) {
+      final activeServerId = activeServer.value?.id;
+      if (activeServerId != null) return activeServerId == certifiedServerId;
+    }
+
+    // Narrow tests override an unmanaged in-memory database without an active
+    // server. Production databases always have a manager owner and therefore
+    // require the certified logical server above.
+    final database = ref.read(appDatabaseProvider) as AppDatabase?;
+    if (database == null) return false;
+    final managedServerId = ref
+        .read(databaseManagerProvider)
+        .serverIdForDatabase(database);
+    return managedServerId == null;
+  } catch (_) {
+    return false;
+  }
+}
+
+bool openWebUiConversationReadIsCertifiedForPublication(
+  dynamic ref,
+  OpenWebUiConversationReadSnapshot snapshot,
+) {
+  return snapshot.databaseAccessPhase == OpenWebUiDatabaseAccessPhase.open &&
+      openWebUiConversationReadIsCurrent(ref, snapshot) &&
+      openWebUiAccountStorageIsCertified(ref);
 }
 
 typedef SocketServiceFactory =
@@ -3811,8 +4017,8 @@ Future<Conversation> _loadConversation(Ref ref, String conversationId) async {
               openWebUiOwnership.database,
             ) ||
             !openWebUiConversationReadIsCurrent(ref, openWebUiOwnership))) {
-      throw StateError(
-        'OpenWebUI conversation ownership changed while loading',
+      throw OpenWebUiConversationOwnershipException(
+        OpenWebUiConversationOwnershipFailureReason.changedWhileLoading,
       );
     }
     final local = withChatStorageProvenance(
@@ -3844,7 +4050,9 @@ Future<Conversation> _loadConversation(Ref ref, String conversationId) async {
 
   if (openWebUiOwnership == null ||
       !openWebUiConversationReadIsCurrent(ref, openWebUiOwnership)) {
-    throw StateError('OpenWebUI conversation ownership is unavailable');
+    throw OpenWebUiConversationOwnershipException(
+      OpenWebUiConversationOwnershipFailureReason.unavailable,
+    );
   }
   final api = openWebUiOwnership.api;
   if (api == null) {
@@ -3858,7 +4066,9 @@ Future<Conversation> _loadConversation(Ref ref, String conversationId) async {
   );
   final fullConversation = await api.getConversation(rawConversationId);
   if (!openWebUiConversationReadIsCurrent(ref, openWebUiOwnership)) {
-    throw StateError('OpenWebUI conversation ownership changed while fetching');
+    throw OpenWebUiConversationOwnershipException(
+      OpenWebUiConversationOwnershipFailureReason.changedWhileFetching,
+    );
   }
   DebugLogger.log(
     'load-ok',

--- a/lib/core/providers/app_startup_providers.dart
+++ b/lib/core/providers/app_startup_providers.dart
@@ -662,7 +662,13 @@ class OpenWebUiAccountStorageIsolation extends Notifier<void> {
     try {
       if (clearAccountChatState) {
         ref.invalidate(activeConversationInPlaceRemapProvider);
-        ref.invalidate(chatMessagesProvider);
+        // Keep the notifier instance alive across the auth boundary. Its
+        // active-conversation listener is installed once in build();
+        // invalidating a listened Notifier rebuilds the same instance and
+        // leaves that listener detached behind its initialization guard.
+        if (ref.exists(chatMessagesProvider)) {
+          ref.read(chatMessagesProvider.notifier).clearMessages();
+        }
       }
       ref.invalidate(conversationsProvider);
       ref.invalidate(foldersProvider);

--- a/lib/core/providers/app_startup_providers.dart
+++ b/lib/core/providers/app_startup_providers.dart
@@ -91,6 +91,25 @@ final userScopedProviderCleanupProvider = Provider<void>((ref) {
 typedef _OpenWebUiAccountIdentity = ({String token, String? userId});
 typedef OpenWebUiAccountCacheClear = Future<void> Function();
 typedef OpenWebUiCertifiedUserPersist = Future<void> Function(User user);
+typedef OpenWebUiPostCertificationSyncKickoff = void Function();
+
+final openWebUiPostCertificationSyncKickoffProvider =
+    Provider<OpenWebUiPostCertificationSyncKickoff>((ref) {
+      return () {
+        try {
+          ref
+              .read(syncTriggersProvider.notifier)
+              .requestPostCertificationSync();
+        } catch (error, stackTrace) {
+          DebugLogger.error(
+            'post-certification-sync-kickoff-failed',
+            scope: 'auth/storage-isolation',
+            error: error,
+            stackTrace: stackTrace,
+          );
+        }
+      };
+    });
 
 final openWebUiAccountCacheClearProvider = Provider<OpenWebUiAccountCacheClear>(
   (ref) {
@@ -150,7 +169,7 @@ class OpenWebUiAccountStorageIsolation extends Notifier<void> {
     );
   }
 
-  @visibleForTesting
+  /// Completes when the current account-storage isolation operation settles.
   Future<void> get settled => _settled;
 
   _OpenWebUiAccountIdentity? _identityFrom(AsyncValue<AuthState> value) {
@@ -595,6 +614,7 @@ class OpenWebUiAccountStorageIsolation extends Notifier<void> {
     ref.invalidate(foldersProvider);
     ref.invalidate(modelsProvider);
     ref.invalidate(currentUserProvider);
+    ref.read(openWebUiPostCertificationSyncKickoffProvider)();
     ref.read(openWebUiCachedAccountOwnerMismatchProvider.notifier).set(false);
     final authenticated = ref.read(authStateManagerProvider).asData?.value;
     final certifiedUser = authenticated?.user;

--- a/lib/core/services/navigation_service.dart
+++ b/lib/core/services/navigation_service.dart
@@ -30,6 +30,8 @@ class NavigationService {
       GlobalKey<NavigatorState>(debugLabel: 'rootNavigator');
 
   static GoRouter? _router;
+  static int _routeRevision = 0;
+  static String? _lastRoute;
 
   static GoRouter get router {
     final router = _router;
@@ -40,11 +42,25 @@ class NavigationService {
   }
 
   static void attachRouter(GoRouter router) {
+    _router?.routeInformationProvider.removeListener(_handleRouteChanged);
     _router = router;
+    _lastRoute = router.routeInformationProvider.value.uri.toString();
+    _routeRevision += 1;
+    router.routeInformationProvider.addListener(_handleRouteChanged);
+  }
+
+  static void _handleRouteChanged() {
+    final route = _router?.routeInformationProvider.value.uri.toString();
+    if (route == _lastRoute) return;
+    _lastRoute = route;
+    _routeRevision += 1;
   }
 
   static NavigatorState? get navigator => navigatorKey.currentState;
   static BuildContext? get context => navigatorKey.currentContext;
+
+  /// Changes whenever the attached router or its location changes.
+  static int get currentRouteRevision => _routeRevision;
 
   /// The current location reported by GoRouter.
   static String? get currentRoute {

--- a/lib/core/sync/pull_sync.dart
+++ b/lib/core/sync/pull_sync.dart
@@ -133,12 +133,14 @@ class PullSync {
     IdRemapper? remapper,
     ConversationParseOffload? parseOffload,
     ChatRowsParseOffload? rowsParseOffload,
+    SyncItemProgressCallback? onProgress,
   }) : _client = client,
        _db = db,
        _locks = locks,
        _remapper = remapper,
        _parseOffload = parseOffload,
-       _rowsParseOffload = rowsParseOffload;
+       _rowsParseOffload = rowsParseOffload,
+       _onProgress = onProgress;
 
   final SyncApiClient _client;
   final AppDatabase _db;
@@ -146,6 +148,7 @@ class PullSync {
   final IdRemapper? _remapper;
   final ConversationParseOffload? _parseOffload;
   final ChatRowsParseOffload? _rowsParseOffload;
+  final SyncItemProgressCallback? _onProgress;
 
   /// Runs one pull cycle. The watermark advances only when every list page
   /// and every chat fetch succeeded (REQ 5); on any failure it stays frozen
@@ -292,10 +295,12 @@ class PullSync {
     // 5. Chat fetches: newest-first (list order already is), worker pool of
     // exactly kPullFetchConcurrency sharing one queue index.
     final toFetch = changed.values.toList(growable: false);
+    _onProgress?.call(0, toFetch.length);
     final hasPendingCreateHashes = _remapper == null
         ? false
         : await _db.outboxDao.hasPendingCreateContentHashes();
     var nextIndex = 0;
+    var completedFetches = 0;
     Future<void> worker() async {
       while (true) {
         if (nextIndex >= toFetch.length) return;
@@ -321,6 +326,9 @@ class PullSync {
             stackTrace: stackTrace,
             data: {'chatId': item.id},
           );
+        } finally {
+          completedFetches++;
+          _onProgress?.call(completedFetches, toFetch.length);
         }
       }
     }

--- a/lib/core/sync/sync_engine.dart
+++ b/lib/core/sync/sync_engine.dart
@@ -39,15 +39,29 @@ const Duration kSyncPullDebounce = Duration(milliseconds: 300);
 
 enum SyncPhase { idle, running }
 
+enum SyncStage { chats, notes, finalizing }
+
 /// Engine status surfaced to the UI.
 class SyncStatus {
   const SyncStatus({
     this.phase = SyncPhase.idle,
+    this.stage,
+    this.completedItems = 0,
+    this.totalItems,
     this.lastSuccessUpdatedAtWatermark,
     this.lastError,
   });
 
   final SyncPhase phase;
+  final SyncStage? stage;
+  final int completedItems;
+  final int? totalItems;
+
+  double? get progress {
+    final total = totalItems;
+    if (phase != SyncPhase.running || total == null || total <= 0) return null;
+    return (completedItems / total).clamp(0.0, 1.0);
+  }
 
   /// Server epoch seconds of the last successful cycle's watermark.
   final int? lastSuccessUpdatedAtWatermark;
@@ -526,7 +540,7 @@ class SyncEngine extends _$SyncEngine {
     return pull.pullChat(chatId);
   }
 
-  PullSync? _buildPullSync() {
+  PullSync? _buildPullSync({SyncItemProgressCallback? onProgress}) {
     final db = _boundDb;
     final client = _boundClient;
     final chatLocks = _boundChatLocks;
@@ -549,6 +563,7 @@ class SyncEngine extends _$SyncEngine {
         response,
         debugLabel: 'pull.normalizeChatRows',
       ),
+      onProgress: onProgress,
     );
   }
 
@@ -959,6 +974,7 @@ class SyncEngine extends _$SyncEngine {
       if (ref.mounted) {
         state = SyncStatus(
           phase: SyncPhase.running,
+          stage: SyncStage.chats,
           lastSuccessUpdatedAtWatermark: state.lastSuccessUpdatedAtWatermark,
           lastError: state.lastError,
         );
@@ -1016,7 +1032,14 @@ class SyncEngine extends _$SyncEngine {
   Future<PullResult?> _runOnce(int cycleEpoch) async {
     final db = _boundDb;
     final clock = _boundClock;
-    final pull = _buildPullSync();
+    final pull = _buildPullSync(
+      onProgress: (completed, total) => _publishProgress(
+        cycleEpoch,
+        stage: SyncStage.chats,
+        completed: completed,
+        total: total,
+      ),
+    );
     if (db == null ||
         clock == null ||
         pull == null ||
@@ -1035,6 +1058,13 @@ class SyncEngine extends _$SyncEngine {
     final result = await pull.run();
     if (!_cycleStillBound(cycleEpoch, 'after-chat-pull')) return null;
 
+    _publishProgress(
+      cycleEpoch,
+      stage: SyncStage.notes,
+      completed: 0,
+      total: null,
+    );
+
     // Phase 5 (D-11): pull NOTES through the generic adapter driver, on the
     // SEPARATE nanosecond `notes_pull_watermark` (R-09 — never compared to the
     // chat seconds watermark; runPullFor reads the adapter's OWN key). A note
@@ -1046,7 +1076,16 @@ class SyncEngine extends _$SyncEngine {
     if (noteAdapter != null) {
       try {
         previousNotesWatermark = await db.syncMetaDao.getNotesPullWatermark();
-        noteResult = await runPullFor(noteAdapter, db: db);
+        noteResult = await runPullFor(
+          noteAdapter,
+          db: db,
+          onProgress: (completed, total) => _publishProgress(
+            cycleEpoch,
+            stage: SyncStage.notes,
+            completed: completed,
+            total: total,
+          ),
+        );
         DebugLogger.log(
           'note-cycle-done',
           scope: 'sync/notes',
@@ -1067,6 +1106,13 @@ class SyncEngine extends _$SyncEngine {
       }
       if (!_cycleStillBound(cycleEpoch, 'after-note-pull')) return null;
     }
+
+    _publishProgress(
+      cycleEpoch,
+      stage: SyncStage.finalizing,
+      completed: 0,
+      total: null,
+    );
 
     // A watermark-0 pull is itself a COMPLETE enumeration of the server set,
     // and a watermark-0 DB starts empty (fresh install / post-§9.3 cold pull),
@@ -1175,6 +1221,40 @@ class SyncEngine extends _$SyncEngine {
       await _scheduleFtsBuildIfNeeded(db, cycleEpoch);
     }
     return result;
+  }
+
+  void _publishProgress(
+    int cycleEpoch, {
+    required SyncStage stage,
+    required int completed,
+    required int? total,
+  }) {
+    if (!ref.mounted || !_running || cycleEpoch != _sessionEpoch) return;
+    final current = state;
+    if (current.phase != SyncPhase.running) return;
+
+    if (current.stage == stage &&
+        current.totalItems == total &&
+        total != null &&
+        total > 100 &&
+        completed < total &&
+        (current.completedItems * 100 ~/ total) == (completed * 100 ~/ total)) {
+      return;
+    }
+    if (current.stage == stage &&
+        current.completedItems == completed &&
+        current.totalItems == total) {
+      return;
+    }
+
+    state = SyncStatus(
+      phase: SyncPhase.running,
+      stage: stage,
+      completedItems: completed,
+      totalItems: total,
+      lastSuccessUpdatedAtWatermark: current.lastSuccessUpdatedAtWatermark,
+      lastError: current.lastError,
+    );
   }
 
   void _clearCachedDrainerIfIdle() {

--- a/lib/core/sync/sync_entity_adapter.dart
+++ b/lib/core/sync/sync_entity_adapter.dart
@@ -5,6 +5,9 @@ import '../database/app_database.dart';
 import '../database/daos/outbox_dao.dart';
 import '../utils/debug_logger.dart';
 
+/// Reports completed full-entity fetches once a pull has discovered its total.
+typedef SyncItemProgressCallback = void Function(int completed, int total);
+
 /// Decodes a JSON outbox-op `payload` string to a `Map<String, dynamic>`,
 /// returning an empty map when the payload is absent or not a JSON object.
 /// Shared by the sync-package adapters/drainer (CDT-RFC-001 Phase 5).
@@ -154,6 +157,7 @@ const int kAdapterPullFetchConcurrency = 4;
 Future<AdapterPullResult> runPullFor(
   SyncEntityAdapter adapter, {
   required AppDatabase db,
+  SyncItemProgressCallback? onProgress,
 }) async {
   final watermark = await _readWatermark(db, adapter.watermarkKey);
   final threshold = watermark - adapter.pullOverlap;
@@ -205,7 +209,9 @@ Future<AdapterPullResult> runPullFor(
   }
 
   final toFetch = changed.values.toList(growable: false);
+  onProgress?.call(0, toFetch.length);
   var nextIndex = 0;
+  var completedFetches = 0;
   var failedFetches = 0;
   Future<void> worker() async {
     while (true) {
@@ -226,6 +232,9 @@ Future<AdapterPullResult> runPullFor(
           stackTrace: stackTrace,
           data: {'id': item.id, 'watermarkKey': adapter.watermarkKey},
         );
+      } finally {
+        completedFetches++;
+        onProgress?.call(completedFetches, toFetch.length);
       }
     }
   }

--- a/lib/core/sync/sync_triggers.dart
+++ b/lib/core/sync/sync_triggers.dart
@@ -32,6 +32,7 @@ class SyncTriggers extends _$SyncTriggers {
   bool _isForeground = false;
   bool _startFired = false;
   bool _startCheckQueued = false;
+  bool _postCertificationPending = false;
   Object? _startDatabase;
   Object? _startClient;
 
@@ -43,7 +44,11 @@ class SyncTriggers extends _$SyncTriggers {
     // App start: fire once the first time (authenticated && db && client)
     // are all ready.
     ref.listen(isAuthenticatedProvider2, (previous, next) {
-      if (previous != true && next) {
+      if (!next) {
+        _postCertificationPending = false;
+        return;
+      }
+      if (previous != true) {
         _requestIfReady('auth');
       }
       _maybeFireStart();
@@ -116,22 +121,57 @@ class SyncTriggers extends _$SyncTriggers {
     _maybeFireStart();
   }
 
+  /// Requests the shared chat-and-note pull that follows account-storage
+  /// certification. The request remains pending until authentication, the
+  /// certified database, and its API client are all available.
+  void requestPostCertificationSync() {
+    final db = ref.read(appDatabaseProvider);
+    final client = ref.read(syncApiClientProvider);
+    if (_startFired &&
+        db != null &&
+        client != null &&
+        identical(db, _startDatabase) &&
+        identical(client, _startClient)) {
+      return;
+    }
+
+    _postCertificationPending = true;
+    _queueMaybeFireStart();
+  }
+
   void _maybeFireStart() {
     final db = ref.read(appDatabaseProvider);
     final client = ref.read(syncApiClientProvider);
     if (!ref.read(isAuthenticatedProvider2) || db == null || client == null) {
       return;
     }
-    if (_startFired &&
+
+    final currentPairAlreadyStarted =
+        _startFired &&
         identical(db, _startDatabase) &&
-        identical(client, _startClient)) {
+        identical(client, _startClient);
+    if (_postCertificationPending) {
+      if (currentPairAlreadyStarted) {
+        _postCertificationPending = false;
+        return;
+      }
+      if (_request('account-certified')) {
+        _postCertificationPending = false;
+        _recordStartedPair(db, client);
+      }
       return;
     }
+
+    if (currentPairAlreadyStarted) return;
     if (_request('start')) {
-      _startFired = true;
-      _startDatabase = db;
-      _startClient = client;
+      _recordStartedPair(db, client);
     }
+  }
+
+  void _recordStartedPair(Object database, Object client) {
+    _startFired = true;
+    _startDatabase = database;
+    _startClient = client;
   }
 
   void _queueMaybeFireStart() {

--- a/lib/features/channels/views/channel_page.dart
+++ b/lib/features/channels/views/channel_page.dart
@@ -1377,6 +1377,7 @@ class _ChannelToolbarPopupButton extends StatelessWidget {
         AdaptivePopupMenuItem<String>(
           value: 'leave',
           label: l10n?.channelLeave ?? 'Leave Channel',
+          isDestructive: true,
           icon: conduitAdaptivePopupMenuIcon(
             iosSymbol: 'rectangle.portrait.and.arrow.right',
             materialIcon: Icons.logout_outlined,
@@ -1385,6 +1386,7 @@ class _ChannelToolbarPopupButton extends StatelessWidget {
         AdaptivePopupMenuItem<String>(
           value: 'delete',
           label: l10n?.channelDelete ?? 'Delete Channel',
+          isDestructive: true,
           icon: conduitAdaptivePopupMenuIcon(
             iosSymbol: 'trash',
             materialIcon: Icons.delete_outline,

--- a/lib/features/chat/providers/chat_providers.dart
+++ b/lib/features/chat/providers/chat_providers.dart
@@ -1459,7 +1459,7 @@ class ChatMessagesNotifier extends Notifier<List<ChatMessage>> {
         );
 
         if (conversationUsesOpenWebUiStorage(next) &&
-            !_openWebUiAccountStorageIsCertified(ref)) {
+            !openWebUiAccountStorageIsCertified(ref)) {
           _modelRebindGeneration += 1;
           _cancelMessageStream();
           _stopRemoteTaskMonitor();
@@ -1580,7 +1580,7 @@ class ChatMessagesNotifier extends Notifier<List<ChatMessage>> {
     final activeConversation = ref.read(activeConversationProvider);
     _captureActiveOpenWebUiContext();
     if (conversationUsesOpenWebUiStorage(activeConversation) &&
-        !_openWebUiAccountStorageIsCertified(ref)) {
+        !openWebUiAccountStorageIsCertified(ref)) {
       _clearStaleOpenWebUiActiveConversation(activeConversation);
       return const <ChatMessage>[];
     }
@@ -1595,7 +1595,7 @@ class ChatMessagesNotifier extends Notifier<List<ChatMessage>> {
   void _clearStaleOpenWebUiActiveConversation(Conversation? expected) {
     if (expected == null) return;
     Future.microtask(() {
-      if (_disposed || _openWebUiAccountStorageIsCertified(ref)) return;
+      if (_disposed || openWebUiAccountStorageIsCertified(ref)) return;
       final current = ref.read(activeConversationProvider);
       if (identical(current, expected) ||
           isSameStoredConversation(current, expected)) {
@@ -9163,35 +9163,6 @@ bool conversationUsesOpenWebUiStorage(Conversation? conversation) {
     return false;
   }
   return true;
-}
-
-bool _openWebUiAccountStorageIsCertified(dynamic ref) {
-  try {
-    if (ref.read(openWebUiDatabaseAccessProvider) !=
-        OpenWebUiDatabaseAccessPhase.open) {
-      return false;
-    }
-    final certifiedServerId = ref.read(
-      openWebUiCertifiedDatabaseServerProvider,
-    );
-    final activeServer = ref.read(activeServerProvider);
-    if (activeServer is AsyncData<ServerConfig?>) {
-      final activeServerId = activeServer.value?.id;
-      if (activeServerId != null) return activeServerId == certifiedServerId;
-    }
-
-    // Narrow tests override an unmanaged in-memory database without an active
-    // server. Preserve that seam; production databases always have a manager
-    // owner and therefore require the certified logical server above.
-    final database = _readAppDatabaseOrNull(ref);
-    if (database == null) return false;
-    final managedServerId =
-        (ref.read(databaseManagerProvider) as DatabaseManager)
-            .serverIdForDatabase(database);
-    return managedServerId == null;
-  } catch (_) {
-    return false;
-  }
 }
 
 /// Durable send (CDT-RFC-001 §7.2 write path; Group 1 of the task_queue

--- a/lib/features/navigation/providers/conversation_selection_provider.dart
+++ b/lib/features/navigation/providers/conversation_selection_provider.dart
@@ -1,0 +1,544 @@
+import 'dart:async';
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+import '../../../core/database/database_provider.dart';
+import '../../../core/models/conversation.dart';
+import '../../../core/providers/app_providers.dart';
+import '../../../core/providers/app_startup_providers.dart';
+import '../../../core/utils/debug_logger.dart';
+import '../../chat/providers/chat_providers.dart' as chat;
+
+part 'conversation_selection_provider.g.dart';
+
+final conversationSelectionTimeoutProvider = Provider<Duration>(
+  (ref) => const Duration(seconds: 10),
+);
+
+@immutable
+class ConversationSelectionState {
+  const ConversationSelectionState({
+    this.generation = 0,
+    this.pendingConversationId,
+    this.isLoading = false,
+  });
+
+  final int generation;
+  final String? pendingConversationId;
+  final bool isLoading;
+}
+
+enum ConversationSelectionDisposition { committed, canceled, failed }
+
+@immutable
+class ConversationSelectionResult {
+  const ConversationSelectionResult._(
+    this.disposition, {
+    this.error,
+    this.stackTrace,
+  });
+
+  const ConversationSelectionResult.committed()
+    : this._(ConversationSelectionDisposition.committed);
+
+  const ConversationSelectionResult.canceled()
+    : this._(ConversationSelectionDisposition.canceled);
+
+  const ConversationSelectionResult.failed(Object error, StackTrace stackTrace)
+    : this._(
+        ConversationSelectionDisposition.failed,
+        error: error,
+        stackTrace: stackTrace,
+      );
+
+  final ConversationSelectionDisposition disposition;
+  final Object? error;
+  final StackTrace? stackTrace;
+}
+
+@Riverpod(keepAlive: true)
+class ConversationSelection extends _$ConversationSelection {
+  Completer<void>? _superseded;
+
+  @override
+  ConversationSelectionState build() {
+    ref.onDispose(() {
+      final cancellation = _superseded;
+      if (cancellation != null && !cancellation.isCompleted) {
+        cancellation.complete();
+      }
+    });
+    return const ConversationSelectionState();
+  }
+
+  bool _ownsGeneration(int generation) =>
+      ref.mounted && state.generation == generation;
+
+  bool _ownsIntent(int generation, OpenWebUiConversationSelectionOwner owner) =>
+      _ownsGeneration(generation) &&
+      openWebUiConversationSelectionOwnerIsCurrent(ref, owner);
+
+  ({Future<void> departed, bool Function() didDepart, void Function() close})
+  _watchOwnerDeparture(OpenWebUiConversationSelectionOwner owner) {
+    final departed = Completer<void>();
+    final closeSubscriptions = <void Function()>[];
+
+    void signal() {
+      if (!departed.isCompleted) departed.complete();
+    }
+
+    void checkCurrent() {
+      if (!openWebUiConversationSelectionOwnerIsCurrent(ref, owner)) {
+        signal();
+      }
+    }
+
+    final authSubscription = ref.listen<Object>(
+      openWebUiAuthSessionEpochProvider,
+      (_, next) {
+        if (!identical(next, owner.authSessionEpoch)) signal();
+      },
+    );
+    closeSubscriptions.add(authSubscription.close);
+
+    void watch<T>(ProviderListenable<T> provider) {
+      final subscription = ref.listen<T>(provider, (_, _) => checkCurrent());
+      closeSubscriptions.add(subscription.close);
+    }
+
+    watch(activeServerProvider);
+    watch(apiServiceProvider);
+    checkCurrent();
+
+    return (
+      departed: departed.future,
+      didDepart: () => departed.isCompleted,
+      close: () {
+        for (final close in closeSubscriptions) {
+          close();
+        }
+      },
+    );
+  }
+
+  Future<ConversationSelectionResult> select(Conversation summary) async {
+    final previousCancellation = _superseded;
+    if (previousCancellation != null && !previousCancellation.isCompleted) {
+      previousCancellation.complete();
+    }
+    final cancellation = Completer<void>();
+    _superseded = cancellation;
+
+    final scopedId = conversationScopedId(summary);
+    final generation = state.generation + 1;
+    final storage = chatStorageKindOf(summary);
+    final usesOpenWebUiStorage = chat.conversationUsesOpenWebUiStorage(summary);
+    state = ConversationSelectionState(
+      generation: generation,
+      pendingConversationId: scopedId,
+      isLoading: true,
+    );
+    ref.read(chat.isLoadingConversationProvider.notifier).set(true);
+
+    DebugLogger.log(
+      'selection-start',
+      scope: 'navigation/conversation-selection',
+      data: {
+        'id': scopedId,
+        'generation': generation,
+        'storage': storage?.name ?? 'unknown',
+      },
+    );
+
+    try {
+      final result = usesOpenWebUiStorage
+          ? await _selectOpenWebUi(
+              summary,
+              scopedId: scopedId,
+              generation: generation,
+              canceled: cancellation.future,
+            )
+          : await _selectLocal(
+              summary,
+              scopedId: scopedId,
+              generation: generation,
+              canceled: cancellation.future,
+            );
+      return result;
+    } catch (error, stackTrace) {
+      if (!_ownsGeneration(generation)) {
+        return const ConversationSelectionResult.canceled();
+      }
+      DebugLogger.error(
+        'selection-failed',
+        scope: 'navigation/conversation-selection',
+        error: error,
+        stackTrace: stackTrace,
+        data: {'id': scopedId, 'generation': generation},
+      );
+      return ConversationSelectionResult.failed(error, stackTrace);
+    } finally {
+      if (_ownsGeneration(generation)) {
+        state = ConversationSelectionState(generation: generation);
+        ref.read(chat.isLoadingConversationProvider.notifier).set(false);
+      }
+      if (identical(_superseded, cancellation)) {
+        _superseded = null;
+      }
+    }
+  }
+
+  Future<ConversationSelectionResult> _selectLocal(
+    Conversation summary, {
+    required String scopedId,
+    required int generation,
+    required Future<void> canceled,
+  }) async {
+    ref.invalidate(loadConversationProvider(scopedId));
+    final full = await _loadUntilCanceled(scopedId, canceled);
+    if (full == null || !_ownsGeneration(generation)) {
+      _logCanceled(scopedId, generation, reason: 'superseded');
+      return const ConversationSelectionResult.canceled();
+    }
+    _commit(summary, full, scopedId: scopedId);
+    _logCommitted(scopedId, generation, attempt: 1);
+    return const ConversationSelectionResult.committed();
+  }
+
+  Future<ConversationSelectionResult> _selectOpenWebUi(
+    Conversation summary, {
+    required String scopedId,
+    required int generation,
+    required Future<void> canceled,
+  }) async {
+    final owner = captureOpenWebUiConversationSelectionOwner(ref);
+    if (owner == null) {
+      throw StateError('OpenWebUI account ownership is unavailable');
+    }
+
+    final ownerWatch = _watchOwnerDeparture(owner);
+    final operationCanceled = Future.any<void>([canceled, ownerWatch.departed]);
+    try {
+      final timeout = ref.read(conversationSelectionTimeoutProvider);
+      final deadline = DateTime.now().add(timeout);
+      await _awaitInitialIsolation(
+        owner,
+        generation,
+        deadline,
+        operationCanceled,
+      );
+
+      var attempt = 0;
+      while (true) {
+        if (ownerWatch.didDepart() || !_ownsIntent(generation, owner)) {
+          _logCanceled(scopedId, generation, reason: 'owner-changed');
+          return const ConversationSelectionResult.canceled();
+        }
+
+        final ownership = await _waitForCertifiedRead(
+          owner,
+          generation,
+          deadline,
+          operationCanceled,
+        );
+        if (ownership == null) {
+          if (ownerWatch.didDepart() || !_ownsIntent(generation, owner)) {
+            _logCanceled(scopedId, generation, reason: 'owner-changed');
+            return const ConversationSelectionResult.canceled();
+          }
+          throw TimeoutException(
+            'Timed out waiting for OpenWebUI conversation storage',
+            timeout,
+          );
+        }
+
+        attempt += 1;
+        DebugLogger.log(
+          'selection-load-attempt',
+          scope: 'navigation/conversation-selection',
+          data: {'id': scopedId, 'generation': generation, 'attempt': attempt},
+        );
+
+        Conversation full;
+        try {
+          ref.invalidate(loadConversationProvider(scopedId));
+          final loaded = await _loadUntilCanceled(
+            scopedId,
+            operationCanceled,
+            deadline: deadline,
+            timeout: timeout,
+          );
+          if (loaded == null) {
+            _logCanceled(
+              scopedId,
+              generation,
+              reason: ownerWatch.didDepart() ? 'owner-changed' : 'superseded',
+            );
+            return const ConversationSelectionResult.canceled();
+          }
+          full = loaded;
+        } on OpenWebUiConversationOwnershipException catch (error, stackTrace) {
+          if (ownerWatch.didDepart() || !_ownsIntent(generation, owner)) {
+            _logCanceled(scopedId, generation, reason: 'owner-changed');
+            return const ConversationSelectionResult.canceled();
+          }
+          if (!DateTime.now().isBefore(deadline)) {
+            Error.throwWithStackTrace(error, stackTrace);
+          }
+          DebugLogger.warning(
+            'selection-retry-ownership',
+            scope: 'navigation/conversation-selection',
+            data: {
+              'id': scopedId,
+              'generation': generation,
+              'attempt': attempt,
+              'reason': error.reason.name,
+            },
+          );
+          await _paceRetry(deadline, operationCanceled);
+          continue;
+        }
+
+        if (ownerWatch.didDepart() || !_ownsIntent(generation, owner)) {
+          _logCanceled(scopedId, generation, reason: 'owner-changed');
+          return const ConversationSelectionResult.canceled();
+        }
+        if (!openWebUiConversationReadIsCertifiedForPublication(
+          ref,
+          ownership,
+        )) {
+          if (!DateTime.now().isBefore(deadline)) {
+            throw TimeoutException(
+              'OpenWebUI conversation ownership did not stabilize',
+              timeout,
+            );
+          }
+          DebugLogger.log(
+            'selection-read-snapshot-replaced',
+            scope: 'navigation/conversation-selection',
+            data: {
+              'id': scopedId,
+              'generation': generation,
+              'attempt': attempt,
+            },
+          );
+          await _paceRetry(deadline, operationCanceled);
+          continue;
+        }
+
+        _commit(summary, full, scopedId: scopedId);
+        _logCommitted(scopedId, generation, attempt: attempt);
+        return const ConversationSelectionResult.committed();
+      }
+    } finally {
+      ownerWatch.close();
+    }
+  }
+
+  Future<void> _awaitInitialIsolation(
+    OpenWebUiConversationSelectionOwner owner,
+    int generation,
+    DateTime deadline,
+    Future<void> canceled,
+  ) async {
+    final settled = ref
+        .read(openWebUiAccountStorageIsolationProvider.notifier)
+        .settled;
+    final remaining = deadline.difference(DateTime.now());
+    if (remaining <= Duration.zero) return;
+
+    final ownerChanged = Completer<void>();
+    final closeSubscriptions = <void Function()>[];
+
+    void signal() {
+      if (!ownerChanged.isCompleted) ownerChanged.complete();
+    }
+
+    void watch<T>(ProviderListenable<T> provider) {
+      final subscription = ref.listen<T>(provider, (_, _) => signal());
+      closeSubscriptions.add(subscription.close);
+    }
+
+    watch(openWebUiAuthSessionEpochProvider);
+    watch(activeServerProvider);
+    final timer = Timer(remaining, signal);
+    try {
+      await Future.any<void>([settled, ownerChanged.future, canceled]);
+    } finally {
+      timer.cancel();
+      for (final close in closeSubscriptions) {
+        close();
+      }
+    }
+
+    if (!_ownsIntent(generation, owner)) return;
+  }
+
+  Future<OpenWebUiConversationReadSnapshot?> _waitForCertifiedRead(
+    OpenWebUiConversationSelectionOwner owner,
+    int generation,
+    DateTime deadline,
+    Future<void> canceled,
+  ) async {
+    while (_ownsIntent(generation, owner)) {
+      final ownership = captureOpenWebUiConversationRead(ref);
+      if (ownership != null &&
+          openWebUiConversationReadIsCertifiedForPublication(ref, ownership)) {
+        return ownership;
+      }
+      if (!DateTime.now().isBefore(deadline)) return null;
+
+      DebugLogger.log(
+        'selection-waiting-for-ownership',
+        scope: 'navigation/conversation-selection',
+        data: {
+          'generation': generation,
+          'phase': ref.read(openWebUiDatabaseAccessProvider).name,
+        },
+      );
+      await _waitForReadinessChange(owner, generation, deadline, canceled);
+    }
+    return null;
+  }
+
+  Future<void> _waitForReadinessChange(
+    OpenWebUiConversationSelectionOwner owner,
+    int generation,
+    DateTime deadline,
+    Future<void> canceled,
+  ) async {
+    final completer = Completer<void>();
+    final closeSubscriptions = <void Function()>[];
+    Timer? timer;
+
+    void signal() {
+      if (!completer.isCompleted) completer.complete();
+    }
+
+    void watch<T>(ProviderListenable<T> provider) {
+      final subscription = ref.listen<T>(provider, (_, _) => signal());
+      closeSubscriptions.add(subscription.close);
+    }
+
+    watch(openWebUiDatabaseAccessProvider);
+    watch(openWebUiCertifiedDatabaseServerProvider);
+    watch(appDatabaseProvider);
+    watch(apiServiceProvider);
+    watch(activeServerProvider);
+    watch(openWebUiAuthSessionEpochProvider);
+
+    final remaining = deadline.difference(DateTime.now());
+    timer = Timer(
+      remaining > Duration.zero ? remaining : Duration.zero,
+      signal,
+    );
+
+    final ownership = captureOpenWebUiConversationRead(ref);
+    if (!_ownsIntent(generation, owner) ||
+        (ownership != null &&
+            openWebUiConversationReadIsCertifiedForPublication(
+              ref,
+              ownership,
+            ))) {
+      signal();
+    }
+
+    try {
+      await Future.any<void>([completer.future, canceled]);
+    } finally {
+      timer.cancel();
+      for (final close in closeSubscriptions) {
+        close();
+      }
+    }
+  }
+
+  Future<Conversation?> _loadUntilCanceled(
+    String scopedId,
+    Future<void> canceled, {
+    DateTime? deadline,
+    Duration? timeout,
+  }) async {
+    Timer? timer;
+    final futures = <Future<Conversation?>>[
+      ref
+          .read(loadConversationProvider(scopedId).future)
+          .then<Conversation?>((conversation) => conversation),
+      canceled.then<Conversation?>((_) => null),
+    ];
+
+    if (deadline != null) {
+      final timedOut = Completer<Conversation?>();
+      final remaining = deadline.difference(DateTime.now());
+      timer = Timer(remaining > Duration.zero ? remaining : Duration.zero, () {
+        timedOut.completeError(
+          TimeoutException('Timed out loading conversation', timeout),
+        );
+      });
+      futures.add(timedOut.future);
+    }
+
+    try {
+      return await Future.any(futures);
+    } finally {
+      timer?.cancel();
+    }
+  }
+
+  Future<void> _paceRetry(DateTime deadline, Future<void> canceled) async {
+    final remaining = deadline.difference(DateTime.now());
+    if (remaining <= Duration.zero) return;
+    const retryDelay = Duration(milliseconds: 25);
+    final delay = remaining < retryDelay ? remaining : retryDelay;
+    final elapsed = Completer<void>();
+    final timer = Timer(delay, elapsed.complete);
+    try {
+      await Future.any<void>([elapsed.future, canceled]);
+    } finally {
+      timer.cancel();
+    }
+  }
+
+  void _commit(
+    Conversation summary,
+    Conversation full, {
+    required String scopedId,
+  }) {
+    ref.read(temporaryChatEnabledProvider.notifier).set(false);
+    final outgoing = ref.read(activeConversationProvider);
+    if (!isSameStoredConversation(outgoing, summary)) {
+      chat.clearSelectedFiltersForConversationBoundary(ref);
+      if (outgoing != null) {
+        markConversationRead(ref, conversationScopedId(outgoing));
+      }
+    }
+
+    final selectedReadAt = DateTime.now();
+    markConversationRead(ref, scopedId, readAt: selectedReadAt);
+    final currentReadAt = full.lastReadAt;
+    final selected =
+        currentReadAt == null || selectedReadAt.isAfter(currentReadAt)
+        ? full.copyWith(lastReadAt: selectedReadAt)
+        : full;
+    ref.read(pendingFolderIdProvider.notifier).clear();
+    ref.read(activeConversationProvider.notifier).set(selected);
+  }
+
+  void _logCanceled(String scopedId, int generation, {required String reason}) {
+    DebugLogger.log(
+      'selection-canceled',
+      scope: 'navigation/conversation-selection',
+      data: {'id': scopedId, 'generation': generation, 'reason': reason},
+    );
+  }
+
+  void _logCommitted(String scopedId, int generation, {required int attempt}) {
+    DebugLogger.log(
+      'selection-committed',
+      scope: 'navigation/conversation-selection',
+      data: {'id': scopedId, 'generation': generation, 'attempt': attempt},
+    );
+  }
+}

--- a/lib/features/navigation/views/folder_page.dart
+++ b/lib/features/navigation/views/folder_page.dart
@@ -9,7 +9,6 @@ import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
-import '../../../core/database/local_conversation_loader.dart';
 import '../../../core/models/conversation.dart';
 import '../../../core/models/folder.dart';
 import '../../../core/models/model.dart';
@@ -18,6 +17,7 @@ import '../../../core/services/haptic_service.dart';
 import '../../../core/services/native_sheet_bridge.dart';
 import '../../../core/services/native_sheet_hydration_service.dart';
 import '../../../core/services/navigation_service.dart';
+import '../../../core/services/user_friendly_error_handler.dart';
 import '../../../core/services/settings_service.dart';
 import '../../../core/widgets/error_boundary.dart';
 import '../../../l10n/app_localizations.dart';
@@ -49,6 +49,7 @@ import '../../chat/widgets/modern_chat_input.dart';
 import '../../chat/widgets/server_file_picker_sheet.dart';
 import '../../chat/voice_call/presentation/voice_call_launcher.dart';
 import '../../tools/providers/tools_providers.dart';
+import '../providers/conversation_selection_provider.dart';
 import '../widgets/conversation_tile.dart';
 import '../widgets/folder_icon.dart';
 
@@ -82,11 +83,9 @@ class FolderPage extends ConsumerStatefulWidget {
 }
 
 class _FolderPageState extends ConsumerState<FolderPage> {
-  bool _isLoadingConversation = false;
   bool _isSendingComposerMessage = false;
   double _inputHeight = 0;
   int _composerResetNonce = 0;
-  String? _pendingConversationId;
 
   @override
   void initState() {
@@ -457,7 +456,8 @@ class _FolderPageState extends ConsumerState<FolderPage> {
   }
 
   Future<void> _handleComposerSend(String text) async {
-    if (_isSendingComposerMessage || _isLoadingConversation) {
+    if (_isSendingComposerMessage ||
+        ref.read(conversationSelectionProvider).isLoading) {
       return;
     }
 
@@ -1154,110 +1154,39 @@ class _FolderPageState extends ConsumerState<FolderPage> {
     context.goNamed(RouteNames.folder, pathParameters: {'id': folderId});
   }
 
-  Future<void> _selectConversation(String conversationId) async {
-    if (_isLoadingConversation) {
-      return;
-    }
-
-    setState(() => _isLoadingConversation = true);
-    final container = ProviderScope.containerOf(context, listen: false);
-    final ownership = captureOpenWebUiConversationRead(container);
-
-    try {
-      if (ownership == null) return;
-      final outgoing = container.read(activeConversationProvider);
-      if (outgoing == null ||
-          !conversationMatchesScopedId(outgoing, conversationId)) {
-        chat.clearSelectedFiltersForConversationBoundary(container);
-      }
-      container.read(temporaryChatEnabledProvider.notifier).set(false);
-      container.read(chat.isLoadingConversationProvider.notifier).set(true);
-      _pendingConversationId = conversationId;
-
-      container.read(activeConversationProvider.notifier).clear();
-      container.read(chat.chatMessagesProvider.notifier).clearMessages();
-      container.read(pendingFolderIdProvider.notifier).clear();
-
-      NavigationService.router.go(Routes.chat);
-
-      // DB-first open (CDT-RFC-001 Phase 1): a synced local row renders
-      // instantly — offline included — and a background pull freshens it.
-      final local = await loadLocalConversation(
-        container,
-        conversationId,
-        ownership: ownership,
-      );
-      if (!openWebUiConversationReadIsCurrent(container, ownership)) return;
-      if (local != null) {
-        container.read(activeConversationProvider.notifier).set(local);
-        schedulePullChatNow(container, conversationId, ownership: ownership);
-      } else {
-        Future<void> useCachedConversation() async {
-          if (!openWebUiConversationReadIsCurrent(container, ownership)) {
-            return;
-          }
-          final conversations = await container.read(
-            conversationsProvider.future,
-          );
-          if (!openWebUiConversationReadIsCurrent(container, ownership)) {
-            return;
-          }
-          Conversation? conversation;
-          for (final item in conversations) {
-            if (item.id == conversationId) {
-              conversation = item;
-              break;
-            }
-          }
-          if (conversation != null) {
-            container
-                .read(activeConversationProvider.notifier)
-                .set(conversation);
-          }
+  Future<void> _selectConversation(Conversation conversation) async {
+    final originRoute = NavigationService.currentRoute;
+    final originRouteRevision = NavigationService.currentRouteRevision;
+    final result = await ref
+        .read(conversationSelectionProvider.notifier)
+        .select(conversation);
+    switch (result.disposition) {
+      case ConversationSelectionDisposition.committed:
+        if (!mounted ||
+            (NavigationService.currentRoute != originRoute ||
+                NavigationService.currentRouteRevision !=
+                    originRouteRevision)) {
+          return;
         }
-
-        final api = ownership.api;
-        if (api != null) {
-          try {
-            final fullConversation = await api.getConversation(conversationId);
-            if (!openWebUiConversationReadIsCurrent(container, ownership)) {
-              return;
-            }
-            container
-                .read(activeConversationProvider.notifier)
-                .set(fullConversation);
-            // Materialize the local row so the next open is DB-first.
-            schedulePullChatNow(
-              container,
-              conversationId,
-              ownership: ownership,
-            );
-          } catch (error, stackTrace) {
-            if (!openWebUiConversationReadIsCurrent(container, ownership)) {
-              return;
-            }
-            DebugLogger.error(
-              'folder-conversation-fetch-failed',
-              scope: 'navigation/folder',
-              error: error,
-              stackTrace: stackTrace,
-              data: {'conversationId': conversationId},
-            );
-            await useCachedConversation();
-          }
-        } else {
-          await useCachedConversation();
+        NavigationService.router.go(Routes.chat);
+        return;
+      case ConversationSelectionDisposition.canceled:
+        return;
+      case ConversationSelectionDisposition.failed:
+        if (!mounted ||
+            result.error == null ||
+            (NavigationService.currentRoute != originRoute ||
+                NavigationService.currentRouteRevision !=
+                    originRouteRevision)) {
+          return;
         }
-      }
-    } catch (_) {
-      // The chat remains empty on failure. Shared loading state is reset in
-      // finally, including ownership changes that intentionally return early.
-    } finally {
-      container.read(chat.isLoadingConversationProvider.notifier).set(false);
-      _pendingConversationId = null;
-      if (mounted) {
-        setState(() => _isLoadingConversation = false);
-      }
+        UserFriendlyErrorHandler().showErrorSnackbar(
+          context,
+          result.error,
+          onRetry: () {
+            if (mounted) unawaited(_selectConversation(conversation));
+          },
+        );
     }
   }
 
@@ -1330,7 +1259,8 @@ class _FolderPageState extends ConsumerState<FolderPage> {
                   ),
                   onSendMessage: _handleComposerSend,
                   enabled:
-                      !_isLoadingConversation && !_isSendingComposerMessage,
+                      !ref.watch(conversationSelectionProvider).isLoading &&
+                      !_isSendingComposerMessage,
                   bottomPadding: 0,
                   onVoiceCall: _handleVoiceCall,
                   onFileAttachment: _handleFileAttachment,
@@ -1443,9 +1373,14 @@ class _FolderPageState extends ConsumerState<FolderPage> {
           sliver: SliverList(
             delegate: SliverChildBuilderDelegate((context, index) {
               final conversation = sortedConversations[index];
-              final isLoadingSelected =
-                  (_pendingConversationId == conversation.id) &&
-                  ref.watch(chat.isLoadingConversationProvider);
+              final scopedId = conversationScopedId(conversation);
+              final isLoadingSelected = ref.watch(
+                conversationSelectionProvider.select(
+                  (selection) =>
+                      selection.isLoading &&
+                      selection.pendingConversationId == scopedId,
+                ),
+              );
 
               return ConduitContextMenu(
                 actions: buildConversationActionsWithFolders(
@@ -1463,9 +1398,7 @@ class _FolderPageState extends ConsumerState<FolderPage> {
                   pinned: conversation.pinned,
                   selected: false,
                   isLoading: isLoadingSelected,
-                  onTap: _isLoadingConversation
-                      ? null
-                      : () => _selectConversation(conversation.id),
+                  onTap: () => _selectConversation(conversation),
                 ),
               );
             }, childCount: sortedConversations.length),

--- a/lib/features/navigation/widgets/chats_drawer.dart
+++ b/lib/features/navigation/widgets/chats_drawer.dart
@@ -11,9 +11,9 @@ import '../../../core/providers/app_providers.dart';
 import '../../../core/services/native_sheet_bridge.dart';
 import '../../../shared/theme/theme_extensions.dart';
 import '../../../shared/utils/platform_scroll_physics.dart';
-import '../../chat/providers/chat_providers.dart' as chat;
 import '../../../core/utils/debug_logger.dart';
 import '../../../core/services/navigation_service.dart';
+import '../../../core/services/user_friendly_error_handler.dart';
 import '../../../shared/widgets/conduit_components.dart';
 import '../../../shared/widgets/conduit_loading.dart';
 import '../../../shared/widgets/themed_dialogs.dart';
@@ -28,6 +28,7 @@ import 'create_folder_dialog.dart';
 import 'folder_tree_guides.dart';
 import 'drawer_section_notifiers.dart';
 import 'folder_icon.dart';
+import '../providers/conversation_selection_provider.dart';
 import '../providers/sidebar_providers.dart';
 
 /// Chevron / expand icon for section headers — matches folder row disclosure.
@@ -58,8 +59,6 @@ class _ChatsDrawerState extends ConsumerState<ChatsDrawer>
   final ScrollController _listController = ScrollController();
   Timer? _debounce;
   String _query = '';
-  bool _isLoadingConversation = false;
-  String? _pendingConversationId;
   bool _isLoadingMoreConversations = false;
   bool _isRefreshingEmptyState = false;
   bool _hasVisiblePaginatedRows = false;
@@ -1676,9 +1675,12 @@ class _ChatsDrawerState extends ConsumerState<ChatsDrawer>
       ),
     );
     final title = conversation.title.isEmpty ? 'Chat' : conversation.title;
-    final bool isLoadingSelected =
-        (_pendingConversationId == scopedId) &&
-        (ref.watch(chat.isLoadingConversationProvider) == true);
+    final isLoadingSelected = ref.watch(
+      conversationSelectionProvider.select(
+        (selection) =>
+            selection.isLoading && selection.pendingConversationId == scopedId,
+      ),
+    );
     final bool isPinned = conversation.pinned;
     final activeChatIds = ref.watch(activeChatIdsProvider);
     final bool isGenerating = _conversationIsActive(
@@ -1702,9 +1704,7 @@ class _ChatsDrawerState extends ConsumerState<ChatsDrawer>
       badge: isDirectLocalConversation(conversation)
           ? AppLocalizations.of(context)!.onDevice
           : null,
-      onTap: _isLoadingConversation
-          ? null
-          : () => _selectConversation(context, conversation),
+      onTap: () => _selectConversation(conversation),
     );
 
     final wrappedTile = showHierarchyBranch
@@ -1815,100 +1815,45 @@ class _ChatsDrawerState extends ConsumerState<ChatsDrawer>
     );
   }
 
-  Future<void> _selectConversation(
-    BuildContext context,
-    Conversation conversation,
-  ) async {
-    if (_isLoadingConversation) return;
-    final scopedId = conversationScopedId(conversation);
-    setState(() => _isLoadingConversation = true);
-    // Keep a reference only if needed in the future; currently unused.
-    // Capture a provider container detached from this widget's lifecycle so
-    // we can continue to read/write providers after the drawer is closed.
-    final container = ProviderScope.containerOf(context, listen: false);
-    final usesOpenWebUiStorage = chat.conversationUsesOpenWebUiStorage(
-      conversation,
-    );
-    final openWebUiOwnership = usesOpenWebUiStorage
-        ? captureOpenWebUiConversationRead(container)
-        : null;
-    if (usesOpenWebUiStorage && openWebUiOwnership == null) {
-      if (mounted) setState(() => _isLoadingConversation = false);
-      return;
-    }
-
-    // Selecting a real conversation exits temporary mode
-    container.read(temporaryChatEnabledProvider.notifier).set(false);
-    final outgoing = container.read(activeConversationProvider);
-    if (!isSameStoredConversation(outgoing, conversation)) {
-      chat.clearSelectedFiltersForConversationBoundary(container);
-      if (outgoing != null) {
-        markConversationRead(container, conversationScopedId(outgoing));
-      }
-    }
-    final selectedReadAt = DateTime.now();
-    markConversationRead(container, scopedId, readAt: selectedReadAt);
-
-    // Overlay the just-selected read time when it is newer than the source's
-    // own lastReadAt, so the active conversation reflects the optimistic read.
-    Conversation withOptimisticReadAt(Conversation c) {
-      final readAt = c.lastReadAt;
-      return readAt == null || selectedReadAt.isAfter(readAt)
-          ? c.copyWith(lastReadAt: selectedReadAt)
-          : c;
-    }
-
-    try {
-      // Mark global loading to show skeletons in chat
-      container.read(chat.isLoadingConversationProvider.notifier).set(true);
-      _pendingConversationId = scopedId;
-
-      // Immediately clear current chat to show loading skeleton in the chat view
-      container.read(activeConversationProvider.notifier).clear();
-      container.read(chat.chatMessagesProvider.notifier).clearMessages();
-
-      // Clear any pending folder selection when selecting an existing conversation
-      container.read(pendingFolderIdProvider.notifier).clear();
-
-      // Navigate to chat route (needed when sidebar is open from
-      // a non-chat page like notes editor or channel page).
-      NavigationService.router.go(Routes.chat);
-
-      // Close the slide drawer for faster perceived performance
-      // (only on mobile; keep tablet drawer unless user toggles it)
-      if (mounted) {
+  Future<void> _selectConversation(Conversation conversation) async {
+    final originRoute = NavigationService.currentRoute;
+    final originRouteRevision = NavigationService.currentRouteRevision;
+    final result = await ref
+        .read(conversationSelectionProvider.notifier)
+        .select(conversation);
+    switch (result.disposition) {
+      case ConversationSelectionDisposition.committed:
+        if (!mounted ||
+            (NavigationService.currentRoute != originRoute ||
+                NavigationService.currentRouteRevision !=
+                    originRouteRevision)) {
+          return;
+        }
+        NavigationService.router.go(Routes.chat);
         final mediaQuery = MediaQuery.maybeOf(context);
         final isTablet =
             mediaQuery != null && mediaQuery.size.shortestSide >= 600;
         if (!isTablet) {
           ResponsiveDrawerLayout.of(context)?.close();
         }
-      }
-
-      // Resolve through the provenance-aware repository. This reads both the
-      // OpenWebUI cache and the independent on-device direct-chat database,
-      // while only scheduling a server pull for OpenWebUI-owned rows.
-      final full = await container.read(
-        loadConversationProvider(scopedId).future,
-      );
-      if (openWebUiOwnership != null &&
-          !openWebUiConversationReadIsCurrent(container, openWebUiOwnership)) {
-        container.read(chat.isLoadingConversationProvider.notifier).set(false);
-        _pendingConversationId = null;
         return;
-      }
-      container
-          .read(activeConversationProvider.notifier)
-          .set(withOptimisticReadAt(full));
-
-      // Clear loading after data is ready
-      container.read(chat.isLoadingConversationProvider.notifier).set(false);
-      _pendingConversationId = null;
-    } catch (_) {
-      container.read(chat.isLoadingConversationProvider.notifier).set(false);
-      _pendingConversationId = null;
-    } finally {
-      if (mounted) setState(() => _isLoadingConversation = false);
+      case ConversationSelectionDisposition.canceled:
+        return;
+      case ConversationSelectionDisposition.failed:
+        if (!mounted ||
+            result.error == null ||
+            (NavigationService.currentRoute != originRoute ||
+                NavigationService.currentRouteRevision !=
+                    originRouteRevision)) {
+          return;
+        }
+        UserFriendlyErrorHandler().showErrorSnackbar(
+          context,
+          result.error,
+          onRetry: () {
+            if (mounted) unawaited(_selectConversation(conversation));
+          },
+        );
     }
   }
 

--- a/lib/features/navigation/widgets/sidebar_page.dart
+++ b/lib/features/navigation/widgets/sidebar_page.dart
@@ -7,6 +7,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../../core/providers/app_providers.dart';
+import '../../../core/sync/sync_engine.dart';
 import '../../../shared/theme/theme_extensions.dart';
 import '../../../shared/utils/ui_utils.dart';
 import '../../../shared/widgets/adaptive_toolbar_components.dart';
@@ -104,6 +105,43 @@ class _SidebarTabStack extends StatelessWidget {
             ),
           ),
       ],
+    );
+  }
+}
+
+class _SidebarSyncProgressBar extends StatelessWidget {
+  const _SidebarSyncProgressBar({required this.status});
+
+  final SyncStatus status;
+
+  @override
+  Widget build(BuildContext context) {
+    if (status.phase != SyncPhase.running) return const SizedBox.shrink();
+
+    final localizations = AppLocalizations.of(context)!;
+    final theme = context.conduitTheme;
+    final label = switch (status.stage) {
+      SyncStage.notes => localizations.sidebarSyncingNotes,
+      SyncStage.finalizing => localizations.sidebarFinishingSync,
+      SyncStage.chats || null => localizations.sidebarSyncingChats,
+    };
+    final progress = status.progress;
+    final reduceMotion = MediaQuery.disableAnimationsOf(context);
+    final semanticsValue = progress == null
+        ? null
+        : '${(progress * 100).round()}%';
+
+    return ClipRRect(
+      borderRadius: BorderRadius.circular(AppBorderRadius.pill),
+      child: LinearProgressIndicator(
+        key: const ValueKey<String>('sidebar-sync-progress'),
+        minHeight: 3,
+        value: progress ?? (reduceMotion ? 0.08 : null),
+        semanticsLabel: label,
+        semanticsValue: semanticsValue,
+        color: theme.sidebarPrimary,
+        backgroundColor: theme.sidebarBorder.withValues(alpha: 0.45),
+      ),
     );
   }
 }
@@ -577,6 +615,19 @@ class _SidebarPageState extends ConsumerState<SidebarPage> {
       sidebarBody,
       hasBottomNavigationBar: hasBottomNavigationBar,
     );
+    final syncStatus = ref.watch(syncEngineProvider);
+    final sidebarBodyWithSyncProgress = Stack(
+      fit: StackFit.expand,
+      children: [
+        Positioned.fill(child: sidebarBodyWithBottomFade),
+        Positioned(
+          top: Spacing.xs,
+          left: Spacing.md,
+          right: Spacing.md,
+          child: _SidebarSyncProgressBar(status: syncStatus),
+        ),
+      ],
+    );
 
     return KeyedSubtree(
       key: const ValueKey<String>('sidebar-page-surface'),
@@ -624,7 +675,7 @@ class _SidebarPageState extends ConsumerState<SidebarPage> {
               actions: appBarActions,
               minimizeBehavior: TabBarMinimizeBehavior.never,
               showNativeView: composeNativeIos26Chrome,
-              body: sidebarBodyWithBottomFade,
+              body: sidebarBodyWithSyncProgress,
             );
           }
 
@@ -643,7 +694,7 @@ class _SidebarPageState extends ConsumerState<SidebarPage> {
               ),
             ),
             bottomNavigationBar: bottomNavigationBar,
-            body: sidebarBodyWithBottomFade,
+            body: sidebarBodyWithSyncProgress,
           );
         },
       ),

--- a/lib/features/navigation/widgets/sidebar_page.dart
+++ b/lib/features/navigation/widgets/sidebar_page.dart
@@ -615,7 +615,6 @@ class _SidebarPageState extends ConsumerState<SidebarPage> {
       sidebarBody,
       hasBottomNavigationBar: hasBottomNavigationBar,
     );
-    final syncStatus = ref.watch(syncEngineProvider);
     final sidebarBodyWithSyncProgress = Stack(
       fit: StackFit.expand,
       children: [
@@ -624,7 +623,10 @@ class _SidebarPageState extends ConsumerState<SidebarPage> {
           top: Spacing.xs,
           left: Spacing.md,
           right: Spacing.md,
-          child: _SidebarSyncProgressBar(status: syncStatus),
+          child: Consumer(
+            builder: (context, ref, _) =>
+                _SidebarSyncProgressBar(status: ref.watch(syncEngineProvider)),
+          ),
         ),
       ],
     );

--- a/lib/features/notes/views/note_editor_page.dart
+++ b/lib/features/notes/views/note_editor_page.dart
@@ -2782,6 +2782,7 @@ class _NoteEditorToolbarPopupButton extends StatelessWidget {
         AdaptivePopupMenuItem<String>(
           value: 'delete',
           label: l10n.delete,
+          isDestructive: true,
           icon: conduitAdaptivePopupMenuIcon(
             iosSymbol: 'trash',
             materialIcon: Icons.delete_outline,

--- a/lib/features/terminal/widgets/terminal_tab.dart
+++ b/lib/features/terminal/widgets/terminal_tab.dart
@@ -1664,6 +1664,7 @@ class _TerminalTabState extends ConsumerState<TerminalTab>
       AdaptivePopupMenuItem<String>(
         value: 'delete',
         label: l10n.delete,
+        isDestructive: true,
         icon: conduitAdaptivePopupMenuIcon(
           iosSymbol: 'trash',
           materialIcon: Icons.delete_outline,

--- a/lib/features/workspace/views/workspace_page.dart
+++ b/lib/features/workspace/views/workspace_page.dart
@@ -219,12 +219,12 @@ class WorkspaceScaffold extends ConsumerWidget {
       );
     }
 
-    // The adaptive iOS nav bar is a translucent overlay, so the body renders
-    // behind it. Mirror SettingsPageScaffold and inset the top by the status
-    // bar + nav bar height so the section switcher and content clear it;
-    // Android's Material app bar reserves its own space, so no extra inset is
-    // needed.
-    final topInset = Theme.of(context).platform == TargetPlatform.iOS
+    // iOS 26 native toolbars contribute their height to MediaQuery padding as
+    // of adaptive_platform_ui 0.1.110. Older Cupertino bars still need the
+    // explicit status-bar + navigation-bar offset used before that release.
+    final isIos = Theme.of(context).platform == TargetPlatform.iOS;
+    final usesNativeToolbarInset = isIos && PlatformInfo.isIOS26OrHigher();
+    final topInset = isIos && !usesNativeToolbarInset
         ? MediaQuery.paddingOf(context).top + kTextTabBarHeight
         : 0.0;
 
@@ -236,7 +236,8 @@ class WorkspaceScaffold extends ConsumerWidget {
             canCreate: _canCreateSection(ref, section),
           )
         : AdaptiveAppBar(
-            title: '${l10n.workspaceTitle} · ${_sectionLabel(l10n, section)}',
+            title: l10n.workspaceTitle,
+            subtitle: _sectionLabel(l10n, section),
             leading: _workspaceExitButton(context),
           );
 
@@ -248,7 +249,7 @@ class WorkspaceScaffold extends ConsumerWidget {
         child: Padding(
           padding: EdgeInsets.only(top: topInset),
           child: SafeArea(
-            top: false,
+            top: usesNativeToolbarInset,
             child: wide
                 ? _buildWide(context, permitted)
                 : _buildCompact(context, permitted),

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -2335,6 +2335,18 @@
   "@sidebarNotesTab": {
     "description": "Label for the Notes tab in the sidebar"
   },
+  "sidebarSyncingChats": "Syncing chats",
+  "@sidebarSyncingChats": {
+    "description": "Accessibility label for sidebar progress while chats are syncing"
+  },
+  "sidebarSyncingNotes": "Syncing notes",
+  "@sidebarSyncingNotes": {
+    "description": "Accessibility label for sidebar progress while notes are syncing"
+  },
+  "sidebarFinishingSync": "Finishing sync",
+  "@sidebarFinishingSync": {
+    "description": "Accessibility label for sidebar progress while sync finalization runs"
+  },
   "sidebarChannelsTab": "Channels",
   "@sidebarChannelsTab": {
     "description": "Label for the Channels tab in the sidebar"

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -13,10 +13,10 @@ packages:
     dependency: "direct main"
     description:
       name: adaptive_platform_ui
-      sha256: "72ebe76218ea43b6bef370f1daaf6f80f4abe75f4a7b75e10f1392c13a9f1ce4"
+      sha256: "43ab9f08b3fea200b5281720653603c0b689cdb8ae8969ed4c8e26c1c11e19a0"
       url: "https://pub.dev"
     source: hosted
-    version: "0.1.107"
+    version: "0.1.110"
   analysis_server_plugin:
     dependency: transitive
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -101,34 +101,34 @@ packages:
     dependency: transitive
     description:
       name: build
-      sha256: a156715e7cd728130c592f30552575908aae5b100005fbc1f0fb16b3c03a3d10
+      sha256: "45d14a0fb23e018d8287c32fc98d726ce466b231928ed9b9200f29bd3ccd39ae"
       url: "https://pub.dev"
     source: hosted
-    version: "4.0.6"
+    version: "4.0.7"
   build_config:
     dependency: transitive
     description:
       name: build_config
-      sha256: "4070d2a59f8eec34c97c86ceb44403834899075f66e8a9d59706f8e7834f6f71"
+      sha256: f2c223156a26eea323e6244b85141d76413a80aeee9fe0b380773789fabaf8ae
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.0"
+    version: "1.3.1"
   build_daemon:
     dependency: transitive
     description:
       name: build_daemon
-      sha256: bf05f6e12cfea92d3c09308d7bcdab1906cd8a179b023269eed00c071004b957
+      sha256: fd754058c342243718d5171a95f352cfc9fcf0cba8cfa26df67cb13a5836db78
       url: "https://pub.dev"
     source: hosted
-    version: "4.1.1"
+    version: "4.1.2"
   build_runner:
     dependency: "direct dev"
     description:
       name: build_runner
-      sha256: "1523ce62448ebac2c15a8ba5fbad8acac169788658a7dd2a1c2d9c2a9318b9a6"
+      sha256: "5367e521935b102bdf1e735d2aab461e36b2edca6517662d088dd04cc39f8d16"
       url: "https://pub.dev"
     source: hosted
-    version: "2.15.0"
+    version: "2.15.1"
   built_collection:
     dependency: transitive
     description:
@@ -253,10 +253,10 @@ packages:
     dependency: "direct main"
     description:
       name: connectivity_plus
-      sha256: cad0e811a289ea2a941119dc483c204ec1684cbb9a8fc7351fe4a230b8313160
+      sha256: "25cebb79dfe304022550e0c3c893ae051ded07183d2607f7b88473cb3ade33cb"
       url: "https://pub.dev"
     source: hosted
-    version: "7.2.0"
+    version: "7.3.0"
   connectivity_plus_platform_interface:
     dependency: transitive
     description:
@@ -285,10 +285,10 @@ packages:
     dependency: transitive
     description:
       name: cross_file
-      sha256: "28bb3ae56f117b5aec029d702a90f57d285cd975c3c5c281eaca38dbc47c5937"
+      sha256: "92c9c43c383bfa1c32079d3bc492d55d6d4318044b7b47edaff8971cbb555c51"
       url: "https://pub.dev"
     source: hosted
-    version: "0.3.5+2"
+    version: "0.3.5+4"
   crypto:
     dependency: "direct main"
     description:
@@ -357,10 +357,10 @@ packages:
     dependency: "direct main"
     description:
       name: drift
-      sha256: "6cc0b623c0e83f7080524d8396e9301b1d78b9c66a4fdceeb0f798211303254c"
+      sha256: "84688491040b0ceb26575709a84d701c84ad4df4d8aff020adf6d85f155fb0dd"
       url: "https://pub.dev"
     source: hosted
-    version: "2.34.0"
+    version: "2.34.2"
   drift_dev:
     dependency: "direct dev"
     description:
@@ -373,18 +373,18 @@ packages:
     dependency: "direct main"
     description:
       name: drift_flutter
-      sha256: "887fdec622174dc7eaefd0048403e34ee07cc18626ac8a7544cc3b8a4a172166"
+      sha256: "91acf4bee7c3c84467cba46455aa70e5292a3b889f4582645d74f2e5a8c106f2"
       url: "https://pub.dev"
     source: hosted
-    version: "0.3.0"
+    version: "0.3.1"
   equatable:
     dependency: transitive
     description:
       name: equatable
-      sha256: "3e0141505477fd8ad55d6eb4e7776d3fe8430be8e497ccb1521370c3f21a3e2b"
+      sha256: "3bce007a596ff8b3119c45d68aaef631272537c03d30e5d4534dd24bf4c5eaa2"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.8"
+    version: "2.1.0"
   fake_async:
     dependency: "direct dev"
     description:
@@ -519,50 +519,50 @@ packages:
     dependency: "direct main"
     description:
       name: flutter_image_compress
-      sha256: "51d23be39efc2185e72e290042a0da41aed70b14ef97db362a6b5368d0523b27"
+      sha256: e7c48e0832f52ae65e775bf0d2324447a1781ed6d7e55a6c4136046ad44f2f22
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.0"
+    version: "2.5.0"
   flutter_image_compress_common:
     dependency: transitive
     description:
       name: flutter_image_compress_common
-      sha256: c5c5d50c15e97dd7dc72ff96bd7077b9f791932f2076c5c5b6c43f2c88607bfb
+      sha256: "10520a2d4bade23d31ba5a4b9f56fa7d11b6a62f11fe3576106c1867cc10dcf6"
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.6"
+    version: "1.1.0"
   flutter_image_compress_macos:
     dependency: transitive
     description:
       name: flutter_image_compress_macos
-      sha256: "20019719b71b743aba0ef874ed29c50747461e5e8438980dfa5c2031898f7337"
+      sha256: "0d2a842d2e544828fb32bda16dcfccb3149107df568898a4936d78232e486847"
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.3"
+    version: "1.1.0"
   flutter_image_compress_ohos:
     dependency: transitive
     description:
       name: flutter_image_compress_ohos
-      sha256: e76b92bbc830ee08f5b05962fc78a532011fcd2041f620b5400a593e96da3f51
+      sha256: "1491bb7bcfdf59e3b127c263c116cfbf8ed3afade6e7fa691d9622e838ed7e48"
       url: "https://pub.dev"
     source: hosted
-    version: "0.0.3"
+    version: "0.0.3+1"
   flutter_image_compress_platform_interface:
     dependency: transitive
     description:
       name: flutter_image_compress_platform_interface
-      sha256: "579cb3947fd4309103afe6442a01ca01e1e6f93dc53bb4cbd090e8ce34a41889"
+      sha256: bbefb7967bda565004fdabdb3300dcbfb40c7ef8402675d23206e5bddc358178
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.5"
+    version: "1.1.0"
   flutter_image_compress_web:
     dependency: transitive
     description:
       name: flutter_image_compress_web
-      sha256: b9b141ac7c686a2ce7bb9a98176321e1182c9074650e47bb140741a44b6f5a96
+      sha256: "91cc58e091a1e09c7683d216d579e2b964119a8527fc43b64dfdb00f1acc94ec"
       url: "https://pub.dev"
     source: hosted
-    version: "0.1.5"
+    version: "0.1.5+1"
   flutter_inappwebview:
     dependency: "direct main"
     description:
@@ -639,10 +639,10 @@ packages:
     dependency: "direct main"
     description:
       name: flutter_local_notifications
-      sha256: a0d7141f14cabcee42967470a858dfc99dd6cfb70d3cab404bacfcafa9e84e70
+      sha256: "40c6a69189a622bda89ddcf50a139f4ba0f0eb9c0fef6718845b1f8b95452ed6"
       url: "https://pub.dev"
     source: hosted
-    version: "22.0.1"
+    version: "22.1.0"
   flutter_local_notifications_linux:
     dependency: transitive
     description:
@@ -655,10 +655,10 @@ packages:
     dependency: transitive
     description:
       name: flutter_local_notifications_platform_interface
-      sha256: ff0013eae795e8dc8fad4a8992a209e64d3ba2fbd8bf5e43c36bf448f95bd814
+      sha256: "4dfbae10debab9ac975d8b01943fed94c0c19dad43f825964b29f3c3f9a8a852"
       url: "https://pub.dev"
     source: hosted
-    version: "12.0.0"
+    version: "12.0.1"
   flutter_local_notifications_web:
     dependency: transitive
     description:
@@ -1019,10 +1019,10 @@ packages:
     dependency: "direct main"
     description:
       name: image_picker
-      sha256: "91c025426c2881c551100bce834e201c835a170151545f58d17da5180ca7d9ac"
+      sha256: d8402284df184bc05f4a2210c6c23983b0720f4cd87cbd05c5390a78af602667
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.2"
+    version: "1.2.3"
   image_picker_android:
     dependency: transitive
     description:
@@ -1339,10 +1339,10 @@ packages:
     dependency: "direct main"
     description:
       name: package_info_plus
-      sha256: f5c435dc0e0d461e5b32471a870f769b6a1cc46930637efe24fbc535314e78ad
+      sha256: "127e1751e37ffb2ff4658beeaca77bad0c27bf5f932bd3a501c2296926d4b481"
       url: "https://pub.dev"
     source: hosted
-    version: "10.2.0"
+    version: "10.2.1"
   package_info_plus_platform_interface:
     dependency: transitive
     description:
@@ -1443,26 +1443,26 @@ packages:
     dependency: transitive
     description:
       name: pdfium_flutter
-      sha256: "420ba8e7673b54da387ceeeb18a72c8bc6e4452128dbb391dca900c748f9e9ba"
+      sha256: "0b115c0917aef9cf6bb9c4d47d0efc61d97f44844cd76287c921f997c26cf15d"
       url: "https://pub.dev"
     source: hosted
-    version: "0.2.2"
+    version: "0.2.3"
   pdfrx:
     dependency: "direct main"
     description:
       name: pdfrx
-      sha256: e0ca318004c3f32144db8e74fa612abb80ebe79004677293af74ed9af119f47f
+      sha256: acce61944c31bd36f0c3031b1bbf41f59d0b0d4e5e27614fbdc74ff093d55464
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.4"
+    version: "2.4.7"
   pdfrx_engine:
     dependency: transitive
     description:
       name: pdfrx_engine
-      sha256: "89865e158ced818690ab207a13a34a65803cd67ee1bec9f5f87838eb5a79600b"
+      sha256: ef8f8cfa64255bfc91a559dd2d32d7cfe7a0f8003bac297bbf9a0aed1182fae5
       url: "https://pub.dev"
     source: hosted
-    version: "0.4.3"
+    version: "0.4.6"
   permission_handler:
     dependency: "direct main"
     description:
@@ -1523,10 +1523,10 @@ packages:
     dependency: "direct dev"
     description:
       name: pigeon
-      sha256: a716c5729bad574ab45d94d3ca13d6348b5d20d6c1f7f89a0acecab2ebdc6dda
+      sha256: dff8a0619d49652daeba23064f5480961c2a0275779394e3b606d8df07eb2ff3
       url: "https://pub.dev"
     source: hosted
-    version: "27.1.0"
+    version: "27.2.0"
   platform:
     dependency: transitive
     description:
@@ -1755,10 +1755,10 @@ packages:
     dependency: "direct main"
     description:
       name: share_plus
-      sha256: "9eee8283462d91a7a1c8bdb67d08874abd75a2f8fae3bc0ca033035e375fb3d8"
+      sha256: "02180b01c1237b9706b663d9402b2cf2402b3407f48cce99cc19e3200f095b8a"
       url: "https://pub.dev"
     source: hosted
-    version: "13.2.0"
+    version: "13.2.1"
   share_plus_platform_interface:
     dependency: transitive
     description:
@@ -1779,10 +1779,10 @@ packages:
     dependency: transitive
     description:
       name: shared_preferences_android
-      sha256: "93ae5884a9df5d3bb696825bceb3a17590754548b5d740eba51500afc8d088f5"
+      sha256: "0634e64bd719f89c012f392938e173521f535d3ecaf66558fa94a056d22b5cc7"
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.26"
+    version: "2.4.27"
   shared_preferences_foundation:
     dependency: transitive
     description:
@@ -1968,10 +1968,10 @@ packages:
     dependency: transitive
     description:
       name: sqlite3
-      sha256: "37356bcb56ce0d9404d602c41e4bdb7765e7e9732a3e47adb3d98c556a6abdad"
+      sha256: c73fd75df1332d76a6257f4823ae4df9c791f522b97e4a60cbcad214de1becf4
       url: "https://pub.dev"
     source: hosted
-    version: "3.3.3"
+    version: "3.5.0"
   sqlite3_flutter_libs:
     dependency: transitive
     description:
@@ -2177,10 +2177,10 @@ packages:
     dependency: "direct main"
     description:
       name: uuid
-      sha256: "1fef9e8e11e2991bb773070d4656b7bd5d850967a2456cfc83cf47925ba79489"
+      sha256: "9b129329f58692f6e6578329498a8fe9fbe98f090beb764ffbb8ee2eadd01dcd"
       url: "https://pub.dev"
     source: hosted
-    version: "4.5.3"
+    version: "4.6.0"
   vad:
     dependency: "direct main"
     description:
@@ -2297,10 +2297,10 @@ packages:
     dependency: transitive
     description:
       name: webview_flutter
-      sha256: e4d3474277c5043f5f3100ed27d94ad693abfd5c602b0221c719a4497e4ba1e4
+      sha256: d53e1ccf5516f25017e3c9d44c39034db352d20fa34fe200674270242c2c5111
       url: "https://pub.dev"
     source: hosted
-    version: "4.14.0"
+    version: "4.14.1"
   webview_flutter_android:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -36,7 +36,7 @@ dependencies:
   
   # UI Components - Markdown Rendering
   markdown: ^7.3.0
-  pdfrx: ^2.4.3
+  pdfrx: ^2.4.7
   archive: ^4.0.9
   xml: ^7.0.1
   flutter_inappwebview: ^6.1.5
@@ -53,18 +53,18 @@ dependencies:
   record: ^6.2.0
   audio_session: ^0.2.2
   permission_handler: ^12.0.1
-  image_picker: ^1.2.0
+  image_picker: ^1.2.3
   # Retained on beta: latest stable 11.0.2 conflicts with share_plus via win32 as of 2026-06-10.
   file_picker: ^12.0.0-beta.5
   flutter_sharing_intent: ^2.0.4
-  flutter_image_compress: ^2.1.0
+  flutter_image_compress: ^2.5.0
   path_provider: ^2.1.4
   
   # Utilities
   path: ^1.9.0
-  uuid: ^4.5.0
+  uuid: ^4.6.0
   crypto: ^3.0.3
-  package_info_plus: ^10.1.0
+  package_info_plus: ^10.2.1
   url_launcher: ^6.3.0
   intl: ^0.20.2
 
@@ -73,10 +73,10 @@ dependencies:
   json_annotation: ^4.12.0
   freezed_annotation: ^3.0.0
   wakelock_plus: ^1.4.0
-  share_plus: ^13.1.0
+  share_plus: ^13.2.1
   riverpod_annotation: ^4.0.0
-  flutter_local_notifications: ^22.0.0
-  connectivity_plus: ^7.0.0
+  flutter_local_notifications: ^22.1.0
+  connectivity_plus: ^7.3.0
   flutter_cache_manager: ^3.4.1
   http: ^1.5.0
   flutter_callkit_incoming: ^3.1.1
@@ -101,8 +101,8 @@ dependencies:
     git:
       url: https://github.com/Telosnex/super_sliver_list.git
       ref: fe038453b41305baf032b29bbdf3aa64f62b2c09
-  drift: ^2.34.0
-  drift_flutter: ^0.3.0
+  drift: ^2.34.2
+  drift_flutter: ^0.3.1
   fleather: ^1.27.0
   # Document model + markdown/HTML codecs backing the Fleather note editor.
   parchment: ^1.27.0
@@ -111,7 +111,7 @@ dev_dependencies:
   flutter_test:
     sdk: flutter
   flutter_lints: ^6.0.0
-  build_runner: ^2.7.1
+  build_runner: ^2.15.1
   freezed: ^3.2.0
   json_serializable: ^6.11.1
   flutter_native_splash: ^2.4.6
@@ -120,7 +120,7 @@ dev_dependencies:
   mocktail: ^1.0.4
   checks: ^0.3.1
   collection: ^1.19.1
-  pigeon: ^27.1.0
+  pigeon: ^27.2.0
   drift_dev: ^2.34.0
   fake_async: ^1.3.3
   # Used only in tests to mock the microphone permission platform channel.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ version: 3.4.3+136
 publish_to: 'none'
 
 environment:
-  sdk: ">=3.9.0 <4.0.0"
+  sdk: ">=3.9.2 <4.0.0"
 
 dependencies:
   flutter:
@@ -85,7 +85,7 @@ dependencies:
   home_widget: ^0.9.2
   flutter_highlight: ^0.7.0
   just_audio: ^0.10.5
-  adaptive_platform_ui: ^0.1.103
+  adaptive_platform_ui: ^0.1.110
   flutter_tex: ^5.2.6
   gaimon: ^1.4.2
   xterm: ^4.0.0

--- a/test/core/auth/auth_state_manager_prevalidated_proxy_test.dart
+++ b/test/core/auth/auth_state_manager_prevalidated_proxy_test.dart
@@ -194,6 +194,91 @@ void main() {
   });
 
   test(
+    'login keeps the replacement API authenticated when clearing logout fence',
+    () async {
+      SharedPreferences.setMockInitialValues(<String, Object>{});
+      PreferencesStore.debugOverride(await SharedPreferences.getInstance());
+      addTearDown(PreferencesStore.debugReset);
+
+      final storage = _Storage();
+      when(() => storage.getAuthTokenStrict()).thenAnswer((_) async => '');
+      when(
+        () => storage.getSavedCredentialsStrict(),
+      ).thenAnswer((_) async => null);
+      when(() => storage.saveLocalUser(null)).thenAnswer((_) async {});
+      when(
+        () =>
+            storage.saveLocalUserWithAvatar(user, avatarUrl: user.profileImage),
+      ).thenAnswer((_) async {});
+      when(
+        () => storage.captureServerSessionOwnership(
+          validatedConfig: any(named: 'validatedConfig'),
+          requireActive: true,
+        ),
+      ).thenAnswer(
+        (_) async =>
+            (revision: 1, serverConfig: previousConfig, requireActive: true),
+      );
+      when(
+        () => storage.commitExistingServerSession(
+          ownership: any(named: 'ownership'),
+          token: any(named: 'token'),
+          canCommit: any(named: 'canCommit'),
+          publish: any(named: 'publish'),
+          rememberedCredentials: any(named: 'rememberedCredentials'),
+          onRollbackUncertain: any(named: 'onRollbackUncertain'),
+        ),
+      ).thenAnswer((invocation) async {
+        final canCommit =
+            invocation.namedArguments[#canCommit] as bool Function();
+        final publish =
+            invocation.namedArguments[#publish] as FutureOr<void> Function();
+        if (!canCommit()) return false;
+        await publish();
+        return canCommit();
+      });
+
+      final createdApis = <_SuccessfulAuthApi>[];
+      final container = ProviderContainer(
+        overrides: [
+          optimizedStorageServiceProvider.overrideWithValue(storage),
+          apiServiceProvider.overrideWith((ref) {
+            ref.watch(incompleteLogoutFenceProvider);
+            final api = _SuccessfulAuthApi();
+            createdApis.add(api);
+            ref.onDispose(api.dispose);
+            return api;
+          }),
+          defaultModelProvider.overrideWith((ref) async => null),
+        ],
+      );
+      addTearDown(container.dispose);
+      await container.read(authStateManagerProvider.future);
+      await _waitForAuthStatus(container, AuthStatus.unauthenticated);
+
+      check(
+        await container
+            .read(incompleteLogoutFenceProvider.notifier)
+            .persist(true),
+      ).isTrue();
+      final preLoginApi = container.read(apiServiceProvider);
+      check(preLoginApi).isNotNull();
+
+      check(
+        await container
+            .read(authStateManagerProvider.notifier)
+            .login('user', 'password'),
+      ).isTrue();
+
+      final activeApi = container.read(apiServiceProvider);
+      check(activeApi).isNotNull();
+      check(activeApi!.authToken).equals(token);
+      check(identical(activeApi, preLoginApi)).isFalse();
+      check(createdApis.length >= 3).isTrue();
+    },
+  );
+
+  test(
     'prevalidated proxy persistence failure restores config and session',
     () async {
       final storage = _Storage();

--- a/test/core/providers/openwebui_account_storage_isolation_test.dart
+++ b/test/core/providers/openwebui_account_storage_isolation_test.dart
@@ -371,6 +371,7 @@ _harness({
   OpenWebUiAccountOwnerMarker? ownerMarker,
   OpenWebUiAccountCacheClear? accountCacheClear,
   OpenWebUiDatabasePurge? databasePurge,
+  OpenWebUiPostCertificationSyncKickoff? postCertificationSyncKickoff,
   List<Override> additionalOverrides = const <Override>[],
 }) async {
   if (!PreferencesStore.isReady) {
@@ -431,6 +432,9 @@ _harness({
         accountCacheClear ?? () async {},
       ),
       openWebUiCertifiedUserPersistProvider.overrideWithValue((_) async {}),
+      openWebUiPostCertificationSyncKickoffProvider.overrideWithValue(
+        postCertificationSyncKickoff ?? () {},
+      ),
       openWebUiDatabasePurgeProvider.overrideWithValue(
         databasePurge ??
             (serverId) async {
@@ -1138,6 +1142,9 @@ void main() {
             markerStore,
           ),
           openWebUiAccountCacheClearProvider.overrideWithValue(() async {}),
+          openWebUiPostCertificationSyncKickoffProvider.overrideWithValue(
+            () {},
+          ),
           openWebUiDatabasePurgeProvider.overrideWithValue(manager.deleteFor),
         ],
       );
@@ -1306,6 +1313,9 @@ void main() {
             markerStore,
           ),
           openWebUiAccountCacheClearProvider.overrideWithValue(() async {}),
+          openWebUiPostCertificationSyncKickoffProvider.overrideWithValue(
+            () {},
+          ),
           openWebUiDatabasePurgeProvider.overrideWithValue((serverId) async {
             purgeCalls++;
             await manager.deleteFor(serverId);
@@ -1628,17 +1638,23 @@ void main() {
   );
 
   test('startup auth error with no token purges before manual login', () async {
+    var postCertificationSyncKickoffs = 0;
     final harness = await _harness(
       initialAuth: const AuthState(
         status: AuthStatus.error,
         error: 'secure storage failed',
       ),
       expectInitiallyOpen: false,
+      postCertificationSyncKickoff: () => postCertificationSyncKickoffs++,
     );
     final container = harness.container;
 
     harness.auth.publish(_authenticated('token-b', _userB));
     await Future<void>.delayed(Duration.zero);
+    await container
+        .read(openWebUiAccountStorageIsolationProvider.notifier)
+        .settled;
+    check(postCertificationSyncKickoffs).equals(1);
     check(
       container.read(openWebUiDatabaseAccessProvider),
     ).equals(OpenWebUiDatabaseAccessPhase.open);

--- a/test/core/providers/openwebui_account_storage_isolation_test.dart
+++ b/test/core/providers/openwebui_account_storage_isolation_test.dart
@@ -1637,6 +1637,41 @@ void main() {
     },
   );
 
+  test(
+    'chat messages keep following selections after sign-out and sign-in',
+    () async {
+      final harness = await _harness();
+      final container = harness.container;
+      final subscription = container.listen<List<ChatMessage>>(
+        chatMessagesProvider,
+        (_, _) {},
+        fireImmediately: true,
+      );
+      addTearDown(subscription.close);
+
+      harness.auth.publish(const AuthState(status: AuthStatus.unauthenticated));
+      await Future<void>.delayed(Duration.zero);
+      await container
+          .read(openWebUiAccountStorageIsolationProvider.notifier)
+          .settled;
+
+      harness.auth.publish(_authenticated('token-a', _userA));
+      await Future<void>.delayed(Duration.zero);
+      await container
+          .read(openWebUiAccountStorageIsolationProvider.notifier)
+          .settled;
+
+      container
+          .read(activeConversationProvider.notifier)
+          .set(_openWebUiConversation('reopened-chat', 'visible after login'));
+      await Future<void>.delayed(Duration.zero);
+
+      check(
+        container.read(chatMessagesProvider).map((message) => message.content),
+      ).deepEquals(<String>['visible after login']);
+    },
+  );
+
   test('startup auth error with no token purges before manual login', () async {
     var postCertificationSyncKickoffs = 0;
     final harness = await _harness(

--- a/test/core/sync/sync_engine_test.dart
+++ b/test/core/sync/sync_engine_test.dart
@@ -337,6 +337,59 @@ void main() {
       check(container.read(syncEngineProvider).phase).equals(SyncPhase.idle);
     });
 
+    test('publishes determinate chat and note fetch progress', () async {
+      seedChat('chat-1', 100);
+      server.seedNote(
+        id: 'note-1',
+        title: 'Note 1',
+        data: const <String, dynamic>{
+          'content': <String, dynamic>{'md': 'hello'},
+        },
+        createdAt: 1000000000,
+        updatedAt: 1000000000,
+      );
+      final container = makeContainer();
+      final statuses = <SyncStatus>[];
+      final subscription = container.listen<SyncStatus>(
+        syncEngineProvider,
+        (_, next) => statuses.add(next),
+        fireImmediately: true,
+      );
+      addTearDown(subscription.close);
+
+      final result = await container
+          .read(syncEngineProvider.notifier)
+          .requestPull(reason: 'progress-test');
+
+      check(result).isNotNull();
+      check(
+        statuses.any(
+          (status) =>
+              status.stage == SyncStage.chats &&
+              status.completedItems == 0 &&
+              status.totalItems == 1,
+        ),
+      ).isTrue();
+      check(
+        statuses.any(
+          (status) =>
+              status.stage == SyncStage.chats &&
+              status.completedItems == 1 &&
+              status.totalItems == 1,
+        ),
+      ).isTrue();
+      check(
+        statuses.any(
+          (status) =>
+              status.stage == SyncStage.notes &&
+              status.completedItems == 1 &&
+              status.totalItems == 1,
+        ),
+      ).isTrue();
+      check(statuses.last.phase).equals(SyncPhase.idle);
+      check(statuses.last.stage).isNull();
+    });
+
     test(
       'requests during a running cycle coalesce into one queued rerun',
       () async {

--- a/test/core/sync/sync_triggers_test.dart
+++ b/test/core/sync/sync_triggers_test.dart
@@ -236,6 +236,48 @@ void main() {
         check(countOf('start')).equals(2);
       },
     );
+
+    test(
+      'post-certification pull waits for auth, database, and client readiness',
+      () async {
+        final container = makeContainer();
+        final triggers = container.read(syncTriggersProvider.notifier);
+
+        triggers.requestPostCertificationSync();
+        await flushMicrotasks();
+        check(pulls).isEmpty();
+
+        container.read(_authProvider.notifier).set(true);
+        await flushMicrotasks();
+        container.read(_clientProvider.notifier).set(client);
+        await flushMicrotasks();
+        check(pulls).isEmpty();
+
+        container.read(_dbProvider.notifier).set(db);
+        await flushMicrotasks();
+
+        check(pulls).deepEquals(<String>['account-certified']);
+        check(countOf('start')).equals(0);
+      },
+    );
+
+    test(
+      'post-certification request does not duplicate a start for the same pair',
+      () async {
+        final container = makeContainer();
+        container.read(_authProvider.notifier).set(true);
+        container.read(_dbProvider.notifier).set(db);
+        container.read(_clientProvider.notifier).set(client);
+        final triggers = container.read(syncTriggersProvider.notifier);
+        await flushMicrotasks();
+        check(pulls).deepEquals(<String>['start']);
+
+        triggers.requestPostCertificationSync();
+        await flushMicrotasks();
+
+        check(pulls).deepEquals(<String>['start']);
+      },
+    );
   });
 
   group('connectivity edge', () {

--- a/test/features/navigation/providers/conversation_selection_provider_test.dart
+++ b/test/features/navigation/providers/conversation_selection_provider_test.dart
@@ -1,0 +1,720 @@
+import 'dart:async';
+
+import 'package:conduit/core/database/app_database.dart';
+import 'package:conduit/core/database/chat_database_repository.dart';
+import 'package:conduit/core/database/database_provider.dart';
+import 'package:conduit/core/models/chat_message.dart';
+import 'package:conduit/core/models/conversation.dart';
+import 'package:conduit/core/models/server_config.dart';
+import 'package:conduit/core/providers/app_providers.dart';
+import 'package:conduit/core/providers/app_startup_providers.dart';
+import 'package:conduit/core/services/settings_service.dart';
+import 'package:conduit/features/auth/providers/unified_auth_providers.dart';
+import 'package:conduit/features/navigation/providers/conversation_selection_provider.dart';
+import 'package:drift/native.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_riverpod/misc.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+const _server = ServerConfig(
+  id: 'selection-test-server',
+  name: 'Selection Test Server',
+  url: 'https://example.com',
+);
+
+const _otherServer = ServerConfig(
+  id: 'selection-test-server-other',
+  name: 'Other Selection Test Server',
+  url: 'https://other.example.com',
+);
+
+final _serverOwnerProvider =
+    NotifierProvider<_ServerOwnerNotifier, ServerConfig?>(
+      _ServerOwnerNotifier.new,
+    );
+
+final class _ServerOwnerNotifier extends Notifier<ServerConfig?> {
+  @override
+  ServerConfig? build() => _server;
+
+  void set(ServerConfig? server) => state = server;
+}
+
+final _authOwnerProvider = NotifierProvider<_AuthOwnerNotifier, _AuthOwner>(
+  _AuthOwnerNotifier.new,
+);
+
+final class _AuthOwner {
+  const _AuthOwner({required this.token, required this.epoch});
+
+  final String? token;
+  final Object epoch;
+}
+
+final class _AuthOwnerNotifier extends Notifier<_AuthOwner> {
+  @override
+  _AuthOwner build() => _AuthOwner(token: 'token-a', epoch: Object());
+
+  void setToken(String? token) {
+    state = _AuthOwner(token: token, epoch: Object());
+  }
+}
+
+final class _NoopAccountStorageIsolation
+    extends OpenWebUiAccountStorageIsolation {
+  @override
+  void build() {}
+}
+
+final class _PendingAccountStorageIsolation
+    extends OpenWebUiAccountStorageIsolation {
+  _PendingAccountStorageIsolation(this.gate);
+
+  final Future<void> gate;
+
+  @override
+  void build() {}
+
+  @override
+  Future<void> get settled => gate;
+}
+
+final class _SeededActiveConversation extends ActiveConversationNotifier {
+  _SeededActiveConversation(this.initialConversation);
+
+  final Conversation initialConversation;
+
+  @override
+  Conversation? build() => initialConversation;
+}
+
+Future<void> _flushMicrotasks([int count = 3]) async {
+  for (var i = 0; i < count; i++) {
+    await Future<void>.delayed(Duration.zero);
+  }
+}
+
+Conversation _conversation(
+  String id, {
+  required ChatStorageKind storage,
+  String? body,
+}) {
+  final timestamp = DateTime(2026, 1, 1);
+  return withChatStorageProvenance(
+    Conversation(
+      id: id,
+      title: id,
+      createdAt: timestamp,
+      updatedAt: timestamp,
+      messages: body == null
+          ? const <ChatMessage>[]
+          : <ChatMessage>[
+              ChatMessage(
+                id: '$id-message',
+                role: 'assistant',
+                content: body,
+                timestamp: timestamp,
+              ),
+            ],
+    ),
+    storage,
+  );
+}
+
+Future<ProviderContainer> _createContainer({
+  Conversation? activeConversation,
+  Override? isolationOverride,
+  Duration timeout = const Duration(milliseconds: 250),
+  List<Override> extraOverrides = const <Override>[],
+}) async {
+  final database = AppDatabase(NativeDatabase.memory());
+  final container = ProviderContainer(
+    overrides: [
+      appSettingsProvider.overrideWithValue(const AppSettings()),
+      isAuthenticatedProvider2.overrideWith(
+        (ref) => ref.watch(_authOwnerProvider).token != null,
+      ),
+      authTokenProvider3.overrideWith(
+        (ref) => ref.watch(_authOwnerProvider).token,
+      ),
+      currentUserProvider2.overrideWithValue(null),
+      openWebUiAuthSessionEpochProvider.overrideWith(
+        (ref) => ref.watch(_authOwnerProvider).epoch,
+      ),
+      activeServerProvider.overrideWith(
+        (ref) async => ref.watch(_serverOwnerProvider),
+      ),
+      apiServiceProvider.overrideWithValue(null),
+      appDatabaseProvider.overrideWithValue(database),
+      isolationOverride ??
+          openWebUiAccountStorageIsolationProvider.overrideWith(
+            _NoopAccountStorageIsolation.new,
+          ),
+      conversationSelectionTimeoutProvider.overrideWithValue(timeout),
+      if (activeConversation != null)
+        activeConversationProvider.overrideWith(
+          () => _SeededActiveConversation(activeConversation),
+        ),
+      ...extraOverrides,
+    ],
+  );
+  addTearDown(() async {
+    container.dispose();
+    await database.close();
+  });
+  await container.read(activeServerProvider.future);
+  return container;
+}
+
+void _certifyOpenWebUiStorage(ProviderContainer container) {
+  container
+      .read(openWebUiCertifiedDatabaseServerProvider.notifier)
+      .set(_server.id);
+  container.read(openWebUiDatabaseAccessProvider.notifier).open();
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  test(
+    'transient OpenWebUI certification resumes pending selection and commits',
+    () async {
+      final previous = _conversation(
+        'previous',
+        storage: ChatStorageKind.directLocal,
+        body: 'Previous body',
+      );
+      final summary = _conversation(
+        'server-chat',
+        storage: ChatStorageKind.openWebUi,
+      );
+      final full = _conversation(
+        'server-chat',
+        storage: ChatStorageKind.openWebUi,
+        body: 'Loaded after certification',
+      );
+      var loadCalls = 0;
+      final scopedId = conversationScopedId(summary);
+      final container = await _createContainer(
+        activeConversation: previous,
+        extraOverrides: [
+          loadConversationProvider(scopedId).overrideWith((ref) async {
+            loadCalls += 1;
+            return full;
+          }),
+        ],
+      );
+
+      final selection = container
+          .read(conversationSelectionProvider.notifier)
+          .select(summary);
+      await _flushMicrotasks();
+
+      final pending = container.read(conversationSelectionProvider);
+      expect(pending.isLoading, isTrue);
+      expect(pending.pendingConversationId, scopedId);
+      expect(container.read(activeConversationProvider)?.id, previous.id);
+      expect(loadCalls, 0);
+
+      _certifyOpenWebUiStorage(container);
+      final result = await selection;
+
+      expect(result.disposition, ConversationSelectionDisposition.committed);
+      expect(loadCalls, 1);
+      expect(container.read(activeConversationProvider)?.id, full.id);
+      expect(
+        container.read(activeConversationProvider)?.messages.single.content,
+        'Loaded after certification',
+      );
+      expect(container.read(conversationSelectionProvider).isLoading, isFalse);
+    },
+  );
+
+  test(
+    'superseding during initial isolation cancels the first wait promptly',
+    () async {
+      final isolationGate = Completer<void>();
+      final first = _conversation(
+        'waiting-for-isolation',
+        storage: ChatStorageKind.openWebUi,
+      );
+      final second = _conversation(
+        'replacement',
+        storage: ChatStorageKind.directLocal,
+      );
+      final secondFull = _conversation(
+        'replacement',
+        storage: ChatStorageKind.directLocal,
+        body: 'Replacement body',
+      );
+      final container = await _createContainer(
+        isolationOverride: openWebUiAccountStorageIsolationProvider
+            .overrideWith(
+              () => _PendingAccountStorageIsolation(isolationGate.future),
+            ),
+        extraOverrides: [
+          loadConversationProvider(
+            conversationScopedId(second),
+          ).overrideWith((ref) async => secondFull),
+        ],
+      );
+
+      final firstSelection = container
+          .read(conversationSelectionProvider.notifier)
+          .select(first);
+      await _flushMicrotasks();
+      final secondResult = await container
+          .read(conversationSelectionProvider.notifier)
+          .select(second);
+      final firstResult = await firstSelection.timeout(
+        const Duration(milliseconds: 100),
+      );
+
+      expect(
+        secondResult.disposition,
+        ConversationSelectionDisposition.committed,
+      );
+      expect(
+        firstResult.disposition,
+        ConversationSelectionDisposition.canceled,
+      );
+      expect(isolationGate.isCompleted, isFalse);
+      expect(container.read(activeConversationProvider)?.id, second.id);
+    },
+  );
+
+  test(
+    'superseding during readiness cancels the first wait promptly',
+    () async {
+      final first = _conversation(
+        'waiting-for-readiness',
+        storage: ChatStorageKind.openWebUi,
+      );
+      final second = _conversation(
+        'replacement',
+        storage: ChatStorageKind.directLocal,
+      );
+      final secondFull = _conversation(
+        'replacement',
+        storage: ChatStorageKind.directLocal,
+        body: 'Replacement body',
+      );
+      final container = await _createContainer(
+        extraOverrides: [
+          loadConversationProvider(
+            conversationScopedId(second),
+          ).overrideWith((ref) async => secondFull),
+        ],
+      );
+
+      final firstSelection = container
+          .read(conversationSelectionProvider.notifier)
+          .select(first);
+      await _flushMicrotasks();
+      expect(container.read(conversationSelectionProvider).isLoading, isTrue);
+
+      final secondResult = await container
+          .read(conversationSelectionProvider.notifier)
+          .select(second);
+      final firstResult = await firstSelection.timeout(
+        const Duration(milliseconds: 100),
+      );
+
+      expect(
+        secondResult.disposition,
+        ConversationSelectionDisposition.committed,
+      );
+      expect(
+        firstResult.disposition,
+        ConversationSelectionDisposition.canceled,
+      );
+      expect(container.read(activeConversationProvider)?.id, second.id);
+    },
+  );
+
+  test('latest selection wins when an earlier load completes last', () async {
+    final first = _conversation('first', storage: ChatStorageKind.directLocal);
+    final second = _conversation(
+      'second',
+      storage: ChatStorageKind.directLocal,
+    );
+    final firstGate = Completer<Conversation>();
+    final secondGate = Completer<Conversation>();
+    final container = await _createContainer(
+      extraOverrides: [
+        loadConversationProvider(
+          conversationScopedId(first),
+        ).overrideWith((ref) => firstGate.future),
+        loadConversationProvider(
+          conversationScopedId(second),
+        ).overrideWith((ref) => secondGate.future),
+      ],
+    );
+
+    final firstSelection = container
+        .read(conversationSelectionProvider.notifier)
+        .select(first);
+    await _flushMicrotasks();
+    final secondSelection = container
+        .read(conversationSelectionProvider.notifier)
+        .select(second);
+    await _flushMicrotasks();
+
+    secondGate.complete(
+      _conversation(
+        'second',
+        storage: ChatStorageKind.directLocal,
+        body: 'Second body',
+      ),
+    );
+    final secondResult = await secondSelection;
+    expect(
+      secondResult.disposition,
+      ConversationSelectionDisposition.committed,
+    );
+    expect(container.read(activeConversationProvider)?.id, second.id);
+    expect(container.read(conversationSelectionProvider).generation, 2);
+    expect(container.read(conversationSelectionProvider).isLoading, isFalse);
+
+    final firstResult = await firstSelection.timeout(
+      const Duration(milliseconds: 100),
+    );
+    expect(firstResult.disposition, ConversationSelectionDisposition.canceled);
+
+    firstGate.complete(
+      _conversation(
+        'first',
+        storage: ChatStorageKind.directLocal,
+        body: 'First body',
+      ),
+    );
+    expect(container.read(activeConversationProvider)?.id, second.id);
+    expect(container.read(conversationSelectionProvider).generation, 2);
+    expect(container.read(conversationSelectionProvider).isLoading, isFalse);
+  });
+
+  test('account change cancels a pending OpenWebUI selection', () async {
+    final previous = _conversation(
+      'previous',
+      storage: ChatStorageKind.directLocal,
+      body: 'Previous body',
+    );
+    final summary = _conversation(
+      'server-chat',
+      storage: ChatStorageKind.openWebUi,
+    );
+    final loadGate = Completer<Conversation>();
+    final scopedId = conversationScopedId(summary);
+    final container = await _createContainer(
+      activeConversation: previous,
+      extraOverrides: [
+        loadConversationProvider(
+          scopedId,
+        ).overrideWith((ref) => loadGate.future),
+      ],
+    );
+    _certifyOpenWebUiStorage(container);
+
+    final selection = container
+        .read(conversationSelectionProvider.notifier)
+        .select(summary);
+    await _flushMicrotasks();
+    container.read(_authOwnerProvider.notifier).setToken('token-b');
+    loadGate.complete(
+      _conversation(
+        'server-chat',
+        storage: ChatStorageKind.openWebUi,
+        body: 'Account A private body',
+      ),
+    );
+
+    final result = await selection;
+    expect(result.disposition, ConversationSelectionDisposition.canceled);
+    expect(container.read(activeConversationProvider)?.id, previous.id);
+  });
+
+  test('account ABA cannot revive a pending OpenWebUI selection', () async {
+    final previous = _conversation(
+      'previous',
+      storage: ChatStorageKind.directLocal,
+      body: 'Previous body',
+    );
+    final summary = _conversation(
+      'server-chat',
+      storage: ChatStorageKind.openWebUi,
+    );
+    final loadGate = Completer<Conversation>();
+    final container = await _createContainer(
+      activeConversation: previous,
+      extraOverrides: [
+        loadConversationProvider(
+          conversationScopedId(summary),
+        ).overrideWith((ref) => loadGate.future),
+      ],
+    );
+    _certifyOpenWebUiStorage(container);
+
+    final selection = container
+        .read(conversationSelectionProvider.notifier)
+        .select(summary);
+    await _flushMicrotasks();
+    container.read(_authOwnerProvider.notifier).setToken('token-b');
+    await _flushMicrotasks();
+    container.read(_authOwnerProvider.notifier).setToken('token-a');
+    await _flushMicrotasks();
+    loadGate.complete(
+      _conversation(
+        'server-chat',
+        storage: ChatStorageKind.openWebUi,
+        body: 'Stale account body',
+      ),
+    );
+
+    final result = await selection;
+    expect(result.disposition, ConversationSelectionDisposition.canceled);
+    expect(container.read(activeConversationProvider)?.id, previous.id);
+  });
+
+  test('server ABA cannot revive a pending OpenWebUI selection', () async {
+    final previous = _conversation(
+      'previous',
+      storage: ChatStorageKind.directLocal,
+      body: 'Previous body',
+    );
+    final summary = _conversation(
+      'server-chat',
+      storage: ChatStorageKind.openWebUi,
+    );
+    final loadGate = Completer<Conversation>();
+    final container = await _createContainer(
+      activeConversation: previous,
+      extraOverrides: [
+        loadConversationProvider(
+          conversationScopedId(summary),
+        ).overrideWith((ref) => loadGate.future),
+      ],
+    );
+    _certifyOpenWebUiStorage(container);
+
+    final selection = container
+        .read(conversationSelectionProvider.notifier)
+        .select(summary);
+    await _flushMicrotasks();
+    container.read(_serverOwnerProvider.notifier).set(_otherServer);
+    await container.read(activeServerProvider.future);
+    container.read(_serverOwnerProvider.notifier).set(_server);
+    await container.read(activeServerProvider.future);
+    loadGate.complete(
+      _conversation(
+        'server-chat',
+        storage: ChatStorageKind.openWebUi,
+        body: 'Stale server body',
+      ),
+    );
+
+    final result = await selection;
+    expect(result.disposition, ConversationSelectionDisposition.canceled);
+    expect(container.read(activeConversationProvider)?.id, previous.id);
+  });
+
+  test('stalled OpenWebUI load fails at the selection deadline', () async {
+    final previous = _conversation(
+      'previous',
+      storage: ChatStorageKind.directLocal,
+      body: 'Previous body',
+    );
+    final summary = _conversation(
+      'stalled-server-chat',
+      storage: ChatStorageKind.openWebUi,
+    );
+    final loadGate = Completer<Conversation>();
+    final container = await _createContainer(
+      activeConversation: previous,
+      timeout: const Duration(milliseconds: 50),
+      extraOverrides: [
+        loadConversationProvider(
+          conversationScopedId(summary),
+        ).overrideWith((ref) => loadGate.future),
+      ],
+    );
+    _certifyOpenWebUiStorage(container);
+
+    final result = await container
+        .read(conversationSelectionProvider.notifier)
+        .select(summary)
+        .timeout(const Duration(milliseconds: 250));
+
+    expect(result.disposition, ConversationSelectionDisposition.failed);
+    expect(result.error, isA<TimeoutException>());
+    expect(container.read(activeConversationProvider)?.id, previous.id);
+    expect(container.read(conversationSelectionProvider).isLoading, isFalse);
+  });
+
+  test('disposing the provider cancels an in-flight selection', () async {
+    final summary = _conversation(
+      'disposed-selection',
+      storage: ChatStorageKind.directLocal,
+    );
+    final loadGate = Completer<Conversation>();
+    final container = await _createContainer(
+      extraOverrides: [
+        loadConversationProvider(
+          conversationScopedId(summary),
+        ).overrideWith((ref) => loadGate.future),
+      ],
+    );
+
+    final selection = container
+        .read(conversationSelectionProvider.notifier)
+        .select(summary);
+    await _flushMicrotasks();
+    container.dispose();
+
+    final result = await selection.timeout(const Duration(milliseconds: 100));
+    expect(result.disposition, ConversationSelectionDisposition.canceled);
+  });
+
+  test(
+    'typed ownership failures retry within the same selection intent',
+    () async {
+      final summary = _conversation(
+        'retry-owner-chat',
+        storage: ChatStorageKind.openWebUi,
+      );
+      final full = _conversation(
+        'retry-owner-chat',
+        storage: ChatStorageKind.openWebUi,
+        body: 'Loaded after ownership replacement',
+      );
+      var attempts = 0;
+      final scopedId = conversationScopedId(summary);
+      final container = await _createContainer(
+        extraOverrides: [
+          loadConversationProvider(scopedId).overrideWith((ref) async {
+            attempts += 1;
+            if (attempts == 1) {
+              throw OpenWebUiConversationOwnershipException(
+                OpenWebUiConversationOwnershipFailureReason.changedWhileLoading,
+              );
+            }
+            return full;
+          }),
+        ],
+      );
+      _certifyOpenWebUiStorage(container);
+
+      final result = await container
+          .read(conversationSelectionProvider.notifier)
+          .select(summary);
+
+      expect(result.disposition, ConversationSelectionDisposition.committed);
+      expect(attempts, 2);
+      expect(container.read(activeConversationProvider)?.id, full.id);
+    },
+  );
+
+  test('repeated ownership failures are paced and remain cancelable', () async {
+    final first = _conversation(
+      'repeated-owner-failure',
+      storage: ChatStorageKind.openWebUi,
+    );
+    final second = _conversation(
+      'replacement',
+      storage: ChatStorageKind.directLocal,
+    );
+    final secondFull = _conversation(
+      'replacement',
+      storage: ChatStorageKind.directLocal,
+      body: 'Replacement body',
+    );
+    var attempts = 0;
+    final container = await _createContainer(
+      timeout: const Duration(seconds: 1),
+      extraOverrides: [
+        loadConversationProvider(conversationScopedId(first)).overrideWith((
+          ref,
+        ) async {
+          attempts += 1;
+          throw OpenWebUiConversationOwnershipException(
+            OpenWebUiConversationOwnershipFailureReason.changedWhileLoading,
+          );
+        }),
+        loadConversationProvider(
+          conversationScopedId(second),
+        ).overrideWith((ref) async => secondFull),
+      ],
+    );
+    _certifyOpenWebUiStorage(container);
+
+    final firstSelection = container
+        .read(conversationSelectionProvider.notifier)
+        .select(first);
+    await Future<void>.delayed(const Duration(milliseconds: 80));
+    expect(attempts, lessThan(10));
+
+    final secondResult = await container
+        .read(conversationSelectionProvider.notifier)
+        .select(second);
+    final firstResult = await firstSelection.timeout(
+      const Duration(milliseconds: 100),
+    );
+
+    expect(
+      secondResult.disposition,
+      ConversationSelectionDisposition.committed,
+    );
+    expect(firstResult.disposition, ConversationSelectionDisposition.canceled);
+    expect(container.read(activeConversationProvider)?.id, second.id);
+  });
+
+  test(
+    'terminal failure preserves the active chat and a fresh retry succeeds',
+    () async {
+      final previous = _conversation(
+        'previous',
+        storage: ChatStorageKind.directLocal,
+        body: 'Previous body',
+      );
+      final summary = _conversation(
+        'retry-chat',
+        storage: ChatStorageKind.directLocal,
+      );
+      final full = _conversation(
+        'retry-chat',
+        storage: ChatStorageKind.directLocal,
+        body: 'Recovered body',
+      );
+      var attempts = 0;
+      final scopedId = conversationScopedId(summary);
+      final container = await _createContainer(
+        activeConversation: previous,
+        extraOverrides: [
+          loadConversationProvider(scopedId).overrideWith((ref) async {
+            attempts += 1;
+            if (attempts == 1) throw StateError('offline');
+            return full;
+          }),
+        ],
+      );
+
+      final first = await container
+          .read(conversationSelectionProvider.notifier)
+          .select(summary);
+      expect(first.disposition, ConversationSelectionDisposition.failed);
+      expect(first.error, isA<StateError>());
+      expect(container.read(activeConversationProvider)?.id, previous.id);
+      expect(container.read(conversationSelectionProvider).isLoading, isFalse);
+
+      final second = await container
+          .read(conversationSelectionProvider.notifier)
+          .select(summary);
+      expect(second.disposition, ConversationSelectionDisposition.committed);
+      expect(attempts, 2);
+      expect(container.read(activeConversationProvider)?.id, full.id);
+      expect(
+        container.read(activeConversationProvider)?.messages.single.content,
+        'Recovered body',
+      );
+    },
+  );
+}

--- a/test/features/navigation/views/folder_page_test.dart
+++ b/test/features/navigation/views/folder_page_test.dart
@@ -4,6 +4,7 @@ import 'dart:io';
 
 import 'package:checks/checks.dart';
 import 'package:conduit/core/database/app_database.dart';
+import 'package:conduit/core/database/chat_database_repository.dart';
 import 'package:conduit/core/database/database_provider.dart';
 import 'package:conduit/core/models/chat_message.dart';
 import 'package:conduit/core/models/conversation.dart';
@@ -32,6 +33,7 @@ import 'package:drift/drift.dart' show Value;
 import 'package:drift/native.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_riverpod/misc.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:go_router/go_router.dart';
 
@@ -560,8 +562,82 @@ void main() {
     FlutterError.onError = originalFlutterErrorOnError;
   });
 
+  testWidgets('folder conversation open uses the shared full loader', (
+    tester,
+  ) async {
+    final originalErrorWidgetBuilder = ErrorWidget.builder;
+    final originalFlutterErrorOnError = FlutterError.onError;
+    addTearDown(() async {
+      await tester.pumpWidget(const SizedBox.shrink());
+      ErrorWidget.builder = originalErrorWidgetBuilder;
+      FlutterError.onError = originalFlutterErrorOnError;
+    });
+
+    final timestamp = DateTime(2026, 1, 1);
+    final conversation = withChatStorageProvenance(
+      Conversation(
+        id: 'folder-chat-1',
+        title: 'Folder Chat',
+        createdAt: timestamp,
+        updatedAt: timestamp,
+        folderId: 'work',
+      ),
+      ChatStorageKind.directLocal,
+    );
+    final full = withChatStorageProvenance(
+      conversation.copyWith(
+        messages: [
+          ChatMessage(
+            id: 'assistant-1',
+            role: 'assistant',
+            content: 'Loaded through the shared provider',
+            timestamp: timestamp,
+          ),
+        ],
+      ),
+      ChatStorageKind.directLocal,
+    );
+    final scopedId = conversationScopedId(conversation);
+    var loadCalls = 0;
+    final container = _createContainer(
+      folders: const [Folder(id: 'work', name: 'Work')],
+      conversations: [conversation],
+      extraOverrides: [
+        folderConversationSummariesProvider(
+          'work',
+        ).overrideWith((ref) async => [conversation]),
+        loadConversationProvider(scopedId).overrideWith((ref) async {
+          loadCalls += 1;
+          return full;
+        }),
+      ],
+    );
+    addTearDown(container.dispose);
+
+    await tester.pumpWidget(_buildHarnessFromContainer(container));
+    await tester.pumpAndSettle();
+
+    container.read(selectedFilterIdsProvider.notifier).set(const ['filter-a']);
+    await tester.tap(
+      find.byKey(const ValueKey<String>('folder-chat-folder-chat-1')),
+    );
+    await tester.pumpAndSettle();
+
+    expect(loadCalls, 1);
+    expect(container.read(activeConversationProvider)?.id, 'folder-chat-1');
+    expect(
+      container.read(activeConversationProvider)?.messages.single.content,
+      'Loaded through the shared provider',
+    );
+    expect(container.read(selectedFilterIdsProvider), isEmpty);
+
+    await tester.pumpWidget(const SizedBox.shrink());
+    ErrorWidget.builder = originalErrorWidgetBuilder;
+    FlutterError.onError = originalFlutterErrorOnError;
+  });
+
   testWidgets(
-    'folder conversation open falls back to cached row on API error',
+    'same-route router refresh does not cancel delayed folder navigation',
     (tester) async {
       final originalErrorWidgetBuilder = ErrorWidget.builder;
       final originalFlutterErrorOnError = FlutterError.onError;
@@ -572,55 +648,172 @@ void main() {
       });
 
       final timestamp = DateTime(2026, 1, 1);
-      final conversation = Conversation(
-        id: 'folder-chat-1',
-        title: 'Folder Chat',
-        createdAt: timestamp,
-        updatedAt: timestamp,
-        folderId: 'work',
+      final conversation = withChatStorageProvenance(
+        Conversation(
+          id: 'same-route-refresh-chat',
+          title: 'Same Route Refresh Chat',
+          createdAt: timestamp,
+          updatedAt: timestamp,
+          folderId: 'work',
+        ),
+        ChatStorageKind.directLocal,
       );
-      final api = _FakeFolderApiService(
-        getConversationError: StateError('offline'),
+      final full = withChatStorageProvenance(
+        conversation.copyWith(
+          messages: [
+            ChatMessage(
+              id: 'assistant-same-route',
+              role: 'assistant',
+              content: 'Loaded after a same-route router refresh',
+              timestamp: timestamp,
+            ),
+          ],
+        ),
+        ChatStorageKind.directLocal,
       );
-      final db = AppDatabase(NativeDatabase.memory());
-      addTearDown(db.close);
-      await db.chatsDao.upsertEnvelopeStub(
-        id: 'folder-chat-1',
-        title: 'Folder Chat',
-        createdAt: timestamp.millisecondsSinceEpoch ~/ 1000,
-        updatedAt: timestamp.millisecondsSinceEpoch ~/ 1000,
-        folderId: const Value('work'),
-      );
+      final loadGate = Completer<Conversation>();
+      final scopedId = conversationScopedId(conversation);
+      final routerRefresh = ChangeNotifier();
+      addTearDown(routerRefresh.dispose);
       final container = _createContainer(
-        api: api,
         folders: const [Folder(id: 'work', name: 'Work')],
         conversations: [conversation],
-        isAuthenticated: true,
-        database: db,
+        extraOverrides: [
+          folderConversationSummariesProvider(
+            'work',
+          ).overrideWith((ref) async => [conversation]),
+          loadConversationProvider(
+            scopedId,
+          ).overrideWith((ref) => loadGate.future),
+        ],
       );
       addTearDown(container.dispose);
 
-      await tester.pumpWidget(_buildHarnessFromContainer(container));
-      await tester.pumpAndSettle();
-
-      container.read(selectedFilterIdsProvider.notifier).set(const [
-        'filter-a',
-      ]);
-      await tester.tap(
-        find.byKey(const ValueKey<String>('folder-chat-folder-chat-1')),
+      await tester.pumpWidget(
+        _buildHarnessFromContainer(
+          container,
+          routerRefreshListenable: routerRefresh,
+        ),
       );
       await tester.pumpAndSettle();
 
-      expect(api.requestedConversationIds, ['folder-chat-1']);
-      expect(container.read(activeConversationProvider)?.id, 'folder-chat-1');
-      expect(container.read(activeConversationProvider)?.title, 'Folder Chat');
-      expect(container.read(selectedFilterIdsProvider), isEmpty);
+      await tester.tap(
+        find.byKey(
+          const ValueKey<String>('folder-chat-same-route-refresh-chat'),
+        ),
+      );
+      await tester.pump();
+      final routeRevision = NavigationService.currentRouteRevision;
+
+      routerRefresh.notifyListeners();
+      await tester.pump();
+      expect(NavigationService.currentRoute, '/folder/work');
+      expect(NavigationService.currentRouteRevision, routeRevision);
+
+      loadGate.complete(full);
+      await tester.pumpAndSettle();
+
+      expect(NavigationService.currentRoute, '/chat');
+      expect(container.read(activeConversationProvider)?.id, conversation.id);
 
       await tester.pumpWidget(const SizedBox.shrink());
       ErrorWidget.builder = originalErrorWidgetBuilder;
       FlutterError.onError = originalFlutterErrorOnError;
     },
   );
+
+  testWidgets('delayed folder selection does not navigate after route ABA', (
+    tester,
+  ) async {
+    final originalErrorWidgetBuilder = ErrorWidget.builder;
+    final originalFlutterErrorOnError = FlutterError.onError;
+    addTearDown(() async {
+      await tester.pumpWidget(const SizedBox.shrink());
+      ErrorWidget.builder = originalErrorWidgetBuilder;
+      FlutterError.onError = originalFlutterErrorOnError;
+    });
+
+    final timestamp = DateTime(2026, 1, 1);
+    final conversation = withChatStorageProvenance(
+      Conversation(
+        id: 'delayed-folder-chat',
+        title: 'Delayed Folder Chat',
+        createdAt: timestamp,
+        updatedAt: timestamp,
+        folderId: 'work',
+      ),
+      ChatStorageKind.directLocal,
+    );
+    final full = withChatStorageProvenance(
+      conversation.copyWith(
+        messages: [
+          ChatMessage(
+            id: 'assistant-delayed',
+            role: 'assistant',
+            content: 'Loaded after leaving and returning',
+            timestamp: timestamp,
+          ),
+        ],
+      ),
+      ChatStorageKind.directLocal,
+    );
+    final loadGate = Completer<Conversation>();
+    final scopedId = conversationScopedId(conversation);
+    var loadCalls = 0;
+    final container = _createContainer(
+      folders: const [
+        Folder(id: 'work', name: 'Work'),
+        Folder(id: 'other', name: 'Other'),
+      ],
+      conversations: [conversation],
+      extraOverrides: [
+        folderConversationSummariesProvider(
+          'work',
+        ).overrideWith((ref) async => [conversation]),
+        folderConversationSummariesProvider(
+          'other',
+        ).overrideWith((ref) async => const <Conversation>[]),
+        loadConversationProvider(scopedId).overrideWith((ref) {
+          loadCalls += 1;
+          return loadGate.future;
+        }),
+      ],
+    );
+    addTearDown(container.dispose);
+
+    await tester.pumpWidget(_buildHarnessFromContainer(container));
+    await tester.pumpAndSettle();
+
+    await tester.tap(
+      find.byKey(const ValueKey<String>('folder-chat-delayed-folder-chat')),
+    );
+    await tester.pump();
+    expect(loadCalls, 1);
+
+    NavigationService.router.go('/folder/other');
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 300));
+    expect(NavigationService.currentRoute, '/folder/other');
+
+    NavigationService.router.go('/folder/work');
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 300));
+    expect(NavigationService.currentRoute, '/folder/work');
+
+    loadGate.complete(full);
+    await tester.pumpAndSettle();
+
+    expect(NavigationService.currentRoute, '/folder/work');
+    expect(container.read(activeConversationProvider)?.id, conversation.id);
+    expect(
+      container.read(activeConversationProvider)?.messages.single.content,
+      'Loaded after leaving and returning',
+    );
+
+    await tester.pumpWidget(const SizedBox.shrink());
+    ErrorWidget.builder = originalErrorWidgetBuilder;
+    FlutterError.onError = originalFlutterErrorOnError;
+  });
 }
 
 Widget _buildHarness({
@@ -651,6 +844,7 @@ ProviderContainer _createContainer({
   Conversation? activeConversation,
   List<ChatMessage> initialMessages = const <ChatMessage>[],
   AppDatabase? database,
+  List<Override> extraOverrides = const <Override>[],
 }) {
   final resolvedSelectedModel =
       selectedModel ?? const Model(id: 'model-1', name: 'Model 1');
@@ -682,13 +876,18 @@ ProviderContainer _createContainer({
       modelsProvider.overrideWith(() => _TestModels(resolvedModels)),
       foldersProvider.overrideWith(() => _TestFolders(folders)),
       toolsListProvider.overrideWith(_TestToolsList.new),
+      ...extraOverrides,
     ],
   );
 }
 
-Widget _buildHarnessFromContainer(ProviderContainer container) {
+Widget _buildHarnessFromContainer(
+  ProviderContainer container, {
+  Listenable? routerRefreshListenable,
+}) {
   final router = GoRouter(
     initialLocation: '/folder/work',
+    refreshListenable: routerRefreshListenable,
     routes: [
       GoRoute(
         path: '/folder/:id',
@@ -784,13 +983,9 @@ class _FakeOptimizedStorageService extends Fake
 }
 
 class _FakeFolderApiService extends Fake implements ApiService {
-  _FakeFolderApiService({this.getConversationError});
-
   String? lastUpdatedName;
   Map<String, dynamic>? lastUpdatedMeta;
   Map<String, dynamic>? lastUpdatedData;
-  final Object? getConversationError;
-  final List<String> requestedConversationIds = <String>[];
 
   Map<String, dynamic> _folder = <String, dynamic>{
     'id': 'work',
@@ -815,21 +1010,6 @@ class _FakeFolderApiService extends Fake implements ApiService {
   @override
   Future<Map<String, dynamic>> getUserPermissions() async =>
       <String, dynamic>{};
-
-  @override
-  Future<Conversation> getConversation(String id) async {
-    requestedConversationIds.add(id);
-    final error = getConversationError;
-    if (error != null) {
-      throw error;
-    }
-    return Conversation(
-      id: id,
-      title: id,
-      createdAt: DateTime(2026, 1, 1),
-      updatedAt: DateTime(2026, 1, 1),
-    );
-  }
 
   @override
   Future<Map<String, dynamic>?> updateFolder(

--- a/test/features/navigation/widgets/sidebar_page_test.dart
+++ b/test/features/navigation/widgets/sidebar_page_test.dart
@@ -17,6 +17,7 @@ import 'package:conduit/core/models/user.dart';
 import 'package:conduit/core/services/navigation_service.dart';
 import 'package:conduit/core/services/optimized_storage_service.dart';
 import 'package:conduit/core/services/settings_service.dart';
+import 'package:conduit/core/sync/sync_engine.dart';
 import 'package:conduit/features/auth/providers/unified_auth_providers.dart';
 import 'package:conduit/features/channels/widgets/channel_list_tab.dart';
 import 'package:conduit/features/channels/providers/channel_providers.dart';
@@ -99,6 +100,54 @@ void main() {
       expect(terminalLayer.opacity, 0);
     },
   );
+
+  testWidgets('shows determinate sync progress above every sidebar tab', (
+    tester,
+  ) async {
+    final controllers = _SidebarHarnessControllers();
+
+    await tester.pumpWidget(
+      _buildSidebarHarness(
+        controllers: controllers,
+        syncStatus: const SyncStatus(
+          phase: SyncPhase.running,
+          stage: SyncStage.chats,
+          completedItems: 3,
+          totalItems: 8,
+        ),
+      ),
+    );
+
+    final progress = tester.widget<LinearProgressIndicator>(
+      find.byKey(const ValueKey<String>('sidebar-sync-progress')),
+    );
+    check(progress.value).isNotNull().equals(3 / 8);
+    check(progress.semanticsLabel).equals('Syncing chats');
+    check(progress.semanticsValue).equals('38%');
+
+    await tester.tap(_sidebarBottomNavTabLabel('Notes'));
+    await tester.pump();
+    expect(
+      find.byKey(const ValueKey<String>('sidebar-sync-progress')),
+      findsOneWidget,
+    );
+  });
+
+  testWidgets('hides sidebar sync progress while idle', (tester) async {
+    final controllers = _SidebarHarnessControllers();
+
+    await tester.pumpWidget(
+      _buildSidebarHarness(
+        controllers: controllers,
+        syncStatus: const SyncStatus(),
+      ),
+    );
+
+    expect(
+      find.byKey(const ValueKey<String>('sidebar-sync-progress')),
+      findsNothing,
+    );
+  });
 
   testWidgets(
     'tapping terminal syncs provider state and activates the terminal layer',
@@ -1633,6 +1682,7 @@ Widget _buildSidebarHarness({
   bool openWebUiStorageOpen = true,
   Conversation? activeConversation,
   ThemeData? theme,
+  SyncStatus? syncStatus,
 }) {
   final availableTerminalServers = terminalServers ?? _defaultTerminalServers();
   final router = GoRouter(
@@ -1665,6 +1715,8 @@ Widget _buildSidebarHarness({
   return ProviderScope(
     overrides: [
       ...openWebUiStorageOpenOverrides(open: openWebUiStorageOpen),
+      if (syncStatus != null)
+        syncEngineProvider.overrideWith(() => _FixedSyncEngine(syncStatus)),
       // The sidebar harness owns its in-memory OpenWebUI database explicitly;
       // unrelated auth bootstrap must not close that test seam underneath it.
       openWebUiAccountStorageIsolationProvider.overrideWith(
@@ -1769,6 +1821,15 @@ Widget _buildSidebarHarness({
       routerConfig: router,
     ),
   );
+}
+
+final class _FixedSyncEngine extends SyncEngine {
+  _FixedSyncEngine(this.initial);
+
+  final SyncStatus initial;
+
+  @override
+  SyncStatus build() => initial;
 }
 
 final class _NoopOpenWebUiAccountStorageIsolation

--- a/test/features/navigation/widgets/sidebar_page_test.dart
+++ b/test/features/navigation/widgets/sidebar_page_test.dart
@@ -20,6 +20,7 @@ import 'package:conduit/core/services/settings_service.dart';
 import 'package:conduit/features/auth/providers/unified_auth_providers.dart';
 import 'package:conduit/features/channels/widgets/channel_list_tab.dart';
 import 'package:conduit/features/channels/providers/channel_providers.dart';
+import 'package:conduit/features/navigation/providers/conversation_selection_provider.dart';
 import 'package:conduit/features/navigation/providers/sidebar_providers.dart';
 import 'package:conduit/features/navigation/widgets/chats_drawer.dart';
 import 'package:conduit/features/navigation/widgets/drawer_section_notifiers.dart';
@@ -1288,6 +1289,90 @@ void main() {
   });
 
   testWidgets(
+    'server chat tapped during bootstrap opens when storage becomes ready',
+    (tester) async {
+      final controllers = _SidebarHarnessControllers();
+      final timestamp = DateTime(2026, 1, 1);
+      final previous = withChatStorageProvenance(
+        Conversation(
+          id: 'previous-chat',
+          title: 'Previously committed chat',
+          createdAt: timestamp,
+          updatedAt: timestamp,
+        ),
+        ChatStorageKind.directLocal,
+      );
+      final summary = withChatStorageProvenance(
+        Conversation(
+          id: 'server-bootstrap-chat',
+          title: 'Newly synchronized chat',
+          createdAt: timestamp,
+          updatedAt: timestamp,
+        ),
+        ChatStorageKind.openWebUi,
+      );
+      final full = withChatStorageProvenance(
+        summary.copyWith(
+          messages: [
+            ChatMessage(
+              id: 'assistant-1',
+              role: 'assistant',
+              content: 'Loaded after storage certification',
+              timestamp: timestamp,
+            ),
+          ],
+        ),
+        ChatStorageKind.openWebUi,
+      );
+      final scopedId = conversationScopedId(summary);
+
+      await tester.pumpWidget(
+        _buildSidebarHarness(
+          controllers: controllers,
+          conversations: [summary],
+          isAuthenticated: true,
+          openWebUiServerId: 'test-server',
+          openWebUiStorageOpen: false,
+          activeConversation: previous,
+          loadedConversations: {scopedId: full},
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      final row = find.byKey(ValueKey<String>('drawer-chat-$scopedId'));
+      final container = ProviderScope.containerOf(
+        tester.element(find.byType(SidebarPage)),
+        listen: false,
+      );
+      await tester.tap(row);
+      await tester.pump();
+
+      expect(container.read(activeConversationProvider)?.id, previous.id);
+      expect(container.read(conversationSelectionProvider).isLoading, isTrue);
+      expect(
+        find.descendant(
+          of: row,
+          matching: find.byType(CircularProgressIndicator),
+        ),
+        findsOneWidget,
+      );
+
+      container.read(openWebUiDatabaseAccessProvider.notifier).open();
+      await tester.pumpAndSettle();
+
+      expect(container.read(activeConversationProvider)?.id, full.id);
+      expect(
+        container.read(activeConversationProvider)?.messages.single.content,
+        'Loaded after storage certification',
+      );
+      expect(container.read(conversationSelectionProvider).isLoading, isFalse);
+
+      await tester.pumpWidget(const SizedBox.shrink());
+      await tester.pump(const Duration(milliseconds: 1));
+    },
+  );
+
+  testWidgets(
     'account switch while a server chat loads cannot republish its body',
     (tester) async {
       final controllers = _SidebarHarnessControllers();
@@ -1311,12 +1396,24 @@ void main() {
           ),
         ],
       );
+      final previous = withChatStorageProvenance(
+        Conversation(
+          id: 'previous-chat',
+          title: 'Previously committed chat',
+          createdAt: timestamp,
+          updatedAt: timestamp,
+        ),
+        ChatStorageKind.directLocal,
+      );
       final loadGate = Completer<Conversation>();
 
       await tester.pumpWidget(
         _buildSidebarHarness(
           controllers: controllers,
           conversations: [summary],
+          isAuthenticated: true,
+          openWebUiServerId: 'test-server',
+          activeConversation: previous,
           pendingLoadedConversations: {
             conversationScopedId(summary): loadGate.future,
           },
@@ -1335,11 +1432,11 @@ void main() {
       );
       await tester.pump();
 
-      container.read(openWebUiDatabaseAccessProvider.notifier).beginPurge();
+      container.read(_sidebarAuthTokenProvider.notifier).set('account-b-token');
       loadGate.complete(full);
       await tester.pumpAndSettle();
 
-      expect(container.read(activeConversationProvider), isNull);
+      expect(container.read(activeConversationProvider)?.id, previous.id);
     },
   );
 
@@ -1371,6 +1468,8 @@ void main() {
       _buildSidebarHarness(
         controllers: controllers,
         conversations: [direct, server],
+        isAuthenticated: true,
+        openWebUiServerId: 'test-server',
         loadedConversations: {
           conversationScopedId(server): server,
           conversationScopedId(direct): direct,
@@ -1529,6 +1628,10 @@ Widget _buildSidebarHarness({
   List<HermesJob> hermesJobs = const [],
   Map<String, Conversation> loadedConversations = const {},
   Map<String, Future<Conversation>> pendingLoadedConversations = const {},
+  bool isAuthenticated = false,
+  String? openWebUiServerId,
+  bool openWebUiStorageOpen = true,
+  Conversation? activeConversation,
   ThemeData? theme,
 }) {
   final availableTerminalServers = terminalServers ?? _defaultTerminalServers();
@@ -1561,7 +1664,7 @@ Widget _buildSidebarHarness({
 
   return ProviderScope(
     overrides: [
-      ...openWebUiStorageOpenOverrides(),
+      ...openWebUiStorageOpenOverrides(open: openWebUiStorageOpen),
       // The sidebar harness owns its in-memory OpenWebUI database explicitly;
       // unrelated auth bootstrap must not close that test seam underneath it.
       openWebUiAccountStorageIsolationProvider.overrideWith(
@@ -1576,9 +1679,24 @@ Widget _buildSidebarHarness({
       // ignore: scoped_providers_should_specify_dependencies
       openWebUiAuthSessionEpochProvider.overrideWithValue(Object()),
       // ignore: scoped_providers_should_specify_dependencies
+      isAuthenticatedProvider2.overrideWithValue(isAuthenticated),
+      if (isAuthenticated)
+        // ignore: scoped_providers_should_specify_dependencies
+        authTokenProvider3.overrideWith(
+          (ref) => ref.watch(_sidebarAuthTokenProvider),
+        ),
+      if (openWebUiServerId != null)
+        openWebUiCertifiedDatabaseServerProvider.overrideWith(
+          () => _SeededCertifiedDatabaseServer(openWebUiServerId),
+        ),
+      // ignore: scoped_providers_should_specify_dependencies
       currentUserProvider2.overrideWithValue(currentUser),
       // ignore: scoped_providers_should_specify_dependencies
       currentUserProvider.overrideWith((ref) async => currentUser),
+      if (activeConversation != null)
+        activeConversationProvider.overrideWith(
+          () => _SeededActiveConversation(activeConversation),
+        ),
       // ignore: scoped_providers_should_specify_dependencies
       conversationsProvider.overrideWith(
         () => _TestConversations(
@@ -1657,6 +1775,36 @@ final class _NoopOpenWebUiAccountStorageIsolation
     extends OpenWebUiAccountStorageIsolation {
   @override
   void build() {}
+}
+
+final _sidebarAuthTokenProvider = NotifierProvider<_SidebarAuthToken, String?>(
+  _SidebarAuthToken.new,
+);
+
+final class _SidebarAuthToken extends Notifier<String?> {
+  @override
+  String? build() => 'test-token';
+
+  void set(String? token) => state = token;
+}
+
+final class _SeededCertifiedDatabaseServer
+    extends OpenWebUiCertifiedDatabaseServerNotifier {
+  _SeededCertifiedDatabaseServer(this.serverId);
+
+  final String serverId;
+
+  @override
+  String? build() => serverId;
+}
+
+final class _SeededActiveConversation extends ActiveConversationNotifier {
+  _SeededActiveConversation(this.conversation);
+
+  final Conversation conversation;
+
+  @override
+  Conversation? build() => conversation;
 }
 
 List<TerminalServerInfo> _defaultTerminalServers() {

--- a/test/features/workspace/views/workspace_shell_test.dart
+++ b/test/features/workspace/views/workspace_shell_test.dart
@@ -208,7 +208,11 @@ void main() {
 
     expect(find.byType(AdaptiveRouteShell), findsOneWidget);
     expect(find.byIcon(Icons.error_outline), findsOneWidget);
-    expect(find.text('Workspace · Models'), findsOneWidget);
+    final shell = tester.widget<AdaptiveRouteShell>(
+      find.byType(AdaptiveRouteShell),
+    );
+    expect(shell.appBar?.title, 'Workspace');
+    expect(shell.appBar?.subtitle, 'Models');
   });
 
   testWidgets('gate never builds protected content for a denied section', (

--- a/test/support/openwebui_storage_test_overrides.dart
+++ b/test/support/openwebui_storage_test_overrides.dart
@@ -12,8 +12,12 @@ import 'package:flutter_riverpod/misc.dart';
 /// coordinator should not use this helper; provider tests that deliberately
 /// replace [appDatabaseProvider] with an unmanaged database may use it to make
 /// their authenticated storage assumption explicit.
-List<Override> openWebUiStorageOpenOverrides({AppDatabase? database}) => [
-  openWebUiDatabaseAccessProvider.overrideWith(_OpenWebUiDatabaseAccess.new),
+List<Override> openWebUiStorageOpenOverrides({
+  AppDatabase? database,
+  bool open = true,
+}) => [
+  if (open)
+    openWebUiDatabaseAccessProvider.overrideWith(_OpenWebUiDatabaseAccess.new),
   if (database != null)
     appDatabaseProvider.overrideWithValue(database)
   else


### PR DESCRIPTION
## Summary

- update adaptive platform UI and project dependencies
- preserve OpenWebUI conversation selection and chat loading across sign-out and sign-in
- expose chat and note pull progress through the sync engine
- show an accessible, reduced-motion-safe progress indicator in the sidebar

## Verification

- `flutter analyze`
- `flutter test` (4,579 passed, 2 expected skips)
- `flutter build ios --simulator --debug`
- manually verified sign-out/sign-in and the sidebar layout in the iOS simulator

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Stabilize adaptive navigation and account sync with a centralized conversation selection provider
> - Introduces `ConversationSelection` Riverpod notifier in [`conversation_selection_provider.dart`](https://github.com/cogwheel0/conduit/pull/584/files#diff-ee3816399f4c26f0b441d12013b0026e58182705a7503273ac9ed763ad88865f) to centralize conversation loading state, cancellation, and disposition handling (committed/canceled/failed) across folder, drawer, and sidebar views.
> - Adds staged sync progress reporting to `SyncEngine` and `PullSync` (chats → notes → finalizing), surfacing a `LinearProgressIndicator` in the sidebar via the new `_SidebarSyncProgressBar` widget.
> - Introduces `apiAuthTokenMirrorProvider` and mirrors the auth token into it on every `_updateApiServiceToken` call, so rebuilt `ApiService` instances retain authentication state.
> - Adds `SyncTriggers.requestPostCertificationSync` to trigger a combined chat-and-note pull after account certification, called from `OpenWebUiAccountStorageIsolation` on certification publication.
> - Fixes iOS 26+ layout in `WorkspaceScaffold` to rely on native toolbar padding via `SafeArea` instead of manual insets, and splits the app bar title into separate title and subtitle fields.
> - Adds `NavigationService.currentRouteRevision` to detect route changes during delayed navigation, used to guard against ABA route transitions canceling pending conversation loads.
> - Marks destructive menu actions (delete, leave) with `isDestructive: true` in channel, note editor, and terminal tab menus.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 46f80af.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added determinate live sync progress indicators for chats, notes, and finalization in the sidebar.
  * Improved conversation selection with structured outcomes (loading/cancel/timeout/retry) and more reliable OpenWebUI conversation ownership handling.
* **Bug Fixes**
  * Prevented transient unauthenticated API behavior during auth transitions.
  * Added safer post-certification synchronization kickoff and tightened sync trigger sequencing.
* **Style**
  * Marked “leave/delete” (and other delete actions) as destructive in menus.
  * Refined iOS workspace/app-bar spacing and title/subtitle layout.
* **Tests**
  * Expanded sync, conversation selection, and startup/isolation coverage for the new behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR stabilizes adaptive navigation and account sync. The main changes are:

- Adds centralized, owner-aware conversation selection with cancellation and retry handling.
- Mirrors the current auth token into rebuilt API service instances.
- Triggers chat and note pulls after OpenWebUI account storage certification.
- Surfaces staged chat, note, and finalizing sync progress in the sidebar.
- Updates iOS adaptive toolbar layout and dependency lockfiles.
- Expands tests for auth publication, storage isolation, sync triggers, conversation selection, sidebar progress, and workspace layout.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

This PR appears safe to merge with low risk.

No blocking or actionable bugs were found in the changed ownership guards, token mirroring, sync progress callbacks, route-revision checks, or related tests.

No files require special attention.
</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- The Flutter toolchain is unavailable in the environment, as shown by flutter\_exit=127, dart\_exit=127, pod\_exit=127, and xcodebuild\_exit=127, with only Ruby present.
- As a result, flutter pub get could not run and failed with 'No such file or directory' and exit code 127.
- Flutter analyze could not run for the same reason, failing with exit code 127.
- The command for the targeted changed tests also blocked due to the missing Flutter executable, with exit code 127.

<a href="https://app.greptile.com/trex/runs/15260616/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| lib/features/navigation/providers/conversation_selection_provider.dart | Introduces centralized conversation selection with cancellation, ownership checks, retries, and loading state. |
| lib/core/providers/app_providers.dart | Adds API token mirroring plus OpenWebUI conversation ownership and certification helpers. |
| lib/core/auth/auth_state_manager.dart | Mirrors auth tokens into the new API token provider during auth publication. |
| lib/core/sync/sync_engine.dart | Adds staged sync status and progress publishing for chats, notes, and finalization. |
| lib/core/sync/sync_triggers.dart | Adds a pending post-certification sync trigger that waits for authenticated DB and client readiness. |
| lib/features/navigation/widgets/sidebar_page.dart | Adds staged, accessible sidebar sync progress UI. |
| lib/features/navigation/widgets/chats_drawer.dart | Uses central conversation selection and route-revision checks from the drawer. |
| lib/features/navigation/views/folder_page.dart | Delegates folder conversation opens to the central selection provider and suppresses stale route continuations. |
| lib/features/workspace/views/workspace_page.dart | Updates iOS toolbar inset handling with SafeArea and separate title/subtitle fields. |
| test/features/navigation/providers/conversation_selection_provider_test.dart | Adds coverage for centralized conversation selection cancellation, retries, and ownership changes. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
  participant User
  participant Drawer as ChatsDrawer/FolderPage
  participant Selection as ConversationSelection
  participant Owner as OpenWebUI ownership helpers
  participant Loader as loadConversationProvider
  participant Active as activeConversationProvider
  participant Sync as SyncEngine
  participant Sidebar as Sidebar progress bar

  User->>Drawer: Tap conversation
  Drawer->>Selection: select(summary)
  Selection->>Owner: capture selection owner
  Selection->>Owner: wait for certified read context
  Selection->>Loader: invalidate + load full conversation
  Loader-->>Selection: full conversation or ownership exception
  Selection->>Owner: verify owner/read snapshot still current
  Selection->>Active: publish selected conversation
  Selection-->>Drawer: committed
  Drawer->>Drawer: navigate to chat if route revision unchanged

  Sync->>Sync: pull chats
  Sync-->>Sidebar: SyncStage.chats progress
  Sync->>Sync: pull notes
  Sync-->>Sidebar: SyncStage.notes progress
  Sync->>Sync: finalization/reconcile/drain
  Sync-->>Sidebar: SyncStage.finalizing
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
  participant User
  participant Drawer as ChatsDrawer/FolderPage
  participant Selection as ConversationSelection
  participant Owner as OpenWebUI ownership helpers
  participant Loader as loadConversationProvider
  participant Active as activeConversationProvider
  participant Sync as SyncEngine
  participant Sidebar as Sidebar progress bar

  User->>Drawer: Tap conversation
  Drawer->>Selection: select(summary)
  Selection->>Owner: capture selection owner
  Selection->>Owner: wait for certified read context
  Selection->>Loader: invalidate + load full conversation
  Loader-->>Selection: full conversation or ownership exception
  Selection->>Owner: verify owner/read snapshot still current
  Selection->>Active: publish selected conversation
  Selection-->>Drawer: committed
  Drawer->>Drawer: navigate to chat if route revision unchanged

  Sync->>Sync: pull chats
  Sync-->>Sidebar: SyncStage.chats progress
  Sync->>Sync: pull notes
  Sync-->>Sidebar: SyncStage.notes progress
  Sync->>Sync: finalization/reconcile/drain
  Sync-->>Sidebar: SyncStage.finalizing
```

</a>
</details>

<sub>Reviews (2): Last reviewed commit: ["Scope sidebar sync progress rebuilds"](https://github.com/cogwheel0/conduit/commit/46f80afbac6f23c34980d899e9d8ee1aad33b097) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45984180)</sub>

<!-- /greptile_comment -->