### PR TITLE
fix: reconcile remote deletions and generated titles

### DIFF
--- a/lib/core/database/daos/chats_dao.dart
+++ b/lib/core/database/daos/chats_dao.dart
@@ -728,10 +728,10 @@ class ChatsDao extends DatabaseAccessor<AppDatabase> with _$ChatsDaoMixin {
   ///
   /// The caller holds `ChatLocks.runExclusive(chatId)`. This is a
   /// server-origin write, so it deliberately leaves dirty/outbox state alone.
-  Future<int> updateServerGeneratedTitle(String chatId, String title) {
+  Future<String?> updateServerGeneratedTitle(String chatId, String title) {
     return transaction(() async {
       final existing = await getChat(chatId);
-      if (existing == null) return 0;
+      if (existing == null) return null;
 
       Map<String, dynamic> blobMeta;
       try {
@@ -742,16 +742,26 @@ class ChatsDao extends DatabaseAccessor<AppDatabase> with _$ChatsDaoMixin {
       } catch (_) {
         blobMeta = <String, dynamic>{};
       }
+      // A local envelope rename changes `chats.title` before the reconstructed
+      // blob metadata is updated. Preserve that divergence while the row is
+      // dirty; a dirty row whose title still matches its blob has only local
+      // body/message edits and can safely accept the generated title.
+      final blobHadTitle = blobMeta['blobHadTitle'] == true;
+      final hasPendingLocalTitle =
+          existing.dirty &&
+          (!blobHadTitle || blobMeta['blobTitleValue'] != existing.title);
+      final persistedTitle = hasPendingLocalTitle ? existing.title : title;
       blobMeta['v'] ??= 1;
       blobMeta['blobHadTitle'] = true;
-      blobMeta['blobTitleValue'] = title;
+      blobMeta['blobTitleValue'] = persistedTitle;
 
-      return (update(chats)..where((t) => t.id.equals(chatId))).write(
+      await (update(chats)..where((t) => t.id.equals(chatId))).write(
         ChatsCompanion(
-          title: Value(title),
+          title: Value(persistedTitle),
           blobMeta: Value(jsonEncode(blobMeta)),
         ),
       );
+      return persistedTitle;
     });
   }
 

--- a/lib/core/database/daos/chats_dao.dart
+++ b/lib/core/database/daos/chats_dao.dart
@@ -723,6 +723,38 @@ class ChatsDao extends DatabaseAccessor<AppDatabase> with _$ChatsDaoMixin {
     );
   }
 
+  /// Persists a server-generated title in both the list envelope and the
+  /// round-trip blob metadata without advancing the server watermark.
+  ///
+  /// The caller holds `ChatLocks.runExclusive(chatId)`. This is a
+  /// server-origin write, so it deliberately leaves dirty/outbox state alone.
+  Future<int> updateServerGeneratedTitle(String chatId, String title) {
+    return transaction(() async {
+      final existing = await getChat(chatId);
+      if (existing == null) return 0;
+
+      Map<String, dynamic> blobMeta;
+      try {
+        final decoded = jsonDecode(existing.blobMeta);
+        blobMeta = decoded is Map
+            ? Map<String, dynamic>.from(decoded)
+            : <String, dynamic>{};
+      } catch (_) {
+        blobMeta = <String, dynamic>{};
+      }
+      blobMeta['v'] ??= 1;
+      blobMeta['blobHadTitle'] = true;
+      blobMeta['blobTitleValue'] = title;
+
+      return (update(chats)..where((t) => t.id.equals(chatId))).write(
+        ChatsCompanion(
+          title: Value(title),
+          blobMeta: Value(jsonEncode(blobMeta)),
+        ),
+      );
+    });
+  }
+
   // ---- local-mutation variants (CDT-RFC-001 §7.2.1, Wiring W1) ------------
   //
   // Each writes its rows AND (when [enqueue]) its outbox op in ONE drift

--- a/lib/core/database/daos/chats_dao.dart
+++ b/lib/core/database/daos/chats_dao.dart
@@ -105,6 +105,19 @@ class ChatListEntry {
   final int? lastReadAt;
 }
 
+/// Minimal local envelope used by full-list server reconciliation.
+class ServerChatReconcileEntry {
+  const ServerChatReconcileEntry({
+    required this.id,
+    required this.title,
+    required this.dirty,
+  });
+
+  final String id;
+  final String title;
+  final bool dirty;
+}
+
 /// Chat row accessor (CDT-RFC-001 §6, §7.4, §10).
 @DriftAccessor(tables: [Chats, Messages])
 class ChatsDao extends DatabaseAccessor<AppDatabase> with _$ChatsDaoMixin {
@@ -224,16 +237,24 @@ class ChatsDao extends DatabaseAccessor<AppDatabase> with _$ChatsDaoMixin {
     return (select(chats)..where((t) => t.id.equals(chatId))).getSingleOrNull();
   }
 
-  /// NARROW id-only projection (REQ §10.2) of every non-tombstoned chat that
+  /// NARROW envelope projection (REQ §10.2) of every non-tombstoned chat that
   /// carries a SERVER id (`id NOT LIKE 'local:%'`). Used by the §7.5 full-ID
-  /// deletion reconcile to diff local server-keyed chats against the complete
-  /// server id set. `local:` rows (never reached the server) are excluded.
-  Future<List<String>> allServerChatIds() async {
+  /// reconcile to diff ids and recover titles missed by the watermark pull.
+  /// `local:` rows (never reached the server) are excluded.
+  Future<List<ServerChatReconcileEntry>> allServerChatReconcileEntries() async {
     final query = selectOnly(chats)
-      ..addColumns([chats.id])
+      ..addColumns([chats.id, chats.title, chats.dirty])
       ..where(chats.deleted.equals(false) & chats.id.like('local:%').not());
     final rows = await query.get();
-    return rows.map((row) => row.read(chats.id)!).toList(growable: false);
+    return rows
+        .map(
+          (row) => ServerChatReconcileEntry(
+            id: row.read(chats.id)!,
+            title: row.read(chats.title)!,
+            dirty: row.read(chats.dirty)!,
+          ),
+        )
+        .toList(growable: false);
   }
 
   /// Transactional server write (fast-forward replace, RFC §7.4 line 2 — no

--- a/lib/core/providers/app_providers.dart
+++ b/lib/core/providers/app_providers.dart
@@ -3703,23 +3703,7 @@ class Conversations extends _$Conversations {
       return;
     }
 
-    final scopedId = ChatStorageIdentity(
-      rawId: rawId,
-      storage: ChatStorageKind.openWebUi,
-    ).scopedId;
-    final current = state.asData?.value;
-    final index = current == null
-        ? -1
-        : _conversationIndexForSelection(current, scopedId);
-    if (current != null &&
-        index >= 0 &&
-        current[index].title != normalizedTitle) {
-      final updated = <Conversation>[...current];
-      updated[index] = current[index].copyWith(title: normalizedTitle);
-      state = AsyncData<List<Conversation>>(
-        List<Conversation>.unmodifiable(updated),
-      );
-    }
+    _applyGeneratedTitleToLoadedState(rawId, normalizedTitle);
 
     final db = ref.read(appDatabaseProvider);
     if (db == null) return;
@@ -3731,7 +3715,11 @@ class Conversations extends _$Conversations {
             () =>
                 db.chatsDao.updateServerGeneratedTitle(rawId, normalizedTitle),
           )
-          .then<void>((_) {})
+          .then<void>((persistedTitle) {
+            if (persistedTitle != null && persistedTitle != normalizedTitle) {
+              _applyGeneratedTitleToLoadedState(rawId, persistedTitle);
+            }
+          })
           .catchError((Object error, StackTrace stackTrace) {
             DebugLogger.error(
               'generated-title-write-failed',
@@ -3742,6 +3730,31 @@ class Conversations extends _$Conversations {
             );
           }),
     );
+  }
+
+  void _applyGeneratedTitleToLoadedState(String rawId, String title) {
+    final scopedId = ChatStorageIdentity(
+      rawId: rawId,
+      storage: ChatStorageKind.openWebUi,
+    ).scopedId;
+    final current = state.asData?.value;
+    final index = current == null
+        ? -1
+        : _conversationIndexForSelection(current, scopedId);
+    if (current != null && index >= 0 && current[index].title != title) {
+      final updated = <Conversation>[...current];
+      updated[index] = current[index].copyWith(title: title);
+      state = AsyncData<List<Conversation>>(
+        List<Conversation>.unmodifiable(updated),
+      );
+    }
+
+    final active = ref.read(activeConversationProvider);
+    if (active != null && conversationMatchesScopedId(active, scopedId)) {
+      ref
+          .read(activeConversationProvider.notifier)
+          .set(active.copyWith(title: title));
+    }
   }
 
   /// Rows are id-keyed in the database; the summary "trust" machinery is
@@ -7184,7 +7197,8 @@ class ActiveChatsSync extends _$ActiveChatsSync {
     final payload = data['data'];
     final title = switch (payload) {
       String value => value.trim(),
-      Map value => value['title']?.toString().trim() ?? '',
+      Map value when value['title'] is String =>
+        (value['title'] as String).trim(),
       _ => '',
     };
     final chatId = _extractChatEventId(map);
@@ -7201,17 +7215,6 @@ class ActiveChatsSync extends _$ActiveChatsSync {
     ref
         .read(conversationsProvider.notifier)
         .applyServerGeneratedTitle(chatId, title);
-
-    final active = ref.read(activeConversationProvider);
-    final scopedId = ChatStorageIdentity(
-      rawId: chatId,
-      storage: ChatStorageKind.openWebUi,
-    ).scopedId;
-    if (active != null && conversationMatchesScopedId(active, scopedId)) {
-      ref
-          .read(activeConversationProvider.notifier)
-          .set(active.copyWith(title: title));
-    }
   }
 
   String? _extractChatEventId(Map<String, dynamic> map) {

--- a/lib/core/providers/app_providers.dart
+++ b/lib/core/providers/app_providers.dart
@@ -3438,9 +3438,9 @@ class Conversations extends _$Conversations {
     return cancellation;
   }
 
-  /// Refreshing is a pull request; the database stream delivers the result.
-  /// Folders are part of every pull cycle, so [includeFolders] needs no extra
-  /// work.
+  /// Refreshing pulls changed rows and reconciles remote deletions; the
+  /// database stream delivers the result. Folders are part of every pull
+  /// cycle, so [includeFolders] needs no extra work.
   Future<void> refresh({
     bool includeFolders = false,
     bool forceFresh = false,
@@ -3452,9 +3452,12 @@ class Conversations extends _$Conversations {
     // optional Open WebUI side when it is available.
     if (ref.read(appDatabaseProvider) != null &&
         ref.read(isAuthenticatedProvider2)) {
-      await ref
-          .read(syncEngineProvider.notifier)
-          .requestPull(reason: 'refresh');
+      final syncEngine = ref.read(syncEngineProvider.notifier);
+      await syncEngine.requestPull(reason: 'refresh');
+      // A normal pull uses the 24-hour background deletion throttle. A user
+      // initiated refresh must also run the unthrottled reconcile so chats
+      // deleted from another Open WebUI client disappear immediately.
+      await syncEngine.reconcileNow();
     }
     folderConversationRefresh.bumpIfMounted();
   }
@@ -3682,6 +3685,63 @@ class Conversations extends _$Conversations {
     Conversation Function(Conversation conversation) transform,
   ) {
     updateConversation(id, transform);
+  }
+
+  /// Applies Open WebUI's `chat:title` event without changing `updatedAt`.
+  ///
+  /// Title generation updates the server row and blob but does not advance the
+  /// server watermark. Persist the event directly so a title cannot remain
+  /// stale merely because the row is outside the loaded page.
+  void applyServerGeneratedTitle(String serverId, String title) {
+    final normalizedTitle = title.trim();
+    final identity = ChatStorageIdentity.parse(serverId);
+    final rawId = identity.rawId;
+    if (rawId.isEmpty ||
+        normalizedTitle.isEmpty ||
+        identity.storage == ChatStorageKind.directLocal ||
+        isTemporaryChat(rawId)) {
+      return;
+    }
+
+    final scopedId = ChatStorageIdentity(
+      rawId: rawId,
+      storage: ChatStorageKind.openWebUi,
+    ).scopedId;
+    final current = state.asData?.value;
+    final index = current == null
+        ? -1
+        : _conversationIndexForSelection(current, scopedId);
+    if (current != null &&
+        index >= 0 &&
+        current[index].title != normalizedTitle) {
+      final updated = <Conversation>[...current];
+      updated[index] = current[index].copyWith(title: normalizedTitle);
+      state = AsyncData<List<Conversation>>(
+        List<Conversation>.unmodifiable(updated),
+      );
+    }
+
+    final db = ref.read(appDatabaseProvider);
+    if (db == null) return;
+    final locks = ref.read(chatLocksProvider);
+    unawaited(
+      locks
+          .runExclusive(
+            rawId,
+            () =>
+                db.chatsDao.updateServerGeneratedTitle(rawId, normalizedTitle),
+          )
+          .then<void>((_) {})
+          .catchError((Object error, StackTrace stackTrace) {
+            DebugLogger.error(
+              'generated-title-write-failed',
+              scope: 'conversations',
+              error: error,
+              stackTrace: stackTrace,
+              data: {'id': rawId},
+            );
+          }),
+    );
   }
 
   /// Rows are id-keyed in the database; the summary "trust" machinery is
@@ -6957,13 +7017,13 @@ class ActiveChatIds extends _$ActiveChatIds {
   }
 }
 
-/// Keeps [activeChatIdsProvider] correct beyond the locally-streaming chat.
+/// Keeps global chat task state and generated titles synchronized.
 ///
 /// OpenWebUI's sidebar both bulk-fetches active chats on load and listens for
 /// `chat:active` events for any chat. This provider mirrors that: it
 /// bulk-fetches on cold open + socket reconnect (`setAll`) and registers a
-/// GLOBAL `chat:active` handler so generations started by other sessions/
-/// devices also light up the sidebar spinner.
+/// GLOBAL chat handler so generations started by other sessions/devices light
+/// up the sidebar spinner and `chat:title` events update durable list state.
 @Riverpod(keepAlive: true)
 class ActiveChatsSync extends _$ActiveChatsSync {
   SocketEventSubscription? _globalActiveSub;
@@ -7070,6 +7130,7 @@ class ActiveChatsSync extends _$ActiveChatsSync {
           return;
         }
         _handleChatActiveEvent(map);
+        _handleChatTitleEvent(map);
       },
     );
 
@@ -7103,7 +7164,7 @@ class ActiveChatsSync extends _$ActiveChatsSync {
     if (active is! bool) {
       return;
     }
-    final chatId = _extractActiveChatId(map);
+    final chatId = _extractChatEventId(map);
     if (chatId == null || chatId.isEmpty) {
       return;
     }
@@ -7115,7 +7176,45 @@ class ActiveChatsSync extends _$ActiveChatsSync {
     }
   }
 
-  String? _extractActiveChatId(Map<String, dynamic> map) {
+  void _handleChatTitleEvent(Map<String, dynamic> map) {
+    final data = map['data'];
+    if (data is! Map || data['type'] != 'chat:title') {
+      return;
+    }
+    final payload = data['data'];
+    final title = switch (payload) {
+      String value => value.trim(),
+      Map value => value['title']?.toString().trim() ?? '',
+      _ => '',
+    };
+    final chatId = _extractChatEventId(map);
+    if (chatId == null || chatId.isEmpty || title.isEmpty) {
+      return;
+    }
+
+    DebugLogger.log(
+      'generated-title-received',
+      scope: 'chat/global-sync',
+      data: {'chatId': chatId},
+    );
+
+    ref
+        .read(conversationsProvider.notifier)
+        .applyServerGeneratedTitle(chatId, title);
+
+    final active = ref.read(activeConversationProvider);
+    final scopedId = ChatStorageIdentity(
+      rawId: chatId,
+      storage: ChatStorageKind.openWebUi,
+    ).scopedId;
+    if (active != null && conversationMatchesScopedId(active, scopedId)) {
+      ref
+          .read(activeConversationProvider.notifier)
+          .set(active.copyWith(title: title));
+    }
+  }
+
+  String? _extractChatEventId(Map<String, dynamic> map) {
     final direct = map['chat_id'] ?? map['chatId'];
     if (direct != null) {
       return direct.toString();

--- a/lib/core/providers/app_providers.dart
+++ b/lib/core/providers/app_providers.dart
@@ -3703,10 +3703,11 @@ class Conversations extends _$Conversations {
       return;
     }
 
-    _applyGeneratedTitleToLoadedState(rawId, normalizedTitle);
-
     final db = ref.read(appDatabaseProvider);
-    if (db == null) return;
+    if (db == null) {
+      _applyGeneratedTitleToLoadedState(rawId, normalizedTitle);
+      return;
+    }
     final locks = ref.read(chatLocksProvider);
     unawaited(
       locks
@@ -3716,7 +3717,7 @@ class Conversations extends _$Conversations {
                 db.chatsDao.updateServerGeneratedTitle(rawId, normalizedTitle),
           )
           .then<void>((persistedTitle) {
-            if (persistedTitle != null && persistedTitle != normalizedTitle) {
+            if (persistedTitle != null) {
               _applyGeneratedTitleToLoadedState(rawId, persistedTitle);
             }
           })

--- a/lib/core/services/api_service.dart
+++ b/lib/core/services/api_service.dart
@@ -3358,7 +3358,10 @@ class ApiService {
   }
 
   Future<void> deleteConversation(String id) async {
-    await _dio.delete('/api/v1/chats/$id');
+    // Deleting an already-absent chat is successful from the caller's point
+    // of view. This also closes the race where another Open WebUI client
+    // deletes the chat after it was rendered locally but before this request.
+    await deleteChatRaw(id);
   }
 
   // Pin/Unpin conversation

--- a/lib/core/sync/deletion_reconcile.dart
+++ b/lib/core/sync/deletion_reconcile.dart
@@ -3,6 +3,7 @@ import 'dart:math' as math;
 import 'package:dio/dio.dart';
 
 import '../database/app_database.dart';
+import '../database/daos/chats_dao.dart';
 import '../utils/debug_logger.dart';
 import 'chat_locks.dart';
 import 'clock.dart';
@@ -112,9 +113,9 @@ class DeletionReconcile {
     // 1. Enumerate the COMPLETE server id set: both the main list (pinned +
     //    folders + root, archived excluded server-side) and the archived list,
     //    each paged to EXHAUSTION with NO updated_at cutoff.
-    final Set<String> completeServerIds;
+    final Map<String, String> completeServerChats;
     try {
-      completeServerIds = await _enumerateCompleteServerIds();
+      completeServerChats = await _enumerateCompleteServerChats();
     } catch (error, stackTrace) {
       // A list-page failure makes the id set incomplete; purging against it
       // would false-delete. Abort WITHOUT advancing the throttle so the next
@@ -128,15 +129,34 @@ class DeletionReconcile {
       return const ReconcileResult(ran: false);
     }
 
+    // Open WebUI title generation updates the row title and chat blob without
+    // advancing `updated_at`. A watermark pull therefore cannot recover a
+    // missed `chat:title` socket event. This full-list pass is authoritative
+    // for clean local envelopes and repairs those stale titles while the same
+    // pages are already in memory for deletion reconciliation.
     // 2. Diff against local server-keyed, non-tombstoned chats.
-    final localServerIds = await _db.chatsDao.allServerChatIds();
+    final localServerChats = await _db.chatsDao.allServerChatReconcileEntries();
+    final reconciledTitles = await _reconcileServerTitles(
+      completeServerChats,
+      localServerChats,
+    );
     final candidates = [
-      for (final id in localServerIds)
-        if (!completeServerIds.contains(id)) id,
+      for (final chat in localServerChats)
+        if (!completeServerChats.containsKey(chat.id)) chat.id,
     ];
 
     if (candidates.isEmpty) {
       await _db.syncMetaDao.setLastFullReconcileAt(now);
+      DebugLogger.log(
+        'reconcile-done',
+        scope: 'sync/reconcile',
+        data: {
+          'candidates': 0,
+          'purged': 0,
+          'skipped': 0,
+          'titles': reconciledTitles,
+        },
+      );
       return const ReconcileResult(ran: true);
     }
 
@@ -148,12 +168,15 @@ class DeletionReconcile {
     if (candidates.length >
         math.max(
           kReconcileMinCandidatesForValve,
-          localServerIds.length * kReconcileMaxPurgeFraction,
+          localServerChats.length * kReconcileMaxPurgeFraction,
         )) {
       DebugLogger.warning(
         'reconcile-aborted-safety-valve',
         scope: 'sync/reconcile',
-        data: {'candidates': candidates.length, 'local': localServerIds.length},
+        data: {
+          'candidates': candidates.length,
+          'local': localServerChats.length,
+        },
       );
       // Do NOT advance the throttle: this is an abnormal condition that should
       // be retried, not suppressed for 24h.
@@ -271,6 +294,7 @@ class DeletionReconcile {
         'candidates': candidates.length,
         'purged': purged,
         'skipped': skipped,
+        'titles': reconciledTitles,
       },
     );
     return ReconcileResult(
@@ -284,16 +308,16 @@ class DeletionReconcile {
   /// Pages BOTH the main and archived lists to exhaustion (page until a page
   /// returns fewer than [kOpenWebUiChatListPageSize] items), unioning every
   /// id. NO `updated_at` early-stop — every page is read.
-  Future<Set<String>> _enumerateCompleteServerIds() async {
-    final ids = <String>{};
-    await _pageToExhaustion(_client.getChatListPage, ids);
-    await _pageToExhaustion(_client.getArchivedChatListPage, ids);
-    return ids;
+  Future<Map<String, String>> _enumerateCompleteServerChats() async {
+    final chats = <String, String>{};
+    await _pageToExhaustion(_client.getChatListPage, chats);
+    await _pageToExhaustion(_client.getArchivedChatListPage, chats);
+    return chats;
   }
 
   Future<void> _pageToExhaustion(
     Future<List<Map<String, dynamic>>> Function(int page) fetch,
-    Set<String> into,
+    Map<String, String> into,
   ) async {
     var page = 1;
     while (true) {
@@ -301,12 +325,56 @@ class DeletionReconcile {
       final idsBefore = into.length;
       for (final item in items) {
         final id = item['id'];
-        if (id is String && id.isNotEmpty) into.add(id);
+        final title = item['title'];
+        if (id is String && id.isNotEmpty) {
+          into.putIfAbsent(id, () => title is String ? title : '');
+        }
       }
       if (items.length < kOpenWebUiChatListPageSize) break;
       if (into.length == idsBefore) break;
       page++;
     }
+  }
+
+  Future<int> _reconcileServerTitles(
+    Map<String, String> serverChats,
+    List<ServerChatReconcileEntry> localChats,
+  ) async {
+    var updated = 0;
+    for (final local in localChats) {
+      final serverTitle = serverChats[local.id];
+      if (serverTitle == null ||
+          serverTitle.trim().isEmpty ||
+          local.dirty ||
+          local.title == serverTitle) {
+        continue;
+      }
+      try {
+        final changed = await _locks.runExclusive(local.id, () async {
+          final current = await _db.chatsDao.getChat(local.id);
+          if (current == null ||
+              current.dirty ||
+              current.title == serverTitle) {
+            return false;
+          }
+          final persisted = await _db.chatsDao.updateServerGeneratedTitle(
+            local.id,
+            serverTitle,
+          );
+          return persisted == serverTitle;
+        });
+        if (changed) updated++;
+      } catch (error, stackTrace) {
+        DebugLogger.error(
+          'reconcile-title-failed',
+          scope: 'sync/reconcile',
+          error: error,
+          stackTrace: stackTrace,
+          data: {'chatId': local.id},
+        );
+      }
+    }
+    return updated;
   }
 
   bool _isTerminalProbeError(Object error) {

--- a/lib/core/sync/sync_engine.dart
+++ b/lib/core/sync/sync_engine.dart
@@ -937,6 +937,15 @@ class SyncEngine extends _$SyncEngine {
   Future<void> reconcileNow() async {
     if (!_refreshBoundDependencies()) return;
     if (_inert) return;
+    final ownsProgressStatus = state.phase != SyncPhase.running;
+    if (ownsProgressStatus && ref.mounted) {
+      state = SyncStatus(
+        phase: SyncPhase.running,
+        stage: SyncStage.finalizing,
+        lastSuccessUpdatedAtWatermark: state.lastSuccessUpdatedAtWatermark,
+        lastError: state.lastError,
+      );
+    }
     // Independent try/catch per entity: an unexpected error from the chat
     // reconcile must NOT skip the note reconcile (and vice versa).
     try {
@@ -958,6 +967,16 @@ class SyncEngine extends _$SyncEngine {
         error: error,
         stackTrace: stackTrace,
       );
+    } finally {
+      if (ownsProgressStatus &&
+          ref.mounted &&
+          state.phase == SyncPhase.running &&
+          state.stage == SyncStage.finalizing) {
+        state = SyncStatus(
+          lastSuccessUpdatedAtWatermark: state.lastSuccessUpdatedAtWatermark,
+          lastError: state.lastError,
+        );
+      }
     }
   }
 

--- a/lib/features/chat/services/chat_transport_dispatch.dart
+++ b/lib/features/chat/services/chat_transport_dispatch.dart
@@ -373,19 +373,14 @@ Future<bool> dispatchChatTransport({
       if (!ownsConversation()) return;
       final active = ref.read(activeConversationProvider);
       if (active == null || isTemporaryChat(active.id)) return;
+      final normalizedTitle = newTitle.trim();
+      if (normalizedTitle.isEmpty) return;
       ref
           .read(activeConversationProvider.notifier)
-          .set(active.copyWith(title: newTitle));
+          .set(active.copyWith(title: normalizedTitle));
       ref
           .read(conversationsProvider.notifier)
-          .updateConversationFromRemote(
-            active.id,
-            (conversation) => conversation.copyWith(
-              title: newTitle,
-              updatedAt: DateTime.now(),
-            ),
-          );
-      refreshConversationsCache(ref);
+          .applyServerGeneratedTitle(active.id, normalizedTitle);
     },
     onChatTagsUpdated: () {
       if (!ownsConversation()) return;

--- a/lib/features/navigation/widgets/chats_drawer.dart
+++ b/lib/features/navigation/widgets/chats_drawer.dart
@@ -15,7 +15,6 @@ import '../../../core/utils/debug_logger.dart';
 import '../../../core/services/navigation_service.dart';
 import '../../../core/services/user_friendly_error_handler.dart';
 import '../../../shared/widgets/conduit_components.dart';
-import '../../../shared/widgets/conduit_loading.dart';
 import '../../../shared/widgets/themed_dialogs.dart';
 import 'package:conduit/l10n/app_localizations.dart';
 import '../../../shared/utils/conversation_context_menu.dart';
@@ -62,6 +61,7 @@ class _ChatsDrawerState extends ConsumerState<ChatsDrawer>
   bool _isLoadingMoreConversations = false;
   bool _isRefreshingEmptyState = false;
   bool _hasVisiblePaginatedRows = false;
+  RefreshIndicatorStatus? _refreshStatus;
 
   @override
   void initState() {
@@ -200,11 +200,73 @@ class _ChatsDrawerState extends ConsumerState<ChatsDrawer>
   // Legacy helper removed: drawer now uses slivers with lazy delegates.
 
   Widget _buildRefreshableScrollableSlivers({required List<Widget> slivers}) {
-    // Top inset matches Notes tab pinned header row (`EdgeInsets` top 8).
+    final refreshStatus = _refreshStatus;
+    final showRefreshSlot =
+        refreshStatus != null &&
+        refreshStatus != RefreshIndicatorStatus.canceled;
+    final motionDuration = MediaQuery.disableAnimationsOf(context)
+        ? Duration.zero
+        : const Duration(milliseconds: 180);
+    final refreshIndicator = switch (refreshStatus) {
+      RefreshIndicatorStatus.drag || RefreshIndicatorStatus.armed => Icon(
+        Icons.arrow_downward_rounded,
+        key: const ValueKey<String>('chats-refresh-pull'),
+        size: IconSize.sm,
+        color: context.conduitTheme.textSecondary,
+      ),
+      RefreshIndicatorStatus.snap || RefreshIndicatorStatus.refresh => SizedBox(
+        key: const ValueKey<String>('chats-refresh-progress'),
+        width: IconSize.sm,
+        height: IconSize.sm,
+        child: CircularProgressIndicator(
+          strokeWidth: 2,
+          semanticsLabel: MaterialLocalizations.of(
+            context,
+          ).refreshIndicatorSemanticLabel,
+          valueColor: AlwaysStoppedAnimation<Color>(
+            context.conduitTheme.loadingIndicator,
+          ),
+        ),
+      ),
+      RefreshIndicatorStatus.done => Icon(
+        Icons.check_rounded,
+        key: const ValueKey<String>('chats-refresh-done'),
+        size: IconSize.sm,
+        color: context.conduitTheme.loadingIndicator,
+      ),
+      RefreshIndicatorStatus.canceled || null => const SizedBox.shrink(
+        key: ValueKey<String>('chats-refresh-idle'),
+      ),
+    };
+
+    // Reserve a compact gutter while pulling/refreshing so progress sits in
+    // the list flow instead of painting over the first conversation tile.
     // Bottom inset keeps the last row clear of the native bottom tab bar.
     final paddedSlivers = <Widget>[
       SliverToBoxAdapter(
-        child: SizedBox(height: sidebarTabContentTopPadding(context)),
+        child: AnimatedContainer(
+          key: const ValueKey<String>('chats-refresh-slot'),
+          duration: motionDuration,
+          curve: Curves.easeOutCubic,
+          height:
+              sidebarTabContentTopPadding(context) +
+              (showRefreshSlot ? Spacing.xl : 0),
+          alignment: Alignment.bottomCenter,
+          padding: EdgeInsets.only(bottom: showRefreshSlot ? Spacing.sm : 0),
+          child: AnimatedSwitcher(
+            duration: motionDuration,
+            switchInCurve: Curves.easeOut,
+            switchOutCurve: Curves.easeIn,
+            transitionBuilder: (child, animation) => FadeTransition(
+              opacity: animation,
+              child: ScaleTransition(
+                scale: Tween<double>(begin: 0.86, end: 1).animate(animation),
+                child: child,
+              ),
+            ),
+            child: refreshIndicator,
+          ),
+        ),
       ),
       ...slivers,
       // Bottom padding for the tab bar and a little breathing room.
@@ -220,9 +282,12 @@ class _ChatsDrawerState extends ConsumerState<ChatsDrawer>
       slivers: paddedSlivers,
     );
 
-    final refreshableScroll = ConduitRefreshIndicator(
-      edgeOffset: sidebarRefreshIndicatorEdgeOffset(context),
+    final refreshableScroll = RefreshIndicator.noSpinner(
       onRefresh: _refreshChats,
+      onStatusChange: (status) {
+        if (!mounted || _refreshStatus == status) return;
+        setState(() => _refreshStatus = status);
+      },
       child: scroll,
     );
 

--- a/lib/features/navigation/widgets/chats_drawer.dart
+++ b/lib/features/navigation/widgets/chats_drawer.dart
@@ -62,6 +62,7 @@ class _ChatsDrawerState extends ConsumerState<ChatsDrawer>
   bool _isRefreshingEmptyState = false;
   bool _hasVisiblePaginatedRows = false;
   RefreshIndicatorStatus? _refreshStatus;
+  Timer? _refreshDoneHideTimer;
 
   @override
   void initState() {
@@ -201,6 +202,7 @@ class _ChatsDrawerState extends ConsumerState<ChatsDrawer>
 
   Widget _buildRefreshableScrollableSlivers({required List<Widget> slivers}) {
     final refreshStatus = _refreshStatus;
+    final usesCupertinoChrome = context.usesCupertinoChrome;
     final showRefreshSlot =
         refreshStatus != null &&
         refreshStatus != RefreshIndicatorStatus.canceled;
@@ -209,7 +211,9 @@ class _ChatsDrawerState extends ConsumerState<ChatsDrawer>
     );
     final refreshIndicator = switch (refreshStatus) {
       RefreshIndicatorStatus.drag || RefreshIndicatorStatus.armed => Icon(
-        Icons.arrow_downward_rounded,
+        usesCupertinoChrome
+            ? CupertinoIcons.arrow_down
+            : Icons.arrow_downward_rounded,
         key: const ValueKey<String>('chats-refresh-pull'),
         size: IconSize.sm,
         color: context.conduitTheme.textSecondary,
@@ -218,18 +222,25 @@ class _ChatsDrawerState extends ConsumerState<ChatsDrawer>
         key: const ValueKey<String>('chats-refresh-progress'),
         width: IconSize.sm,
         height: IconSize.sm,
-        child: CircularProgressIndicator(
-          strokeWidth: 2,
-          semanticsLabel: MaterialLocalizations.of(
+        child: Semantics(
+          label: MaterialLocalizations.of(
             context,
           ).refreshIndicatorSemanticLabel,
-          valueColor: AlwaysStoppedAnimation<Color>(
-            context.conduitTheme.loadingIndicator,
-          ),
+          child: usesCupertinoChrome
+              ? CupertinoActivityIndicator(
+                  radius: IconSize.sm / 2,
+                  color: context.conduitTheme.loadingIndicator,
+                )
+              : CircularProgressIndicator(
+                  strokeWidth: 2,
+                  valueColor: AlwaysStoppedAnimation<Color>(
+                    context.conduitTheme.loadingIndicator,
+                  ),
+                ),
         ),
       ),
       RefreshIndicatorStatus.done => Icon(
-        Icons.check_rounded,
+        usesCupertinoChrome ? CupertinoIcons.check_mark : Icons.check_rounded,
         key: const ValueKey<String>('chats-refresh-done'),
         size: IconSize.sm,
         color: context.conduitTheme.loadingIndicator,
@@ -284,10 +295,7 @@ class _ChatsDrawerState extends ConsumerState<ChatsDrawer>
 
     final refreshableScroll = RefreshIndicator.noSpinner(
       onRefresh: _refreshChats,
-      onStatusChange: (status) {
-        if (!mounted || _refreshStatus == status) return;
-        setState(() => _refreshStatus = status);
-      },
+      onStatusChange: _handleRefreshStatusChange,
       child: scroll,
     );
 
@@ -299,6 +307,19 @@ class _ChatsDrawerState extends ConsumerState<ChatsDrawer>
     }
 
     return Scrollbar(controller: _listController, child: refreshableScroll);
+  }
+
+  void _handleRefreshStatusChange(RefreshIndicatorStatus? status) {
+    if (!mounted || _refreshStatus == status) return;
+    _refreshDoneHideTimer?.cancel();
+    setState(() => _refreshStatus = status);
+    if (status != RefreshIndicatorStatus.done) return;
+
+    final hideDelay = context.motionDuration(const Duration(milliseconds: 450));
+    _refreshDoneHideTimer = Timer(hideDelay, () {
+      if (!mounted || _refreshStatus != RefreshIndicatorStatus.done) return;
+      setState(() => _refreshStatus = null);
+    });
   }
 
   Widget _buildPaginationFooter() {
@@ -404,6 +425,7 @@ class _ChatsDrawerState extends ConsumerState<ChatsDrawer>
   @override
   void dispose() {
     _debounce?.cancel();
+    _refreshDoneHideTimer?.cancel();
     _listController.removeListener(_onListScrolled);
     _sidebarSearchController.removeListener(_onSearchChanged);
     _listController.dispose();

--- a/lib/features/navigation/widgets/chats_drawer.dart
+++ b/lib/features/navigation/widgets/chats_drawer.dart
@@ -204,9 +204,9 @@ class _ChatsDrawerState extends ConsumerState<ChatsDrawer>
     final showRefreshSlot =
         refreshStatus != null &&
         refreshStatus != RefreshIndicatorStatus.canceled;
-    final motionDuration = MediaQuery.disableAnimationsOf(context)
-        ? Duration.zero
-        : const Duration(milliseconds: 180);
+    final motionDuration = context.motionDuration(
+      const Duration(milliseconds: 180),
+    );
     final refreshIndicator = switch (refreshStatus) {
       RefreshIndicatorStatus.drag || RefreshIndicatorStatus.armed => Icon(
         Icons.arrow_downward_rounded,

--- a/lib/features/notes/providers/notes_providers.dart
+++ b/lib/features/notes/providers/notes_providers.dart
@@ -372,9 +372,9 @@ class NotesList extends _$NotesList {
   Future<void> refresh() async {
     if (ref.read(appDatabaseProvider) != null) {
       try {
-        await ref
-            .read(syncEngineProvider.notifier)
-            .requestPull(reason: 'notes-refresh');
+        final syncEngine = ref.read(syncEngineProvider.notifier);
+        await syncEngine.requestPull(reason: 'notes-refresh');
+        await syncEngine.reconcileNow();
       } catch (error, stackTrace) {
         DebugLogger.error(
           'refresh-failed',

--- a/lib/features/notes/services/note_audio_upload_service.dart
+++ b/lib/features/notes/services/note_audio_upload_service.dart
@@ -381,83 +381,91 @@ class NoteAudioUploadStore {
       path.join(destinationNoteDirectory.path, _safeId(item.id)),
     );
 
-    return _withItemLock(sourceDirectory, () async {
-      // A retry may arrive after the directory was already moved but before
-      // the caller received the rebound item. Treat that as success.
-      if (!await sourceDirectory.exists()) {
-        if (!await destinationDirectory.exists()) return null;
-        return _readOrRecover(
-          destinationDirectory,
-          serverScope: item.serverScope,
-          accountScope: item.accountScope,
-          noteId: noteId,
-        );
-      }
-
-      final current = await _readOrRecover(
-        sourceDirectory,
-        serverScope: item.serverScope,
-        accountScope: item.accountScope,
-        noteId: item.noteId,
-      );
-      if (current == null) return null;
-      if (await destinationDirectory.exists()) {
-        throw StateError('A note audio upload already exists at its new scope');
-      }
-
-      await destinationNoteDirectory.create(recursive: true);
-      await sourceDirectory.rename(destinationDirectory.path);
-      final rebound = PendingNoteAudioUpload(
-        id: current.id,
-        serverScope: current.serverScope,
-        accountScope: current.accountScope,
-        noteId: noteId,
-        localPath: path.join(
-          destinationDirectory.path,
-          path.basename(current.localPath),
-        ),
-        fileName: current.fileName,
-        fileSize: current.fileSize,
-        status: current.status,
-        createdAt: current.createdAt,
-        lastError: current.lastError,
-        serverFileId: current.serverFileId,
-        sourceCacheFileName: current.sourceCacheFileName,
-      );
-      try {
-        if (!await _saveUnlocked(rebound, destinationDirectory)) {
-          throw const FileSystemException(
-            'Rebound note audio directory disappeared',
+    return _withItemLocks(
+      <Directory>[sourceDirectory, destinationDirectory],
+      () async {
+        // A retry may arrive after the directory was already moved but before
+        // the caller received the rebound item. Treat that as success.
+        if (!await sourceDirectory.exists()) {
+          if (!await destinationDirectory.exists()) return null;
+          return _readOrRecover(
+            destinationDirectory,
+            serverScope: item.serverScope,
+            accountScope: item.accountScope,
+            noteId: noteId,
           );
         }
-      } catch (_) {
-        // The old manifest still identifies the old note until the atomic
-        // manifest save succeeds, so moving the directory back restores a
-        // valid, discoverable job when persistence fails.
-        if (await destinationDirectory.exists() &&
-            !await sourceDirectory.exists()) {
-          await destinationDirectory.rename(sourceDirectory.path);
-        }
-        rethrow;
-      }
 
-      final oldNoteDirectory = sourceDirectory.parent;
-      try {
-        if (await oldNoteDirectory.exists() &&
-            await oldNoteDirectory.list(followLinks: false).isEmpty) {
-          await oldNoteDirectory.delete();
-        }
-      } catch (error, stackTrace) {
-        DebugLogger.error(
-          'note-audio-rebind-cleanup-failed',
-          scope: 'notes/audio',
-          error: error,
-          stackTrace: stackTrace,
-          data: {'id': item.id},
+        final current = await _readOrRecover(
+          sourceDirectory,
+          serverScope: item.serverScope,
+          accountScope: item.accountScope,
+          noteId: item.noteId,
         );
-      }
-      return rebound;
-    });
+        if (current == null) return null;
+        if (await destinationDirectory.exists()) {
+          return _readOrRecover(
+            destinationDirectory,
+            serverScope: item.serverScope,
+            accountScope: item.accountScope,
+            noteId: noteId,
+          );
+        }
+
+        await destinationNoteDirectory.create(recursive: true);
+        await sourceDirectory.rename(destinationDirectory.path);
+        final rebound = PendingNoteAudioUpload(
+          id: current.id,
+          serverScope: current.serverScope,
+          accountScope: current.accountScope,
+          noteId: noteId,
+          localPath: path.join(
+            destinationDirectory.path,
+            path.basename(current.localPath),
+          ),
+          fileName: current.fileName,
+          fileSize: current.fileSize,
+          status: current.status,
+          createdAt: current.createdAt,
+          lastError: current.lastError,
+          serverFileId: current.serverFileId,
+          sourceCacheFileName: current.sourceCacheFileName,
+        );
+        try {
+          if (!await _saveUnlocked(rebound, destinationDirectory)) {
+            throw const FileSystemException(
+              'Rebound note audio directory disappeared',
+            );
+          }
+        } catch (_) {
+          // The old manifest still identifies the old note until the atomic
+          // manifest save succeeds, so moving the directory back restores a
+          // valid, discoverable job when persistence fails.
+          if (await destinationDirectory.exists() &&
+              !await sourceDirectory.exists()) {
+            await destinationDirectory.rename(sourceDirectory.path);
+          }
+          rethrow;
+        }
+
+        final oldNoteDirectory = sourceDirectory.parent;
+        try {
+          if (await oldNoteDirectory.exists() &&
+              await oldNoteDirectory.list(followLinks: false).isEmpty) {
+            await oldNoteDirectory.delete();
+          }
+        } catch (error, stackTrace) {
+          DebugLogger.error(
+            'note-audio-rebind-cleanup-failed',
+            scope: 'notes/audio',
+            error: error,
+            stackTrace: stackTrace,
+            data: {'id': item.id},
+          );
+        }
+        return rebound;
+      },
+    );
   }
 
   /// Loads every recording owned by an account on a server.
@@ -790,6 +798,27 @@ class NoteAudioUploadStore {
     }
   }
 
+  Future<T> _withItemLocks<T>(
+    Iterable<Directory> itemDirectories,
+    Future<T> Function() operation,
+  ) {
+    final byPath = <String, Directory>{
+      for (final directory in itemDirectories)
+        path.normalize(path.absolute(directory.path)): directory,
+    };
+    final orderedPaths = byPath.keys.toList()..sort();
+
+    Future<T> acquire(int index) {
+      if (index == orderedPaths.length) return operation();
+      return _withItemLock(
+        byPath[orderedPaths[index]]!,
+        () => acquire(index + 1),
+      );
+    }
+
+    return acquire(0);
+  }
+
   static String _scope(String value) =>
       sha256.convert(utf8.encode(value)).toString();
 
@@ -830,6 +859,31 @@ class NoteAudioUploadCoordinator {
       <String, Future<PendingNoteAudioUpload?>>{};
   static final Map<String, Completer<void>> _removalReservations =
       <String, Completer<void>>{};
+  static final Map<String, Completer<PendingNoteAudioUpload?>>
+  _rebindReservations = <String, Completer<PendingNoteAudioUpload?>>{};
+
+  /// Prevents new work for [item] and waits for existing work to finish before
+  /// its durable directory is moved to a replacement note.
+  static Future<void> reserveForRebind(PendingNoteAudioUpload item) async {
+    final key = _keyFor(item);
+    _rebindReservations.putIfAbsent(
+      key,
+      () => Completer<PendingNoteAudioUpload?>(),
+    );
+    final existing = _inFlight[key];
+    if (existing != null) await existing;
+  }
+
+  /// Releases callers that encountered the old item while it was being moved.
+  static void completeRebind(
+    PendingNoteAudioUpload item,
+    PendingNoteAudioUpload? rebound,
+  ) {
+    final reservation = _rebindReservations.remove(_keyFor(item));
+    if (reservation != null && !reservation.isCompleted) {
+      reservation.complete(rebound);
+    }
+  }
 
   /// Atomically reserves an item for deletion across every editor instance.
   /// Returns false while upload/attach work already owns the item.
@@ -864,6 +918,8 @@ class NoteAudioUploadCoordinator {
 
   Future<PendingNoteAudioUpload?> process(PendingNoteAudioUpload item) {
     final key = _keyFor(item);
+    final rebind = _rebindReservations[key]?.future;
+    if (rebind != null) return _reloadAfterRebind(rebind);
     final removal = _removalReservations[key]?.future;
     if (removal != null) return _reloadAfterRemoval(item, removal);
     final existing = _inFlight[key];
@@ -877,6 +933,14 @@ class NoteAudioUploadCoordinator {
     });
     _inFlight[key] = tracked;
     return tracked;
+  }
+
+  Future<PendingNoteAudioUpload?> _reloadAfterRebind(
+    Future<PendingNoteAudioUpload?> rebind,
+  ) async {
+    final rebound = await rebind;
+    _notify(rebound);
+    return rebound;
   }
 
   Future<PendingNoteAudioUpload?> _reloadAfterRemoval(

--- a/lib/features/notes/services/note_audio_upload_service.dart
+++ b/lib/features/notes/services/note_audio_upload_service.dart
@@ -1091,7 +1091,7 @@ class NoteAudioUploadCoordinator {
   Future<PendingNoteAudioUpload?> process(PendingNoteAudioUpload item) {
     final key = _keyFor(item);
     final rebind = _rebindReservations[key]?.future;
-    if (rebind != null) return _reloadAfterRebind(rebind);
+    if (rebind != null) return _reloadAfterRebind(item, rebind);
     final removal = _removalReservations[key]?.future;
     if (removal != null) return _reloadAfterRemoval(item, removal);
     final existing = _inFlight[key];
@@ -1108,9 +1108,12 @@ class NoteAudioUploadCoordinator {
   }
 
   Future<PendingNoteAudioUpload?> _reloadAfterRebind(
+    PendingNoteAudioUpload item,
     Future<PendingNoteAudioUpload?> rebind,
   ) async {
-    final rebound = await rebind;
+    // A null result can also mean the owner failed before it could return the
+    // rolled-back item. Confirm durable state before treating it as removed.
+    final rebound = await rebind ?? await _store.loadCurrent(item);
     _notify(rebound);
     return rebound;
   }

--- a/lib/features/notes/services/note_audio_upload_service.dart
+++ b/lib/features/notes/services/note_audio_upload_service.dart
@@ -468,8 +468,10 @@ class NoteAudioUploadStore {
           if (await destinationDirectory.exists() &&
               !await sourceDirectory.exists()) {
             await destinationDirectory.rename(sourceDirectory.path);
-            if (await journal.exists()) await journal.delete();
           }
+          // Keep the flushed intent journal after rollback. A later account or
+          // note scan can retry the move and associate the recording with the
+          // replacement note even if this editor closes immediately.
           rethrow;
         }
         if (await journal.exists()) await journal.delete();

--- a/lib/features/notes/services/note_audio_upload_service.dart
+++ b/lib/features/notes/services/note_audio_upload_service.dart
@@ -19,6 +19,11 @@ const _rebindJournalVersion = 1;
 
 enum NoteAudioUploadStatus { pending, uploading, attaching, failed }
 
+typedef NoteAudioRebindReservation = ({
+  bool isOwner,
+  PendingNoteAudioUpload? rebound,
+});
+
 @immutable
 class PendingNoteAudioUpload {
   const PendingNoteAudioUpload({
@@ -1027,14 +1032,27 @@ class NoteAudioUploadCoordinator {
 
   /// Prevents new work for [item] and waits for existing work to finish before
   /// its durable directory is moved to a replacement note.
-  static Future<void> reserveForRebind(PendingNoteAudioUpload item) async {
+  static Future<NoteAudioRebindReservation> reserveForRebind(
+    PendingNoteAudioUpload item,
+  ) async {
     final key = _keyFor(item);
-    _rebindReservations.putIfAbsent(
-      key,
-      () => Completer<PendingNoteAudioUpload?>(),
-    );
-    final existing = _inFlight[key];
-    if (existing != null) await existing;
+    final existingReservation = _rebindReservations[key];
+    if (existingReservation != null) {
+      return (isOwner: false, rebound: await existingReservation.future);
+    }
+    final reservation = Completer<PendingNoteAudioUpload?>();
+    _rebindReservations[key] = reservation;
+    try {
+      final existing = _inFlight[key];
+      if (existing != null) await existing;
+    } catch (_) {
+      if (identical(_rebindReservations[key], reservation)) {
+        _rebindReservations.remove(key);
+      }
+      if (!reservation.isCompleted) reservation.complete(null);
+      rethrow;
+    }
+    return (isOwner: true, rebound: null);
   }
 
   /// Releases callers that encountered the old item while it was being moved.

--- a/lib/features/notes/services/note_audio_upload_service.dart
+++ b/lib/features/notes/services/note_audio_upload_service.dart
@@ -1034,6 +1034,9 @@ class NoteAudioUploadCoordinator {
     Future<PendingNoteAudioUpload?> Function() operation,
   ) async {
     final key = _keyFor(item);
+    // Explicit removal wins over recovery: never move an item that another
+    // editor has already reserved for deletion.
+    if (_removalReservations.containsKey(key)) return null;
     final existingReservation = _rebindReservations[key];
     if (existingReservation != null) {
       return existingReservation.future;
@@ -1061,7 +1064,9 @@ class NoteAudioUploadCoordinator {
   /// Returns false while upload/attach work already owns the item.
   static bool tryReserveRemoval(PendingNoteAudioUpload item) {
     final key = _keyFor(item);
-    if (_inFlight.containsKey(key) || _removalReservations.containsKey(key)) {
+    if (_inFlight.containsKey(key) ||
+        _removalReservations.containsKey(key) ||
+        _rebindReservations.containsKey(key)) {
       return false;
     }
     _removalReservations[key] = Completer<void>();

--- a/lib/features/notes/services/note_audio_upload_service.dart
+++ b/lib/features/notes/services/note_audio_upload_service.dart
@@ -14,6 +14,8 @@ const _manifestVersion = 1;
 const _storeDirectoryName = 'note_audio_uploads';
 const _manifestFileName = 'manifest.json';
 const _defaultAudioFileName = 'recording.m4a';
+const _rebindJournalPrefix = '.rebind-';
+const _rebindJournalVersion = 1;
 
 enum NoteAudioUploadStatus { pending, uploading, attaching, failed }
 
@@ -312,6 +314,11 @@ class NoteAudioUploadStore {
       accountScope: accountScope,
       noteId: noteId,
     );
+    await _recoverRebindJournals(
+      noteDirectory.parent,
+      serverScope: serverScope,
+      accountScope: accountScope,
+    );
     if (!await noteDirectory.exists()) return <PendingNoteAudioUpload>[];
 
     final items = <PendingNoteAudioUpload>[];
@@ -380,6 +387,12 @@ class NoteAudioUploadStore {
     final destinationDirectory = Directory(
       path.join(destinationNoteDirectory.path, _safeId(item.id)),
     );
+    final accountDirectory = destinationNoteDirectory.parent;
+    await _recoverRebindJournals(
+      accountDirectory,
+      serverScope: item.serverScope,
+      accountScope: item.accountScope,
+    );
 
     return _withItemLocks(
       <Directory>[sourceDirectory, destinationDirectory],
@@ -413,7 +426,6 @@ class NoteAudioUploadStore {
         }
 
         await destinationNoteDirectory.create(recursive: true);
-        await sourceDirectory.rename(destinationDirectory.path);
         final rebound = PendingNoteAudioUpload(
           id: current.id,
           serverScope: current.serverScope,
@@ -431,6 +443,18 @@ class NoteAudioUploadStore {
           serverFileId: current.serverFileId,
           sourceCacheFileName: current.sourceCacheFileName,
         );
+        final journal = File(
+          path.join(
+            accountDirectory.path,
+            '$_rebindJournalPrefix${_safeId(current.id)}.json',
+          ),
+        );
+        await _writeRebindJournal(
+          journal,
+          sourceNoteId: current.noteId,
+          rebound: rebound,
+        );
+        await sourceDirectory.rename(destinationDirectory.path);
         try {
           if (!await _saveUnlocked(rebound, destinationDirectory)) {
             throw const FileSystemException(
@@ -444,9 +468,11 @@ class NoteAudioUploadStore {
           if (await destinationDirectory.exists() &&
               !await sourceDirectory.exists()) {
             await destinationDirectory.rename(sourceDirectory.path);
+            if (await journal.exists()) await journal.delete();
           }
           rethrow;
         }
+        if (await journal.exists()) await journal.delete();
 
         final oldNoteDirectory = sourceDirectory.parent;
         try {
@@ -487,6 +513,11 @@ class NoteAudioUploadStore {
     if (!await accountDirectory.exists()) {
       return <PendingNoteAudioUpload>[];
     }
+    await _recoverRebindJournals(
+      accountDirectory,
+      serverScope: serverScope,
+      accountScope: accountScope,
+    );
 
     final items = <PendingNoteAudioUpload>[];
     await for (final noteEntity in accountDirectory.list(followLinks: false)) {
@@ -536,6 +567,138 @@ class NoteAudioUploadStore {
     await temporary.writeAsString(jsonEncode(item.toJson()), flush: true);
     await temporary.rename(manifest.path);
     return true;
+  }
+
+  Future<void> _writeRebindJournal(
+    File journal, {
+    required String sourceNoteId,
+    required PendingNoteAudioUpload rebound,
+  }) async {
+    final temporary = File('${journal.path}.tmp');
+    await temporary.writeAsString(
+      jsonEncode(<String, dynamic>{
+        'version': _rebindJournalVersion,
+        'sourceNoteId': sourceNoteId,
+        'item': rebound.toJson(),
+      }),
+      flush: true,
+    );
+    await temporary.rename(journal.path);
+  }
+
+  Future<void> _recoverRebindJournals(
+    Directory accountDirectory, {
+    required String serverScope,
+    required String accountScope,
+  }) async {
+    if (!await accountDirectory.exists()) return;
+    final journals = <File>[];
+    await for (final entity in accountDirectory.list(followLinks: false)) {
+      if (entity is File) {
+        final name = path.basename(entity.path);
+        if (name.startsWith(_rebindJournalPrefix) && name.endsWith('.json')) {
+          journals.add(entity);
+        }
+      }
+    }
+
+    for (final journal in journals) {
+      try {
+        final decoded = jsonDecode(await journal.readAsString());
+        if (decoded is! Map<String, dynamic> ||
+            decoded['version'] != _rebindJournalVersion ||
+            decoded['sourceNoteId'] is! String ||
+            decoded['item'] is! Map<String, dynamic>) {
+          throw const FormatException('Invalid note audio rebind journal');
+        }
+        final sourceNoteId = decoded['sourceNoteId'] as String;
+        final itemJson = decoded['item'] as Map<String, dynamic>;
+        final noteId = itemJson['noteId'] as String?;
+        final id = itemJson['id'] as String?;
+        if (noteId == null || id == null) {
+          throw const FormatException('Incomplete note audio rebind journal');
+        }
+        final sourceDirectory = Directory(
+          path.join(accountDirectory.path, _scope(sourceNoteId), _safeId(id)),
+        );
+        final destinationDirectory = Directory(
+          path.join(accountDirectory.path, _scope(noteId), _safeId(id)),
+        );
+        final rebound = PendingNoteAudioUpload.fromJson(
+          itemJson,
+          itemDirectory: destinationDirectory,
+        );
+        if (rebound.serverScope != serverScope ||
+            rebound.accountScope != accountScope) {
+          throw const FormatException('Mismatched note audio rebind scope');
+        }
+
+        await _withItemLocks(
+          <Directory>[sourceDirectory, destinationDirectory],
+          () async {
+            if (!await journal.exists()) return;
+            if (!await destinationDirectory.exists()) {
+              if (!await sourceDirectory.exists()) {
+                await journal.delete();
+                return;
+              }
+              await destinationDirectory.parent.create(recursive: true);
+              await sourceDirectory.rename(destinationDirectory.path);
+            }
+
+            final existing = await _readValidManifest(
+              destinationDirectory,
+              serverScope: serverScope,
+              accountScope: accountScope,
+              noteId: noteId,
+            );
+            if (existing == null &&
+                !await _saveUnlocked(rebound, destinationDirectory)) {
+              throw const FileSystemException(
+                'Rebound note audio directory disappeared during recovery',
+              );
+            }
+            if (await sourceDirectory.exists()) {
+              await sourceDirectory.delete(recursive: true);
+            }
+            await journal.delete();
+          },
+        );
+      } catch (error, stackTrace) {
+        DebugLogger.error(
+          'note-audio-rebind-recovery-failed',
+          scope: 'notes/audio',
+          error: error,
+          stackTrace: stackTrace,
+          data: {'journal': path.basename(journal.path)},
+        );
+      }
+    }
+  }
+
+  Future<PendingNoteAudioUpload?> _readValidManifest(
+    Directory itemDirectory, {
+    required String serverScope,
+    required String accountScope,
+    required String noteId,
+  }) async {
+    try {
+      final manifest = File(path.join(itemDirectory.path, _manifestFileName));
+      final decoded = jsonDecode(await manifest.readAsString());
+      if (decoded is! Map<String, dynamic>) return null;
+      final item = PendingNoteAudioUpload.fromJson(
+        decoded,
+        itemDirectory: itemDirectory,
+      );
+      if (item.serverScope != serverScope ||
+          item.accountScope != accountScope ||
+          item.noteId != noteId) {
+        return null;
+      }
+      return item;
+    } catch (_) {
+      return null;
+    }
   }
 
   Future<void> remove(PendingNoteAudioUpload item) async {

--- a/lib/features/notes/services/note_audio_upload_service.dart
+++ b/lib/features/notes/services/note_audio_upload_service.dart
@@ -358,6 +358,108 @@ class NoteAudioUploadStore {
     );
   }
 
+  /// Moves a durable recording to a replacement note without changing its
+  /// upload identity or retry state.
+  ///
+  /// This is used when an editor recovers unsaved work after the server deleted
+  /// its original note. Keeping the recording under the deleted note id would
+  /// make it undiscoverable after the recovered editor is closed.
+  Future<PendingNoteAudioUpload?> rebindToNote(
+    PendingNoteAudioUpload item, {
+    required String noteId,
+  }) async {
+    if (item.noteId == noteId) return loadCurrent(item);
+
+    final sourceDirectory = File(item.localPath).parent;
+    await _validateItemDirectory(item, sourceDirectory);
+    final destinationNoteDirectory = await _noteDirectory(
+      serverScope: item.serverScope,
+      accountScope: item.accountScope,
+      noteId: noteId,
+    );
+    final destinationDirectory = Directory(
+      path.join(destinationNoteDirectory.path, _safeId(item.id)),
+    );
+
+    return _withItemLock(sourceDirectory, () async {
+      // A retry may arrive after the directory was already moved but before
+      // the caller received the rebound item. Treat that as success.
+      if (!await sourceDirectory.exists()) {
+        if (!await destinationDirectory.exists()) return null;
+        return _readOrRecover(
+          destinationDirectory,
+          serverScope: item.serverScope,
+          accountScope: item.accountScope,
+          noteId: noteId,
+        );
+      }
+
+      final current = await _readOrRecover(
+        sourceDirectory,
+        serverScope: item.serverScope,
+        accountScope: item.accountScope,
+        noteId: item.noteId,
+      );
+      if (current == null) return null;
+      if (await destinationDirectory.exists()) {
+        throw StateError('A note audio upload already exists at its new scope');
+      }
+
+      await destinationNoteDirectory.create(recursive: true);
+      await sourceDirectory.rename(destinationDirectory.path);
+      final rebound = PendingNoteAudioUpload(
+        id: current.id,
+        serverScope: current.serverScope,
+        accountScope: current.accountScope,
+        noteId: noteId,
+        localPath: path.join(
+          destinationDirectory.path,
+          path.basename(current.localPath),
+        ),
+        fileName: current.fileName,
+        fileSize: current.fileSize,
+        status: current.status,
+        createdAt: current.createdAt,
+        lastError: current.lastError,
+        serverFileId: current.serverFileId,
+        sourceCacheFileName: current.sourceCacheFileName,
+      );
+      try {
+        if (!await _saveUnlocked(rebound, destinationDirectory)) {
+          throw const FileSystemException(
+            'Rebound note audio directory disappeared',
+          );
+        }
+      } catch (_) {
+        // The old manifest still identifies the old note until the atomic
+        // manifest save succeeds, so moving the directory back restores a
+        // valid, discoverable job when persistence fails.
+        if (await destinationDirectory.exists() &&
+            !await sourceDirectory.exists()) {
+          await destinationDirectory.rename(sourceDirectory.path);
+        }
+        rethrow;
+      }
+
+      final oldNoteDirectory = sourceDirectory.parent;
+      try {
+        if (await oldNoteDirectory.exists() &&
+            await oldNoteDirectory.list(followLinks: false).isEmpty) {
+          await oldNoteDirectory.delete();
+        }
+      } catch (error, stackTrace) {
+        DebugLogger.error(
+          'note-audio-rebind-cleanup-failed',
+          scope: 'notes/audio',
+          error: error,
+          stackTrace: stackTrace,
+          data: {'id': item.id},
+        );
+      }
+      return rebound;
+    });
+  }
+
   /// Loads every recording owned by an account on a server.
   ///
   /// This account-level scan is needed when a note was recorded under a

--- a/lib/features/notes/services/note_audio_upload_service.dart
+++ b/lib/features/notes/services/note_audio_upload_service.dart
@@ -19,11 +19,6 @@ const _rebindJournalVersion = 1;
 
 enum NoteAudioUploadStatus { pending, uploading, attaching, failed }
 
-typedef NoteAudioRebindReservation = ({
-  bool isOwner,
-  PendingNoteAudioUpload? rebound,
-});
-
 @immutable
 class PendingNoteAudioUpload {
   const PendingNoteAudioUpload({
@@ -1030,39 +1025,33 @@ class NoteAudioUploadCoordinator {
   static final Map<String, Completer<PendingNoteAudioUpload?>>
   _rebindReservations = <String, Completer<PendingNoteAudioUpload?>>{};
 
-  /// Prevents new work for [item] and waits for existing work to finish before
-  /// its durable directory is moved to a replacement note.
-  static Future<NoteAudioRebindReservation> reserveForRebind(
+  /// Runs one rebind operation for [item], sharing its result with concurrent
+  /// callers and guaranteeing reservation cleanup on every exit path.
+  static Future<PendingNoteAudioUpload?> rebind(
     PendingNoteAudioUpload item,
+    Future<PendingNoteAudioUpload?> Function() operation,
   ) async {
     final key = _keyFor(item);
     final existingReservation = _rebindReservations[key];
     if (existingReservation != null) {
-      return (isOwner: false, rebound: await existingReservation.future);
+      return existingReservation.future;
     }
     final reservation = Completer<PendingNoteAudioUpload?>();
     _rebindReservations[key] = reservation;
     try {
       final existing = _inFlight[key];
       if (existing != null) await existing;
+      final rebound = await operation();
+      reservation.complete(rebound);
+      return rebound;
     } catch (_) {
+      if (!reservation.isCompleted) reservation.complete(null);
+      rethrow;
+    } finally {
       if (identical(_rebindReservations[key], reservation)) {
         _rebindReservations.remove(key);
       }
       if (!reservation.isCompleted) reservation.complete(null);
-      rethrow;
-    }
-    return (isOwner: true, rebound: null);
-  }
-
-  /// Releases callers that encountered the old item while it was being moved.
-  static void completeRebind(
-    PendingNoteAudioUpload item,
-    PendingNoteAudioUpload? rebound,
-  ) {
-    final reservation = _rebindReservations.remove(_keyFor(item));
-    if (reservation != null && !reservation.isCompleted) {
-      reservation.complete(rebound);
     }
   }
 

--- a/lib/features/notes/views/note_editor_page.dart
+++ b/lib/features/notes/views/note_editor_page.dart
@@ -438,7 +438,7 @@ class _NoteEditorPageState extends ConsumerState<NoteEditorPage> {
     // deleted note needs its recovery retry to remain mounted rather than
     // silently discarding the draft during navigation.
     if (mounted) {
-      if (_hasChanges) {
+      if (_hasChanges && _deletedNoteDraftRecoveryRetry != null) {
         _deletedNoteDraftRecoveryRetry?.call();
       } else if (Navigator.of(context).canPop()) {
         Navigator.of(context).pop(result);
@@ -2511,24 +2511,41 @@ class _NoteEditorPageState extends ConsumerState<NoteEditorPage> {
     });
     if (changedDuringRecovery) _debounceSave();
 
+    final recoveredId = recovered.id;
     final reboundUploads = <String, PendingNoteAudioUpload>{};
-    final reservedUploads = <String, PendingNoteAudioUpload>{
+    final attemptedUploadIds = <String>{};
+    Future<PendingNoteAudioUpload?> rebindItem(PendingNoteAudioUpload item) =>
+        NoteAudioUploadCoordinator.rebind(item, () async {
+          try {
+            return await _noteAudioUploadStore.rebindToNote(
+              item,
+              noteId: recoveredId,
+            );
+          } catch (error, stackTrace) {
+            DebugLogger.error(
+              'deleted-note-audio-item-rebind-failed',
+              scope: 'notes/recovery',
+              error: error,
+              stackTrace: stackTrace,
+              data: {'noteId': previous.id, 'uploadId': item.id},
+            );
+            return null;
+          }
+        });
+
+    final initialUploads = <String, PendingNoteAudioUpload>{
       for (final item in _pendingAudioUploads) item.id: item,
     };
-    final completedReservations = <String>{};
-    final ownedReservations = <String>{};
-    final reservationWaits = reservedUploads.entries
+    attemptedUploadIds.addAll(initialUploads.keys);
+    final rebindWaits = initialUploads.entries
         .map(
-          (entry) async => MapEntry(
-            entry.key,
-            await NoteAudioUploadCoordinator.reserveForRebind(entry.value),
-          ),
+          (entry) async => MapEntry(entry.key, await rebindItem(entry.value)),
         )
         .toList(growable: false);
 
-    // Reservation is installed synchronously before reserveForRebind awaits
-    // existing work. Cancellation then lets that work settle against the old
-    // path before any directory is moved.
+    // rebind() installs its reservation synchronously before awaiting existing
+    // work. Cancellation then lets that work settle against the old path before
+    // the operation callback can move the durable directory.
     _activeAudioCancelToken?.cancel(
       'The note was replaced after remote deletion.',
     );
@@ -2537,18 +2554,10 @@ class _NoteEditorPageState extends ConsumerState<NoteEditorPage> {
     _audioUploadFeedbackIds.clear();
 
     try {
-      final reservations = Map<String, NoteAudioRebindReservation>.fromEntries(
-        await Future.wait(reservationWaits),
-      );
-      for (final entry in reservations.entries) {
-        final reservation = entry.value;
-        if (reservation.isOwner) {
-          ownedReservations.add(entry.key);
-        } else {
-          completedReservations.add(entry.key);
-          final rebound = reservation.rebound;
-          if (rebound != null) reboundUploads[entry.key] = rebound;
-        }
+      final initialResults = await Future.wait(rebindWaits);
+      for (final entry in initialResults) {
+        final rebound = entry.value;
+        if (rebound != null) reboundUploads[entry.key] = rebound;
       }
       final audioItemsById = <String, PendingNoteAudioUpload>{
         for (final item in _pendingAudioUploads) item.id: item,
@@ -2568,43 +2577,9 @@ class _NoteEditorPageState extends ConsumerState<NoteEditorPage> {
       }
 
       for (final item in audioItemsById.values) {
-        if (!reservedUploads.containsKey(item.id)) {
-          reservedUploads[item.id] = item;
-          final reservation = await NoteAudioUploadCoordinator.reserveForRebind(
-            item,
-          );
-          if (reservation.isOwner) {
-            ownedReservations.add(item.id);
-          } else {
-            completedReservations.add(item.id);
-            final rebound = reservation.rebound;
-            if (rebound != null) reboundUploads[item.id] = rebound;
-          }
-        }
-        if (!ownedReservations.contains(item.id)) {
-          continue;
-        }
-        PendingNoteAudioUpload? rebound;
-        try {
-          try {
-            rebound = await _noteAudioUploadStore.rebindToNote(
-              item,
-              noteId: recovered.id,
-            );
-            if (rebound != null) reboundUploads[item.id] = rebound;
-          } catch (error, stackTrace) {
-            DebugLogger.error(
-              'deleted-note-audio-item-rebind-failed',
-              scope: 'notes/recovery',
-              error: error,
-              stackTrace: stackTrace,
-              data: {'noteId': previous.id, 'uploadId': item.id},
-            );
-          }
-        } finally {
-          completedReservations.add(item.id);
-          NoteAudioUploadCoordinator.completeRebind(item, rebound);
-        }
+        if (!attemptedUploadIds.add(item.id)) continue;
+        final rebound = await rebindItem(item);
+        if (rebound != null) reboundUploads[item.id] = rebound;
       }
     } catch (error, stackTrace) {
       DebugLogger.error(
@@ -2614,16 +2589,6 @@ class _NoteEditorPageState extends ConsumerState<NoteEditorPage> {
         stackTrace: stackTrace,
         data: {'noteId': previous.id},
       );
-    } finally {
-      for (final entry in reservedUploads.entries) {
-        if (ownedReservations.contains(entry.key) &&
-            completedReservations.add(entry.key)) {
-          NoteAudioUploadCoordinator.completeRebind(
-            entry.value,
-            reboundUploads[entry.key] ?? entry.value,
-          );
-        }
-      }
     }
     if (!mounted ||
         !_isCurrentNoteSession(api: api, db: db, authEpoch: authEpoch)) {

--- a/lib/features/notes/views/note_editor_page.dart
+++ b/lib/features/notes/views/note_editor_page.dart
@@ -2516,8 +2516,14 @@ class _NoteEditorPageState extends ConsumerState<NoteEditorPage> {
       for (final item in _pendingAudioUploads) item.id: item,
     };
     final completedReservations = <String>{};
-    final reservationWaits = reservedUploads.values
-        .map(NoteAudioUploadCoordinator.reserveForRebind)
+    final ownedReservations = <String>{};
+    final reservationWaits = reservedUploads.entries
+        .map(
+          (entry) async => MapEntry(
+            entry.key,
+            await NoteAudioUploadCoordinator.reserveForRebind(entry.value),
+          ),
+        )
         .toList(growable: false);
 
     // Reservation is installed synchronously before reserveForRebind awaits
@@ -2531,7 +2537,19 @@ class _NoteEditorPageState extends ConsumerState<NoteEditorPage> {
     _audioUploadFeedbackIds.clear();
 
     try {
-      await Future.wait(reservationWaits);
+      final reservations = Map<String, NoteAudioRebindReservation>.fromEntries(
+        await Future.wait(reservationWaits),
+      );
+      for (final entry in reservations.entries) {
+        final reservation = entry.value;
+        if (reservation.isOwner) {
+          ownedReservations.add(entry.key);
+        } else {
+          completedReservations.add(entry.key);
+          final rebound = reservation.rebound;
+          if (rebound != null) reboundUploads[entry.key] = rebound;
+        }
+      }
       final audioItemsById = <String, PendingNoteAudioUpload>{
         for (final item in _pendingAudioUploads) item.id: item,
       };
@@ -2552,7 +2570,19 @@ class _NoteEditorPageState extends ConsumerState<NoteEditorPage> {
       for (final item in audioItemsById.values) {
         if (!reservedUploads.containsKey(item.id)) {
           reservedUploads[item.id] = item;
-          await NoteAudioUploadCoordinator.reserveForRebind(item);
+          final reservation = await NoteAudioUploadCoordinator.reserveForRebind(
+            item,
+          );
+          if (reservation.isOwner) {
+            ownedReservations.add(item.id);
+          } else {
+            completedReservations.add(item.id);
+            final rebound = reservation.rebound;
+            if (rebound != null) reboundUploads[item.id] = rebound;
+          }
+        }
+        if (!ownedReservations.contains(item.id)) {
+          continue;
         }
         PendingNoteAudioUpload? rebound;
         try {
@@ -2586,7 +2616,8 @@ class _NoteEditorPageState extends ConsumerState<NoteEditorPage> {
       );
     } finally {
       for (final entry in reservedUploads.entries) {
-        if (completedReservations.add(entry.key)) {
+        if (ownedReservations.contains(entry.key) &&
+            completedReservations.add(entry.key)) {
           NoteAudioUploadCoordinator.completeRebind(
             entry.value,
             reboundUploads[entry.key] ?? entry.value,

--- a/lib/features/notes/views/note_editor_page.dart
+++ b/lib/features/notes/views/note_editor_page.dart
@@ -165,6 +165,8 @@ class _NoteEditorPageState extends ConsumerState<NoteEditorPage> {
 
   Timer? _saveDebounce;
   VoidCallback? _deletedNoteDraftRecoveryRetry;
+  bool _isRecoveringDeletedNoteDraft = false;
+  bool _deletedNoteDraftRecoveryQueued = false;
   bool _isLoading = true;
   bool _isSaving = false;
   bool _hasChanges = false;
@@ -243,6 +245,7 @@ class _NoteEditorPageState extends ConsumerState<NoteEditorPage> {
       openWebUiAuthSessionEpochProvider,
       (previous, next) {
         _deletedNoteDraftRecoveryRetry = null;
+        _deletedNoteDraftRecoveryQueued = false;
         _activeAudioCancelToken?.cancel('Authentication session changed.');
         _activeAudioCancelToken = null;
         _queuedAudioUploadIds.clear();
@@ -2385,6 +2388,37 @@ class _NoteEditorPageState extends ConsumerState<NoteEditorPage> {
     required Object authEpoch,
     required String? userId,
     bool showFailure = true,
+  }) async {
+    if (_isRecoveringDeletedNoteDraft) {
+      _deletedNoteDraftRecoveryQueued = true;
+      return;
+    }
+    _isRecoveringDeletedNoteDraft = true;
+    try {
+      await _recoverDeletedNoteDraftOnce(
+        db,
+        api: api,
+        authEpoch: authEpoch,
+        userId: userId,
+        showFailure: showFailure,
+      );
+    } finally {
+      _isRecoveringDeletedNoteDraft = false;
+      if (_deletedNoteDraftRecoveryQueued) {
+        _deletedNoteDraftRecoveryQueued = false;
+        if (mounted && _hasChanges && _deletedNoteDraftRecoveryRetry != null) {
+          _debounceSave();
+        }
+      }
+    }
+  }
+
+  Future<void> _recoverDeletedNoteDraftOnce(
+    AppDatabase db, {
+    required Object? api,
+    required Object authEpoch,
+    required String? userId,
+    required bool showFailure,
   }) async {
     final previous = _note;
     if (previous == null ||

--- a/lib/features/notes/views/note_editor_page.dart
+++ b/lib/features/notes/views/note_editor_page.dart
@@ -2514,24 +2514,28 @@ class _NoteEditorPageState extends ConsumerState<NoteEditorPage> {
     final recoveredId = recovered.id;
     final reboundUploads = <String, PendingNoteAudioUpload>{};
     final attemptedUploadIds = <String>{};
-    Future<PendingNoteAudioUpload?> rebindItem(PendingNoteAudioUpload item) =>
-        NoteAudioUploadCoordinator.rebind(item, () async {
-          try {
-            return await _noteAudioUploadStore.rebindToNote(
-              item,
-              noteId: recoveredId,
-            );
-          } catch (error, stackTrace) {
-            DebugLogger.error(
-              'deleted-note-audio-item-rebind-failed',
-              scope: 'notes/recovery',
-              error: error,
-              stackTrace: stackTrace,
-              data: {'noteId': previous.id, 'uploadId': item.id},
-            );
-            return null;
-          }
-        });
+    Future<PendingNoteAudioUpload?> rebindItem(
+      PendingNoteAudioUpload item,
+    ) => NoteAudioUploadCoordinator.rebind(item, () async {
+      try {
+        return await _noteAudioUploadStore.rebindToNote(
+          item,
+          noteId: recoveredId,
+        );
+      } catch (error, stackTrace) {
+        DebugLogger.error(
+          'deleted-note-audio-item-rebind-failed',
+          scope: 'notes/recovery',
+          error: error,
+          stackTrace: stackTrace,
+          data: {'noteId': previous.id, 'uploadId': item.id},
+        );
+        // Keep the durable old-scope item visible and retryable in this editor.
+        // rebindToNote leaves its intent journal behind after rollback, so a
+        // later store scan will finish moving it to the recovered note.
+        return item;
+      }
+    });
 
     final initialUploads = <String, PendingNoteAudioUpload>{
       for (final item in _pendingAudioUploads) item.id: item,

--- a/lib/features/notes/views/note_editor_page.dart
+++ b/lib/features/notes/views/note_editor_page.dart
@@ -612,14 +612,15 @@ class _NoteEditorPageState extends ConsumerState<NoteEditorPage> {
   }
 
   Future<void> _deleteNote() async {
-    if (_note == null) return;
+    final note = _note;
+    if (note == null) return;
 
     final l10n = AppLocalizations.of(context)!;
     final confirmed = await ThemedDialogs.confirm(
       context,
       title: l10n.deleteNoteTitle,
       message: l10n.deleteNoteMessage(
-        _note!.title.isEmpty ? l10n.untitled : _note!.title,
+        note.title.isEmpty ? l10n.untitled : note.title,
       ),
       confirmText: l10n.delete,
       isDestructive: true,
@@ -629,7 +630,7 @@ class _NoteEditorPageState extends ConsumerState<NoteEditorPage> {
       ConduitHaptics.mediumImpact();
       final success = await ref
           .read(noteDeleterProvider.notifier)
-          .deleteNote(_note!.id);
+          .deleteNote(note.id);
       if (success && mounted) {
         context.go('/chat');
       }
@@ -2282,7 +2283,10 @@ class _NoteEditorPageState extends ConsumerState<NoteEditorPage> {
 
     // Push local changes and pull remote ones so the local row reflects both
     // sides. Mirrors the notes-list pull-to-refresh.
+    final api = ref.read(apiServiceProvider);
     final db = ref.read(appDatabaseProvider);
+    final authEpoch = ref.read(openWebUiAuthSessionEpochProvider);
+    final userId = ref.read(currentUserProvider2)?.id;
     if (db == null) return;
     try {
       final syncEngine = ref.read(syncEngineProvider.notifier);
@@ -2291,7 +2295,10 @@ class _NoteEditorPageState extends ConsumerState<NoteEditorPage> {
     } catch (_) {
       // Best-effort; still reload from the (at least locally-current) row below.
     }
-    if (!mounted) return;
+    if (!mounted ||
+        !_isCurrentNoteSession(api: api, db: db, authEpoch: authEpoch)) {
+      return;
+    }
 
     // Re-read from the reconciled LOCAL row, not a fresh server fetch: the pull
     // has already merged remote edits into it, and reading the row avoids a
@@ -2301,17 +2308,31 @@ class _NoteEditorPageState extends ConsumerState<NoteEditorPage> {
       // safe here (avoids pulling auth providers into the editor just for the
       // user id).
       final currentNoteId = _note?.id ?? widget.noteId;
-      final note = await readLocalNote(db, currentNoteId);
-      if (!mounted) return;
+      final resolvedNoteId = await db.notesDao.resolveNoteRemapTarget(
+        currentNoteId,
+      );
+      final note = await readLocalNote(db, resolvedNoteId);
+      if (!mounted ||
+          !_isCurrentNoteSession(api: api, db: db, authEpoch: authEpoch)) {
+        return;
+      }
       if (note == null) {
         // The user may have typed while the pull/reconcile/read was in flight.
         // Recover those edits as a new local note because the reconciler has
         // already removed the old row and an update could no longer persist.
         if (_hasChanges) {
-          await _recoverDeletedNoteDraft(db);
+          await _recoverDeletedNoteDraft(
+            db,
+            api: api,
+            authEpoch: authEpoch,
+            userId: userId,
+          );
           return;
         }
         ref.invalidate(noteByIdProvider(currentNoteId));
+        if (resolvedNoteId != currentNoteId) {
+          ref.invalidate(noteByIdProvider(resolvedNoteId));
+        }
         setState(() {
           _note = null;
           _titleController.clear();
@@ -2331,6 +2352,9 @@ class _NoteEditorPageState extends ConsumerState<NoteEditorPage> {
       if (_hasChanges) return;
       // Keep the detail cache consistent with what we just loaded.
       ref.invalidate(noteByIdProvider(currentNoteId));
+      if (resolvedNoteId != currentNoteId) {
+        ref.invalidate(noteByIdProvider(resolvedNoteId));
+      }
       setState(() {
         _note = note;
         _titleController.text = note.title;
@@ -2343,9 +2367,17 @@ class _NoteEditorPageState extends ConsumerState<NoteEditorPage> {
     }
   }
 
-  Future<void> _recoverDeletedNoteDraft(AppDatabase db) async {
+  Future<void> _recoverDeletedNoteDraft(
+    AppDatabase db, {
+    required Object? api,
+    required Object authEpoch,
+    required String? userId,
+  }) async {
     final previous = _note;
-    if (previous == null) return;
+    if (previous == null ||
+        !_isCurrentNoteSession(api: api, db: db, authEpoch: authEpoch)) {
+      return;
+    }
 
     _saveDebounce?.cancel();
     final draftTitle = _titleController.text;
@@ -2357,13 +2389,20 @@ class _NoteEditorPageState extends ConsumerState<NoteEditorPage> {
     final recovered = await durableCreateNote(
       ref,
       db,
-      userId: ref.read(currentUserProvider2)?.id,
+      userId: userId,
       title: draftTitle.trim().isEmpty
           ? AppLocalizations.of(context)!.untitled
           : draftTitle.trim(),
       data: draftData,
     );
-    if (!mounted || recovered == null) return;
+    if (!mounted ||
+        !_isCurrentNoteSession(api: api, db: db, authEpoch: authEpoch)) {
+      return;
+    }
+    if (recovered == null) {
+      _showError(AppLocalizations.of(context)!.errorMessage);
+      return;
+    }
 
     final changedDuringRecovery =
         _titleController.text != draftTitle ||

--- a/lib/features/notes/views/note_editor_page.dart
+++ b/lib/features/notes/views/note_editor_page.dart
@@ -2303,9 +2303,17 @@ class _NoteEditorPageState extends ConsumerState<NoteEditorPage> {
       final note = await readLocalNote(db, widget.noteId);
       if (!mounted) return;
       if (note == null) {
+        // The user may have typed while the pull/reconcile/read was in flight.
+        // Keep the live editor and its queued save intact instead of replacing
+        // it with a not-found state and silently discarding those keystrokes.
+        if (_hasChanges) return;
         ref.invalidate(noteByIdProvider(widget.noteId));
         setState(() {
           _note = null;
+          _titleController.clear();
+          _installContentDocument(documentFromMarkdown(''));
+          _savedMarkdown = '';
+          _cachedWordCount = 0;
           _hasChanges = false;
         });
         return;

--- a/lib/features/notes/views/note_editor_page.dart
+++ b/lib/features/notes/views/note_editor_page.dart
@@ -506,7 +506,7 @@ class _NoteEditorPageState extends ConsumerState<NoteEditorPage> {
       note = await durableUpdateNote(
         ref,
         db,
-        id: widget.noteId,
+        id: _note?.id ?? widget.noteId,
         title: title,
         data: data,
       );
@@ -629,7 +629,7 @@ class _NoteEditorPageState extends ConsumerState<NoteEditorPage> {
       ConduitHaptics.mediumImpact();
       final success = await ref
           .read(noteDeleterProvider.notifier)
-          .deleteNote(widget.noteId);
+          .deleteNote(_note!.id);
       if (success && mounted) {
         context.go('/chat');
       }
@@ -1462,7 +1462,7 @@ class _NoteEditorPageState extends ConsumerState<NoteEditorPage> {
     if (db != null) {
       updatedNote = await _durableAttachNoteAudioFile(
         db,
-        id: widget.noteId,
+        id: note.id,
         attachment: attachment,
         canCommit: () =>
             mounted &&
@@ -2300,14 +2300,18 @@ class _NoteEditorPageState extends ConsumerState<NoteEditorPage> {
       // The note is already open in the current session, so an id-scoped read is
       // safe here (avoids pulling auth providers into the editor just for the
       // user id).
-      final note = await readLocalNote(db, widget.noteId);
+      final currentNoteId = _note?.id ?? widget.noteId;
+      final note = await readLocalNote(db, currentNoteId);
       if (!mounted) return;
       if (note == null) {
         // The user may have typed while the pull/reconcile/read was in flight.
-        // Keep the live editor and its queued save intact instead of replacing
-        // it with a not-found state and silently discarding those keystrokes.
-        if (_hasChanges) return;
-        ref.invalidate(noteByIdProvider(widget.noteId));
+        // Recover those edits as a new local note because the reconciler has
+        // already removed the old row and an update could no longer persist.
+        if (_hasChanges) {
+          await _recoverDeletedNoteDraft(db);
+          return;
+        }
+        ref.invalidate(noteByIdProvider(currentNoteId));
         setState(() {
           _note = null;
           _titleController.clear();
@@ -2326,7 +2330,7 @@ class _NoteEditorPageState extends ConsumerState<NoteEditorPage> {
       // sneak in.)
       if (_hasChanges) return;
       // Keep the detail cache consistent with what we just loaded.
-      ref.invalidate(noteByIdProvider(widget.noteId));
+      ref.invalidate(noteByIdProvider(currentNoteId));
       setState(() {
         _note = note;
         _titleController.text = note.title;
@@ -2337,6 +2341,41 @@ class _NoteEditorPageState extends ConsumerState<NoteEditorPage> {
     } catch (e) {
       if (mounted) _showError(e.toString());
     }
+  }
+
+  Future<void> _recoverDeletedNoteDraft(AppDatabase db) async {
+    final previous = _note;
+    if (previous == null) return;
+
+    _saveDebounce?.cancel();
+    final draftTitle = _titleController.text;
+    final draftMarkdown = _contentMarkdown;
+    final draftData = <String, dynamic>{
+      ...previous.data.toJson(),
+      ..._composeUpdatedNoteData(),
+    };
+    final recovered = await durableCreateNote(
+      ref,
+      db,
+      userId: ref.read(currentUserProvider2)?.id,
+      title: draftTitle.trim().isEmpty
+          ? AppLocalizations.of(context)!.untitled
+          : draftTitle.trim(),
+      data: draftData,
+    );
+    if (!mounted || recovered == null) return;
+
+    final changedDuringRecovery =
+        _titleController.text != draftTitle ||
+        _contentMarkdown != draftMarkdown;
+    ref.invalidate(noteByIdProvider(widget.noteId));
+    ref.invalidate(noteByIdProvider(recovered.id));
+    setState(() {
+      _note = recovered;
+      _savedMarkdown = draftMarkdown;
+      _hasChanges = changedDuringRecovery;
+    });
+    if (changedDuringRecovery) _debounceSave();
   }
 
   Widget _buildContentEditor(BuildContext context) {

--- a/lib/features/notes/views/note_editor_page.dart
+++ b/lib/features/notes/views/note_editor_page.dart
@@ -438,7 +438,7 @@ class _NoteEditorPageState extends ConsumerState<NoteEditorPage> {
     // deleted note needs its recovery retry to remain mounted rather than
     // silently discarding the draft during navigation.
     if (mounted) {
-      if (_hasChanges && _deletedNoteDraftRecoveryRetry != null) {
+      if (_hasChanges) {
         _deletedNoteDraftRecoveryRetry?.call();
       } else if (Navigator.of(context).canPop()) {
         Navigator.of(context).pop(result);

--- a/lib/features/notes/views/note_editor_page.dart
+++ b/lib/features/notes/views/note_editor_page.dart
@@ -164,6 +164,7 @@ class _NoteEditorPageState extends ConsumerState<NoteEditorPage> {
   final ScrollController _scrollController = ScrollController();
 
   Timer? _saveDebounce;
+  VoidCallback? _deletedNoteDraftRecoveryRetry;
   bool _isLoading = true;
   bool _isSaving = false;
   bool _hasChanges = false;
@@ -241,6 +242,7 @@ class _NoteEditorPageState extends ConsumerState<NoteEditorPage> {
     _audioAuthEpochSubscription = ref.listenManual<Object>(
       openWebUiAuthSessionEpochProvider,
       (previous, next) {
+        _deletedNoteDraftRecoveryRetry = null;
         _activeAudioCancelToken?.cancel('Authentication session changed.');
         _activeAudioCancelToken = null;
         _queuedAudioUploadIds.clear();
@@ -416,7 +418,10 @@ class _NoteEditorPageState extends ConsumerState<NoteEditorPage> {
 
   void _debounceSave() {
     _saveDebounce?.cancel();
-    _saveDebounce = Timer(const Duration(milliseconds: 800), _autoSave);
+    _saveDebounce = Timer(
+      const Duration(milliseconds: 800),
+      _deletedNoteDraftRecoveryRetry ?? _autoSave,
+    );
   }
 
   /// Handles a back-navigation attempt. Reached only when [canPop] was false,
@@ -426,8 +431,15 @@ class _NoteEditorPageState extends ConsumerState<NoteEditorPage> {
     if (didPop) return;
     _saveDebounce?.cancel();
     await _autoSave();
-    if (mounted && Navigator.of(context).canPop()) {
-      Navigator.of(context).pop(result);
+    // Keep the editor open if persistence failed. In particular, a remotely
+    // deleted note needs its recovery retry to remain mounted rather than
+    // silently discarding the draft during navigation.
+    if (mounted) {
+      if (_hasChanges) {
+        _deletedNoteDraftRecoveryRetry?.call();
+      } else if (Navigator.of(context).canPop()) {
+        Navigator.of(context).pop(result);
+      }
     }
   }
 
@@ -2372,12 +2384,26 @@ class _NoteEditorPageState extends ConsumerState<NoteEditorPage> {
     required Object? api,
     required Object authEpoch,
     required String? userId,
+    bool showFailure = true,
   }) async {
     final previous = _note;
     if (previous == null ||
         !_isCurrentNoteSession(api: api, db: db, authEpoch: authEpoch)) {
       return;
     }
+
+    _deletedNoteDraftRecoveryRetry = () {
+      if (!mounted) return;
+      unawaited(
+        _recoverDeletedNoteDraft(
+          db,
+          api: api,
+          authEpoch: authEpoch,
+          userId: userId,
+          showFailure: false,
+        ),
+      );
+    };
 
     _saveDebounce?.cancel();
     final draftTitle = _titleController.text;
@@ -2386,28 +2412,63 @@ class _NoteEditorPageState extends ConsumerState<NoteEditorPage> {
       ...previous.data.toJson(),
       ..._composeUpdatedNoteData(),
     };
-    final recovered = await durableCreateNote(
-      ref,
-      db,
-      userId: userId,
-      title: draftTitle.trim().isEmpty
-          ? AppLocalizations.of(context)!.untitled
-          : draftTitle.trim(),
-      data: draftData,
-    );
+    Note? recovered;
+    try {
+      recovered = await durableCreateNote(
+        ref,
+        db,
+        userId: userId,
+        title: draftTitle.trim().isEmpty
+            ? AppLocalizations.of(context)!.untitled
+            : draftTitle.trim(),
+        data: draftData,
+      );
+    } catch (error, stackTrace) {
+      DebugLogger.error(
+        'deleted-note-draft-recovery-failed',
+        scope: 'notes/recovery',
+        error: error,
+        stackTrace: stackTrace,
+        data: {'noteId': previous.id},
+      );
+      if (mounted &&
+          _isCurrentNoteSession(api: api, db: db, authEpoch: authEpoch)) {
+        _scheduleDeletedNoteDraftRecovery(
+          db,
+          api: api,
+          authEpoch: authEpoch,
+          userId: userId,
+        );
+        if (showFailure) _showError(AppLocalizations.of(context)!.errorMessage);
+      }
+      return;
+    }
     if (!mounted ||
         !_isCurrentNoteSession(api: api, db: db, authEpoch: authEpoch)) {
       return;
     }
     if (recovered == null) {
-      _showError(AppLocalizations.of(context)!.errorMessage);
+      _scheduleDeletedNoteDraftRecovery(
+        db,
+        api: api,
+        authEpoch: authEpoch,
+        userId: userId,
+      );
+      if (showFailure) _showError(AppLocalizations.of(context)!.errorMessage);
       return;
     }
 
+    // The draft is durable at this point. Publish the replacement before any
+    // recording migration I/O so a filesystem failure cannot retry creation
+    // and produce a duplicate recovered note.
     final changedDuringRecovery =
         _titleController.text != draftTitle ||
         _contentMarkdown != draftMarkdown;
+    _deletedNoteDraftRecoveryRetry = null;
     ref.invalidate(noteByIdProvider(widget.noteId));
+    if (previous.id != widget.noteId) {
+      ref.invalidate(noteByIdProvider(previous.id));
+    }
     ref.invalidate(noteByIdProvider(recovered.id));
     setState(() {
       _note = recovered;
@@ -2415,6 +2476,95 @@ class _NoteEditorPageState extends ConsumerState<NoteEditorPage> {
       _hasChanges = changedDuringRecovery;
     });
     if (changedDuringRecovery) _debounceSave();
+
+    _activeAudioCancelToken?.cancel(
+      'The note was replaced after remote deletion.',
+    );
+    _activeAudioCancelToken = null;
+    _queuedAudioUploadIds.clear();
+    _audioUploadFeedbackIds.clear();
+
+    final reboundUploads = <String, PendingNoteAudioUpload>{};
+    try {
+      final audioItemsById = <String, PendingNoteAudioUpload>{
+        for (final item in _pendingAudioUploads) item.id: item,
+      };
+      final audioScope = _noteAudioScope();
+      if (audioScope != null) {
+        for (final noteId in <String>{widget.noteId, previous.id}) {
+          final durableItems = await _noteAudioUploadStore.loadForNote(
+            serverId: audioScope.serverId,
+            accountId: audioScope.accountId,
+            noteId: noteId,
+          );
+          for (final item in durableItems) {
+            audioItemsById[item.id] = item;
+          }
+        }
+      }
+
+      for (final item in audioItemsById.values) {
+        final rebound = await _noteAudioUploadStore.rebindToNote(
+          item,
+          noteId: recovered.id,
+        );
+        if (rebound != null) reboundUploads[item.id] = rebound;
+      }
+    } catch (error, stackTrace) {
+      DebugLogger.error(
+        'deleted-note-audio-rebind-failed',
+        scope: 'notes/recovery',
+        error: error,
+        stackTrace: stackTrace,
+        data: {'noteId': previous.id},
+      );
+    }
+    if (!mounted ||
+        !_isCurrentNoteSession(api: api, db: db, authEpoch: authEpoch)) {
+      return;
+    }
+
+    if (reboundUploads.isNotEmpty) {
+      setState(() {
+        _pendingAudioMutationGeneration++;
+        final visibleById = <String, PendingNoteAudioUpload>{
+          for (final item in _pendingAudioUploads) item.id: item,
+          ...reboundUploads,
+        };
+        for (final hiddenId in _hiddenAudioUploadIds) {
+          visibleById.remove(hiddenId);
+        }
+        _pendingAudioUploads
+          ..clear()
+          ..addAll(visibleById.values)
+          ..sort((a, b) => a.createdAt.compareTo(b.createdAt));
+      });
+      if (ref.read(connectivityStatusProvider) == ConnectivityStatus.online) {
+        unawaited(_retryPendingAudioUploads(ids: reboundUploads.keys));
+      }
+    }
+  }
+
+  void _scheduleDeletedNoteDraftRecovery(
+    AppDatabase db, {
+    required Object? api,
+    required Object authEpoch,
+    required String? userId,
+  }) {
+    if (!mounted ||
+        !_hasChanges ||
+        !_isCurrentNoteSession(api: api, db: db, authEpoch: authEpoch)) {
+      return;
+    }
+    _saveDebounce?.cancel();
+    _saveDebounce = Timer(const Duration(seconds: 2), () {
+      if (!mounted ||
+          !_hasChanges ||
+          !_isCurrentNoteSession(api: api, db: db, authEpoch: authEpoch)) {
+        return;
+      }
+      _deletedNoteDraftRecoveryRetry?.call();
+    });
   }
 
   Widget _buildContentEditor(BuildContext context) {

--- a/lib/features/notes/views/note_editor_page.dart
+++ b/lib/features/notes/views/note_editor_page.dart
@@ -2290,6 +2290,11 @@ class _NoteEditorPageState extends ConsumerState<NoteEditorPage> {
   /// without syncing would let the detail fetch return a server copy that is
   /// behind a not-yet-synced local edit and clobber it with stale/empty content.
   Future<void> _refreshNote() async {
+    final noteBeforeRefresh = _note;
+    final hadDraftChanges =
+        noteBeforeRefresh != null &&
+        (_titleController.text != noteBeforeRefresh.title ||
+            _contentMarkdown != _savedMarkdown);
     if (_hasChanges) {
       _saveDebounce?.cancel();
       await _autoSave();
@@ -2335,7 +2340,8 @@ class _NoteEditorPageState extends ConsumerState<NoteEditorPage> {
         // The user may have typed while the pull/reconcile/read was in flight.
         // Recover those edits as a new local note because the reconciler has
         // already removed the old row and an update could no longer persist.
-        if (_hasChanges) {
+        if (hadDraftChanges || _hasChanges) {
+          if (!_hasChanges) setState(() => _hasChanges = true);
           await _recoverDeletedNoteDraft(
             db,
             api: api,
@@ -2516,11 +2522,11 @@ class _NoteEditorPageState extends ConsumerState<NoteEditorPage> {
     final attemptedUploadIds = <String>{};
     Future<PendingNoteAudioUpload?> rebindItem(
       PendingNoteAudioUpload item,
-    ) => NoteAudioUploadCoordinator.rebind(item, () async {
+    ) async {
       try {
-        return await _noteAudioUploadStore.rebindToNote(
+        return await NoteAudioUploadCoordinator.rebind(
           item,
-          noteId: recoveredId,
+          () => _noteAudioUploadStore.rebindToNote(item, noteId: recoveredId),
         );
       } catch (error, stackTrace) {
         DebugLogger.error(
@@ -2535,7 +2541,7 @@ class _NoteEditorPageState extends ConsumerState<NoteEditorPage> {
         // later store scan will finish moving it to the recovered note.
         return item;
       }
-    });
+    }
 
     final initialUploads = <String, PendingNoteAudioUpload>{
       for (final item in _pendingAudioUploads) item.id: item,

--- a/lib/features/notes/views/note_editor_page.dart
+++ b/lib/features/notes/views/note_editor_page.dart
@@ -2477,6 +2477,18 @@ class _NoteEditorPageState extends ConsumerState<NoteEditorPage> {
     });
     if (changedDuringRecovery) _debounceSave();
 
+    final reboundUploads = <String, PendingNoteAudioUpload>{};
+    final reservedUploads = <String, PendingNoteAudioUpload>{
+      for (final item in _pendingAudioUploads) item.id: item,
+    };
+    final completedReservations = <String>{};
+    final reservationWaits = reservedUploads.values
+        .map(NoteAudioUploadCoordinator.reserveForRebind)
+        .toList(growable: false);
+
+    // Reservation is installed synchronously before reserveForRebind awaits
+    // existing work. Cancellation then lets that work settle against the old
+    // path before any directory is moved.
     _activeAudioCancelToken?.cancel(
       'The note was replaced after remote deletion.',
     );
@@ -2484,8 +2496,8 @@ class _NoteEditorPageState extends ConsumerState<NoteEditorPage> {
     _queuedAudioUploadIds.clear();
     _audioUploadFeedbackIds.clear();
 
-    final reboundUploads = <String, PendingNoteAudioUpload>{};
     try {
+      await Future.wait(reservationWaits);
       final audioItemsById = <String, PendingNoteAudioUpload>{
         for (final item in _pendingAudioUploads) item.id: item,
       };
@@ -2504,11 +2516,31 @@ class _NoteEditorPageState extends ConsumerState<NoteEditorPage> {
       }
 
       for (final item in audioItemsById.values) {
-        final rebound = await _noteAudioUploadStore.rebindToNote(
-          item,
-          noteId: recovered.id,
-        );
-        if (rebound != null) reboundUploads[item.id] = rebound;
+        if (!reservedUploads.containsKey(item.id)) {
+          reservedUploads[item.id] = item;
+          await NoteAudioUploadCoordinator.reserveForRebind(item);
+        }
+        PendingNoteAudioUpload? rebound;
+        try {
+          try {
+            rebound = await _noteAudioUploadStore.rebindToNote(
+              item,
+              noteId: recovered.id,
+            );
+            if (rebound != null) reboundUploads[item.id] = rebound;
+          } catch (error, stackTrace) {
+            DebugLogger.error(
+              'deleted-note-audio-item-rebind-failed',
+              scope: 'notes/recovery',
+              error: error,
+              stackTrace: stackTrace,
+              data: {'noteId': previous.id, 'uploadId': item.id},
+            );
+          }
+        } finally {
+          completedReservations.add(item.id);
+          NoteAudioUploadCoordinator.completeRebind(item, rebound);
+        }
       }
     } catch (error, stackTrace) {
       DebugLogger.error(
@@ -2518,6 +2550,15 @@ class _NoteEditorPageState extends ConsumerState<NoteEditorPage> {
         stackTrace: stackTrace,
         data: {'noteId': previous.id},
       );
+    } finally {
+      for (final entry in reservedUploads.entries) {
+        if (completedReservations.add(entry.key)) {
+          NoteAudioUploadCoordinator.completeRebind(
+            entry.value,
+            reboundUploads[entry.key] ?? entry.value,
+          );
+        }
+      }
     }
     if (!mounted ||
         !_isCurrentNoteSession(api: api, db: db, authEpoch: authEpoch)) {

--- a/lib/features/notes/views/note_editor_page.dart
+++ b/lib/features/notes/views/note_editor_page.dart
@@ -2285,9 +2285,9 @@ class _NoteEditorPageState extends ConsumerState<NoteEditorPage> {
     final db = ref.read(appDatabaseProvider);
     if (db == null) return;
     try {
-      await ref
-          .read(syncEngineProvider.notifier)
-          .requestPull(reason: 'note-editor-refresh');
+      final syncEngine = ref.read(syncEngineProvider.notifier);
+      await syncEngine.requestPull(reason: 'note-editor-refresh');
+      await syncEngine.reconcileNow();
     } catch (_) {
       // Best-effort; still reload from the (at least locally-current) row below.
     }
@@ -2301,7 +2301,15 @@ class _NoteEditorPageState extends ConsumerState<NoteEditorPage> {
       // safe here (avoids pulling auth providers into the editor just for the
       // user id).
       final note = await readLocalNote(db, widget.noteId);
-      if (!mounted || note == null) return;
+      if (!mounted) return;
+      if (note == null) {
+        ref.invalidate(noteByIdProvider(widget.noteId));
+        setState(() {
+          _note = null;
+          _hasChanges = false;
+        });
+        return;
+      }
       // If the user typed while the sync/read was in flight, do NOT overwrite
       // their in-progress edits: those keystroke(s) re-set `_hasChanges` and
       // queued a fresh debounce. Bail out and leave the editor as-is so that

--- a/test/core/providers/active_chats_sync_test.dart
+++ b/test/core/providers/active_chats_sync_test.dart
@@ -151,10 +151,10 @@ Map<String, dynamic> _activeEnvelope({
 
 Map<String, dynamic> _titleEnvelope({
   required String chatId,
-  required String title,
+  required Object payload,
 }) => <String, dynamic>{
   'chat_id': chatId,
-  'data': <String, dynamic>{'type': 'chat:title', 'data': title},
+  'data': <String, dynamic>{'type': 'chat:title', 'data': payload},
 };
 
 ProviderContainer _makeContainer({
@@ -321,7 +321,7 @@ void main() {
       container.read(activeConversationProvider.notifier).set(_conv('c1'));
 
       socket.registrations.single.handler(
-        _titleEnvelope(chatId: 'c1', title: 'Generated title'),
+        _titleEnvelope(chatId: 'c1', payload: 'Generated title'),
         null,
       );
 
@@ -332,6 +332,29 @@ void main() {
         container.read(activeConversationProvider)?.title,
       ).equals('Generated title');
       check(container.read(activeChatIdsProvider)).isEmpty();
+    });
+
+    test('persists a Map-shaped generated title payload', () async {
+      final socket = _MockSocketService();
+      addTearDown(socket.disposeController);
+      final container = _makeContainer(
+        socket: socket,
+        conversations: [_conv('c1')],
+      );
+      container.read(activeChatsSyncProvider);
+      await container.read(conversationsProvider.future);
+
+      socket.registrations.single.handler(
+        _titleEnvelope(
+          chatId: 'c1',
+          payload: <String, dynamic>{'title': 'Mapped title'},
+        ),
+        null,
+      );
+
+      check(
+        container.read(conversationsProvider).requireValue.single.title,
+      ).equals('Mapped title');
     });
   });
 

--- a/test/core/providers/active_chats_sync_test.dart
+++ b/test/core/providers/active_chats_sync_test.dart
@@ -149,6 +149,14 @@ Map<String, dynamic> _activeEnvelope({
   };
 }
 
+Map<String, dynamic> _titleEnvelope({
+  required String chatId,
+  required String title,
+}) => <String, dynamic>{
+  'chat_id': chatId,
+  'data': <String, dynamic>{'type': 'chat:title', 'data': title},
+};
+
 ProviderContainer _makeContainer({
   required _MockSocketService socket,
   _FakeApiService? api,
@@ -300,6 +308,31 @@ void main() {
         ).contains('background-chat');
       },
     );
+
+    test('persists generated titles delivered by the global handler', () async {
+      final socket = _MockSocketService();
+      addTearDown(socket.disposeController);
+      final container = _makeContainer(
+        socket: socket,
+        conversations: [_conv('c1')],
+      );
+      container.read(activeChatsSyncProvider);
+      await container.read(conversationsProvider.future);
+      container.read(activeConversationProvider.notifier).set(_conv('c1'));
+
+      socket.registrations.single.handler(
+        _titleEnvelope(chatId: 'c1', title: 'Generated title'),
+        null,
+      );
+
+      check(
+        container.read(conversationsProvider).requireValue.single.title,
+      ).equals('Generated title');
+      check(
+        container.read(activeConversationProvider)?.title,
+      ).equals('Generated title');
+      check(container.read(activeChatIdsProvider)).isEmpty();
+    });
   });
 
   group('ActiveChatsSync — reconciliation fallback', () {

--- a/test/core/providers/conversations_provider_test.dart
+++ b/test/core/providers/conversations_provider_test.dart
@@ -16,6 +16,7 @@ import 'package:conduit/core/database/chat_database_repository.dart';
 import 'package:conduit/core/database/daos/chats_dao.dart';
 import 'package:conduit/core/database/database_provider.dart';
 import 'package:conduit/core/database/mappers/chat_blob_mapper.dart';
+import 'package:conduit/core/database/mappers/conversation_assembler.dart';
 import 'package:conduit/core/models/conversation.dart';
 import 'package:conduit/core/models/server_config.dart';
 import 'package:conduit/core/providers/app_providers.dart';
@@ -691,6 +692,31 @@ void main() {
     );
 
     test(
+      'server-generated title persists without advancing updatedAt',
+      () async {
+        await seedServerChat('chat-1', updatedAt: 100);
+        final container = makeContainer();
+        await container.read(conversationsProvider.future);
+
+        container
+            .read(conversationsProvider.notifier)
+            .applyServerGeneratedTitle('chat-1', '  Generated title  ');
+
+        check(
+          container.read(conversationsProvider).requireValue.single.title,
+        ).equals('Generated title');
+        final row = await waitForAsync<ChatRow?>(
+          () => db.chatsDao.getChat('chat-1'),
+          condition: (row) => row?.title == 'Generated title',
+        );
+        check(row!.updatedAt).equals(100);
+        final messages = await db.messagesDao.getForChat('chat-1');
+        final blob = ChatBlobMapper.rowsToBlob(chatRowsFromDb(row, messages));
+        check(blob['title']).equals('Generated title');
+      },
+    );
+
+    test(
       'missing remote conversation update submits reconcile pull immediately',
       () async {
         final pulls = <String>[];
@@ -916,6 +942,35 @@ void main() {
         return idsOf(state.asData?.value ?? const []).contains('remote-chat');
       });
     });
+
+    test(
+      'manual refresh purges a chat that was deleted on the server',
+      () async {
+        await seedServerChat('deleted-remotely', updatedAt: 100);
+        final server = FakeOpenWebUiServer();
+        final client = FakeSyncApiClient(server);
+        final container = makeContainer(
+          extraOverrides: [syncApiClientProvider.overrideWith((ref) => client)],
+        );
+        await container.read(conversationsProvider.future);
+
+        check(
+          idsOf(container.read(conversationsProvider).requireValue),
+        ).contains('deleted-remotely');
+
+        await container.read(conversationsProvider.notifier).refresh();
+
+        await waitForAsync<ChatRow?>(
+          () => db.chatsDao.getChat('deleted-remotely'),
+          condition: (row) => row == null,
+        );
+        await waitFor(
+          () => !idsOf(
+            container.read(conversationsProvider).asData?.value ?? const [],
+          ).contains('deleted-remotely'),
+        );
+      },
+    );
   });
 
   group('folderConversationSummariesProvider', () {

--- a/test/core/providers/conversations_provider_test.dart
+++ b/test/core/providers/conversations_provider_test.dart
@@ -1015,6 +1015,41 @@ void main() {
         );
       },
     );
+
+    test(
+      'manual refresh restores a server title changed without a timestamp bump',
+      () async {
+        await seedServerChat('retitled', updatedAt: 100);
+        await db.syncMetaDao.setPullWatermark(200);
+        final server = FakeOpenWebUiServer();
+        server.seedChat(
+          id: 'retitled',
+          blob: <String, dynamic>{
+            'title': 'Generated on server',
+            'history': <String, dynamic>{
+              'messages': <String, dynamic>{},
+              'currentId': null,
+            },
+          },
+          createdAt: 100,
+          updatedAt: 100,
+        );
+        final client = FakeSyncApiClient(server);
+        final container = makeContainer(
+          extraOverrides: [syncApiClientProvider.overrideWith((ref) => client)],
+        );
+        await container.read(conversationsProvider.future);
+
+        await container.read(conversationsProvider.notifier).refresh();
+
+        await waitFor(
+          () =>
+              container.read(conversationsProvider).requireValue.single.title ==
+              'Generated on server',
+        );
+        check((await db.chatsDao.getChat('retitled'))!.updatedAt).equals(100);
+      },
+    );
   });
 
   group('folderConversationSummariesProvider', () {

--- a/test/core/providers/conversations_provider_test.dart
+++ b/test/core/providers/conversations_provider_test.dart
@@ -716,6 +716,41 @@ void main() {
       },
     );
 
+    test('server-generated title preserves a pending local rename', () async {
+      await seedServerChat('chat-1', updatedAt: 100);
+      await db.chatsDao.updateEnvelopeWithOutbox(
+        'chat-1',
+        title: const Value('My local title'),
+        updatedAt: const Value(101),
+        enqueue: false,
+      );
+      final container = makeContainer();
+      await container.read(conversationsProvider.future);
+
+      container
+          .read(conversationsProvider.notifier)
+          .applyServerGeneratedTitle('chat-1', 'Generated title');
+
+      final row = await waitForAsync<ChatRow?>(
+        () => db.chatsDao.getChat('chat-1'),
+        condition: (row) =>
+            row?.title == 'My local title' &&
+            row!.blobMeta.contains('My local title'),
+      );
+      check(row!.dirty).isTrue();
+      final messages = await db.messagesDao.getForChat('chat-1');
+      final blob = ChatBlobMapper.rowsToBlob(chatRowsFromDb(row, messages));
+      check(blob['title']).equals('My local title');
+      await waitFor(() {
+        return container
+                .read(conversationsProvider)
+                .requireValue
+                .single
+                .title ==
+            'My local title';
+      });
+    });
+
     test(
       'missing remote conversation update submits reconcile pull immediately',
       () async {

--- a/test/core/providers/conversations_provider_test.dart
+++ b/test/core/providers/conversations_provider_test.dart
@@ -702,13 +702,18 @@ void main() {
             .read(conversationsProvider.notifier)
             .applyServerGeneratedTitle('chat-1', '  Generated title  ');
 
-        check(
-          container.read(conversationsProvider).requireValue.single.title,
-        ).equals('Generated title');
         final row = await waitForAsync<ChatRow?>(
           () => db.chatsDao.getChat('chat-1'),
           condition: (row) => row?.title == 'Generated title',
         );
+        await waitFor(() {
+          return container
+                  .read(conversationsProvider)
+                  .requireValue
+                  .single
+                  .title ==
+              'Generated title';
+        });
         check(row!.updatedAt).equals(100);
         final messages = await db.messagesDao.getForChat('chat-1');
         final blob = ChatBlobMapper.rowsToBlob(chatRowsFromDb(row, messages));
@@ -730,6 +735,10 @@ void main() {
       container
           .read(conversationsProvider.notifier)
           .applyServerGeneratedTitle('chat-1', 'Generated title');
+
+      check(
+        container.read(conversationsProvider).requireValue.single.title,
+      ).equals('My local title');
 
       final row = await waitForAsync<ChatRow?>(
         () => db.chatsDao.getChat('chat-1'),

--- a/test/core/services/api_service_chat_deletion_test.dart
+++ b/test/core/services/api_service_chat_deletion_test.dart
@@ -22,6 +22,17 @@ void main() {
       check(adapter.lastPath).equals('/api/v1/chats/already-gone');
     },
   );
+
+  test('deleteConversation rethrows non-404 server failures', () async {
+    final adapter = _DeleteChatAdapter(statusCode: 500);
+    final api = _buildApiService(adapter);
+
+    await check(api.deleteConversation('still-there')).throws<DioException>();
+
+    check(adapter.requestCount).equals(1);
+    check(adapter.lastMethod).equals('DELETE');
+    check(adapter.lastPath).equals('/api/v1/chats/still-there');
+  });
 }
 
 final class _DeleteChatAdapter implements HttpClientAdapter {

--- a/test/core/services/api_service_chat_deletion_test.dart
+++ b/test/core/services/api_service_chat_deletion_test.dart
@@ -1,0 +1,71 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:checks/checks.dart';
+import 'package:conduit/core/models/server_config.dart';
+import 'package:conduit/core/services/api_service.dart';
+import 'package:conduit/core/services/worker_manager.dart';
+import 'package:dio/dio.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test(
+    'deleteConversation treats an already-missing chat as success',
+    () async {
+      final adapter = _DeleteChatAdapter(statusCode: 404);
+      final api = _buildApiService(adapter);
+
+      await api.deleteConversation('already-gone');
+
+      check(adapter.requestCount).equals(1);
+      check(adapter.lastMethod).equals('DELETE');
+      check(adapter.lastPath).equals('/api/v1/chats/already-gone');
+    },
+  );
+}
+
+final class _DeleteChatAdapter implements HttpClientAdapter {
+  _DeleteChatAdapter({required this.statusCode});
+
+  final int statusCode;
+  int requestCount = 0;
+  String? lastMethod;
+  String? lastPath;
+
+  @override
+  Future<ResponseBody> fetch(
+    RequestOptions options,
+    Stream<Uint8List>? requestStream,
+    Future<void>? cancelFuture,
+  ) async {
+    requestCount++;
+    lastMethod = options.method;
+    lastPath = options.path;
+    return ResponseBody(
+      Stream.value(
+        Uint8List.fromList(utf8.encode(jsonEncode({'detail': 'Not found'}))),
+      ),
+      statusCode,
+      headers: {
+        'content-type': ['application/json'],
+      },
+    );
+  }
+
+  @override
+  void close({bool force = false}) {}
+}
+
+ApiService _buildApiService(HttpClientAdapter adapter) {
+  final service = ApiService(
+    serverConfig: const ServerConfig(
+      id: 'test',
+      name: 'Test',
+      url: 'http://localhost:0',
+    ),
+    workerManager: WorkerManager(),
+  );
+  service.dio.httpClientAdapter = adapter;
+  service.dio.interceptors.clear();
+  return service;
+}

--- a/test/core/sync/deletion_reconcile_test.dart
+++ b/test/core/sync/deletion_reconcile_test.dart
@@ -146,6 +146,56 @@ void main() {
 
   group('pagination absence is NOT a delete signal', () {
     test(
+      'manual reconcile restores a server title changed without a timestamp bump',
+      () async {
+        await seedServerChat(db, id: 'retitled', updatedAt: 100);
+        server.seedChat(
+          id: 'retitled',
+          blob: <String, dynamic>{
+            ...blobFor('retitled'),
+            'title': 'Generated on server',
+          },
+          createdAt: 50,
+          updatedAt: 100,
+        );
+
+        final result = await reconcile.run(ReconcileReason.manualRefresh);
+
+        check(result.ran).isTrue();
+        final row = await db.chatsDao.getChat('retitled');
+        check(row).isNotNull();
+        check(row!.title).equals('Generated on server');
+        check(row.updatedAt).equals(100);
+      },
+    );
+
+    test('manual title reconcile preserves a pending local rename', () async {
+      await seedServerChat(db, id: 'locally-retitled', updatedAt: 100);
+      await db.chatsDao.updateEnvelopeWithOutbox(
+        'locally-retitled',
+        title: const Value('Keep my title'),
+        updatedAt: const Value(101),
+        enqueue: false,
+      );
+      server.seedChat(
+        id: 'locally-retitled',
+        blob: <String, dynamic>{
+          ...blobFor('locally-retitled'),
+          'title': 'Generated on server',
+        },
+        createdAt: 50,
+        updatedAt: 100,
+      );
+
+      await reconcile.run(ReconcileReason.manualRefresh);
+
+      final row = await db.chatsDao.getChat('locally-retitled');
+      check(row).isNotNull();
+      check(row!.title).equals('Keep my title');
+      check(row.dirty).isTrue();
+    });
+
+    test(
       'server list enumeration stops when a full page adds no new ids',
       () async {
         for (var i = 0; i < kOpenWebUiChatListPageSize; i++) {

--- a/test/core/sync/sync_engine_test.dart
+++ b/test/core/sync/sync_engine_test.dart
@@ -391,6 +391,25 @@ void main() {
     });
 
     test(
+      'manual reconcile publishes finalizing progress until complete',
+      () async {
+        final container = makeContainer();
+        final engine = container.read(syncEngineProvider.notifier);
+
+        final reconcile = engine.reconcileNow();
+
+        final running = container.read(syncEngineProvider);
+        check(running.phase).equals(SyncPhase.running);
+        check(running.stage).equals(SyncStage.finalizing);
+
+        await reconcile;
+        final complete = container.read(syncEngineProvider);
+        check(complete.phase).equals(SyncPhase.idle);
+        check(complete.stage).isNull();
+      },
+    );
+
+    test(
       'requests during a running cycle coalesce into one queued rerun',
       () async {
         seedChat('chat-1', 100);

--- a/test/features/navigation/widgets/sidebar_page_test.dart
+++ b/test/features/navigation/widgets/sidebar_page_test.dart
@@ -540,6 +540,66 @@ void main() {
     await tester.pumpAndSettle();
   });
 
+  testWidgets('chat pull-to-refresh reserves a gutter above conversation rows', (
+    tester,
+  ) async {
+    final controllers = _SidebarHarnessControllers();
+    final pendingRefresh = controllers.keepChatRefreshPending();
+    final timestamp = DateTime(2026, 1, 1);
+    final conversation = Conversation(
+      id: 'refresh-layout-chat',
+      title: 'Refresh layout',
+      createdAt: timestamp,
+      updatedAt: timestamp,
+    );
+
+    await tester.pumpWidget(
+      _buildSidebarHarness(
+        controllers: controllers,
+        conversations: [conversation],
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    final tile = find.byKey(
+      ValueKey<String>(
+        'drawer-chat-${conversationScopedId(conversation)}',
+      ),
+    );
+    final refreshSlot = find.byKey(
+      const ValueKey<String>('chats-refresh-slot'),
+    );
+    final idleSlotHeight = tester.getSize(refreshSlot).height;
+    final refreshControl = tester.widget<RefreshIndicator>(
+      find.descendant(
+        of: _layerRootFinder(_SidebarTabLayer.chats),
+        matching: find.byType(RefreshIndicator),
+      ),
+    );
+    check(refreshControl.onStatusChange).isNotNull();
+    refreshControl.onStatusChange!(RefreshIndicatorStatus.refresh);
+    final refreshing = refreshControl.onRefresh();
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 200));
+
+    check(controllers.chatRefreshCalls).equals(1);
+    final progress = find.byKey(
+      const ValueKey<String>('chats-refresh-progress'),
+    );
+    check(progress.evaluate()).length.equals(1);
+    check(tester.getBottomLeft(progress).dy <= tester.getTopLeft(tile).dy)
+        .isTrue();
+    check(tester.getSize(refreshSlot).height > idleSlotHeight).isTrue();
+
+    pendingRefresh.complete();
+    await refreshing;
+    refreshControl.onStatusChange!(RefreshIndicatorStatus.done);
+    await tester.pump(const Duration(milliseconds: 140));
+    refreshControl.onStatusChange!(null);
+    await tester.pumpAndSettle();
+    check(progress.evaluate()).isEmpty();
+  });
+
   testWidgets('collapsed paginated chat sections do not consume hidden pages', (
     tester,
   ) async {

--- a/test/features/navigation/widgets/sidebar_page_test.dart
+++ b/test/features/navigation/widgets/sidebar_page_test.dart
@@ -540,64 +540,111 @@ void main() {
     await tester.pumpAndSettle();
   });
 
-  testWidgets('chat pull-to-refresh reserves a gutter above conversation rows', (
+  testWidgets(
+    'chat pull-to-refresh reserves a gutter above conversation rows',
+    (tester) async {
+      final controllers = _SidebarHarnessControllers();
+      final pendingRefresh = controllers.keepChatRefreshPending();
+      final timestamp = DateTime(2026, 1, 1);
+      final conversation = Conversation(
+        id: 'refresh-layout-chat',
+        title: 'Refresh layout',
+        createdAt: timestamp,
+        updatedAt: timestamp,
+      );
+
+      await tester.pumpWidget(
+        _buildSidebarHarness(
+          controllers: controllers,
+          conversations: [conversation],
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      final tile = find.byKey(
+        ValueKey<String>('drawer-chat-${conversationScopedId(conversation)}'),
+      );
+      final refreshSlot = find.byKey(
+        const ValueKey<String>('chats-refresh-slot'),
+      );
+      final idleSlotHeight = tester.getSize(refreshSlot).height;
+      final refreshControl = tester.widget<RefreshIndicator>(
+        find.descendant(
+          of: _layerRootFinder(_SidebarTabLayer.chats),
+          matching: find.byType(RefreshIndicator),
+        ),
+      );
+      check(refreshControl.onStatusChange).isNotNull();
+      refreshControl.onStatusChange!(RefreshIndicatorStatus.refresh);
+      final refreshing = refreshControl.onRefresh();
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 200));
+
+      check(controllers.chatRefreshCalls).equals(1);
+      final progress = find.byKey(
+        const ValueKey<String>('chats-refresh-progress'),
+      );
+      check(progress.evaluate()).length.equals(1);
+      expect(
+        find.descendant(
+          of: progress,
+          matching: find.byType(CircularProgressIndicator),
+        ),
+        findsOneWidget,
+      );
+      check(
+        tester.getBottomLeft(progress).dy <= tester.getTopLeft(tile).dy,
+      ).isTrue();
+      check(tester.getSize(refreshSlot).height > idleSlotHeight).isTrue();
+
+      pendingRefresh.complete();
+      await refreshing;
+      refreshControl.onStatusChange!(RefreshIndicatorStatus.done);
+      await tester.pump(const Duration(milliseconds: 500));
+      await tester.pumpAndSettle();
+      check(progress.evaluate()).isEmpty();
+      check(tester.getSize(refreshSlot).height).equals(idleSlotHeight);
+    },
+  );
+
+  testWidgets('chat pull-to-refresh uses Cupertino progress on iOS', (
     tester,
   ) async {
     final controllers = _SidebarHarnessControllers();
-    final pendingRefresh = controllers.keepChatRefreshPending();
     final timestamp = DateTime(2026, 1, 1);
-    final conversation = Conversation(
-      id: 'refresh-layout-chat',
-      title: 'Refresh layout',
-      createdAt: timestamp,
-      updatedAt: timestamp,
-    );
 
     await tester.pumpWidget(
       _buildSidebarHarness(
         controllers: controllers,
-        conversations: [conversation],
+        conversations: [
+          Conversation(
+            id: 'cupertino-refresh-chat',
+            title: 'Cupertino refresh',
+            createdAt: timestamp,
+            updatedAt: timestamp,
+          ),
+        ],
+        theme: ThemeData(platform: TargetPlatform.iOS),
       ),
     );
     await tester.pumpAndSettle();
 
-    final tile = find.byKey(
-      ValueKey<String>(
-        'drawer-chat-${conversationScopedId(conversation)}',
-      ),
-    );
-    final refreshSlot = find.byKey(
-      const ValueKey<String>('chats-refresh-slot'),
-    );
-    final idleSlotHeight = tester.getSize(refreshSlot).height;
     final refreshControl = tester.widget<RefreshIndicator>(
-      find.descendant(
-        of: _layerRootFinder(_SidebarTabLayer.chats),
-        matching: find.byType(RefreshIndicator),
-      ),
+      find.byType(RefreshIndicator),
     );
-    check(refreshControl.onStatusChange).isNotNull();
     refreshControl.onStatusChange!(RefreshIndicatorStatus.refresh);
-    final refreshing = refreshControl.onRefresh();
     await tester.pump();
-    await tester.pump(const Duration(milliseconds: 200));
 
-    check(controllers.chatRefreshCalls).equals(1);
     final progress = find.byKey(
       const ValueKey<String>('chats-refresh-progress'),
     );
-    check(progress.evaluate()).length.equals(1);
-    check(tester.getBottomLeft(progress).dy <= tester.getTopLeft(tile).dy)
-        .isTrue();
-    check(tester.getSize(refreshSlot).height > idleSlotHeight).isTrue();
-
-    pendingRefresh.complete();
-    await refreshing;
-    refreshControl.onStatusChange!(RefreshIndicatorStatus.done);
-    await tester.pump(const Duration(milliseconds: 140));
-    refreshControl.onStatusChange!(null);
-    await tester.pumpAndSettle();
-    check(progress.evaluate()).isEmpty();
+    expect(
+      find.descendant(
+        of: progress,
+        matching: find.byType(CupertinoActivityIndicator),
+      ),
+      findsOneWidget,
+    );
   });
 
   testWidgets('collapsed paginated chat sections do not consume hidden pages', (

--- a/test/features/notes/providers/notes_providers_test.dart
+++ b/test/features/notes/providers/notes_providers_test.dart
@@ -16,8 +16,13 @@ import 'package:conduit/core/sync/pull_sync.dart';
 import 'package:conduit/core/sync/sync_engine.dart';
 import 'package:conduit/features/auth/providers/unified_auth_providers.dart';
 import 'package:conduit/features/notes/providers/notes_providers.dart';
+import 'package:conduit/features/notes/views/note_editor_page.dart';
+import 'package:conduit/l10n/app_localizations.dart';
+import 'package:conduit/shared/theme/app_theme.dart';
+import 'package:conduit/shared/theme/tweakcn_themes.dart';
 import 'package:dio/dio.dart';
 import 'package:drift/native.dart';
+import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 
@@ -50,6 +55,82 @@ class _NoDrainSyncEngine extends SyncEngine {
   Future<void> reconcileNow() async {
     reconcileNowCalls++;
   }
+}
+
+class _DeletingOnReconcileSyncEngine extends _NoDrainSyncEngine {
+  _DeletingOnReconcileSyncEngine(this.db, {this.pullStarted, this.releasePull});
+
+  final AppDatabase db;
+  final Completer<void>? pullStarted;
+  final Completer<void>? releasePull;
+
+  @override
+  Future<PullResult?> requestPull({required String reason}) async {
+    pulls.add(reason);
+    final started = pullStarted;
+    if (started != null && !started.isCompleted) started.complete();
+    await releasePull?.future;
+    return null;
+  }
+
+  @override
+  Future<void> reconcileNow() async {
+    reconcileNowCalls++;
+    await db.notesDao.purgeReconciledNote('deleted-note');
+  }
+}
+
+class _EnabledNotesFeature extends NotesFeatureEnabledNotifier {
+  @override
+  bool build() => true;
+}
+
+Map<String, dynamic> _deletedNoteJson() => <String, dynamic>{
+  'id': 'deleted-note',
+  'user_id': _testUser.id,
+  'title': 'Deleted title',
+  'data': {
+    'content': {'md': 'Deleted body', 'html': '<p>Deleted body</p>'},
+  },
+  'meta': {},
+  'is_pinned': false,
+  'created_at': 1713786305000000000,
+  'updated_at': 1713786305000000000,
+};
+
+Future<void> _seedDeletedNote(AppDatabase db) {
+  return db
+      .into(db.notes)
+      .insertOnConflictUpdate(serverToNoteRow(_deletedNoteJson()));
+}
+
+Widget _noteEditorHarness({
+  required AppDatabase db,
+  required SyncEngine syncEngine,
+}) {
+  return ProviderScope(
+    overrides: [
+      appDatabaseProvider.overrideWith((ref) => db),
+      apiServiceProvider.overrideWithValue(null),
+      isAuthenticatedProvider2.overrideWithValue(true),
+      currentUserProvider2.overrideWithValue(_testUser),
+      connectivityStatusProvider.overrideWithValue(ConnectivityStatus.online),
+      openWebUiAuthSessionEpochProvider.overrideWithValue(Object()),
+      syncEngineProvider.overrideWith(() => syncEngine),
+      notesFeatureEnabledProvider.overrideWith(_EnabledNotesFeature.new),
+      noteByIdProvider(
+        'deleted-note',
+      ).overrideWith((ref) async => Note.fromJson(_deletedNoteJson())),
+    ],
+    child: MaterialApp(
+      theme: AppTheme.light(
+        TweakcnThemes.conduit,
+      ).copyWith(platform: TargetPlatform.android),
+      localizationsDelegates: AppLocalizations.localizationsDelegates,
+      supportedLocales: AppLocalizations.supportedLocales,
+      home: const NoteEditorPage(noteId: 'deleted-note'),
+    ),
+  );
 }
 
 void main() {
@@ -118,6 +199,83 @@ void main() {
 
       check(syncEngine.pulls).deepEquals(['notes-refresh']);
       check(syncEngine.reconcileNowCalls).equals(1);
+    });
+
+    testWidgets(
+      'editor refresh clears a remotely deleted note title and content',
+      (tester) async {
+        final originalErrorWidgetBuilder = ErrorWidget.builder;
+        await tester.binding.setSurfaceSize(const Size(1200, 900));
+        addTearDown(() => tester.binding.setSurfaceSize(null));
+        await _seedDeletedNote(db);
+        final syncEngine = _DeletingOnReconcileSyncEngine(db);
+        await tester.pumpWidget(
+          _noteEditorHarness(db: db, syncEngine: syncEngine),
+        );
+        await tester.pumpAndSettle();
+
+        check(find.text('Deleted title').evaluate()).isNotEmpty();
+        final refresh = tester.widget<RefreshIndicator>(
+          find.byType(RefreshIndicator),
+        );
+        await refresh.onRefresh();
+        await tester.pumpAndSettle();
+
+        check(find.text('Note not found').evaluate()).isNotEmpty();
+        check(find.text('Deleted title').evaluate()).isEmpty();
+        check(find.text('Deleted body').evaluate()).isEmpty();
+        await tester.pumpWidget(const SizedBox.shrink());
+        ErrorWidget.builder = originalErrorWidgetBuilder;
+      },
+    );
+
+    testWidgets('editor refresh preserves edits entered while deleting', (
+      tester,
+    ) async {
+      final originalErrorWidgetBuilder = ErrorWidget.builder;
+      await tester.binding.setSurfaceSize(const Size(1200, 900));
+      addTearDown(() => tester.binding.setSurfaceSize(null));
+      await _seedDeletedNote(db);
+      final pullStarted = Completer<void>();
+      final releasePull = Completer<void>();
+      final syncEngine = _DeletingOnReconcileSyncEngine(
+        db,
+        pullStarted: pullStarted,
+        releasePull: releasePull,
+      );
+      await tester.pumpWidget(
+        _noteEditorHarness(db: db, syncEngine: syncEngine),
+      );
+      await tester.pumpAndSettle();
+
+      final refresh = tester.widget<RefreshIndicator>(
+        find.byType(RefreshIndicator),
+      );
+      final refreshing = refresh.onRefresh();
+      await pullStarted.future;
+      await tester.tap(find.text('Deleted title').last);
+      await tester.pump();
+      final titleField = find.byWidgetPredicate(
+        (widget) =>
+            widget is EditableText && widget.controller.text == 'Deleted title',
+      );
+      check(titleField.evaluate()).length.equals(1);
+      await tester.enterText(titleField, 'Edited during refresh');
+
+      releasePull.complete();
+      await refreshing;
+      await tester.pump();
+
+      check(find.text('Note not found').evaluate()).isEmpty();
+      final editedTitle = find.byWidgetPredicate(
+        (widget) =>
+            widget is EditableText &&
+            widget.controller.text == 'Edited during refresh',
+      );
+      check(editedTitle.evaluate()).length.equals(1);
+      check(await db.notesDao.getNote('deleted-note')).isNull();
+      await tester.pumpWidget(const SizedBox.shrink());
+      ErrorWidget.builder = originalErrorWidgetBuilder;
     });
 
     test('does not expose cached notes owned by another user', () async {

--- a/test/features/notes/providers/notes_providers_test.dart
+++ b/test/features/notes/providers/notes_providers_test.dart
@@ -229,6 +229,56 @@ void main() {
       },
     );
 
+    testWidgets('editor refresh recovers edits autosaved before deletion', (
+      tester,
+    ) async {
+      final originalErrorWidgetBuilder = ErrorWidget.builder;
+      await tester.binding.setSurfaceSize(const Size(1200, 900));
+      addTearDown(() => tester.binding.setSurfaceSize(null));
+      await _seedDeletedNote(db);
+      final syncEngine = _DeletingOnReconcileSyncEngine(db);
+      await tester.pumpWidget(
+        _noteEditorHarness(db: db, syncEngine: syncEngine),
+      );
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text('Deleted title').last);
+      await tester.pump();
+      final titleField = find.byWidgetPredicate(
+        (widget) =>
+            widget is EditableText && widget.controller.text == 'Deleted title',
+      );
+      check(titleField.evaluate()).length.equals(1);
+      await tester.enterText(titleField, 'Edited before refresh');
+
+      final refresh = tester.widget<RefreshIndicator>(
+        find.byType(RefreshIndicator),
+      );
+      await refresh.onRefresh();
+      await tester.pump();
+
+      check(find.text('Note not found').evaluate()).isEmpty();
+      final editedTitle = find.byWidgetPredicate(
+        (widget) =>
+            widget is EditableText &&
+            widget.controller.text == 'Edited before refresh',
+      );
+      check(editedTitle.evaluate()).length.equals(1);
+      check(await db.notesDao.getNote('deleted-note')).isNull();
+      final recoveredRows = await db.select(db.notes).get();
+      check(recoveredRows).length.equals(1);
+      final recovered = recoveredRows.single;
+      check(recovered.id.startsWith('local:')).isTrue();
+      check(recovered.title).equals('Edited before refresh');
+      check(recovered.dirtyTitle).isTrue();
+      check(recovered.dirtyData).isTrue();
+      check(
+        (await db.outboxDao.pendingForChat(recovered.id)).map((op) => op.kind),
+      ).deepEquals([OutboxKind.noteCreate.name]);
+      await tester.pumpWidget(const SizedBox.shrink());
+      ErrorWidget.builder = originalErrorWidgetBuilder;
+    });
+
     testWidgets('editor refresh preserves edits entered while deleting', (
       tester,
     ) async {

--- a/test/features/notes/providers/notes_providers_test.dart
+++ b/test/features/notes/providers/notes_providers_test.dart
@@ -274,6 +274,16 @@ void main() {
       );
       check(editedTitle.evaluate()).length.equals(1);
       check(await db.notesDao.getNote('deleted-note')).isNull();
+      final recoveredRows = await db.select(db.notes).get();
+      check(recoveredRows).length.equals(1);
+      final recovered = recoveredRows.single;
+      check(recovered.id.startsWith('local:')).isTrue();
+      check(recovered.title).equals('Edited during refresh');
+      check(recovered.dirtyTitle).isTrue();
+      check(recovered.dirtyData).isTrue();
+      check(
+        (await db.outboxDao.pendingForChat(recovered.id)).map((op) => op.kind),
+      ).deepEquals([OutboxKind.noteCreate.name]);
       await tester.pumpWidget(const SizedBox.shrink());
       ErrorWidget.builder = originalErrorWidgetBuilder;
     });

--- a/test/features/notes/providers/notes_providers_test.dart
+++ b/test/features/notes/providers/notes_providers_test.dart
@@ -31,6 +31,9 @@ const _testUser = User(
 /// Replaces the real engine so the durable write path's fire-and-forget drain
 /// kick is a no-op: the outbox op stays PENDING (never claimed) for assertions.
 class _NoDrainSyncEngine extends SyncEngine {
+  final List<String> pulls = <String>[];
+  int reconcileNowCalls = 0;
+
   @override
   Future<void> drainNow() async {}
 
@@ -38,7 +41,15 @@ class _NoDrainSyncEngine extends SyncEngine {
   Future<void> drainOutbox() async {}
 
   @override
-  Future<PullResult?> requestPull({required String reason}) async => null;
+  Future<PullResult?> requestPull({required String reason}) async {
+    pulls.add(reason);
+    return null;
+  }
+
+  @override
+  Future<void> reconcileNow() async {
+    reconcileNowCalls++;
+  }
 }
 
 void main() {
@@ -87,6 +98,26 @@ void main() {
       check(notes.single.id).equals('cached-note');
       check(notes.single.markdownContent).isEmpty();
       check(notes.single.listPreviewMarkdown).equals('available offline');
+    });
+
+    test('manual refresh runs the unthrottled deletion reconcile', () async {
+      final syncEngine = _NoDrainSyncEngine();
+      final container = ProviderContainer(
+        overrides: [
+          appDatabaseProvider.overrideWith((ref) => db),
+          apiServiceProvider.overrideWithValue(null),
+          isAuthenticatedProvider2.overrideWithValue(true),
+          currentUserProvider2.overrideWithValue(_testUser),
+          syncEngineProvider.overrideWith(() => syncEngine),
+        ],
+      );
+      addTearDown(container.dispose);
+      await container.read(notesListProvider.future);
+
+      await container.read(notesListProvider.notifier).refresh();
+
+      check(syncEngine.pulls).deepEquals(['notes-refresh']);
+      check(syncEngine.reconcileNowCalls).equals(1);
     });
 
     test('does not expose cached notes owned by another user', () async {

--- a/test/features/notes/providers/notes_providers_test.dart
+++ b/test/features/notes/providers/notes_providers_test.dart
@@ -107,6 +107,7 @@ Future<void> _seedDeletedNote(AppDatabase db) {
 Widget _noteEditorHarness({
   required AppDatabase db,
   required SyncEngine syncEngine,
+  bool withBackRoute = false,
 }) {
   return ProviderScope(
     overrides: [
@@ -128,7 +129,14 @@ Widget _noteEditorHarness({
       ).copyWith(platform: TargetPlatform.android),
       localizationsDelegates: AppLocalizations.localizationsDelegates,
       supportedLocales: AppLocalizations.supportedLocales,
-      home: const NoteEditorPage(noteId: 'deleted-note'),
+      initialRoute: withBackRoute ? '/editor' : null,
+      home: withBackRoute ? null : const NoteEditorPage(noteId: 'deleted-note'),
+      routes: withBackRoute
+          ? <String, WidgetBuilder>{
+              '/': (_) => const Scaffold(key: Key('notes-root')),
+              '/editor': (_) => const NoteEditorPage(noteId: 'deleted-note'),
+            }
+          : const <String, WidgetBuilder>{},
     ),
   );
 }
@@ -337,6 +345,66 @@ void main() {
       await tester.pumpWidget(const SizedBox.shrink());
       ErrorWidget.builder = originalErrorWidgetBuilder;
     });
+
+    testWidgets(
+      'failed post-recovery save keeps the dirty editor open on back',
+      (tester) async {
+        final originalErrorWidgetBuilder = ErrorWidget.builder;
+        await tester.binding.setSurfaceSize(const Size(1200, 900));
+        addTearDown(() => tester.binding.setSurfaceSize(null));
+        await _seedDeletedNote(db);
+        final syncEngine = _DeletingOnReconcileSyncEngine(db);
+        await tester.pumpWidget(
+          _noteEditorHarness(
+            db: db,
+            syncEngine: syncEngine,
+            withBackRoute: true,
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        await tester.tap(find.text('Deleted title').last);
+        await tester.pump();
+        var titleField = find.byWidgetPredicate(
+          (widget) =>
+              widget is EditableText &&
+              widget.controller.text == 'Deleted title',
+        );
+        await tester.enterText(titleField, 'Recovered title');
+        final refresh = tester.widget<RefreshIndicator>(
+          find.byType(RefreshIndicator),
+        );
+        await refresh.onRefresh();
+        await tester.pump();
+
+        titleField = find.byWidgetPredicate(
+          (widget) =>
+              widget is EditableText &&
+              widget.controller.text == 'Recovered title',
+        );
+        check(titleField.evaluate()).length.equals(1);
+        await tester.enterText(titleField, 'Unsaved after recovery');
+        await tester.pump();
+
+        // Closing the active database forces the back-navigation autosave to
+        // fail after recovery has already cleared its dedicated retry callback.
+        final failedDb = db;
+        await failedDb.close();
+        db = AppDatabase(NativeDatabase.memory());
+        await tester.binding.handlePopRoute();
+        await tester.pumpAndSettle();
+
+        final dirtyTitle = find.byWidgetPredicate(
+          (widget) =>
+              widget is EditableText &&
+              widget.controller.text == 'Unsaved after recovery',
+        );
+        check(dirtyTitle.evaluate()).length.equals(1);
+        check(find.byKey(const Key('notes-root')).evaluate()).isEmpty();
+        await tester.pumpWidget(const SizedBox.shrink());
+        ErrorWidget.builder = originalErrorWidgetBuilder;
+      },
+    );
 
     test('does not expose cached notes owned by another user', () async {
       await db

--- a/test/features/notes/services/note_audio_upload_service_test.dart
+++ b/test/features/notes/services/note_audio_upload_service_test.dart
@@ -407,6 +407,56 @@ void main() {
       },
     );
 
+    test('rebinds a durable recording to a replacement note', () async {
+      final root = await Directory.systemTemp.createTemp(
+        'conduit_note_audio_upload_test_',
+      );
+      addTearDown(() => _deleteDirectory(root));
+
+      final store = NoteAudioUploadStore(
+        applicationSupportDirectory: () async => root,
+        idGenerator: () => 'upload-rebound',
+      );
+      final staged = await store.stage(
+        source: await _recordingFile(root, 'source.m4a'),
+        serverId: 'server-1',
+        accountId: 'user-1',
+        noteId: 'deleted-note',
+        fileName: 'recording.m4a',
+      );
+
+      final rebound = await store.rebindToNote(
+        staged,
+        noteId: 'recovered-note',
+      );
+
+      check(rebound).isNotNull();
+      check(rebound!.noteId).equals('recovered-note');
+      check(rebound.id).equals(staged.id);
+      check(await File(rebound.localPath).exists()).isTrue();
+      check(
+        await store.loadForNote(
+          serverId: 'server-1',
+          accountId: 'user-1',
+          noteId: 'deleted-note',
+        ),
+      ).isEmpty();
+      final recovered = await store.loadForNote(
+        serverId: 'server-1',
+        accountId: 'user-1',
+        noteId: 'recovered-note',
+      );
+      check(recovered.single.noteId).equals('recovered-note');
+      check(recovered.single.localPath).equals(rebound.localPath);
+
+      // Retrying with the original snapshot is idempotent after the move.
+      final retried = await store.rebindToNote(
+        staged,
+        noteId: 'recovered-note',
+      );
+      check(retried?.localPath).equals(rebound.localPath);
+    });
+
     test('a removal reservation excludes processing across editors', () async {
       final root = await Directory.systemTemp.createTemp(
         'conduit_note_audio_upload_test_',

--- a/test/features/notes/services/note_audio_upload_service_test.dart
+++ b/test/features/notes/services/note_audio_upload_service_test.dart
@@ -425,14 +425,25 @@ void main() {
         fileName: 'recording.m4a',
       );
 
+      final failed = staged.transition(
+        NoteAudioUploadStatus.failed,
+        lastError: 'attach interrupted',
+        serverFileId: 'server-file-rebound',
+      );
+      check(await store.save(failed)).isTrue();
+
       final rebound = await store.rebindToNote(
-        staged,
+        failed,
         noteId: 'recovered-note',
       );
 
       check(rebound).isNotNull();
       check(rebound!.noteId).equals('recovered-note');
       check(rebound.id).equals(staged.id);
+      check(rebound.status).equals(NoteAudioUploadStatus.failed);
+      check(rebound.lastError).equals('attach interrupted');
+      check(rebound.serverFileId).equals('server-file-rebound');
+      check(rebound.createdAt).equals(staged.createdAt);
       check(await File(rebound.localPath).exists()).isTrue();
       check(
         await store.loadForNote(
@@ -451,11 +462,71 @@ void main() {
 
       // Retrying with the original snapshot is idempotent after the move.
       final retried = await store.rebindToNote(
-        staged,
+        failed,
         noteId: 'recovered-note',
       );
       check(retried?.localPath).equals(rebound.localPath);
     });
+
+    test(
+      'rebind reservation drains old work before publishing the new path',
+      () async {
+        final root = await Directory.systemTemp.createTemp(
+          'conduit_note_audio_upload_test_',
+        );
+        addTearDown(() => _deleteDirectory(root));
+
+        final store = NoteAudioUploadStore(
+          applicationSupportDirectory: () async => root,
+          idGenerator: () => 'upload-rebind-race',
+        );
+        final staged = await store.stage(
+          source: await _recordingFile(root, 'source.m4a'),
+          serverId: 'server-1',
+          noteId: 'deleted-note',
+          fileName: 'recording.m4a',
+        );
+        final uploadStarted = Completer<void>();
+        final cancelUpload = Completer<void>();
+        final coordinator = NoteAudioUploadCoordinator(
+          store: store,
+          upload: (_, _) async {
+            uploadStarted.complete();
+            await cancelUpload.future;
+            throw StateError('cancelled for rebind');
+          },
+          attach: (_, _) async => fail('cancelled upload must not attach'),
+        );
+
+        final processing = coordinator.process(staged);
+        await uploadStarted.future;
+        final reservation = NoteAudioUploadCoordinator.reserveForRebind(staged);
+        final waitingProcessor = coordinator.process(staged);
+        cancelUpload.complete();
+
+        final failed = await processing;
+        await reservation;
+        PendingNoteAudioUpload? rebound;
+        try {
+          check(failed).isNotNull();
+          rebound = await store.rebindToNote(failed!, noteId: 'recovered-note');
+        } finally {
+          NoteAudioUploadCoordinator.completeRebind(staged, rebound);
+        }
+
+        check(rebound).isNotNull();
+        check((await waitingProcessor)?.localPath).equals(rebound!.localPath);
+        check(
+          await store.loadForNote(serverId: 'server-1', noteId: 'deleted-note'),
+        ).isEmpty();
+        check(
+          await store.loadForNote(
+            serverId: 'server-1',
+            noteId: 'recovered-note',
+          ),
+        ).length.equals(1);
+      },
+    );
 
     test('a removal reservation excludes processing across editors', () async {
       final root = await Directory.systemTemp.createTemp(

--- a/test/features/notes/services/note_audio_upload_service_test.dart
+++ b/test/features/notes/services/note_audio_upload_service_test.dart
@@ -1,9 +1,12 @@
 import 'dart:async';
+import 'dart:convert';
 import 'dart:io';
 
 import 'package:checks/checks.dart';
+import 'package:crypto/crypto.dart';
 import 'package:dio/dio.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:path/path.dart' as path;
 
 import 'package:conduit/features/notes/services/note_audio_upload_service.dart';
 
@@ -527,6 +530,72 @@ void main() {
         ).length.equals(1);
       },
     );
+
+    test('recovers a process-interrupted rebind journal', () async {
+      final root = await Directory.systemTemp.createTemp(
+        'conduit_note_audio_upload_test_',
+      );
+      addTearDown(() => _deleteDirectory(root));
+
+      final store = NoteAudioUploadStore(
+        applicationSupportDirectory: () async => root,
+        idGenerator: () => 'upload-rebind-journal',
+      );
+      final staged = await store.stage(
+        source: await _recordingFile(root, 'source.m4a'),
+        serverId: 'server-1',
+        accountId: 'user-1',
+        noteId: 'deleted-note',
+        fileName: 'recording.m4a',
+      );
+      final failed = staged.transition(
+        NoteAudioUploadStatus.failed,
+        lastError: 'attach interrupted',
+        serverFileId: 'already-uploaded-file',
+      );
+      check(await store.save(failed)).isTrue();
+
+      // Reproduce process death after the atomic directory move but before
+      // the destination-valid manifest is written.
+      final sourceDirectory = File(failed.localPath).parent;
+      final accountDirectory = sourceDirectory.parent.parent;
+      final destinationDirectory = Directory(
+        path.join(
+          accountDirectory.path,
+          sha256.convert(utf8.encode('recovered-note')).toString(),
+          failed.id,
+        ),
+      );
+      await destinationDirectory.parent.create(recursive: true);
+      await sourceDirectory.rename(destinationDirectory.path);
+      final reboundJson = <String, dynamic>{
+        ...failed.toJson(),
+        'noteId': 'recovered-note',
+      };
+      final journal = File(
+        path.join(accountDirectory.path, '.rebind-${failed.id}.json'),
+      );
+      await journal.writeAsString(
+        jsonEncode(<String, dynamic>{
+          'version': 1,
+          'sourceNoteId': 'deleted-note',
+          'item': reboundJson,
+        }),
+        flush: true,
+      );
+
+      final recovered = await NoteAudioUploadStore(
+        applicationSupportDirectory: () async => root,
+      ).loadForAccount(serverId: 'server-1', accountId: 'user-1');
+
+      check(recovered).length.equals(1);
+      check(recovered.single.noteId).equals('recovered-note');
+      check(recovered.single.status).equals(NoteAudioUploadStatus.failed);
+      check(recovered.single.lastError).equals('attach interrupted');
+      check(recovered.single.serverFileId).equals('already-uploaded-file');
+      check(await File(recovered.single.localPath).exists()).isTrue();
+      check(await journal.exists()).isFalse();
+    });
 
     test('a removal reservation excludes processing across editors', () async {
       final root = await Directory.systemTemp.createTemp(

--- a/test/features/notes/services/note_audio_upload_service_test.dart
+++ b/test/features/notes/services/note_audio_upload_service_test.dart
@@ -565,6 +565,47 @@ void main() {
       check(followerResult?.noteId).equals('recovered-note');
     });
 
+    test('rebind and removal reservations are mutually exclusive', () async {
+      final root = await Directory.systemTemp.createTemp(
+        'conduit_note_audio_upload_test_',
+      );
+      addTearDown(() => _deleteDirectory(root));
+
+      final store = NoteAudioUploadStore(
+        applicationSupportDirectory: () async => root,
+        idGenerator: () => 'upload-exclusive-reservations',
+      );
+      final staged = await store.stage(
+        source: await _recordingFile(root, 'source.m4a'),
+        serverId: 'server-1',
+        noteId: 'deleted-note',
+        fileName: 'recording.m4a',
+      );
+
+      check(NoteAudioUploadCoordinator.tryReserveRemoval(staged)).isTrue();
+      try {
+        final rebound = await NoteAudioUploadCoordinator.rebind(
+          staged,
+          () async => fail('removal ownership must reject rebind'),
+        );
+        check(rebound).isNull();
+      } finally {
+        NoteAudioUploadCoordinator.releaseRemoval(staged);
+      }
+
+      final ownerStarted = Completer<void>();
+      final releaseOwner = Completer<void>();
+      final owner = NoteAudioUploadCoordinator.rebind(staged, () async {
+        ownerStarted.complete();
+        await releaseOwner.future;
+        return staged;
+      });
+      await ownerStarted.future;
+      check(NoteAudioUploadCoordinator.tryReserveRemoval(staged)).isFalse();
+      releaseOwner.complete();
+      check(await owner).equals(staged);
+    });
+
     test('a failed rebind operation releases ownership', () async {
       final root = await Directory.systemTemp.createTemp(
         'conduit_note_audio_upload_test_',

--- a/test/features/notes/services/note_audio_upload_service_test.dart
+++ b/test/features/notes/services/note_audio_upload_service_test.dart
@@ -503,19 +503,15 @@ void main() {
 
         final processing = coordinator.process(staged);
         await uploadStarted.future;
-        final reservation = NoteAudioUploadCoordinator.reserveForRebind(staged);
+        final reboundFuture = NoteAudioUploadCoordinator.rebind(
+          staged,
+          () => store.rebindToNote(staged, noteId: 'recovered-note'),
+        );
         final waitingProcessor = coordinator.process(staged);
         cancelUpload.complete();
 
-        final failed = await processing;
-        check((await reservation).isOwner).isTrue();
-        PendingNoteAudioUpload? rebound;
-        try {
-          check(failed).isNotNull();
-          rebound = await store.rebindToNote(failed!, noteId: 'recovered-note');
-        } finally {
-          NoteAudioUploadCoordinator.completeRebind(staged, rebound);
-        }
+        check(await processing).isNotNull();
+        final rebound = await reboundFuture;
 
         check(rebound).isNotNull();
         check((await waitingProcessor)?.localPath).equals(rebound!.localPath);
@@ -548,19 +544,58 @@ void main() {
         fileName: 'recording.m4a',
       );
 
-      final owner = await NoteAudioUploadCoordinator.reserveForRebind(staged);
-      check(owner.isOwner).isTrue();
-      final follower = NoteAudioUploadCoordinator.reserveForRebind(staged);
-      final rebound = await store.rebindToNote(
+      final ownerStarted = Completer<void>();
+      final releaseOwner = Completer<void>();
+      final owner = NoteAudioUploadCoordinator.rebind(staged, () async {
+        ownerStarted.complete();
+        await releaseOwner.future;
+        return store.rebindToNote(staged, noteId: 'recovered-note');
+      });
+      await ownerStarted.future;
+      final follower = NoteAudioUploadCoordinator.rebind(
         staged,
-        noteId: 'recovered-note',
+        () async => fail('follower must reuse the owner result'),
       );
-      NoteAudioUploadCoordinator.completeRebind(staged, rebound);
+      releaseOwner.complete();
 
+      final rebound = await owner;
       final followerResult = await follower;
-      check(followerResult.isOwner).isFalse();
-      check(followerResult.rebound?.localPath).equals(rebound?.localPath);
-      check(followerResult.rebound?.noteId).equals('recovered-note');
+      check(rebound).isNotNull();
+      check(followerResult?.localPath).equals(rebound!.localPath);
+      check(followerResult?.noteId).equals('recovered-note');
+    });
+
+    test('a failed rebind operation releases ownership', () async {
+      final root = await Directory.systemTemp.createTemp(
+        'conduit_note_audio_upload_test_',
+      );
+      addTearDown(() => _deleteDirectory(root));
+
+      final store = NoteAudioUploadStore(
+        applicationSupportDirectory: () async => root,
+        idGenerator: () => 'upload-rebind-cleanup',
+      );
+      final staged = await store.stage(
+        source: await _recordingFile(root, 'source.m4a'),
+        serverId: 'server-1',
+        noteId: 'deleted-note',
+        fileName: 'recording.m4a',
+      );
+
+      await expectLater(
+        NoteAudioUploadCoordinator.rebind(
+          staged,
+          () async => throw StateError('rebind failed'),
+        ),
+        throwsStateError,
+      );
+      final retried = await NoteAudioUploadCoordinator.rebind(
+        staged,
+        () => store.rebindToNote(staged, noteId: 'recovered-note'),
+      );
+
+      check(retried).isNotNull();
+      check(retried!.noteId).equals('recovered-note');
     });
 
     test('recovers a process-interrupted rebind journal', () async {

--- a/test/features/notes/services/note_audio_upload_service_test.dart
+++ b/test/features/notes/services/note_audio_upload_service_test.dart
@@ -601,8 +601,11 @@ void main() {
         return staged;
       });
       await ownerStarted.future;
-      check(NoteAudioUploadCoordinator.tryReserveRemoval(staged)).isFalse();
-      releaseOwner.complete();
+      try {
+        check(NoteAudioUploadCoordinator.tryReserveRemoval(staged)).isFalse();
+      } finally {
+        releaseOwner.complete();
+      }
       check(await owner).equals(staged);
     });
 

--- a/test/features/notes/services/note_audio_upload_service_test.dart
+++ b/test/features/notes/services/note_audio_upload_service_test.dart
@@ -664,6 +664,62 @@ void main() {
       check(await journal.exists()).isFalse();
     });
 
+    test('retries a journaled rebind after the move rolled back', () async {
+      final root = await Directory.systemTemp.createTemp(
+        'conduit_note_audio_upload_test_',
+      );
+      addTearDown(() => _deleteDirectory(root));
+
+      final store = NoteAudioUploadStore(
+        applicationSupportDirectory: () async => root,
+        idGenerator: () => 'upload-rebind-rollback',
+      );
+      final staged = await store.stage(
+        source: await _recordingFile(root, 'source.m4a'),
+        serverId: 'server-1',
+        accountId: 'user-1',
+        noteId: 'deleted-note',
+        fileName: 'recording.m4a',
+      );
+      final failed = staged.transition(
+        NoteAudioUploadStatus.failed,
+        lastError: 'retry after rollback',
+        serverFileId: 'uploaded-before-rollback',
+      );
+      check(await store.save(failed)).isTrue();
+
+      // A failed manifest save rolls the directory back to this source path
+      // but deliberately retains the flushed rebind intent journal.
+      final sourceDirectory = File(failed.localPath).parent;
+      final accountDirectory = sourceDirectory.parent.parent;
+      final journal = File(
+        path.join(accountDirectory.path, '.rebind-${failed.id}.json'),
+      );
+      await journal.writeAsString(
+        jsonEncode(<String, dynamic>{
+          'version': 1,
+          'sourceNoteId': 'deleted-note',
+          'item': <String, dynamic>{
+            ...failed.toJson(),
+            'noteId': 'recovered-note',
+          },
+        }),
+        flush: true,
+      );
+
+      final recovered = await NoteAudioUploadStore(
+        applicationSupportDirectory: () async => root,
+      ).loadForAccount(serverId: 'server-1', accountId: 'user-1');
+
+      check(recovered).length.equals(1);
+      check(recovered.single.noteId).equals('recovered-note');
+      check(recovered.single.lastError).equals('retry after rollback');
+      check(recovered.single.serverFileId).equals('uploaded-before-rollback');
+      check(await File(recovered.single.localPath).exists()).isTrue();
+      check(await sourceDirectory.exists()).isFalse();
+      check(await journal.exists()).isFalse();
+    });
+
     test('a removal reservation excludes processing across editors', () async {
       final root = await Directory.systemTemp.createTemp(
         'conduit_note_audio_upload_test_',

--- a/test/features/notes/services/note_audio_upload_service_test.dart
+++ b/test/features/notes/services/note_audio_upload_service_test.dart
@@ -508,7 +508,7 @@ void main() {
         cancelUpload.complete();
 
         final failed = await processing;
-        await reservation;
+        check((await reservation).isOwner).isTrue();
         PendingNoteAudioUpload? rebound;
         try {
           check(failed).isNotNull();
@@ -530,6 +530,38 @@ void main() {
         ).length.equals(1);
       },
     );
+
+    test('concurrent rebinders reuse the owner result', () async {
+      final root = await Directory.systemTemp.createTemp(
+        'conduit_note_audio_upload_test_',
+      );
+      addTearDown(() => _deleteDirectory(root));
+
+      final store = NoteAudioUploadStore(
+        applicationSupportDirectory: () async => root,
+        idGenerator: () => 'upload-rebind-owner',
+      );
+      final staged = await store.stage(
+        source: await _recordingFile(root, 'source.m4a'),
+        serverId: 'server-1',
+        noteId: 'deleted-note',
+        fileName: 'recording.m4a',
+      );
+
+      final owner = await NoteAudioUploadCoordinator.reserveForRebind(staged);
+      check(owner.isOwner).isTrue();
+      final follower = NoteAudioUploadCoordinator.reserveForRebind(staged);
+      final rebound = await store.rebindToNote(
+        staged,
+        noteId: 'recovered-note',
+      );
+      NoteAudioUploadCoordinator.completeRebind(staged, rebound);
+
+      final followerResult = await follower;
+      check(followerResult.isOwner).isFalse();
+      check(followerResult.rebound?.localPath).equals(rebound?.localPath);
+      check(followerResult.rebound?.noteId).equals('recovered-note');
+    });
 
     test('recovers a process-interrupted rebind journal', () async {
       final root = await Directory.systemTemp.createTemp(

--- a/test/features/notes/services/note_audio_upload_service_test.dart
+++ b/test/features/notes/services/note_audio_upload_service_test.dart
@@ -598,6 +598,49 @@ void main() {
       check(retried!.noteId).equals('recovered-note');
     });
 
+    test(
+      'a processor waiting on a failed rebind reloads durable state',
+      () async {
+        final root = await Directory.systemTemp.createTemp(
+          'conduit_note_audio_upload_test_',
+        );
+        addTearDown(() => _deleteDirectory(root));
+
+        final store = NoteAudioUploadStore(
+          applicationSupportDirectory: () async => root,
+          idGenerator: () => 'upload-rebind-follower',
+        );
+        final staged = await store.stage(
+          source: await _recordingFile(root, 'source.m4a'),
+          serverId: 'server-1',
+          noteId: 'deleted-note',
+          fileName: 'recording.m4a',
+        );
+        final ownerStarted = Completer<void>();
+        final releaseOwner = Completer<void>();
+        final owner = NoteAudioUploadCoordinator.rebind(staged, () async {
+          ownerStarted.complete();
+          await releaseOwner.future;
+          throw StateError('rebind failed');
+        });
+        await ownerStarted.future;
+
+        final waitingProcessor = NoteAudioUploadCoordinator(
+          store: store,
+          upload: (_, _) async => fail('waiting processor must not upload'),
+          attach: (_, _) async => fail('waiting processor must not attach'),
+        ).process(staged);
+        releaseOwner.complete();
+
+        await expectLater(owner, throwsStateError);
+        final reloaded = await waitingProcessor;
+        check(reloaded).isNotNull();
+        check(reloaded!.id).equals(staged.id);
+        check(reloaded.localPath).equals(staged.localPath);
+        check(reloaded.noteId).equals('deleted-note');
+      },
+    );
+
     test('recovers a process-interrupted rebind journal', () async {
       final root = await Directory.systemTemp.createTemp(
         'conduit_note_audio_upload_test_',


### PR DESCRIPTION
## Summary

- reconcile chats and notes deleted on the Open WebUI server during manual refresh
- treat deletion of an already-absent chat as an idempotent success
- apply global `chat:title` events to the active chat, conversation list, and durable round-trip metadata

## Verification

- `flutter test test/core/providers/active_chats_sync_test.dart test/core/providers/conversations_provider_test.dart test/core/services/api_service_chat_deletion_test.dart test/features/notes/providers/notes_providers_test.dart test/features/notes/services/note_audio_upload_service_test.dart` : 87 passed
- `flutter test test/features/navigation/widgets/sidebar_page_test.dart --plain-name \"chat pull-to-refresh reserves a gutter above conversation rows\"` : 1 passed
- `flutter analyze` — no issues
- full `flutter test` — 4,925 passed; 19 unrelated widget tests are blocked locally by the Flutter SDK shader error: `ink_sparkle.frag` contains Vulkan data but the test backend requests SkSL

Fixes #586

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Reconcile remote chat/note deletions and apply server-generated titles during refresh
> - Manual refresh for both chats and notes now runs an immediate `reconcileNow()` pass, removing remotely deleted items without waiting for background throttle.
> - Deletion reconcile also repairs stale local chat titles when the server title changes without an `updated_at` bump, preserving dirty (locally renamed) rows.
> - Server-generated chat titles received via `chat:title` socket events are persisted to the DB and applied to in-memory state without advancing `updated_at`.
> - The note editor recovers unsaved drafts into a new local note when the original is deleted remotely; pending audio uploads are rebound to the recovered note id via a new durable rebind journal mechanism.
> - `ApiService.deleteConversation` now delegates to `deleteChatRaw`, treating 404 as success to avoid races with other clients.
> - Behavioral Change: back navigation no longer closes the note editor while unsaved changes exist; it triggers draft recovery instead.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 81c73ce.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Durable persistence for server-generated chat titles, including global websocket `chat:title` handling and active/in-memory title updates.
  - Durable note-audio upload rebinding with journal recovery to relocate staged recordings to replacement notes.
- **Bug Fixes**
  - Refresh flows now pull + reconcile to apply remote deletions immediately (conversations and notes).
  - Chat title updates preserve timestamps, ignore empty titles, and keep pending local renames intact; refresh UI reflects the change.
  - Conversation deletion treats “already missing” as success.
  - Note editor refresh/back now reliably recovers deleted drafts and targets the currently loaded note.
- **UI / Documentation**
  - Improved chats pull-to-refresh visuals and refresh slot behavior.
- **Tests**
  - Expanded coverage for title persistence/reconciliation, deleted-draft recovery, audio rebinding, deletion reconciliation, and refresh UI.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Reconciles remote chat and note deletions while preserving editor drafts and generated titles.
- Runs unthrottled deletion reconciliation during manual chat and note refreshes.
- Recreates remotely deleted notes from unsaved drafts and durably rebinds staged audio uploads.
- Persists global server-generated chat titles without overwriting pending local renames.
- Treats deletion of an already-absent remote chat as an idempotent success.
- Replaces the chat refresh overlay with an inline animated status slot.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex attempted the requested test command and captured the resulting failure in chats-drawer-refresh-01-before.log.
- Prerequisite checks were captured and reviewed in chats-drawer-refresh-02-after.log.
- The changed UI behavior remains unexecuted in this environment.

<a href="https://app.greptile.com/trex/runs/16343549/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| lib/features/notes/views/note_editor_page.dart | Recovers drafts after remote deletion, preserves edits made during recovery, retains dirty state after failed saves, and rebinds pending audio to the replacement note. |
| lib/features/notes/services/note_audio_upload_service.dart | Adds journal-backed audio rebind recovery so interrupted filesystem moves can resume during subsequent scans. |
| lib/core/database/daos/chats_dao.dart | Adds reconciliation metadata and durable generated-title persistence while preserving pending local title changes. |
| lib/core/sync/deletion_reconcile.dart | Extends full-list chat reconciliation to recover server titles alongside deletion detection. |
| lib/core/providers/app_providers.dart | Runs explicit reconciliation on refresh and applies global title events to durable, listed, and active conversation state. |
| lib/core/services/api_service.dart | Routes conversation deletion through the idempotent raw-delete behavior. |
| lib/features/navigation/widgets/chats_drawer.dart | Introduces an inline pull-to-refresh indicator that reserves stable list space. |

</details>

<sub>Reviews (14): Last reviewed commit: ["fix: complete adaptive chat refresh sync"](https://github.com/cogwheel0/conduit/commit/81c73ce5659c3932bceda1b4227da69757d006b1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47982919)</sub>

<!-- /greptile_comment -->