### PR TITLE
Polish chat composer and unify cross-platform typography

### DIFF
--- a/lib/features/chat/views/chat_page.dart
+++ b/lib/features/chat/views/chat_page.dart
@@ -3057,9 +3057,8 @@ class _ChatPageState extends ConsumerState<ChatPage> {
         });
       });
     }
-    final baseGreetingStyle = AppTypography.usesAppleRamp
-        ? theme.textTheme.displaySmall ?? AppTypography.displaySmallStyle
-        : theme.textTheme.headlineSmall ?? AppTypography.headlineSmallStyle;
+    final baseGreetingStyle =
+        theme.textTheme.displaySmall ?? AppTypography.displaySmallStyle;
     final greetingStyle = baseGreetingStyle.copyWith(
       fontWeight: FontWeight.w600,
       color: context.conduitTheme.textPrimary,

--- a/lib/features/chat/views/chat_page.dart
+++ b/lib/features/chat/views/chat_page.dart
@@ -3284,8 +3284,6 @@ class _ChatPageState extends ConsumerState<ChatPage> {
     final modelLabel = formattedModelName ?? l10n.chooseModel;
     final overlayStyle = theme.appBarTheme.systemOverlayStyle;
 
-    // Keyboard visibility - use viewInsetsOf for more efficient partial subscription
-    final keyboardVisible = MediaQuery.viewInsetsOf(context).bottom > 0;
     // Whether the messages list can actually scroll (avoids showing button when not needed)
     final canScroll = _hasScrollableTranscriptContent();
 
@@ -3395,10 +3393,11 @@ class _ChatPageState extends ConsumerState<ChatPage> {
                         final hasMessages = scrollButtonRef.watch(
                           hasChatMessagesProvider,
                         );
-                        return (_showScrollToBottom &&
-                                !keyboardVisible &&
-                                canScroll &&
-                                hasMessages)
+                        return debugShouldRenderScrollToLatestForTesting(
+                              requested: _showScrollToBottom,
+                              hasScrollableContent: canScroll,
+                              hasMessages: hasMessages,
+                            )
                             ? Center(
                                 key: const ValueKey('scroll_to_bottom_visible'),
                                 child: AdaptiveTooltip(
@@ -4191,6 +4190,13 @@ bool debugShouldExposeScrollToLatestForTesting({
       ? distanceFromLatest > hideThreshold
       : distanceFromLatest > showThreshold;
 }
+
+@visibleForTesting
+bool debugShouldRenderScrollToLatestForTesting({
+  required bool requested,
+  required bool hasScrollableContent,
+  required bool hasMessages,
+}) => requested && hasScrollableContent && hasMessages;
 
 @visibleForTesting
 bool debugShouldSettlePinImmediatelyForTesting({

--- a/lib/features/chat/widgets/modern_chat_input.dart
+++ b/lib/features/chat/widgets/modern_chat_input.dart
@@ -270,6 +270,8 @@ class _ModernChatInputState extends ConsumerState<ModernChatInput>
   static const int _maxContextSuggestionsPerType = 4;
 
   static const double _composerRadius = AppBorderRadius.card;
+  static const double _composerHorizontalInset = Spacing.sm;
+  static const double _composerControlSize = 36;
   static int _nextGeneratedInsertionTargetId = 0;
 
   final MentionTextEditingController _controller =
@@ -287,6 +289,7 @@ class _ModernChatInputState extends ConsumerState<ModernChatInput>
   bool _pendingFocus = false;
   bool _isRecording = false;
   bool _hasText = false; // track locally without rebuilding on each keystroke
+  bool _hasComposerFocus = false;
   bool _isMultiline = false; // track multiline for dynamic border radius
   /// Tracks the last time the user edited text, used to detect unexpected
   /// focus loss during active typing (e.g. from widget tree restructures).
@@ -362,6 +365,13 @@ class _ModernChatInputState extends ConsumerState<ModernChatInput>
     // Publish focus changes to listeners and guard against unexpected loss
     // during active editing (e.g. widget tree restructure on expansion).
     _focusNode.addListener(() {
+      if (!mounted || _isDeactivated) return;
+      final hasFocus = _focusNode.hasFocus;
+      if (hasFocus != _hasComposerFocus) {
+        setState(() {
+          _hasComposerFocus = hasFocus;
+        });
+      }
       WidgetsBinding.instance.addPostFrameCallback((_) {
         if (!mounted || _isDeactivated) return;
         final hasFocus = _focusNode.hasFocus;
@@ -2560,7 +2570,7 @@ class _ModernChatInputState extends ConsumerState<ModernChatInput>
     _controller.mentionColor = mentionColor;
     _controller.mentionBackground = mentionColor.withValues(alpha: 0.12);
 
-    final bool hasComposerFocus = _focusNode.hasFocus;
+    final bool hasComposerFocus = _hasComposerFocus;
     final bool isActive = hasComposerFocus || _hasText || _isRecording;
     final Color placeholderColor = context.conduitTheme.textSecondary
         .withValues(alpha: 0.5);
@@ -2681,7 +2691,10 @@ class _ModernChatInputState extends ConsumerState<ModernChatInput>
       }
     }
 
-    final bool showCompactComposer = quickPills.isEmpty;
+    // Focus adopts the existing two-tier quick-pill layout even when there
+    // are no selected pills. The resting empty state remains the compact row.
+    final bool showCompactComposer = quickPills.isEmpty && !hasComposerFocus;
+    final bool isCompactComposerExpanded = showCompactComposer && _isMultiline;
     final bool showCreateDraftNoteAction =
         !showCompactComposer &&
         notesEnabled &&
@@ -2689,8 +2702,9 @@ class _ModernChatInputState extends ConsumerState<ModernChatInput>
         !isGenerating &&
         !_isRecording;
 
-    // Keep iOS 26 single-line composer as capsule.
-    final double compactRadius = _isMultiline
+    // Keep the resting single-line composer as a capsule, then soften its
+    // corners when multiline content expands it.
+    final double compactRadius = isCompactComposerExpanded
         ? AppBorderRadius.xl
         : AppBorderRadius.round;
     const double expandedRadius = _composerRadius;
@@ -2714,9 +2728,9 @@ class _ModernChatInputState extends ConsumerState<ModernChatInput>
         Padding(
           key: const ValueKey('composer-expanded-input'),
           padding: const EdgeInsets.fromLTRB(
-            Spacing.md,
+            _composerHorizontalInset,
             Spacing.sm,
-            Spacing.md,
+            _composerHorizontalInset,
             Spacing.sm,
           ),
           child: Stack(
@@ -2763,15 +2777,15 @@ class _ModernChatInputState extends ConsumerState<ModernChatInput>
         Padding(
           key: const ValueKey('composer-expanded-buttons'),
           padding: const EdgeInsets.fromLTRB(
-            Spacing.inputPadding,
+            _composerHorizontalInset,
             0,
-            Spacing.sm,
+            _composerHorizontalInset,
             Spacing.sm,
           ),
           child: Row(
             children: [
               if (_isRecording) ...[
-                _buildDictationStopButton(size: 36.0),
+                _buildDictationStopButton(size: _composerControlSize),
                 const SizedBox(width: Spacing.xs),
               ] else if (showOverflowButton) ...[
                 _buildOverflowButton(
@@ -2781,18 +2795,25 @@ class _ModernChatInputState extends ConsumerState<ModernChatInput>
                 ),
                 const SizedBox(width: Spacing.xs),
               ],
-              Expanded(
-                child: ClipRect(
-                  child: SingleChildScrollView(
-                    scrollDirection: Axis.horizontal,
-                    physics: const BouncingScrollPhysics(),
-                    child: Row(
-                      mainAxisSize: MainAxisSize.min,
-                      children: _withHorizontalSpacing(quickPills, Spacing.xxs),
+              if (quickPills.isNotEmpty)
+                Expanded(
+                  child: ClipRect(
+                    child: SingleChildScrollView(
+                      key: const ValueKey('composer-quick-pills'),
+                      scrollDirection: Axis.horizontal,
+                      physics: const BouncingScrollPhysics(),
+                      child: Row(
+                        mainAxisSize: MainAxisSize.min,
+                        children: _withHorizontalSpacing(
+                          quickPills,
+                          Spacing.xxs,
+                        ),
+                      ),
                     ),
                   ),
-                ),
-              ),
+                )
+              else
+                const Spacer(),
               if (showCreateDraftNoteAction) ...[
                 const SizedBox(width: Spacing.xs),
                 _buildCreateDraftNoteButton(isLoading: isCreatingDraftNote),
@@ -2820,14 +2841,16 @@ class _ModernChatInputState extends ConsumerState<ModernChatInput>
       ],
     ];
 
-    // For compact mode, render text field shell with floating buttons on sides
+    // Compact mode keeps every action inside one full-width shell. Matching
+    // control sizes and insets make the resting row mirror the focused shell.
     if (showCompactComposer) {
       final textFieldContent = Container(
+        key: const ValueKey('compact-composer-content'),
         padding: EdgeInsets.fromLTRB(
-          Spacing.md,
+          _composerHorizontalInset,
           0,
-          Spacing.sm,
-          Platform.isIOS && _isMultiline ? Spacing.sm : 0,
+          _composerHorizontalInset,
+          Platform.isIOS && isCompactComposerExpanded ? Spacing.sm : 0,
         ),
         constraints: const BoxConstraints(minHeight: TouchTarget.input),
         alignment: Alignment.center,
@@ -2835,14 +2858,25 @@ class _ModernChatInputState extends ConsumerState<ModernChatInput>
           clipBehavior: Clip.none,
           children: [
             Row(
-              crossAxisAlignment: _isMultiline
+              crossAxisAlignment: isCompactComposerExpanded
                   ? CrossAxisAlignment.end
                   : CrossAxisAlignment.center,
               children: [
+                if (_isRecording) ...[
+                  _buildDictationStopButton(size: _composerControlSize),
+                  const SizedBox(width: Spacing.xs),
+                ] else if (showOverflowButton) ...[
+                  _buildOverflowButton(
+                    tooltip: l10n.more,
+                    dense: true,
+                    nativeActions: nativeAttachmentActions,
+                  ),
+                  const SizedBox(width: Spacing.xs),
+                ],
                 Expanded(
                   child: Padding(
                     padding: EdgeInsets.only(
-                      bottom: Platform.isAndroid && _isMultiline
+                      bottom: Platform.isAndroid && isCompactComposerExpanded
                           ? Spacing.sm
                           : 0,
                     ),
@@ -2871,13 +2905,13 @@ class _ModernChatInputState extends ConsumerState<ModernChatInput>
                           offset: const Offset(Spacing.xxs, 0),
                           child: _buildInlineMicAction(
                             voiceAvailable,
-                            size: 36.0,
+                            size: _composerControlSize,
                           ),
                         )
                       : SizedBox(
                           height: conduitScaledControlExtent(
                             context,
-                            baseExtent: 36,
+                            baseExtent: _composerControlSize,
                           ),
                           child: Center(
                             child: _buildInlineMicAction(voiceAvailable),
@@ -2917,7 +2951,7 @@ class _ModernChatInputState extends ConsumerState<ModernChatInput>
       final Widget textFieldShell = _buildComposerShell(
         key: const ValueKey('compact-composer-shell'),
         borderRadius: shellRadius,
-        useSmoothRectangleBorder: _isMultiline,
+        useSmoothRectangleBorder: isCompactComposerExpanded,
         isRecording: _isRecording,
         child: textFieldContent,
       );
@@ -2939,29 +2973,7 @@ class _ModernChatInputState extends ConsumerState<ModernChatInput>
                 padding: const EdgeInsets.only(bottom: Spacing.xs),
                 child: _buildActiveOverlay(),
               ),
-            Row(
-              crossAxisAlignment: _isMultiline
-                  ? CrossAxisAlignment.end
-                  : CrossAxisAlignment.center,
-              children: [
-                if (_isRecording) ...[
-                  _buildDictationStopButton(),
-                  const SizedBox(width: Spacing.sm),
-                ] else if (showOverflowButton) ...[
-                  _buildOverflowButton(
-                    tooltip: l10n.more,
-                    nativeActions: nativeAttachmentActions,
-                  ),
-                  const SizedBox(width: Spacing.sm),
-                ],
-                Expanded(
-                  child: _wrapIosSurfaceShadow(
-                    textFieldShell,
-                    borderRadius: shellRadius,
-                  ),
-                ),
-              ],
-            ),
+            _wrapIosSurfaceShadow(textFieldShell, borderRadius: shellRadius),
           ],
         ),
       );
@@ -2972,7 +2984,7 @@ class _ModernChatInputState extends ConsumerState<ModernChatInput>
       );
     }
 
-    // For expanded mode with quick pills, use the full shell.
+    // Focused and quick-pill states use the full two-tier shell.
     final shellContent = ConstrainedBox(
       constraints: BoxConstraints(
         maxHeight: MediaQuery.of(context).size.height * 0.4,
@@ -2993,6 +3005,7 @@ class _ModernChatInputState extends ConsumerState<ModernChatInput>
 
     final Widget shell = _wrapIosSurfaceShadow(
       _buildComposerShell(
+        key: const ValueKey('expanded-composer-shell'),
         borderRadius: shellRadius,
         isRecording: _isRecording,
         child: shellContent,
@@ -3394,6 +3407,7 @@ class _ModernChatInputState extends ConsumerState<ModernChatInput>
     }
 
     return Focus(
+      key: const ValueKey('composer-overflow-button'),
       canRequestFocus: false,
       skipTraversal: true,
       descendantsAreFocusable: false,
@@ -3406,8 +3420,7 @@ class _ModernChatInputState extends ConsumerState<ModernChatInput>
                 }
               : null,
           size: buttonSize,
-          isProminent: false,
-          androidShowBackground: true,
+          forcePlain: true,
           child: ConduitSystemAdaptiveIcon(
             overflowIcon,
             size: iconSize,
@@ -3562,7 +3575,7 @@ class _ModernChatInputState extends ConsumerState<ModernChatInput>
         key: const ValueKey('create-draft-note-button'),
         onPressed: enabled ? _createNoteFromDraft : null,
         size: buttonSize,
-        isProminent: false,
+        forcePlain: true,
         child: isLoading
             ? SizedBox(
                 width: iconSize,
@@ -3803,7 +3816,7 @@ class _ModernChatInputState extends ConsumerState<ModernChatInput>
     );
   }
 
-  /// Builds a circular icon button for the composer.
+  /// Builds an icon button for the composer.
   ///
   /// Uses native glass only where iOS supports it; older iOS follows the same
   /// opaque fallback treatment as Android.
@@ -3814,6 +3827,7 @@ class _ModernChatInputState extends ConsumerState<ModernChatInput>
     required double size,
     bool isProminent = false,
     bool androidShowBackground = false,
+    bool forcePlain = false,
     Color? color,
   }) {
     final theme = context.conduitTheme;
@@ -3829,7 +3843,9 @@ class _ModernChatInputState extends ConsumerState<ModernChatInput>
     }
 
     final usesOpaqueFallback = conduitUsesOpaqueGlassFallback();
-    final buttonStyle = usesOpaqueFallback
+    final buttonStyle = forcePlain
+        ? AdaptiveButtonStyle.plain
+        : usesOpaqueFallback
         ? (isProminent || androidShowBackground
               ? AdaptiveButtonStyle.filled
               : AdaptiveButtonStyle.plain)

--- a/lib/features/chat/widgets/modern_chat_input.dart
+++ b/lib/features/chat/widgets/modern_chat_input.dart
@@ -3377,7 +3377,7 @@ class _ModernChatInputState extends ConsumerState<ModernChatInput>
   }) {
     final double buttonSize = conduitScaledControlExtent(
       context,
-      baseExtent: dense ? 36 : TouchTarget.minimum,
+      baseExtent: dense ? _composerControlSize : TouchTarget.minimum,
     );
     final iconSize = conduitScaledIconExtent(context, IconSize.large);
 
@@ -3497,7 +3497,7 @@ class _ModernChatInputState extends ConsumerState<ModernChatInput>
     final bool active = _isRecording;
     final double buttonSize = conduitScaledControlExtent(
       context,
-      baseExtent: size ?? 36,
+      baseExtent: size ?? _composerControlSize,
     );
     final iconSize = conduitScaledIconExtent(context, IconSize.large);
     final IconData iconData = active
@@ -3563,7 +3563,10 @@ class _ModernChatInputState extends ConsumerState<ModernChatInput>
   Widget _buildCreateDraftNoteButton({required bool isLoading}) {
     final l10n = AppLocalizations.of(context)!;
     final bool enabled = widget.enabled && !isLoading && !_isRecording;
-    final buttonSize = conduitScaledControlExtent(context, baseExtent: 36);
+    final buttonSize = conduitScaledControlExtent(
+      context,
+      baseExtent: _composerControlSize,
+    );
     final iconSize = conduitScaledIconExtent(context, IconSize.large);
     final iconColor = enabled
         ? context.conduitTheme.textSecondary.withValues(alpha: Alpha.strong)
@@ -3607,7 +3610,7 @@ class _ModernChatInputState extends ConsumerState<ModernChatInput>
   }) {
     final double buttonSize = conduitScaledControlExtent(
       context,
-      baseExtent: dense ? 36 : TouchTarget.minimum,
+      baseExtent: dense ? _composerControlSize : TouchTarget.minimum,
     );
     final largeIconSize = conduitScaledIconExtent(context, IconSize.large);
     final primaryIconSize = conduitScaledIconExtent(

--- a/lib/features/navigation/widgets/sidebar_page.dart
+++ b/lib/features/navigation/widgets/sidebar_page.dart
@@ -233,7 +233,7 @@ class _SidebarMaterialBottomNavigationBar extends StatelessWidget {
           }),
           labelTextStyle: WidgetStateProperty.resolveWith<TextStyle?>((states) {
             final selected = states.contains(WidgetState.selected);
-            return AppTypography.labelSmallStyle.copyWith(
+            return AppTypography.materialChromeLabelSmallStyle.copyWith(
               color: selected
                   ? conduitTheme.buttonPrimary
                   : conduitTheme.textSecondary,

--- a/lib/features/profile/widgets/profile_text_styles.dart
+++ b/lib/features/profile/widgets/profile_text_styles.dart
@@ -1,18 +1,10 @@
-import 'dart:io' show Platform;
-
 import 'package:flutter/material.dart';
 
 import '../../../shared/theme/theme_extensions.dart';
 
 TextStyle? profileTitleTextStyle(BuildContext context, {bool large = false}) {
   final theme = context.conduitTheme;
-  final baseStyle = large
-      ? (Platform.isAndroid
-            ? AppTypography.titleLargeStyle
-            : theme.headingMedium)
-      : (Platform.isAndroid
-            ? AppTypography.titleMediumStyle
-            : theme.bodyMedium);
+  final baseStyle = large ? theme.headingMedium : theme.bodyMedium;
 
   return baseStyle?.copyWith(
     color: theme.sidebarForeground,
@@ -22,9 +14,7 @@ TextStyle? profileTitleTextStyle(BuildContext context, {bool large = false}) {
 
 TextStyle? profileSubtitleTextStyle(BuildContext context) {
   final theme = context.conduitTheme;
-  final baseStyle = Platform.isAndroid
-      ? AppTypography.bodyMediumStyle
-      : theme.bodySmall;
+  final baseStyle = theme.bodySmall;
 
   return baseStyle?.copyWith(
     color: theme.sidebarForeground.withValues(alpha: 0.75),

--- a/lib/features/profile/widgets/settings_page_scaffold.dart
+++ b/lib/features/profile/widgets/settings_page_scaffold.dart
@@ -1,5 +1,3 @@
-import 'dart:io' show Platform;
-
 import 'package:adaptive_platform_ui/adaptive_platform_ui.dart';
 import 'package:flutter/material.dart';
 
@@ -147,19 +145,13 @@ class SettingsSelectorTile extends StatelessWidget {
             theme.surfaceBackground,
           )
         : Colors.transparent;
-    final titleStyle =
-        (Platform.isAndroid
-                ? AppTypography.titleMediumStyle
-                : AppTypography.bodyMediumStyle)
-            .copyWith(
-              color: selected ? theme.textPrimary : theme.textSecondary,
-              fontWeight: selected ? FontWeight.w600 : FontWeight.w400,
-            );
-    final subtitleStyle =
-        (Platform.isAndroid
-                ? AppTypography.bodyMediumStyle
-                : AppTypography.labelSmallStyle)
-            .copyWith(color: theme.textSecondary);
+    final titleStyle = AppTypography.bodyMediumStyle.copyWith(
+      color: selected ? theme.textPrimary : theme.textSecondary,
+      fontWeight: selected ? FontWeight.w600 : FontWeight.w400,
+    );
+    final subtitleStyle = AppTypography.bodySmallStyle.copyWith(
+      color: theme.textSecondary,
+    );
 
     return Padding(
       padding: const EdgeInsets.symmetric(vertical: Spacing.xxs),

--- a/lib/shared/theme/app_theme.dart
+++ b/lib/shared/theme/app_theme.dart
@@ -89,6 +89,12 @@ class AppTheme {
     );
 
     final TextTheme textTheme = _buildTextTheme(tokens: tokens, isDark: isDark);
+    final TextTheme materialChromeTextTheme =
+        AppTypography.materialChromeTextTheme(
+          primary: tokens.neutralOnSurface,
+          secondary: isDark ? tokens.neutralTone80 : tokens.neutralTone60,
+          tertiary: tokens.neutralTone60,
+        );
     final cupertinoOverrideTheme = _buildCupertinoThemeData(
       brightness: brightness,
       variant: variant,
@@ -111,6 +117,8 @@ class AppTheme {
         elevation: Elevation.none,
         backgroundColor: surfaces.background,
         foregroundColor: tokens.neutralOnSurface,
+        titleTextStyle: materialChromeTextTheme.titleLarge,
+        toolbarTextStyle: materialChromeTextTheme.bodyMedium,
         systemOverlayStyle: systemUiOverlayStyleForBrightness(brightness),
       ),
       bottomSheetTheme: BottomSheetThemeData(
@@ -300,6 +308,11 @@ class AppTheme {
     final primaryText = tokens.neutralOnSurface;
     final secondaryText = isDark ? tokens.neutralTone80 : tokens.neutralTone60;
     final actionColor = variant.primary;
+    final chromeTextTheme = AppTypography.cupertinoChromeTextTheme(
+      primary: primaryText,
+      secondary: secondaryText,
+      tertiary: secondaryText,
+    );
 
     return CupertinoThemeData(
       brightness: brightness,
@@ -307,27 +320,23 @@ class AppTheme {
       scaffoldBackgroundColor: tokens.neutralTone10,
       barBackgroundColor: tokens.neutralTone10,
       textTheme: CupertinoTextThemeData(
-        textStyle: AppTypography.bodyLargeStyle.copyWith(color: primaryText),
-        actionTextStyle: AppTypography.bodyLargeStyle.copyWith(
+        textStyle: chromeTextTheme.bodyLarge,
+        actionTextStyle: chromeTextTheme.bodyLarge?.copyWith(
           color: actionColor,
         ),
-        actionSmallTextStyle: AppTypography.bodyMediumStyle.copyWith(
+        actionSmallTextStyle: chromeTextTheme.bodyMedium?.copyWith(
           color: actionColor,
         ),
-        tabLabelTextStyle: AppTypography.micro.copyWith(color: secondaryText),
-        navTitleTextStyle: AppTypography.titleLargeStyle.copyWith(
-          color: primaryText,
+        tabLabelTextStyle: AppTypography.cupertinoChromeMicroStyle.copyWith(
+          color: secondaryText,
         ),
-        navLargeTitleTextStyle: AppTypography.displayLargeStyle.copyWith(
-          color: primaryText,
-        ),
-        navActionTextStyle: AppTypography.bodyLargeStyle.copyWith(
+        navTitleTextStyle: chromeTextTheme.titleLarge,
+        navLargeTitleTextStyle: chromeTextTheme.displayLarge,
+        navActionTextStyle: chromeTextTheme.bodyLarge?.copyWith(
           color: actionColor,
         ),
-        pickerTextStyle: AppTypography.extraLarge.copyWith(color: primaryText),
-        dateTimePickerTextStyle: AppTypography.extraLarge.copyWith(
-          color: primaryText,
-        ),
+        pickerTextStyle: chromeTextTheme.titleLarge,
+        dateTimePickerTextStyle: chromeTextTheme.titleLarge,
       ),
     );
   }

--- a/lib/shared/theme/app_theme.dart
+++ b/lib/shared/theme/app_theme.dart
@@ -1,6 +1,5 @@
 import 'dart:math' as math;
 
-import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter_animate/flutter_animate.dart';
@@ -95,7 +94,7 @@ class AppTheme {
       variant: variant,
       tokens: tokens,
     );
-    final textInputAccentColor = _platformTextInputAccentColor(variant);
+    final textInputAccentColor = variant.primary;
 
     return ThemeData(
       useMaterial3: true,
@@ -252,14 +251,10 @@ class AppTheme {
       ),
       textTheme: textTheme,
       textSelectionTheme: TextSelectionThemeData(
-        // Keep cursor, handles, and selection highlight on the same
-        // platform-native accent while using highlight-appropriate opacity.
+        // Keep cursor, handles, and selection highlight on the active theme
+        // accent across both Material and Cupertino text fields.
         cursorColor: textInputAccentColor,
-        selectionColor: switch (defaultTargetPlatform) {
-          TargetPlatform.iOS ||
-          TargetPlatform.macOS => textInputAccentColor.withValues(alpha: 0.15),
-          _ => textInputAccentColor.withValues(alpha: 0.2),
-        },
+        selectionColor: textInputAccentColor.withValues(alpha: 0.2),
         selectionHandleColor: textInputAccentColor,
       ),
       extensions: <ThemeExtension<dynamic>>[
@@ -335,13 +330,6 @@ class AppTheme {
         ),
       ),
     );
-  }
-
-  static Color _platformTextInputAccentColor(TweakcnThemeVariant variant) {
-    return switch (defaultTargetPlatform) {
-      TargetPlatform.iOS || TargetPlatform.macOS => const Color(0xFF007AFF),
-      _ => variant.primary,
-    };
   }
 
   static double _contrastRatio(Color a, Color b) {

--- a/lib/shared/theme/theme_extensions.dart
+++ b/lib/shared/theme/theme_extensions.dart
@@ -1286,6 +1286,9 @@ class AppTypography {
     fontFamily: fontFamily,
   );
 
+  static TextStyle get materialChromeLabelSmallStyle =>
+      _primaryFont(_materialScale.labelSmallStyle);
+
   /// Apple typography reserved for genuine Cupertino navigation chrome.
   static TextTheme cupertinoChromeTextTheme({
     required Color primary,

--- a/lib/shared/theme/theme_extensions.dart
+++ b/lib/shared/theme/theme_extensions.dart
@@ -1137,8 +1137,12 @@ bool _usesAppleTypographyRamp(TargetPlatform platform) {
   };
 }
 
-/// Typography scale that follows the current platform convention:
-/// Cupertino/HIG on Apple platforms and Material 3 elsewhere.
+/// Product typography shared by every platform.
+///
+/// Content and product UI use one stable hierarchy so the same conversation,
+/// sheet, or settings page does not change density between Android and iOS.
+/// Native navigation chrome can opt into the explicit Material or Cupertino
+/// ramps exposed below.
 class AppTypography {
   static const String fontFamily = 'Geist Sans';
   static const String monospaceFontFamily = 'Geist Mono';
@@ -1149,13 +1153,17 @@ class AppTypography {
   static const double letterSpacingWide = 0.0;
   static const double letterSpacingExtraWide = 0.0;
 
-  static _AppTypographyScale get _scale =>
+  // Preserve the previously shipped Apple product hierarchy as the common
+  // baseline. This keeps iOS stable while bringing Android content into parity.
+  static _AppTypographyScale get _scale => _appleScale;
+
+  // Geometry can continue to follow platform conventions without changing the
+  // text hierarchy. Android inputs remain roomier while Cupertino controls keep
+  // their existing compact metrics.
+  static _AppTypographyScale get _platformMetricScale =>
       _usesAppleTypographyRamp(defaultTargetPlatform)
       ? _appleScale
       : _materialScale;
-
-  static bool get usesAppleRamp =>
-      _usesAppleTypographyRamp(defaultTargetPlatform);
 
   static TextStyle _primaryFont(TextStyle style) =>
       style.copyWith(fontFamily: fontFamily);
@@ -1238,17 +1246,22 @@ class AppTypography {
 
   static TextStyle get massive => displaySmallStyle;
 
-  static double get inputVerticalPadding => _scale.inputVerticalPadding;
+  static double get inputVerticalPadding =>
+      _platformMetricScale.inputVerticalPadding;
   static double get compactInputVerticalPadding =>
-      _scale.compactInputVerticalPadding;
+      _platformMetricScale.compactInputVerticalPadding;
   static double get borderlessInputVerticalPadding =>
-      _scale.borderlessInputVerticalPadding;
-  static double get chipHorizontalPadding => _scale.chipHorizontalPadding;
-  static double get chipVerticalPadding => _scale.chipVerticalPadding;
-  static double get badgeHorizontalPadding => _scale.badgeHorizontalPadding;
-  static double get badgeVerticalPadding => _scale.badgeVerticalPadding;
-  static double get badgeLargeSize => _scale.badgeLargeSize;
-  static double get badgeSmallSize => _scale.badgeSmallSize;
+      _platformMetricScale.borderlessInputVerticalPadding;
+  static double get chipHorizontalPadding =>
+      _platformMetricScale.chipHorizontalPadding;
+  static double get chipVerticalPadding =>
+      _platformMetricScale.chipVerticalPadding;
+  static double get badgeHorizontalPadding =>
+      _platformMetricScale.badgeHorizontalPadding;
+  static double get badgeVerticalPadding =>
+      _platformMetricScale.badgeVerticalPadding;
+  static double get badgeLargeSize => _platformMetricScale.badgeLargeSize;
+  static double get badgeSmallSize => _platformMetricScale.badgeSmallSize;
 
   static TextTheme textTheme({
     required Color primary,
@@ -1260,6 +1273,33 @@ class AppTypography {
     tertiary: tertiary,
     fontFamily: fontFamily,
   );
+
+  /// Material typography reserved for genuine Material navigation chrome.
+  static TextTheme materialChromeTextTheme({
+    required Color primary,
+    required Color secondary,
+    required Color tertiary,
+  }) => _materialScale.textTheme(
+    primary: primary,
+    secondary: secondary,
+    tertiary: tertiary,
+    fontFamily: fontFamily,
+  );
+
+  /// Apple typography reserved for genuine Cupertino navigation chrome.
+  static TextTheme cupertinoChromeTextTheme({
+    required Color primary,
+    required Color secondary,
+    required Color tertiary,
+  }) => _appleScale.textTheme(
+    primary: primary,
+    secondary: secondary,
+    tertiary: tertiary,
+    fontFamily: fontFamily,
+  );
+
+  static TextStyle get cupertinoChromeMicroStyle =>
+      _primaryFont(_appleScale.microStyle);
 
   static const _AppTypographyScale _materialScale = _AppTypographyScale(
     displayLargeStyle: TextStyle(

--- a/lib/shared/widgets/markdown/renderer/markdown_style.dart
+++ b/lib/shared/widgets/markdown/renderer/markdown_style.dart
@@ -69,7 +69,6 @@ class ConduitMarkdownStyle {
   factory ConduitMarkdownStyle.fromTheme(BuildContext context) {
     final theme = context.conduitTheme;
     final textTheme = Theme.of(context).textTheme;
-    final textScaler = MediaQuery.textScalerOf(context);
     final tokens = theme.tokens;
     final dark = theme.isDark;
     TextStyle resolveHeadingStyle(
@@ -86,12 +85,6 @@ class ConduitMarkdownStyle {
     final bodyStyle = AppTypography.chatMessageStyle.copyWith(
       color: theme.textPrimary,
     );
-    final bodyLineHeight =
-        textScaler.scale(bodyStyle.fontSize ?? AppTypography.bodyLarge) *
-        (bodyStyle.height ?? 1.0);
-    final paragraphSpacing = AppTypography.usesAppleRamp
-        ? Spacing.md
-        : (bodyLineHeight * 0.5).clamp(Spacing.md, Spacing.lg).toDouble();
 
     // Monospace base for code elements.
     final monoBase =
@@ -148,8 +141,7 @@ class ConduitMarkdownStyle {
       ),
       tableCell: bodyStyle.copyWith(color: theme.textPrimary),
 
-      // Paragraph rhythm follows the active platform ramp.
-      paragraphSpacing: paragraphSpacing,
+      paragraphSpacing: Spacing.md,
       headingTopSpacing: Spacing.md,
       headingBottomSpacing: Spacing.sm,
       listItemSpacing: Spacing.sm,

--- a/test/features/chat/views/chat_page_layout_metadata_test.dart
+++ b/test/features/chat/views/chat_page_layout_metadata_test.dart
@@ -427,6 +427,37 @@ void main() {
     ).isTrue();
   });
 
+  test('latest button remains eligible while the composer is expanded', () {
+    check(
+      debugShouldRenderScrollToLatestForTesting(
+        requested: true,
+        hasScrollableContent: true,
+        hasMessages: true,
+      ),
+    ).isTrue();
+    check(
+      debugShouldRenderScrollToLatestForTesting(
+        requested: false,
+        hasScrollableContent: true,
+        hasMessages: true,
+      ),
+    ).isFalse();
+    check(
+      debugShouldRenderScrollToLatestForTesting(
+        requested: true,
+        hasScrollableContent: false,
+        hasMessages: true,
+      ),
+    ).isFalse();
+    check(
+      debugShouldRenderScrollToLatestForTesting(
+        requested: true,
+        hasScrollableContent: true,
+        hasMessages: false,
+      ),
+    ).isFalse();
+  });
+
   test('only the first turn settles its pin without animation', () {
     expect(
       debugShouldSettlePinImmediatelyForTesting(transcriptWasEmpty: true),

--- a/test/features/chat/widgets/modern_chat_input_direct_test.dart
+++ b/test/features/chat/widgets/modern_chat_input_direct_test.dart
@@ -2,6 +2,7 @@ import 'package:conduit/core/models/model.dart';
 import 'package:conduit/core/models/server_config.dart';
 import 'package:conduit/core/providers/app_providers.dart';
 import 'package:conduit/core/services/api_service.dart';
+import 'package:conduit/core/services/settings_service.dart';
 import 'package:conduit/core/services/worker_manager.dart';
 import 'package:conduit/features/chat/providers/chat_providers.dart';
 import 'package:conduit/features/chat/widgets/composer_overflow_menu.dart';
@@ -9,6 +10,7 @@ import 'package:conduit/features/chat/widgets/modern_chat_input.dart';
 import 'package:conduit/features/direct_connections/direct_connections.dart';
 import 'package:conduit/l10n/app_localizations.dart';
 import 'package:conduit/shared/widgets/themed_sheets.dart';
+import 'package:adaptive_platform_ui/adaptive_platform_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -714,6 +716,206 @@ void main() {
     await tester.pumpAndSettle();
     expect(ThemedSheets.hasActiveSheet, isFalse);
   });
+
+  testWidgets('focus uses two-tier composer without unselected quick pills', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [apiServiceProvider.overrideWithValue(null)],
+        child: MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: Scaffold(body: ModernChatInput(onSendMessage: (_) {})),
+        ),
+      ),
+    );
+    await tester.pump();
+
+    const compactShellKey = ValueKey('compact-composer-shell');
+    const expandedShellKey = ValueKey('expanded-composer-shell');
+    const expandedInputKey = ValueKey('composer-expanded-input');
+    const expandedButtonsKey = ValueKey('composer-expanded-buttons');
+    const quickPillsKey = ValueKey('composer-quick-pills');
+
+    expect(find.byKey(compactShellKey), findsOneWidget);
+    expect(find.byKey(expandedShellKey), findsNothing);
+
+    await tester.tap(find.byType(TextField));
+    await tester.pump();
+    await tester.pump();
+
+    final composerField = tester.widget<TextField>(find.byType(TextField));
+    expect(composerField.focusNode?.hasFocus, isTrue);
+    expect(find.byKey(compactShellKey), findsNothing);
+    expect(find.byKey(expandedShellKey), findsOneWidget);
+    expect(find.byKey(expandedInputKey), findsOneWidget);
+    expect(find.byKey(expandedButtonsKey), findsOneWidget);
+    expect(find.byKey(quickPillsKey), findsNothing);
+
+    final inputInsets = tester
+        .widget<Padding>(find.byKey(expandedInputKey))
+        .padding
+        .resolve(TextDirection.ltr);
+    final actionInsets = tester
+        .widget<Padding>(find.byKey(expandedButtonsKey))
+        .padding
+        .resolve(TextDirection.ltr);
+    expect(inputInsets.left, 8);
+    expect(inputInsets.right, 8);
+    expect(actionInsets.left, 8);
+    expect(actionInsets.right, 8);
+
+    composerField.focusNode?.unfocus();
+    await tester.pump();
+    await tester.pump();
+
+    expect(find.byKey(compactShellKey), findsOneWidget);
+    expect(find.byKey(expandedShellKey), findsNothing);
+  });
+
+  testWidgets('compact composer uses symmetric horizontal insets', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [apiServiceProvider.overrideWithValue(null)],
+        child: MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: Scaffold(
+            body: ModernChatInput(
+              onSendMessage: (_) {},
+              onFileAttachment: _noop,
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.pump();
+
+    final compactInsets = tester
+        .widget<Container>(
+          find.byKey(const ValueKey('compact-composer-content')),
+        )
+        .padding!
+        .resolve(TextDirection.ltr);
+
+    expect(compactInsets.left, 8);
+    expect(compactInsets.right, 8);
+
+    final compactShell = find.byKey(const ValueKey('compact-composer-shell'));
+    final overflowButton = find.byKey(
+      const ValueKey('composer-overflow-button'),
+    );
+    expect(
+      find.descendant(of: compactShell, matching: overflowButton),
+      findsOneWidget,
+    );
+
+    final shellRect = tester.getRect(compactShell);
+    final viewWidth =
+        tester.view.physicalSize.width / tester.view.devicePixelRatio;
+    expect(shellRect.left, 16);
+    expect(viewWidth - shellRect.right, 16);
+
+    final overflowCenter = tester.getCenter(find.byIcon(Icons.add));
+    final primaryCenter = tester.getCenter(
+      find.byKey(const ValueKey('primary-btn-send-muted')),
+    );
+    expect(
+      overflowCenter.dx - shellRect.left,
+      closeTo(shellRect.right - primaryCenter.dx, 0.01),
+    );
+  });
+
+  testWidgets('secondary composer actions use plain icon buttons', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          apiServiceProvider.overrideWithValue(null),
+          notesFeatureEnabledProvider.overrideWith(
+            _EnabledNotesFeatureNotifier.new,
+          ),
+        ],
+        child: MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: Scaffold(
+            body: ModernChatInput(
+              onSendMessage: (_) {},
+              onFileAttachment: _noop,
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.pump();
+
+    AdaptiveButton actionButton(Finder ancestor) => tester.widget(
+      find.descendant(of: ancestor, matching: find.byType(AdaptiveButton)),
+    );
+
+    expect(
+      actionButton(
+        find.byKey(const ValueKey('composer-overflow-button')),
+      ).style,
+      AdaptiveButtonStyle.plain,
+    );
+
+    await tester.tap(find.byType(TextField));
+    await tester.enterText(find.byType(TextField), 'Draft note');
+    await tester.pump();
+    await tester.pump();
+
+    expect(
+      tester
+          .widget<AdaptiveButton>(
+            find.byKey(const ValueKey('create-draft-note-button')),
+          )
+          .style,
+      AdaptiveButtonStyle.plain,
+    );
+  });
+
+  testWidgets('explicit quick-pill selection keeps pill composer visible', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          apiServiceProvider.overrideWithValue(null),
+          appSettingsProvider.overrideWith(_QuickPillAppSettingsNotifier.new),
+          webSearchAvailableProvider.overrideWithValue(true),
+        ],
+        child: MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: Scaffold(body: ModernChatInput(onSendMessage: (_) {})),
+        ),
+      ),
+    );
+    await tester.pump();
+
+    expect(
+      find.byKey(const ValueKey('expanded-composer-shell')),
+      findsOneWidget,
+    );
+    expect(find.byKey(const ValueKey('composer-quick-pills')), findsOneWidget);
+    expect(find.text('Web'), findsOneWidget);
+  });
+}
+
+final class _QuickPillAppSettingsNotifier extends AppSettingsNotifier {
+  @override
+  AppSettings build() => const AppSettings(quickPills: ['web']);
+}
+
+final class _EnabledNotesFeatureNotifier extends NotesFeatureEnabledNotifier {
+  @override
+  bool build() => true;
 }
 
 final class _FixedDiscoveryController extends DirectModelDiscoveryController {

--- a/test/shared/theme/app_theme_test.dart
+++ b/test/shared/theme/app_theme_test.dart
@@ -1,0 +1,24 @@
+import 'package:conduit/shared/theme/app_theme.dart';
+import 'package:conduit/shared/theme/tweakcn_themes.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('iOS text selection uses the themed Android accent colors', () {
+    addTearDown(() => debugDefaultTargetPlatformOverride = null);
+
+    final definition = TweakcnThemes.catppuccin;
+    final expectedAccent = definition.variantFor(Brightness.light).primary;
+
+    debugDefaultTargetPlatformOverride = TargetPlatform.android;
+    final androidSelection = AppTheme.light(definition).textSelectionTheme;
+
+    debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
+    final iosSelection = AppTheme.light(definition).textSelectionTheme;
+
+    expect(iosSelection.cursorColor, expectedAccent);
+    expect(iosSelection.selectionColor, expectedAccent.withValues(alpha: 0.2));
+    expect(iosSelection.selectionHandleColor, expectedAccent);
+    expect(iosSelection, androidSelection);
+  });
+}

--- a/test/shared/theme/app_theme_test.dart
+++ b/test/shared/theme/app_theme_test.dart
@@ -1,6 +1,8 @@
 import 'package:conduit/shared/theme/app_theme.dart';
+import 'package:conduit/shared/theme/theme_extensions.dart';
 import 'package:conduit/shared/theme/tweakcn_themes.dart';
 import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
@@ -20,5 +22,76 @@ void main() {
     expect(iosSelection.selectionColor, expectedAccent.withValues(alpha: 0.2));
     expect(iosSelection.selectionHandleColor, expectedAccent);
     expect(iosSelection, androidSelection);
+  });
+
+  test('product typography is identical on Android and iOS', () {
+    addTearDown(() => debugDefaultTargetPlatformOverride = null);
+
+    debugDefaultTargetPlatformOverride = TargetPlatform.android;
+    final androidTextTheme = AppTheme.light(TweakcnThemes.t3Chat).textTheme;
+
+    debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
+    final iosTextTheme = AppTheme.light(TweakcnThemes.t3Chat).textTheme;
+
+    expect(androidTextTheme, iosTextTheme);
+    expect(androidTextTheme.displaySmall?.fontSize, 24);
+    expect(androidTextTheme.headlineLarge?.fontSize, 22);
+    expect(androidTextTheme.headlineMedium?.fontSize, 20);
+    expect(androidTextTheme.headlineSmall?.fontSize, 17);
+    expect(androidTextTheme.bodyLarge?.fontSize, 17);
+    expect(androidTextTheme.bodyMedium?.fontSize, 16);
+  });
+
+  test('native chrome retains explicit Material and Cupertino ramps', () {
+    const primary = Color(0xFF111111);
+    const secondary = Color(0xFF555555);
+    const tertiary = Color(0xFF777777);
+
+    final material = AppTypography.materialChromeTextTheme(
+      primary: primary,
+      secondary: secondary,
+      tertiary: tertiary,
+    );
+    final cupertino = AppTypography.cupertinoChromeTextTheme(
+      primary: primary,
+      secondary: secondary,
+      tertiary: tertiary,
+    );
+
+    expect(material.displaySmall?.fontSize, 36);
+    expect(cupertino.displaySmall?.fontSize, 24);
+    expect(material.titleLarge?.fontSize, 22);
+    expect(cupertino.titleLarge?.fontSize, 17);
+    expect(material.bodyMedium?.fontSize, 14);
+    expect(cupertino.bodyMedium?.fontSize, 16);
+    expect(AppTypography.cupertinoChromeMicroStyle.fontSize, 11);
+  });
+
+  test('app themes wire native ramps only into navigation chrome', () {
+    final materialTheme = AppTheme.light(TweakcnThemes.t3Chat);
+    final cupertinoTheme = AppTheme.cupertinoLight(TweakcnThemes.t3Chat);
+
+    expect(materialTheme.textTheme.titleLarge?.fontSize, 17);
+    expect(materialTheme.appBarTheme.titleTextStyle?.fontSize, 22);
+    expect(cupertinoTheme.textTheme.navTitleTextStyle.fontSize, 17);
+    expect(cupertinoTheme.textTheme.navLargeTitleTextStyle.fontSize, 34);
+    expect(cupertinoTheme.textTheme.tabLabelTextStyle.fontSize, 11);
+  });
+
+  test('platform control geometry remains adaptive', () {
+    addTearDown(() => debugDefaultTargetPlatformOverride = null);
+
+    debugDefaultTargetPlatformOverride = TargetPlatform.android;
+    final androidInputPadding = AppTypography.inputVerticalPadding;
+    final androidBadgeSize = AppTypography.badgeLargeSize;
+
+    debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
+    final iosInputPadding = AppTypography.inputVerticalPadding;
+    final iosBadgeSize = AppTypography.badgeLargeSize;
+
+    expect(androidInputPadding, 14);
+    expect(iosInputPadding, 12);
+    expect(androidBadgeSize, 24);
+    expect(iosBadgeSize, 22);
   });
 }

--- a/test/shared/theme/app_theme_test.dart
+++ b/test/shared/theme/app_theme_test.dart
@@ -1,6 +1,8 @@
 import 'package:conduit/shared/theme/app_theme.dart';
+import 'package:conduit/shared/theme/color_tokens.dart';
 import 'package:conduit/shared/theme/theme_extensions.dart';
 import 'package:conduit/shared/theme/tweakcn_themes.dart';
+import 'package:checks/checks.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -18,10 +20,12 @@ void main() {
     debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
     final iosSelection = AppTheme.light(definition).textSelectionTheme;
 
-    expect(iosSelection.cursorColor, expectedAccent);
-    expect(iosSelection.selectionColor, expectedAccent.withValues(alpha: 0.2));
-    expect(iosSelection.selectionHandleColor, expectedAccent);
-    expect(iosSelection, androidSelection);
+    check(iosSelection.cursorColor).equals(expectedAccent);
+    check(
+      iosSelection.selectionColor,
+    ).equals(expectedAccent.withValues(alpha: 0.2));
+    check(iosSelection.selectionHandleColor).equals(expectedAccent);
+    check(iosSelection).equals(androidSelection);
   });
 
   test('product typography is identical on Android and iOS', () {
@@ -33,13 +37,13 @@ void main() {
     debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
     final iosTextTheme = AppTheme.light(TweakcnThemes.t3Chat).textTheme;
 
-    expect(androidTextTheme, iosTextTheme);
-    expect(androidTextTheme.displaySmall?.fontSize, 24);
-    expect(androidTextTheme.headlineLarge?.fontSize, 22);
-    expect(androidTextTheme.headlineMedium?.fontSize, 20);
-    expect(androidTextTheme.headlineSmall?.fontSize, 17);
-    expect(androidTextTheme.bodyLarge?.fontSize, 17);
-    expect(androidTextTheme.bodyMedium?.fontSize, 16);
+    check(androidTextTheme).equals(iosTextTheme);
+    check(androidTextTheme.displaySmall?.fontSize).equals(24);
+    check(androidTextTheme.headlineLarge?.fontSize).equals(22);
+    check(androidTextTheme.headlineMedium?.fontSize).equals(20);
+    check(androidTextTheme.headlineSmall?.fontSize).equals(17);
+    check(androidTextTheme.bodyLarge?.fontSize).equals(17);
+    check(androidTextTheme.bodyMedium?.fontSize).equals(16);
   });
 
   test('native chrome retains explicit Material and Cupertino ramps', () {
@@ -58,24 +62,44 @@ void main() {
       tertiary: tertiary,
     );
 
-    expect(material.displaySmall?.fontSize, 36);
-    expect(cupertino.displaySmall?.fontSize, 24);
-    expect(material.titleLarge?.fontSize, 22);
-    expect(cupertino.titleLarge?.fontSize, 17);
-    expect(material.bodyMedium?.fontSize, 14);
-    expect(cupertino.bodyMedium?.fontSize, 16);
-    expect(AppTypography.cupertinoChromeMicroStyle.fontSize, 11);
+    check(material.displaySmall?.fontSize).equals(36);
+    check(cupertino.displaySmall?.fontSize).equals(24);
+    check(material.titleLarge?.fontSize).equals(22);
+    check(cupertino.titleLarge?.fontSize).equals(17);
+    check(material.bodyMedium?.fontSize).equals(14);
+    check(cupertino.bodyMedium?.fontSize).equals(16);
+    check(AppTypography.materialChromeLabelSmallStyle.fontSize).equals(12);
+    check(AppTypography.cupertinoChromeMicroStyle.fontSize).equals(11);
   });
 
   test('app themes wire native ramps only into navigation chrome', () {
     final materialTheme = AppTheme.light(TweakcnThemes.t3Chat);
     final cupertinoTheme = AppTheme.cupertinoLight(TweakcnThemes.t3Chat);
+    final darkTokens = AppColorTokens.dark(theme: TweakcnThemes.t3Chat);
+    final darkMaterialTheme = AppTheme.dark(TweakcnThemes.t3Chat);
+    final darkCupertinoTheme = AppTheme.cupertinoDark(TweakcnThemes.t3Chat);
 
-    expect(materialTheme.textTheme.titleLarge?.fontSize, 17);
-    expect(materialTheme.appBarTheme.titleTextStyle?.fontSize, 22);
-    expect(cupertinoTheme.textTheme.navTitleTextStyle.fontSize, 17);
-    expect(cupertinoTheme.textTheme.navLargeTitleTextStyle.fontSize, 34);
-    expect(cupertinoTheme.textTheme.tabLabelTextStyle.fontSize, 11);
+    check(materialTheme.textTheme.titleLarge?.fontSize).equals(17);
+    check(materialTheme.appBarTheme.titleTextStyle?.fontSize).equals(22);
+    check(cupertinoTheme.textTheme.navTitleTextStyle.fontSize).equals(17);
+    check(cupertinoTheme.textTheme.navLargeTitleTextStyle.fontSize).equals(34);
+    check(cupertinoTheme.textTheme.tabLabelTextStyle.fontSize).equals(11);
+    check(
+      darkMaterialTheme.appBarTheme.titleTextStyle?.color,
+    ).equals(darkTokens.neutralOnSurface);
+    check(
+      darkMaterialTheme
+          .cupertinoOverrideTheme
+          ?.textTheme
+          ?.tabLabelTextStyle
+          .color,
+    ).equals(darkTokens.neutralTone80);
+    check(
+      darkCupertinoTheme.textTheme.navTitleTextStyle.color,
+    ).equals(darkTokens.neutralOnSurface);
+    check(
+      darkCupertinoTheme.textTheme.tabLabelTextStyle.color,
+    ).equals(darkTokens.neutralTone80);
   });
 
   test('platform control geometry remains adaptive', () {
@@ -89,9 +113,9 @@ void main() {
     final iosInputPadding = AppTypography.inputVerticalPadding;
     final iosBadgeSize = AppTypography.badgeLargeSize;
 
-    expect(androidInputPadding, 14);
-    expect(iosInputPadding, 12);
-    expect(androidBadgeSize, 24);
-    expect(iosBadgeSize, 22);
+    check(androidInputPadding).equals(14);
+    check(iosInputPadding).equals(12);
+    check(androidBadgeSize).equals(24);
+    check(iosBadgeSize).equals(22);
   });
 }

--- a/test/shared/widgets/markdown/renderer/markdown_style_test.dart
+++ b/test/shared/widgets/markdown/renderer/markdown_style_test.dart
@@ -3,6 +3,7 @@ import 'package:conduit/shared/theme/app_theme.dart';
 import 'package:conduit/shared/theme/theme_extensions.dart';
 import 'package:conduit/shared/theme/tweakcn_themes.dart';
 import 'package:conduit/shared/widgets/markdown/renderer/markdown_style.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
@@ -58,6 +59,46 @@ void main() {
       check(
         conduitTheme.code?.fontFamily,
       ).equals(AppTypography.monospaceFontFamily);
+    });
+
+    testWidgets('uses the same reading hierarchy on Android and iOS', (
+      tester,
+    ) async {
+      addTearDown(() => debugDefaultTargetPlatformOverride = null);
+
+      Future<ConduitMarkdownStyle> resolveStyle(TargetPlatform platform) async {
+        debugDefaultTargetPlatformOverride = platform;
+        late ConduitMarkdownStyle style;
+        await tester.pumpWidget(
+          MaterialApp(
+            theme: AppTheme.light(TweakcnThemes.t3Chat),
+            home: Builder(
+              builder: (context) {
+                style = ConduitMarkdownStyle.fromTheme(context);
+                return const SizedBox.shrink();
+              },
+            ),
+          ),
+        );
+        return style;
+      }
+
+      final android = await resolveStyle(TargetPlatform.android);
+      final ios = await resolveStyle(TargetPlatform.iOS);
+      debugDefaultTargetPlatformOverride = null;
+
+      expect(android.body, ios.body);
+      expect(android.h1, ios.h1);
+      expect(android.h2, ios.h2);
+      expect(android.h3, ios.h3);
+      expect(android.h4, ios.h4);
+      expect(android.h5, ios.h5);
+      expect(android.h6, ios.h6);
+      expect(android.codeBlock, ios.codeBlock);
+      expect(android.h1.fontSize, 24);
+      expect(android.h2.fontSize, 22);
+      expect(android.body.fontSize, 17);
+      expect(android.body.height, 1.29);
     });
   });
 }


### PR DESCRIPTION
## Summary

- expand the empty composer into a symmetric two-tier layout on focus while keeping the unfocused state compact and only showing explicitly selected quick pills
- move secondary composer actions inside the shell, use plain plus and note actions, apply themed iOS cursor and selection colors, and keep scroll-to-latest available above the expanded composer
- unify product and Markdown typography across Android and iOS while preserving explicit Material and Cupertino navigation chrome ramps

## Testing

- flutter analyze
- flutter test --reporter compact (4,950 passed, 4 skipped)

## Manual verification

- Pending maintainer device check on Android and iOS

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - Refined the chat composer UI with updated compact/expanded sizing, spacing, and quick-pill behavior.
  - Improved composer focus behavior for more consistent expanded layout.
  - Updated the “scroll to latest” button so it only appears when there’s relevant chat content to show.
  - Standardized typography across profiles, settings, chat, and navigation sidebar labels.
  - Refined theme selection and cursor styling for more consistent platform rendering.
  - Made markdown paragraph spacing consistent across platforms.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Unify cross-platform typography and polish chat composer layout
> - Separates product typography from platform chrome in [`AppTypography`](https://github.com/cogwheel0/conduit/pull/598/files#diff-fbed6a99b4f4c4ad51e798f62ddde03dd73d470a27734c16ecff0d6c0012a595): product hierarchy is now identical on Android and iOS, while Material and Cupertino nav chrome use their own native ramps.
> - Removes all `usesAppleRamp` branching in profile, settings, and markdown styles, replacing platform-conditional font selection with a single unified scale.
> - Reworks the chat composer in [`modern_chat_input.dart`](https://github.com/cogwheel0/conduit/pull/598/files#diff-c6dc1bffeaea79facaf47a17818417883c068df43c545c18e8c48e8ce7a1ce63): introduces a two-tier layout on focus (even without quick pills), standardizes horizontal insets to 8px and control sizes to 36px, and renders secondary action buttons as plain icon buttons.
> - Scroll-to-bottom button visibility in [`chat_page.dart`](https://github.com/cogwheel0/conduit/pull/598/files#diff-84403526b0e1de6a48ac9f2c5ba0a7c0d9ebe6626d63e1494d6f4f1fc629d109) no longer factors in keyboard state; a new `debugShouldRenderScrollToLatestForTesting` predicate captures the simplified logic.
> - Text selection cursor and highlight colors now follow the active theme accent on all platforms.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8f16637.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR standardizes cross-platform typography and refines the chat composer.
- Uses a shared product typography hierarchy while preserving explicit Material and Cupertino navigation ramps.
- Updates the Material bottom-navigation label to use the dedicated Material chrome style.
- Expands the focused composer into a two-tier layout, keeps secondary actions inside its shell, and preserves scroll-to-latest access.
- Unifies text-selection colors and Markdown paragraph spacing across platforms.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- The pre-PR baseline runtime was recorded in chat-composer-runtime-01-before.log to document the state before the patch c59da6e.
- The PR-head runtime was recorded in chat-composer-runtime-02-after.log for the patch at 8f16637.
- A concrete runtime blocker is the missing Flutter SDK, which prevents verification of unfocused, focused, and scroll-to-latest visual behavior.

<a href="https://app.greptile.com/trex/runs/16347333/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| lib/features/navigation/widgets/sidebar_page.dart | The Material bottom-navigation label now uses the explicit Material chrome typography getter, resolving the previous review finding. |
| lib/shared/theme/theme_extensions.dart | Product typography now uses one cross-platform scale while platform-specific control metrics and native chrome ramps remain explicit. |
| lib/shared/theme/app_theme.dart | Material and Cupertino navigation themes are wired to their respective chrome ramps, with unified themed text-selection colors. |
| lib/features/chat/widgets/modern_chat_input.dart | Composer focus state now controls compact versus two-tier presentation, with symmetric insets and plain secondary actions. |
| lib/features/chat/views/chat_page.dart | Scroll-to-latest eligibility no longer depends on keyboard visibility and remains gated by scrollable message content. |
| lib/shared/widgets/markdown/renderer/markdown_style.dart | Markdown uses the shared product hierarchy and fixed token-based paragraph spacing on every platform. |

</details>

<sub>Reviews (2): Last reviewed commit: ["Address automated review feedback"](https://github.com/cogwheel0/conduit/commit/8f16637b2972d85cb323afddb3848617f959c409) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48220416)</sub>

<!-- /greptile_comment -->