### PR TITLE
Enable inline interactive HTML tool embeds

### DIFF
--- a/lib/features/chat/widgets/chat_timeline_viewport.dart
+++ b/lib/features/chat/widgets/chat_timeline_viewport.dart
@@ -3,7 +3,8 @@ import 'dart:math' as math;
 
 import 'package:flutter/foundation.dart' show listEquals, visibleForTesting;
 import 'package:flutter/material.dart';
-import 'package:flutter/rendering.dart' show ScrollCacheExtent, ScrollDirection;
+import 'package:flutter/rendering.dart'
+    show RenderBox, RenderObject, ScrollCacheExtent, ScrollDirection;
 
 import '../../../core/database/models/chat_transcript_window.dart';
 import '../../../core/utils/debug_logger.dart';
@@ -350,6 +351,8 @@ class _ChatTimelineViewportState extends State<ChatTimelineViewport>
   int? _cachedRowRectFrameStamp;
   int _rowRectFrameStamp = 0;
   bool _rowRectSnapshotInvalidationScheduled = false;
+  bool _geometryUnavailable = false;
+  bool _geometryRecoveryCallbackScheduled = false;
 
   late List<({String id, int sourceIndex})> _timelineEntries;
   late List<String> _messageIds;
@@ -423,7 +426,11 @@ class _ChatTimelineViewportState extends State<ChatTimelineViewport>
         (_freeAnchor == null || _rowRect(_freeAnchor!.messageId) == null)) {
       // Capture before the new child configuration is laid out. This is the
       // exact screen coordinate that insertions and size changes must retain.
-      _freeAnchor = _captureVisibleMaintenanceAnchor();
+      final capturedAnchor = _captureVisibleMaintenanceAnchor();
+      // A route transition can temporarily detach the row or insert an
+      // unlaid-out transform above it. Keep the last valid anchor until a
+      // complete render tree is measurable again.
+      if (capturedAnchor != null) _freeAnchor = capturedAnchor;
     }
     if (messageIdsChanged) {
       _syncTimelineEntries();
@@ -644,9 +651,52 @@ class _ChatTimelineViewportState extends State<ChatTimelineViewport>
 
   Rect? _globalRectFor(GlobalKey key) {
     final box = _renderBoxFor(key);
-    if (box == null) return null;
+    if (box == null || !_hasUsableGlobalTransform(box)) return null;
     final topLeft = box.localToGlobal(Offset.zero);
-    return topLeft & box.size;
+    if (!topLeft.isFinite) return null;
+    final rect = topLeft & box.size;
+    return rect.isFinite ? rect : null;
+  }
+
+  bool _hasUsableGlobalTransform(RenderBox box) {
+    final owner = box.owner;
+    if (!box.attached || owner == null || owner.rootNode == null) return false;
+
+    RenderObject? current = box;
+    while (current != null) {
+      if (!current.attached || !identical(current.owner, owner)) return false;
+      if (current is RenderBox && !current.hasSize) return false;
+      if (identical(current, owner.rootNode)) return true;
+      final parent = current.parent;
+      if (parent is! RenderObject) return false;
+      current = parent;
+    }
+    return false;
+  }
+
+  bool _hasUsableViewportGeometry() {
+    if (_viewportRect != null) return true;
+    _geometryUnavailable = true;
+    _scheduleGeometryRecoveryCallback();
+    return false;
+  }
+
+  void _scheduleGeometryRecoveryCallback() {
+    if (_geometryRecoveryCallbackScheduled) return;
+    _geometryRecoveryCallbackScheduled = true;
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      _geometryRecoveryCallbackScheduled = false;
+      if (!mounted || !_geometryUnavailable) return;
+      if (_viewportRect == null) {
+        // Observe the next naturally scheduled frame without forcing frames
+        // while this state is detached or covered by another route.
+        _scheduleGeometryRecoveryCallback();
+        return;
+      }
+      _geometryUnavailable = false;
+      _scheduleMetricsCallback();
+      _scheduleLayoutMaintenance();
+    });
   }
 
   Rect? _rowRect(String messageId) {
@@ -862,6 +912,7 @@ class _ChatTimelineViewportState extends State<ChatTimelineViewport>
     binding.addPostFrameCallback((_) {
       _metricsCallbackScheduled = false;
       if (!mounted) return;
+      if (!_hasUsableViewportGeometry()) return;
       final metrics = _currentMetrics(_frameRowRectSnapshot());
       if (metrics == null) return;
       _metricsSnapshot = metrics;
@@ -879,6 +930,9 @@ class _ChatTimelineViewportState extends State<ChatTimelineViewport>
     binding.addPostFrameCallback((_) {
       _layoutMaintenanceScheduled = false;
       if (!mounted || !_scrollController.hasClients) return;
+      // A route transition can leave this mounted state between render trees.
+      // Do not turn that transient measurement outage into empty geometry.
+      if (!_hasUsableViewportGeometry()) return;
       if (!_initialPositionResolved && _messageIds.isNotEmpty) {
         // Re-arm asynchronous transcript settlement even when the parent
         // republishes an identity-equal message-ID list after the empty or

--- a/lib/features/chat/widgets/model_selector_sheet.dart
+++ b/lib/features/chat/widgets/model_selector_sheet.dart
@@ -18,6 +18,7 @@ import '../../../shared/widgets/modal_safe_area.dart';
 import '../../../shared/widgets/model_list_tile.dart';
 import '../../../shared/widgets/sheet_handle.dart';
 import '../../../shared/widgets/themed_dialogs.dart';
+import '../../../shared/widgets/themed_sheets.dart';
 import '../../direct_connections/models/direct_connection_profile.dart';
 import '../../direct_connections/providers/direct_connection_providers.dart';
 import '../../direct_connections/services/direct_model_registry.dart';
@@ -308,19 +309,20 @@ class _SelectorHeader extends StatelessWidget {
         ),
         Align(
           alignment: Alignment.centerLeft,
-          child: IconButton(
-            onPressed: onPressed,
-            tooltip: isBack
-                ? MaterialLocalizations.of(context).backButtonTooltip
-                : MaterialLocalizations.of(context).closeButtonTooltip,
-            icon: Icon(
-              isBack
-                  ? (Platform.isIOS
+          child: isBack
+              ? IconButton(
+                  onPressed: onPressed,
+                  tooltip: MaterialLocalizations.of(context).backButtonTooltip,
+                  icon: Icon(
+                    Platform.isIOS
                         ? CupertinoIcons.back
-                        : Icons.arrow_back_rounded)
-                  : (Platform.isIOS ? CupertinoIcons.xmark : Icons.close),
-            ),
-          ),
+                        : Icons.arrow_back_rounded,
+                  ),
+                )
+              : SheetCloseButton(
+                  onPressed: onPressed,
+                  tooltip: MaterialLocalizations.of(context).closeButtonTooltip,
+                ),
         ),
       ],
     ),

--- a/lib/features/chat/widgets/modern_chat_input.dart
+++ b/lib/features/chat/widgets/modern_chat_input.dart
@@ -263,6 +263,15 @@ class ModernChatInput extends ConsumerStatefulWidget {
   static TextStyle debugComposerInputTextStyle({required bool isRecording}) =>
       _composerInputTextStyle(isRecording);
 
+  @visibleForTesting
+  static double debugOverflowIconSize({
+    required bool isAndroid,
+    required bool attachmentPanelVisible,
+  }) => _overflowIconSize(
+    isAndroid: isAndroid,
+    attachmentPanelVisible: attachmentPanelVisible,
+  );
+
   @override
   ConsumerState<ModernChatInput> createState() => _ModernChatInputState();
 }
@@ -274,6 +283,15 @@ TextStyle _composerInputTextStyle(bool isRecording) =>
       fontWeight: isRecording ? FontWeight.w500 : FontWeight.w400,
       fontStyle: isRecording ? FontStyle.italic : FontStyle.normal,
     );
+
+const double _androidOverflowAddIconSize = 28;
+
+double _overflowIconSize({
+  required bool isAndroid,
+  required bool attachmentPanelVisible,
+}) => isAndroid && !attachmentPanelVisible
+    ? _androidOverflowAddIconSize
+    : IconSize.large;
 
 typedef _ComposerTypography = ({
   ui.TextDirection direction,
@@ -308,7 +326,6 @@ class _ModernChatInputState extends ConsumerState<ModernChatInput>
   static const double _composerRadius = AppBorderRadius.card;
   static const double _composerHorizontalInset = Spacing.sm;
   static const double _composerControlSize = 36;
-  static const double _androidOverflowAddIconSize = 28;
   static int _nextGeneratedInsertionTargetId = 0;
 
   final MentionTextEditingController _controller =
@@ -3560,9 +3577,10 @@ class _ModernChatInputState extends ConsumerState<ModernChatInput>
     // glyph. Compensate optically without changing the shared touch target.
     final iconSize = conduitScaledIconExtent(
       context,
-      !Platform.isIOS && !attachmentPanelVisible
-          ? _androidOverflowAddIconSize
-          : IconSize.large,
+      _overflowIconSize(
+        isAndroid: Platform.isAndroid,
+        attachmentPanelVisible: attachmentPanelVisible,
+      ),
     );
 
     return Focus(

--- a/lib/features/chat/widgets/modern_chat_input.dart
+++ b/lib/features/chat/widgets/modern_chat_input.dart
@@ -265,6 +265,29 @@ class ModernChatInput extends ConsumerStatefulWidget {
 
 // (Removed legacy _MicButton; inline mic logic now lives in primary button)
 
+typedef _ComposerTypography = ({
+  ui.TextDirection direction,
+  TextScaler textScaler,
+  Locale? locale,
+  TextStyle style,
+  double scaledFontSize,
+  bool isRtl,
+});
+
+typedef _ComposerLayoutMetrics = ({
+  double width,
+  double scaledFontSize,
+  bool isRtl,
+  Locale? locale,
+  bool isRecording,
+});
+
+typedef _ComposerLineMeasurement = ({
+  String text,
+  _ComposerLayoutMetrics layout,
+  bool isMultiline,
+});
+
 class _ModernChatInputState extends ConsumerState<ModernChatInput>
     with TickerProviderStateMixin {
   static const Duration _contextSuggestionDelay = Duration(milliseconds: 250);
@@ -289,33 +312,10 @@ class _ModernChatInputState extends ConsumerState<ModernChatInput>
   /// remount the TextField, losing focus and keyboard state.
   final GlobalKey _textFieldKey = GlobalKey();
   double _compactTextFieldWidth = 0;
-  ({
-    double width,
-    double scaledFontSize,
-    bool isRtl,
-    Locale? locale,
-    bool isRecording,
-  })?
-  _composerLayoutMetrics;
-  ({
-    double width,
-    double scaledFontSize,
-    bool isRtl,
-    Locale? locale,
-    bool isRecording,
-  })?
-  _pendingComposerLayoutMetrics;
+  _ComposerLayoutMetrics? _composerLayoutMetrics;
+  _ComposerLayoutMetrics? _pendingComposerLayoutMetrics;
   bool _composerLayoutMeasurementScheduled = false;
-  ({
-    String text,
-    double width,
-    double scaledFontSize,
-    bool isRtl,
-    Locale? locale,
-    bool isRecording,
-    bool isMultiline,
-  })?
-  _composerLineMeasurement;
+  _ComposerLineMeasurement? _composerLineMeasurement;
   bool _pendingFocus = false;
   bool _isRecording = false;
   bool _hasText = false; // track locally without rebuilding on each keystroke
@@ -888,23 +888,38 @@ class _ModernChatInputState extends ConsumerState<ModernChatInput>
 
   static final RegExp _promptCommandBoundary = RegExp(r'\s');
 
-  void _scheduleComposerLineMeasurement(
-    BuildContext context,
-    double compactTextFieldWidth,
-  ) {
-    if (!compactTextFieldWidth.isFinite || compactTextFieldWidth <= 0) return;
-
+  _ComposerTypography _composerTypography(BuildContext context) {
     final direction = Directionality.of(context);
     final textScaler = MediaQuery.textScalerOf(context);
     final locale = Localizations.maybeLocaleOf(context);
     final style = AppTypography.chatMessageStyle.copyWith(
       fontWeight: _isRecording ? FontWeight.w500 : FontWeight.w400,
     );
-    final metrics = (
-      width: compactTextFieldWidth,
+    return (
+      direction: direction,
+      textScaler: textScaler,
+      locale: locale,
+      style: style,
       scaledFontSize: textScaler.scale(style.fontSize ?? 14),
       isRtl: direction == ui.TextDirection.rtl,
-      locale: locale,
+    );
+  }
+
+  bool _shouldShowComposerExpandButton(String text, bool isMultiline) =>
+      isMultiline && (text.split('\n').length >= 4 || text.length > 160);
+
+  void _scheduleComposerLineMeasurement(
+    BuildContext context,
+    double compactTextFieldWidth,
+  ) {
+    if (!compactTextFieldWidth.isFinite || compactTextFieldWidth <= 0) return;
+
+    final typography = _composerTypography(context);
+    final metrics = (
+      width: compactTextFieldWidth,
+      scaledFontSize: typography.scaledFontSize,
+      isRtl: typography.isRtl,
+      locale: typography.locale,
       isRecording: _isRecording,
     );
     if (metrics == _composerLayoutMetrics &&
@@ -930,8 +945,7 @@ class _ModernChatInputState extends ConsumerState<ModernChatInput>
   void _recomputeComposerLineState() {
     final text = _controller.text;
     final isMultiline = _composerTextUsesMultipleLines(text);
-    final showExpand =
-        isMultiline && (text.split('\n').length >= 4 || text.length > 160);
+    final showExpand = _shouldShowComposerExpandButton(text, isMultiline);
     if (isMultiline == _isMultiline && showExpand == _showExpandButton) {
       return;
     }
@@ -946,30 +960,24 @@ class _ModernChatInputState extends ConsumerState<ModernChatInput>
     if (text.contains('\n')) return true;
     if (text.isEmpty || _compactTextFieldWidth <= 0) return false;
 
-    final direction = Directionality.of(context);
-    final textScaler = MediaQuery.textScalerOf(context);
-    final locale = Localizations.maybeLocaleOf(context);
-    final isRtl = direction == ui.TextDirection.rtl;
-    final style = AppTypography.chatMessageStyle.copyWith(
-      fontWeight: _isRecording ? FontWeight.w500 : FontWeight.w400,
+    final typography = _composerTypography(context);
+    final layout = (
+      width: _compactTextFieldWidth,
+      scaledFontSize: typography.scaledFontSize,
+      isRtl: typography.isRtl,
+      locale: typography.locale,
+      isRecording: _isRecording,
     );
-    final scaledFontSize = textScaler.scale(style.fontSize ?? 14);
     final cached = _composerLineMeasurement;
-    if (cached != null &&
-        cached.text == text &&
-        cached.width == _compactTextFieldWidth &&
-        cached.scaledFontSize == scaledFontSize &&
-        cached.isRtl == isRtl &&
-        cached.locale == locale &&
-        cached.isRecording == _isRecording) {
+    if (cached != null && cached.text == text && cached.layout == layout) {
       return cached.isMultiline;
     }
 
     final painter = TextPainter(
-      text: TextSpan(text: text, style: style),
-      textDirection: direction,
-      textScaler: textScaler,
-      locale: locale,
+      text: TextSpan(text: text, style: typography.style),
+      textDirection: typography.direction,
+      textScaler: typography.textScaler,
+      locale: typography.locale,
       maxLines: 2,
     )..layout(maxWidth: _compactTextFieldWidth);
 
@@ -977,11 +985,7 @@ class _ModernChatInputState extends ConsumerState<ModernChatInput>
         painter.didExceedMaxLines || painter.computeLineMetrics().length > 1;
     _composerLineMeasurement = (
       text: text,
-      width: _compactTextFieldWidth,
-      scaledFontSize: scaledFontSize,
-      isRtl: isRtl,
-      locale: locale,
-      isRecording: _isRecording,
+      layout: layout,
       isMultiline: isMultiline,
     );
     return isMultiline;
@@ -997,8 +1001,7 @@ class _ModernChatInputState extends ConsumerState<ModernChatInput>
     final bool isMultiline = _composerTextUsesMultipleLines(text);
     // Show the expand button when content is tall enough
     // (~4 lines: 3+ explicit newlines or ~160 wrapped chars).
-    final bool showExpand =
-        isMultiline && (text.split('\n').length >= 4 || text.length > 160);
+    final bool showExpand = _shouldShowComposerExpandButton(text, isMultiline);
     final PromptCommandMatch? match = _resolvePromptCommand(
       text,
       selection,

--- a/lib/features/chat/widgets/modern_chat_input.dart
+++ b/lib/features/chat/widgets/modern_chat_input.dart
@@ -1015,16 +1015,20 @@ class _ModernChatInputState extends ConsumerState<ModernChatInput>
       textScaler: typography.textScaler,
       locale: typography.locale,
       maxLines: 2,
-    )..layout(maxWidth: _compactTextFieldWidth);
-
-    final isMultiline =
-        painter.didExceedMaxLines || painter.computeLineMetrics().length > 1;
-    _composerLineMeasurement = (
-      text: text,
-      layout: layout,
-      isMultiline: isMultiline,
     );
-    return isMultiline;
+    try {
+      painter.layout(maxWidth: _compactTextFieldWidth);
+      final isMultiline =
+          painter.didExceedMaxLines || painter.computeLineMetrics().length > 1;
+      _composerLineMeasurement = (
+        text: text,
+        layout: layout,
+        isMultiline: isMultiline,
+      );
+      return isMultiline;
+    } finally {
+      painter.dispose();
+    }
   }
 
   void _handleComposerChanged() {

--- a/lib/features/chat/widgets/modern_chat_input.dart
+++ b/lib/features/chat/widgets/modern_chat_input.dart
@@ -1,6 +1,6 @@
 import 'package:adaptive_platform_ui/adaptive_platform_ui.dart';
 import 'package:dio/dio.dart';
-import 'package:flutter/foundation.dart' show kIsWeb;
+import 'package:flutter/foundation.dart' show kIsWeb, visibleForTesting;
 import 'package:flutter/material.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/scheduler.dart';
@@ -259,11 +259,21 @@ class ModernChatInput extends ConsumerStatefulWidget {
     this.composerTextInsertionTargetId,
   });
 
+  @visibleForTesting
+  static TextStyle debugComposerInputTextStyle({required bool isRecording}) =>
+      _composerInputTextStyle(isRecording);
+
   @override
   ConsumerState<ModernChatInput> createState() => _ModernChatInputState();
 }
 
 // (Removed legacy _MicButton; inline mic logic now lives in primary button)
+
+TextStyle _composerInputTextStyle(bool isRecording) =>
+    AppTypography.chatMessageStyle.copyWith(
+      fontWeight: isRecording ? FontWeight.w500 : FontWeight.w400,
+      fontStyle: isRecording ? FontStyle.italic : FontStyle.normal,
+    );
 
 typedef _ComposerTypography = ({
   ui.TextDirection direction,
@@ -287,6 +297,8 @@ typedef _ComposerLineMeasurement = ({
   _ComposerLayoutMetrics layout,
   bool isMultiline,
 });
+
+typedef _CompactComposerControls = ({bool showLeading, bool showMic});
 
 class _ModernChatInputState extends ConsumerState<ModernChatInput>
     with TickerProviderStateMixin {
@@ -892,9 +904,7 @@ class _ModernChatInputState extends ConsumerState<ModernChatInput>
     final direction = Directionality.of(context);
     final textScaler = MediaQuery.textScalerOf(context);
     final locale = Localizations.maybeLocaleOf(context);
-    final style = AppTypography.chatMessageStyle.copyWith(
-      fontWeight: _isRecording ? FontWeight.w500 : FontWeight.w400,
-    );
+    final style = _composerInputTextStyle(_isRecording);
     return (
       direction: direction,
       textScaler: textScaler,
@@ -907,6 +917,15 @@ class _ModernChatInputState extends ConsumerState<ModernChatInput>
 
   bool _shouldShowComposerExpandButton(String text, bool isMultiline) =>
       isMultiline && (text.split('\n').length >= 4 || text.length > 160);
+
+  _CompactComposerControls _compactComposerControls({
+    required bool showOverflowButton,
+    required bool voiceAvailable,
+    required bool isGenerating,
+  }) => (
+    showLeading: _isRecording || showOverflowButton,
+    showMic: !_isRecording && !_hasText && voiceAvailable && !isGenerating,
+  );
 
   void _scheduleComposerLineMeasurement(
     BuildContext context,
@@ -2665,6 +2684,11 @@ class _ModernChatInputState extends ConsumerState<ModernChatInput>
           attachmentAvailability.photo ||
           attachmentAvailability.camera,
     );
+    final compactControls = _compactComposerControls(
+      showOverflowButton: showOverflowButton,
+      voiceAvailable: voiceAvailable,
+      isGenerating: isGenerating,
+    );
     if (_isFallbackAttachmentPanelVisible && !showOverflowButton) {
       WidgetsBinding.instance.addPostFrameCallback((_) {
         if (mounted && !_isDeactivated) {
@@ -2989,7 +3013,7 @@ class _ModernChatInputState extends ConsumerState<ModernChatInput>
                 if (_isRecording) ...[
                   _buildDictationStopButton(size: _composerControlSize),
                   const SizedBox(width: Spacing.xs),
-                ] else if (showOverflowButton) ...[
+                ] else if (compactControls.showLeading) ...[
                   _buildOverflowButton(
                     tooltip: l10n.more,
                     dense: true,
@@ -3012,10 +3036,7 @@ class _ModernChatInputState extends ConsumerState<ModernChatInput>
                     isActive: isActive,
                   ),
                 ),
-                if (!_isRecording &&
-                    !_hasText &&
-                    voiceAvailable &&
-                    !isGenerating) ...[
+                if (compactControls.showMic) ...[
                   const SizedBox(width: Spacing.xs),
                   Platform.isAndroid
                       ? Transform.translate(
@@ -3095,9 +3116,7 @@ class _ModernChatInputState extends ConsumerState<ModernChatInput>
         ),
       );
       return _wrapWithComposerLineMeasurement(
-        showOverflowButton: showOverflowButton,
-        voiceAvailable: voiceAvailable,
-        isGenerating: isGenerating,
+        compactControls: compactControls,
         child: _wrapWithFallbackAttachmentPanel(
           composer: composer,
           localAttachmentsOnly: isHermesComposer,
@@ -3147,9 +3166,7 @@ class _ModernChatInputState extends ConsumerState<ModernChatInput>
       child: shell,
     );
     return _wrapWithComposerLineMeasurement(
-      showOverflowButton: showOverflowButton,
-      voiceAvailable: voiceAvailable,
-      isGenerating: isGenerating,
+      compactControls: compactControls,
       child: _wrapWithFallbackAttachmentPanel(
         composer: composer,
         localAttachmentsOnly: isHermesComposer,
@@ -3160,9 +3177,7 @@ class _ModernChatInputState extends ConsumerState<ModernChatInput>
 
   Widget _wrapWithComposerLineMeasurement({
     required Widget child,
-    required bool showOverflowButton,
-    required bool voiceAvailable,
-    required bool isGenerating,
+    required _CompactComposerControls compactControls,
   }) {
     return LayoutBuilder(
       builder: (context, constraints) {
@@ -3171,10 +3186,10 @@ class _ModernChatInputState extends ConsumerState<ModernChatInput>
           baseExtent: _composerControlSize,
         );
         var reservedWidth = controlSize + Spacing.xs;
-        if (_isRecording || showOverflowButton) {
+        if (compactControls.showLeading) {
           reservedWidth += controlSize + Spacing.xs;
         }
-        if (!_isRecording && !_hasText && voiceAvailable && !isGenerating) {
+        if (compactControls.showMic) {
           reservedWidth += controlSize + Spacing.xs;
         }
         final compactTextFieldWidth =
@@ -3391,10 +3406,9 @@ class _ModernChatInputState extends ConsumerState<ModernChatInput>
                 factor,
               )!;
 
-              final FontWeight recordingWeight = _isRecording
-                  ? FontWeight.w500
-                  : FontWeight.w400;
-              final TextStyle baseChatStyle = AppTypography.chatMessageStyle;
+              final TextStyle baseChatStyle = _composerInputTextStyle(
+                _isRecording,
+              );
               final inputPlaceholder = _isRecording
                   ? AppLocalizations.of(context)!.recordingAudio
                   : widget.placeholder ??
@@ -3413,10 +3427,6 @@ class _ModernChatInputState extends ConsumerState<ModernChatInput>
                   placeholder: inputPlaceholder,
                   placeholderStyle: baseChatStyle.copyWith(
                     color: animatedPlaceholder,
-                    fontWeight: recordingWeight,
-                    fontStyle: _isRecording
-                        ? FontStyle.italic
-                        : FontStyle.normal,
                   ),
                   enabled: widget.enabled,
                   autofocus: false,
@@ -3431,13 +3441,7 @@ class _ModernChatInputState extends ConsumerState<ModernChatInput>
                   cursorColor: Theme.of(context).textSelectionTheme.cursorColor,
                   scrollPadding: const EdgeInsets.only(bottom: 80),
                   keyboardAppearance: brightness,
-                  style: baseChatStyle.copyWith(
-                    color: animatedTextColor,
-                    fontStyle: _isRecording
-                        ? FontStyle.italic
-                        : FontStyle.normal,
-                    fontWeight: recordingWeight,
-                  ),
+                  style: baseChatStyle.copyWith(color: animatedTextColor),
                   contentInsertionConfiguration: _selectedModelAcceptsImageInput
                       ? ContentInsertionConfiguration(
                           allowedMimeTypes: ClipboardAttachmentService
@@ -3478,20 +3482,12 @@ class _ModernChatInputState extends ConsumerState<ModernChatInput>
                 showCursor: true,
                 scrollPadding: const EdgeInsets.only(bottom: 80),
                 keyboardAppearance: brightness,
-                style: baseChatStyle.copyWith(
-                  color: animatedTextColor,
-                  fontStyle: _isRecording ? FontStyle.italic : FontStyle.normal,
-                  fontWeight: recordingWeight,
-                ),
+                style: baseChatStyle.copyWith(color: animatedTextColor),
                 decoration: context.conduitInputStyles
                     .borderless(hint: inputPlaceholder)
                     .copyWith(
                       hintStyle: baseChatStyle.copyWith(
                         color: animatedPlaceholder,
-                        fontWeight: recordingWeight,
-                        fontStyle: _isRecording
-                            ? FontStyle.italic
-                            : FontStyle.normal,
                       ),
                       contentPadding: contentPadding,
                       isDense: true,

--- a/lib/features/chat/widgets/modern_chat_input.dart
+++ b/lib/features/chat/widgets/modern_chat_input.dart
@@ -15,6 +15,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'dart:io' show Platform;
 import 'dart:async';
 import 'dart:math' as math;
+import 'dart:ui' as ui;
 import '../providers/chat_providers.dart';
 import '../services/clipboard_attachment_service.dart';
 import '../services/file_attachment_service.dart';
@@ -272,6 +273,7 @@ class _ModernChatInputState extends ConsumerState<ModernChatInput>
   static const double _composerRadius = AppBorderRadius.card;
   static const double _composerHorizontalInset = Spacing.sm;
   static const double _composerControlSize = 36;
+  static const double _androidOverflowAddIconSize = 28;
   static int _nextGeneratedInsertionTargetId = 0;
 
   final MentionTextEditingController _controller =
@@ -286,6 +288,18 @@ class _ModernChatInputState extends ConsumerState<ModernChatInput>
   /// Without this, different parent ValueKeys cause Flutter to unmount and
   /// remount the TextField, losing focus and keyboard state.
   final GlobalKey _textFieldKey = GlobalKey();
+  final GlobalKey _compactTextFieldMeasureKey = GlobalKey();
+  double _compactTextFieldWidth = 0;
+  ({
+    String text,
+    double width,
+    double scaledFontSize,
+    bool isRtl,
+    Locale? locale,
+    bool isRecording,
+    bool isMultiline,
+  })?
+  _composerLineMeasurement;
   bool _pendingFocus = false;
   bool _isRecording = false;
   bool _hasText = false; // track locally without rebuilding on each keystroke
@@ -858,6 +872,62 @@ class _ModernChatInputState extends ConsumerState<ModernChatInput>
 
   static final RegExp _promptCommandBoundary = RegExp(r'\s');
 
+  void _captureCompactTextFieldWidth() {
+    final renderObject = _compactTextFieldMeasureKey.currentContext
+        ?.findRenderObject();
+    if (renderObject is! RenderBox || !renderObject.hasSize) return;
+
+    final width = renderObject.size.width;
+    if (width.isFinite && width > 0) {
+      _compactTextFieldWidth = width;
+    }
+  }
+
+  bool _composerTextUsesMultipleLines(String text) {
+    if (text.contains('\n')) return true;
+    if (text.isEmpty || _compactTextFieldWidth <= 0) return false;
+
+    final direction = Directionality.of(context);
+    final textScaler = MediaQuery.textScalerOf(context);
+    final locale = Localizations.maybeLocaleOf(context);
+    final isRtl = direction == ui.TextDirection.rtl;
+    final style = AppTypography.chatMessageStyle.copyWith(
+      fontWeight: _isRecording ? FontWeight.w500 : FontWeight.w400,
+    );
+    final scaledFontSize = textScaler.scale(style.fontSize ?? 14);
+    final cached = _composerLineMeasurement;
+    if (cached != null &&
+        cached.text == text &&
+        cached.width == _compactTextFieldWidth &&
+        cached.scaledFontSize == scaledFontSize &&
+        cached.isRtl == isRtl &&
+        cached.locale == locale &&
+        cached.isRecording == _isRecording) {
+      return cached.isMultiline;
+    }
+
+    final painter = TextPainter(
+      text: TextSpan(text: text, style: style),
+      textDirection: direction,
+      textScaler: textScaler,
+      locale: locale,
+      maxLines: 2,
+    )..layout(maxWidth: _compactTextFieldWidth);
+
+    final isMultiline =
+        painter.didExceedMaxLines || painter.computeLineMetrics().length > 1;
+    _composerLineMeasurement = (
+      text: text,
+      width: _compactTextFieldWidth,
+      scaledFontSize: scaledFontSize,
+      isRtl: isRtl,
+      locale: locale,
+      isRecording: _isRecording,
+      isMultiline: isMultiline,
+    );
+    return isMultiline;
+  }
+
   void _handleComposerChanged() {
     if (!mounted || _isDeactivated) return;
     _lastEditTime = DateTime.now();
@@ -865,8 +935,8 @@ class _ModernChatInputState extends ConsumerState<ModernChatInput>
     final String text = _controller.text;
     final TextSelection selection = _controller.selection;
     final bool hasText = text.trim().isNotEmpty;
-    // Consider multiline if text contains newlines or exceeds ~50 chars
-    final bool isMultiline = text.contains('\n') || text.length > 50;
+    _captureCompactTextFieldWidth();
+    final bool isMultiline = _composerTextUsesMultipleLines(text);
     // Show the expand button when content is tall enough
     // (~4 lines: 3+ explicit newlines or ~160 wrapped chars).
     final bool showExpand =
@@ -2691,10 +2761,9 @@ class _ModernChatInputState extends ConsumerState<ModernChatInput>
       }
     }
 
-    // Focus adopts the existing two-tier quick-pill layout even when there
-    // are no selected pills. The resting empty state remains the compact row.
-    final bool showCompactComposer = quickPills.isEmpty && !hasComposerFocus;
-    final bool isCompactComposerExpanded = showCompactComposer && _isMultiline;
+    // Keep focused single-line input compact. Move to the two-tier shell only
+    // when the text becomes multiline or selected quick pills need a row.
+    final bool showCompactComposer = quickPills.isEmpty && !_isMultiline;
     final bool showCreateDraftNoteAction =
         !showCompactComposer &&
         notesEnabled &&
@@ -2702,11 +2771,7 @@ class _ModernChatInputState extends ConsumerState<ModernChatInput>
         !isGenerating &&
         !_isRecording;
 
-    // Keep the resting single-line composer as a capsule, then soften its
-    // corners when multiline content expands it.
-    final double compactRadius = isCompactComposerExpanded
-        ? AppBorderRadius.xl
-        : AppBorderRadius.round;
+    const double compactRadius = AppBorderRadius.round;
     const double expandedRadius = _composerRadius;
     final BorderRadius shellRadius = BorderRadius.circular(
       showCompactComposer ? compactRadius : expandedRadius,
@@ -2846,11 +2911,11 @@ class _ModernChatInputState extends ConsumerState<ModernChatInput>
     if (showCompactComposer) {
       final textFieldContent = Container(
         key: const ValueKey('compact-composer-content'),
-        padding: EdgeInsets.fromLTRB(
+        padding: const EdgeInsets.fromLTRB(
           _composerHorizontalInset,
           0,
           _composerHorizontalInset,
-          Platform.isIOS && isCompactComposerExpanded ? Spacing.sm : 0,
+          0,
         ),
         constraints: const BoxConstraints(minHeight: TouchTarget.input),
         alignment: Alignment.center,
@@ -2858,9 +2923,7 @@ class _ModernChatInputState extends ConsumerState<ModernChatInput>
           clipBehavior: Clip.none,
           children: [
             Row(
-              crossAxisAlignment: isCompactComposerExpanded
-                  ? CrossAxisAlignment.end
-                  : CrossAxisAlignment.center,
+              crossAxisAlignment: CrossAxisAlignment.center,
               children: [
                 if (_isRecording) ...[
                   _buildDictationStopButton(size: _composerControlSize),
@@ -2874,12 +2937,8 @@ class _ModernChatInputState extends ConsumerState<ModernChatInput>
                   const SizedBox(width: Spacing.xs),
                 ],
                 Expanded(
-                  child: Padding(
-                    padding: EdgeInsets.only(
-                      bottom: Platform.isAndroid && isCompactComposerExpanded
-                          ? Spacing.sm
-                          : 0,
-                    ),
+                  child: KeyedSubtree(
+                    key: _compactTextFieldMeasureKey,
                     child: _buildComposerTextField(
                       brightness: brightness,
                       sendOnEnter: sendOnEnter,
@@ -2918,7 +2977,7 @@ class _ModernChatInputState extends ConsumerState<ModernChatInput>
                           ),
                         ),
                 ],
-                SizedBox(width: Platform.isAndroid ? 0 : Spacing.xs),
+                const SizedBox(width: Spacing.xs),
                 _buildPrimaryButton(
                   _hasText,
                   isGenerating,
@@ -2951,7 +3010,7 @@ class _ModernChatInputState extends ConsumerState<ModernChatInput>
       final Widget textFieldShell = _buildComposerShell(
         key: const ValueKey('compact-composer-shell'),
         borderRadius: shellRadius,
-        useSmoothRectangleBorder: isCompactComposerExpanded,
+        useSmoothRectangleBorder: false,
         isRecording: _isRecording,
         child: textFieldContent,
       );
@@ -2984,7 +3043,7 @@ class _ModernChatInputState extends ConsumerState<ModernChatInput>
       );
     }
 
-    // Focused and quick-pill states use the full two-tier shell.
+    // Multiline and quick-pill states use the full two-tier shell.
     final shellContent = ConstrainedBox(
       constraints: BoxConstraints(
         maxHeight: MediaQuery.of(context).size.height * 0.4,
@@ -3379,8 +3438,6 @@ class _ModernChatInputState extends ConsumerState<ModernChatInput>
       context,
       baseExtent: dense ? _composerControlSize : TouchTarget.minimum,
     );
-    final iconSize = conduitScaledIconExtent(context, IconSize.large);
-
     // Let the parent supply a completely custom overflow button.
     if (widget.overflowButtonBuilder != null) {
       return widget.overflowButtonBuilder!(buttonSize);
@@ -3405,6 +3462,14 @@ class _ModernChatInputState extends ConsumerState<ModernChatInput>
     } else {
       overflowIcon = Platform.isIOS ? CupertinoIcons.add : Icons.add;
     }
+    // Material's add glyph occupies less of its nominal square than the mic
+    // glyph. Compensate optically without changing the shared touch target.
+    final iconSize = conduitScaledIconExtent(
+      context,
+      !Platform.isIOS && !attachmentPanelVisible
+          ? _androidOverflowAddIconSize
+          : IconSize.large,
+    );
 
     return Focus(
       key: const ValueKey('composer-overflow-button'),
@@ -3856,20 +3921,23 @@ class _ModernChatInputState extends ConsumerState<ModernChatInput>
               ? AdaptiveButtonStyle.prominentGlass
               : AdaptiveButtonStyle.glass);
 
-    return AdaptiveButton.child(
-      key: key,
-      onPressed: onPressed,
-      enabled: onPressed != null,
-      style: buttonStyle,
-      color: usesOpaqueFallback && androidShowBackground && !isProminent
-          ? androidBackgroundColor
-          : effectiveColor,
-      size: size > 40 ? AdaptiveButtonSize.large : AdaptiveButtonSize.medium,
-      minSize: Size(size, size),
-      padding: EdgeInsets.zero,
-      borderRadius: BorderRadius.circular(size),
-      useSmoothRectangleBorder: false,
-      child: child,
+    return SizedBox.square(
+      dimension: size,
+      child: AdaptiveButton.child(
+        key: key,
+        onPressed: onPressed,
+        enabled: onPressed != null,
+        style: buttonStyle,
+        color: usesOpaqueFallback && androidShowBackground && !isProminent
+            ? androidBackgroundColor
+            : effectiveColor,
+        size: size > 40 ? AdaptiveButtonSize.large : AdaptiveButtonSize.medium,
+        minSize: Size.square(size),
+        padding: EdgeInsets.zero,
+        borderRadius: BorderRadius.circular(size),
+        useSmoothRectangleBorder: false,
+        child: child,
+      ),
     );
   }
 

--- a/lib/features/chat/widgets/modern_chat_input.dart
+++ b/lib/features/chat/widgets/modern_chat_input.dart
@@ -288,8 +288,24 @@ class _ModernChatInputState extends ConsumerState<ModernChatInput>
   /// Without this, different parent ValueKeys cause Flutter to unmount and
   /// remount the TextField, losing focus and keyboard state.
   final GlobalKey _textFieldKey = GlobalKey();
-  final GlobalKey _compactTextFieldMeasureKey = GlobalKey();
   double _compactTextFieldWidth = 0;
+  ({
+    double width,
+    double scaledFontSize,
+    bool isRtl,
+    Locale? locale,
+    bool isRecording,
+  })?
+  _composerLayoutMetrics;
+  ({
+    double width,
+    double scaledFontSize,
+    bool isRtl,
+    Locale? locale,
+    bool isRecording,
+  })?
+  _pendingComposerLayoutMetrics;
+  bool _composerLayoutMeasurementScheduled = false;
   ({
     String text,
     double width,
@@ -872,15 +888,58 @@ class _ModernChatInputState extends ConsumerState<ModernChatInput>
 
   static final RegExp _promptCommandBoundary = RegExp(r'\s');
 
-  void _captureCompactTextFieldWidth() {
-    final renderObject = _compactTextFieldMeasureKey.currentContext
-        ?.findRenderObject();
-    if (renderObject is! RenderBox || !renderObject.hasSize) return;
+  void _scheduleComposerLineMeasurement(
+    BuildContext context,
+    double compactTextFieldWidth,
+  ) {
+    if (!compactTextFieldWidth.isFinite || compactTextFieldWidth <= 0) return;
 
-    final width = renderObject.size.width;
-    if (width.isFinite && width > 0) {
-      _compactTextFieldWidth = width;
+    final direction = Directionality.of(context);
+    final textScaler = MediaQuery.textScalerOf(context);
+    final locale = Localizations.maybeLocaleOf(context);
+    final style = AppTypography.chatMessageStyle.copyWith(
+      fontWeight: _isRecording ? FontWeight.w500 : FontWeight.w400,
+    );
+    final metrics = (
+      width: compactTextFieldWidth,
+      scaledFontSize: textScaler.scale(style.fontSize ?? 14),
+      isRtl: direction == ui.TextDirection.rtl,
+      locale: locale,
+      isRecording: _isRecording,
+    );
+    if (metrics == _composerLayoutMetrics &&
+        _pendingComposerLayoutMetrics == null) {
+      return;
     }
+
+    _pendingComposerLayoutMetrics = metrics;
+    if (_composerLayoutMeasurementScheduled) return;
+    _composerLayoutMeasurementScheduled = true;
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      _composerLayoutMeasurementScheduled = false;
+      final pendingMetrics = _pendingComposerLayoutMetrics;
+      _pendingComposerLayoutMetrics = null;
+      if (!mounted || _isDeactivated || pendingMetrics == null) return;
+
+      _composerLayoutMetrics = pendingMetrics;
+      _compactTextFieldWidth = pendingMetrics.width;
+      _recomputeComposerLineState();
+    });
+  }
+
+  void _recomputeComposerLineState() {
+    final text = _controller.text;
+    final isMultiline = _composerTextUsesMultipleLines(text);
+    final showExpand =
+        isMultiline && (text.split('\n').length >= 4 || text.length > 160);
+    if (isMultiline == _isMultiline && showExpand == _showExpandButton) {
+      return;
+    }
+
+    setState(() {
+      _isMultiline = isMultiline;
+      _showExpandButton = showExpand;
+    });
   }
 
   bool _composerTextUsesMultipleLines(String text) {
@@ -935,7 +994,6 @@ class _ModernChatInputState extends ConsumerState<ModernChatInput>
     final String text = _controller.text;
     final TextSelection selection = _controller.selection;
     final bool hasText = text.trim().isNotEmpty;
-    _captureCompactTextFieldWidth();
     final bool isMultiline = _composerTextUsesMultipleLines(text);
     // Show the expand button when content is tall enough
     // (~4 lines: 3+ explicit newlines or ~160 wrapped chars).
@@ -2937,21 +2995,18 @@ class _ModernChatInputState extends ConsumerState<ModernChatInput>
                   const SizedBox(width: Spacing.xs),
                 ],
                 Expanded(
-                  child: KeyedSubtree(
-                    key: _compactTextFieldMeasureKey,
-                    child: _buildComposerTextField(
-                      brightness: brightness,
-                      sendOnEnter: sendOnEnter,
-                      voiceAvailable: voiceAvailable,
-                      isGenerating: isGenerating,
-                      allUploadsComplete: allUploadsComplete,
-                      placeholderBase: placeholderBase,
-                      placeholderFocused: placeholderFocused,
-                      contentPadding: const EdgeInsets.symmetric(
-                        vertical: Spacing.xs,
-                      ),
-                      isActive: isActive,
+                  child: _buildComposerTextField(
+                    brightness: brightness,
+                    sendOnEnter: sendOnEnter,
+                    voiceAvailable: voiceAvailable,
+                    isGenerating: isGenerating,
+                    allUploadsComplete: allUploadsComplete,
+                    placeholderBase: placeholderBase,
+                    placeholderFocused: placeholderFocused,
+                    contentPadding: const EdgeInsets.symmetric(
+                      vertical: Spacing.xs,
                     ),
+                    isActive: isActive,
                   ),
                 ),
                 if (!_isRecording &&
@@ -3036,10 +3091,15 @@ class _ModernChatInputState extends ConsumerState<ModernChatInput>
           ],
         ),
       );
-      return _wrapWithFallbackAttachmentPanel(
-        composer: composer,
-        localAttachmentsOnly: isHermesComposer,
-        attachmentAvailability: attachmentAvailability,
+      return _wrapWithComposerLineMeasurement(
+        showOverflowButton: showOverflowButton,
+        voiceAvailable: voiceAvailable,
+        isGenerating: isGenerating,
+        child: _wrapWithFallbackAttachmentPanel(
+          composer: composer,
+          localAttachmentsOnly: isHermesComposer,
+          attachmentAvailability: attachmentAvailability,
+        ),
       );
     }
 
@@ -3083,10 +3143,45 @@ class _ModernChatInputState extends ConsumerState<ModernChatInput>
       ),
       child: shell,
     );
-    return _wrapWithFallbackAttachmentPanel(
-      composer: composer,
-      localAttachmentsOnly: isHermesComposer,
-      attachmentAvailability: attachmentAvailability,
+    return _wrapWithComposerLineMeasurement(
+      showOverflowButton: showOverflowButton,
+      voiceAvailable: voiceAvailable,
+      isGenerating: isGenerating,
+      child: _wrapWithFallbackAttachmentPanel(
+        composer: composer,
+        localAttachmentsOnly: isHermesComposer,
+        attachmentAvailability: attachmentAvailability,
+      ),
+    );
+  }
+
+  Widget _wrapWithComposerLineMeasurement({
+    required Widget child,
+    required bool showOverflowButton,
+    required bool voiceAvailable,
+    required bool isGenerating,
+  }) {
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        final controlSize = conduitScaledControlExtent(
+          context,
+          baseExtent: _composerControlSize,
+        );
+        var reservedWidth = controlSize + Spacing.xs;
+        if (_isRecording || showOverflowButton) {
+          reservedWidth += controlSize + Spacing.xs;
+        }
+        if (!_isRecording && !_hasText && voiceAvailable && !isGenerating) {
+          reservedWidth += controlSize + Spacing.xs;
+        }
+        final compactTextFieldWidth =
+            constraints.maxWidth -
+            (Spacing.screenPadding * 2) -
+            (_composerHorizontalInset * 2) -
+            reservedWidth;
+        _scheduleComposerLineMeasurement(context, compactTextFieldWidth);
+        return child;
+      },
     );
   }
 

--- a/lib/shared/widgets/markdown/renderer/details_block_widget.dart
+++ b/lib/shared/widgets/markdown/renderer/details_block_widget.dart
@@ -75,6 +75,8 @@ class _MarkdownDetailsBlockState extends State<MarkdownDetailsBlock> {
 
   bool get _deferHeavyContent => widget.deferHeavyContent;
 
+  bool get _canRenderToolCallEmbeds => !_deferHeavyContent && !_isPending;
+
   CompiledMarkdownToolCallData get _toolCallData {
     final data = _detailsData.toolCallData;
     if (data != null) {
@@ -125,7 +127,7 @@ class _MarkdownDetailsBlockState extends State<MarkdownDetailsBlock> {
   Widget build(BuildContext context) {
     final groupRenderMode = MarkdownDetailsGroupRenderScope.maybeOf(context);
     if (groupRenderMode == MarkdownDetailsGroupRenderMode.previewsOnly) {
-      if (_deferHeavyContent) {
+      if (!_canRenderToolCallEmbeds) {
         return const SizedBox.shrink();
       }
       final embeds = _buildToolCallEmbeds(context);
@@ -160,7 +162,7 @@ class _MarkdownDetailsBlockState extends State<MarkdownDetailsBlock> {
             ),
           ),
           if (inlineBody != null) _buildInlineBody(context, inlineBody),
-          if (groupRenderMode == null && !_deferHeavyContent)
+          if (groupRenderMode == null && _canRenderToolCallEmbeds)
             ..._buildToolCallEmbeds(context),
         ],
       ),

--- a/lib/shared/widgets/markdown/renderer/details_block_widget.dart
+++ b/lib/shared/widgets/markdown/renderer/details_block_widget.dart
@@ -9,6 +9,7 @@ import '../../web_content_embed.dart';
 import '../../../theme/theme_extensions.dart';
 import '../compiled_markdown_document.dart';
 import '../markdown_config.dart';
+import 'details_group_widget.dart';
 import 'markdown_style.dart';
 
 /// Builds markdown body content from the current [CompiledMarkdownDetailsData].
@@ -63,7 +64,14 @@ class _MarkdownDetailsBlockState extends State<MarkdownDetailsBlock> {
 
   bool get _usesInlineExpansion => _supportsInlineExpansion && _isPending;
 
-  bool get _canExpand => _detailsData.canExpand;
+  bool get _canExpand {
+    if (!_isToolCall) {
+      return _detailsData.canExpand;
+    }
+
+    final data = _toolCallData;
+    return data.hasExpandableContent || data.hasImages || _detailsData.hasBody;
+  }
 
   bool get _deferHeavyContent => widget.deferHeavyContent;
 
@@ -115,6 +123,20 @@ class _MarkdownDetailsBlockState extends State<MarkdownDetailsBlock> {
 
   @override
   Widget build(BuildContext context) {
+    final groupRenderMode = MarkdownDetailsGroupRenderScope.maybeOf(context);
+    if (groupRenderMode == MarkdownDetailsGroupRenderMode.previewsOnly) {
+      if (_deferHeavyContent) {
+        return const SizedBox.shrink();
+      }
+      final embeds = _buildToolCallEmbeds(context);
+      return embeds.isEmpty
+          ? const SizedBox.shrink()
+          : Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: embeds,
+            );
+    }
+
     final title = _headerTitle(context);
     final showInlineChevron = _usesInlineExpansion && _canExpand;
     final inlineBody = showInlineChevron && _isInlineExpanded
@@ -138,6 +160,8 @@ class _MarkdownDetailsBlockState extends State<MarkdownDetailsBlock> {
             ),
           ),
           if (inlineBody != null) _buildInlineBody(context, inlineBody),
+          if (groupRenderMode == null && !_deferHeavyContent)
+            ..._buildToolCallEmbeds(context),
         ],
       ),
     );
@@ -379,6 +403,9 @@ class _MarkdownDetailsBlockState extends State<MarkdownDetailsBlock> {
     if (_isToolCall) {
       final name = _detailsData.name.trim();
       final safeName = name.isEmpty ? 'tool' : name;
+      if (_toolCallData.hasEmbeds) {
+        return safeName;
+      }
       return _isPending ? 'Executing $safeName…' : 'View Result from $safeName';
     }
 
@@ -442,10 +469,8 @@ class _MarkdownDetailsBlockState extends State<MarkdownDetailsBlock> {
   ) {
     final builder = widget.bodyBuilder;
     final hasExtraBody = builder != null && _detailsData.hasBody;
-    final isHeavyPreviewDeferred =
-        _deferHeavyContent && data.hasDeferredPreviewContent;
-    final hasDeferredPreviewContent =
-        !_deferHeavyContent && data.hasDeferredPreviewContent;
+    final isHeavyPreviewDeferred = _deferHeavyContent && data.hasImages;
+    final hasDeferredPreviewContent = !_deferHeavyContent && data.hasImages;
     if (!data.hasExpandableContent &&
         !hasExtraBody &&
         !hasDeferredPreviewContent &&
@@ -575,14 +600,6 @@ class _MarkdownDetailsBlockState extends State<MarkdownDetailsBlock> {
         }
 
         if (!_deferHeavyContent) {
-          final embedWidgets = _buildToolCallEmbeds(context);
-          if (embedWidgets.isNotEmpty) {
-            if (children.isNotEmpty) {
-              children.add(const SizedBox(height: Spacing.sm));
-            }
-            children.addAll(embedWidgets);
-          }
-
           final imageWidgets = _buildToolCallImages(context);
           if (imageWidgets.isNotEmpty) {
             if (children.isNotEmpty) {

--- a/lib/shared/widgets/markdown/renderer/details_group_widget.dart
+++ b/lib/shared/widgets/markdown/renderer/details_group_widget.dart
@@ -5,6 +5,27 @@ import 'package:conduit/l10n/app_localizations.dart';
 import '../../../theme/theme_extensions.dart';
 import '../../assistant_detail_header.dart';
 
+enum MarkdownDetailsGroupRenderMode { details, previewsOnly }
+
+class MarkdownDetailsGroupRenderScope extends InheritedWidget {
+  const MarkdownDetailsGroupRenderScope({
+    super.key,
+    required this.mode,
+    required super.child,
+  });
+
+  final MarkdownDetailsGroupRenderMode mode;
+
+  static MarkdownDetailsGroupRenderMode? maybeOf(BuildContext context) =>
+      context
+          .dependOnInheritedWidgetOfExactType<MarkdownDetailsGroupRenderScope>()
+          ?.mode;
+
+  @override
+  bool updateShouldNotify(MarkdownDetailsGroupRenderScope oldWidget) =>
+      mode != oldWidget.mode;
+}
+
 class MarkdownDetailsGroupItem {
   const MarkdownDetailsGroupItem({
     required this.type,
@@ -147,12 +168,26 @@ class _MarkdownDetailsGroupState extends State<MarkdownDetailsGroup> {
                   child: Column(
                     crossAxisAlignment: CrossAxisAlignment.start,
                     children: widget.items
-                        .map((item) => Builder(builder: item.childBuilder))
+                        .map(
+                          (item) => MarkdownDetailsGroupRenderScope(
+                            mode: MarkdownDetailsGroupRenderMode.details,
+                            child: Builder(builder: item.childBuilder),
+                          ),
+                        )
                         .toList(growable: false),
                   ),
                 ),
               ),
             ),
+          MarkdownDetailsGroupRenderScope(
+            mode: MarkdownDetailsGroupRenderMode.previewsOnly,
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: widget.items
+                  .map((item) => Builder(builder: item.childBuilder))
+                  .toList(growable: false),
+            ),
+          ),
         ],
       ),
     );

--- a/lib/shared/widgets/themed_sheets.dart
+++ b/lib/shared/widgets/themed_sheets.dart
@@ -6,6 +6,7 @@ import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 
 import '../theme/theme_extensions.dart';
+import '../utils/adaptive_glass.dart';
 import 'modal_safe_area.dart';
 import 'sheet_handle.dart';
 
@@ -298,14 +299,38 @@ class SheetCloseButton extends StatelessWidget {
       color: iconColor,
     );
 
+    if (!conduitSupportsNativeGlass()) {
+      return SizedBox.square(
+        dimension: buttonSize,
+        child: IconButton(
+          tooltip: tooltip,
+          onPressed: onPressed,
+          icon: icon,
+          padding: EdgeInsets.zero,
+          constraints: BoxConstraints.tightFor(
+            width: buttonSize,
+            height: buttonSize,
+          ),
+          style: IconButton.styleFrom(
+            minimumSize: Size.zero,
+            maximumSize: Size.square(buttonSize),
+            tapTargetSize: MaterialTapTargetSize.shrinkWrap,
+          ),
+          color: iconColor,
+        ),
+      );
+    }
+
     final button = AdaptiveButton.child(
       onPressed: onPressed,
+      enabled: onPressed != null,
       style: AdaptiveButtonStyle.glass,
       size: buttonSize > 36
           ? AdaptiveButtonSize.large
           : AdaptiveButtonSize.medium,
       padding: EdgeInsets.zero,
       minSize: Size.square(buttonSize),
+      borderRadius: BorderRadius.circular(buttonSize),
       useSmoothRectangleBorder: false,
       child: icon,
     );

--- a/lib/shared/widgets/web_content_embed.dart
+++ b/lib/shared/widgets/web_content_embed.dart
@@ -97,11 +97,9 @@ class WebContentEmbed extends StatefulWidget {
   static bool debugShouldResolveMissingPopupUrl({
     required bool requestIsCurrent,
     required String? targetUrl,
-    required bool? hasGesture,
   }) => _WebContentEmbedState._shouldResolveMissingPopupUrl(
     requestIsCurrent: requestIsCurrent,
     targetUrl: targetUrl,
-    hasGesture: hasGesture,
   );
 
   @visibleForTesting
@@ -451,10 +449,12 @@ class _WebContentEmbedState extends State<WebContentEmbed> {
       return false;
     }
 
+    // javaScriptCanOpenWindowsAutomatically is false, so the platform has
+    // already approved this popup. Do not re-gate on Android's unreliable
+    // hasGesture metadata when recovering its omitted URL.
     if (!_shouldResolveMissingPopupUrl(
       requestIsCurrent: requestId == _loadRequestId,
       targetUrl: targetUrl,
-      hasGesture: createWindowAction.hasGesture,
     )) {
       return false;
     }
@@ -884,11 +884,7 @@ class _WebContentEmbedState extends State<WebContentEmbed> {
   static bool _shouldResolveMissingPopupUrl({
     required bool requestIsCurrent,
     required String? targetUrl,
-    required bool? hasGesture,
-  }) =>
-      requestIsCurrent &&
-      (targetUrl == null || targetUrl.isEmpty) &&
-      hasGesture == true;
+  }) => requestIsCurrent && (targetUrl == null || targetUrl.isEmpty);
 
   static bool _shouldOpenNavigationExternally({
     required String targetUrl,

--- a/lib/shared/widgets/web_content_embed.dart
+++ b/lib/shared/widgets/web_content_embed.dart
@@ -102,6 +102,10 @@ class WebContentEmbed extends StatefulWidget {
     linkActivated: linkActivated,
   );
 
+  @visibleForTesting
+  static bool debugShouldAllowInlineFragmentNavigation(String targetUrl) =>
+      _WebContentEmbedState._shouldAllowInlineFragmentNavigation(targetUrl);
+
   @override
   State<WebContentEmbed> createState() => _WebContentEmbedState();
 }
@@ -380,6 +384,9 @@ class _WebContentEmbedState extends State<WebContentEmbed> {
       return _shouldAllowAutomaticNavigation(targetUrl)
           ? NavigationActionPolicy.ALLOW
           : NavigationActionPolicy.CANCEL;
+    }
+    if (_shouldAllowInlineFragmentNavigation(targetUrl)) {
+      return NavigationActionPolicy.ALLOW;
     }
     if (parseAllowedExternalLink(targetUrl) == null) {
       return NavigationActionPolicy.CANCEL;
@@ -762,6 +769,14 @@ class _WebContentEmbedState extends State<WebContentEmbed> {
         scheme == 'https' ||
         (scheme == 'about' &&
             const {'blank', 'srcdoc'}.contains(uri.path.toLowerCase()));
+  }
+
+  static bool _shouldAllowInlineFragmentNavigation(String targetUrl) {
+    final uri = Uri.tryParse(targetUrl.trim());
+    return uri != null &&
+        uri.hasFragment &&
+        uri.scheme.toLowerCase() == 'about' &&
+        const {'blank', 'srcdoc'}.contains(uri.path.toLowerCase());
   }
 
   static bool _shouldHandleCreateWindow({

--- a/lib/shared/widgets/web_content_embed.dart
+++ b/lib/shared/widgets/web_content_embed.dart
@@ -61,6 +61,15 @@ class WebContentEmbed extends StatefulWidget {
   }
 
   @visibleForTesting
+  static String debugWrapRemoteDocument(
+    String source, {
+    bool fillAvailableHeight = false,
+  }) => _WebContentEmbedState._wrapRemoteDocument(
+    Uri.parse(source),
+    fillAvailableHeight: fillAvailableHeight,
+  );
+
+  @visibleForTesting
   static Future<bool> debugOpenExternalLink(
     String rawUrl, {
     required Future<bool> Function(String url) launcher,
@@ -346,24 +355,26 @@ class _WebContentEmbedState extends State<WebContentEmbed> {
     }
 
     try {
-      if (_isRemoteUrl) {
-        final uri = _resolvedRemoteUri;
-        if (uri == null) {
-          throw StateError('Invalid embed URL');
-        }
-        await controller.loadUrl(urlRequest: URLRequest(url: WebUri.uri(uri)));
-      } else {
-        final baseUrl = WebUri('https://embed.conduit.local/');
-        await controller.loadData(
-          data: _wrapHtmlDocument(
-            widget.source,
-            argsText: widget.argsText,
-            fillAvailableHeight: widget.fillAvailableHeight,
-          ),
-          baseUrl: baseUrl,
-          historyUrl: baseUrl,
-        );
+      final remoteUri = _resolvedRemoteUri;
+      if (_isRemoteUrl && remoteUri == null) {
+        throw StateError('Invalid embed URL');
       }
+      final document = remoteUri != null
+          ? _wrapRemoteDocument(
+              remoteUri,
+              fillAvailableHeight: widget.fillAvailableHeight,
+            )
+          : _wrapHtmlDocument(
+              widget.source,
+              argsText: widget.argsText,
+              fillAvailableHeight: widget.fillAvailableHeight,
+            );
+      final baseUrl = WebUri('https://embed.conduit.local/');
+      await controller.loadData(
+        data: document,
+        baseUrl: baseUrl,
+        historyUrl: baseUrl,
+      );
     } catch (_) {
       if (!mounted || requestId != _loadRequestId) {
         return;
@@ -375,19 +386,6 @@ class _WebContentEmbedState extends State<WebContentEmbed> {
         _loadError = 'Unable to load embedded content.';
       });
     }
-  }
-
-  Future<void> _injectArguments(InAppWebViewController controller) async {
-    final argsText = widget.argsText.trim();
-    if (argsText.isEmpty) {
-      return;
-    }
-
-    try {
-      await controller.evaluateJavascript(
-        source: 'window.args = ${jsonEncode(argsText)};',
-      );
-    } catch (_) {}
   }
 
   Future<NavigationActionPolicy> _handleNavigationAction(
@@ -440,6 +438,9 @@ class _WebContentEmbedState extends State<WebContentEmbed> {
     CreateWindowAction createWindowAction,
     int requestId,
   ) async {
+    if (!mounted) {
+      return false;
+    }
     final targetUrl = createWindowAction.request.url?.toString();
     if (_shouldHandleCreateWindow(
       requestIsCurrent: requestId == _loadRequestId,
@@ -495,15 +496,16 @@ class _WebContentEmbedState extends State<WebContentEmbed> {
       windowId: createWindowAction.windowId,
       initialSettings: InAppWebViewSettings(
         javaScriptEnabled: false,
+        allowContentAccess: false,
+        allowFileAccess: false,
+        allowFileAccessFromFileURLs: false,
+        allowUniversalAccessFromFileURLs: false,
         supportMultipleWindows: false,
         useShouldOverrideUrlLoading: true,
       ),
       shouldOverrideUrlLoading: (controller, navigationAction) async {
         unawaited(resolvePopupUrl(navigationAction.request.url));
         return NavigationActionPolicy.CANCEL;
-      },
-      onLoadStart: (controller, url) {
-        unawaited(resolvePopupUrl(url));
       },
     );
     _popupWebViews.add(popupWebView);
@@ -629,9 +631,6 @@ class _WebContentEmbedState extends State<WebContentEmbed> {
               if (requestId != _loadRequestId) {
                 return;
               }
-              if (_isRemoteUrl) {
-                await _injectArguments(controller);
-              }
               _scheduleHeightUpdates(controller, requestId);
             },
             onReceivedError: (controller, request, error) {
@@ -703,6 +702,27 @@ class _WebContentEmbedState extends State<WebContentEmbed> {
   }) {
     final sandboxedSource = _injectSandboxBootstrap(source, argsText: argsText);
     final encodedSource = _escapeHtmlAttribute(sandboxedSource);
+    return _wrapSandboxedFrameDocument(
+      sourceAttribute: 'srcdoc="$encodedSource"',
+      fillAvailableHeight: fillAvailableHeight,
+    );
+  }
+
+  static String _wrapRemoteDocument(
+    Uri source, {
+    bool fillAvailableHeight = false,
+  }) {
+    final encodedSource = _escapeHtmlAttribute(source.toString());
+    return _wrapSandboxedFrameDocument(
+      sourceAttribute: 'src="$encodedSource"',
+      fillAvailableHeight: fillAvailableHeight,
+    );
+  }
+
+  static String _wrapSandboxedFrameDocument({
+    required String sourceAttribute,
+    required bool fillAvailableHeight,
+  }) {
     return '''
 <!DOCTYPE html>
 <html>
@@ -753,7 +773,7 @@ class _WebContentEmbedState extends State<WebContentEmbed> {
       id="embed-frame"
       sandbox="allow-scripts allow-forms allow-popups"
       referrerpolicy="no-referrer"
-      srcdoc="$encodedSource"
+      $sourceAttribute
     ></iframe>
   </body>
 </html>

--- a/lib/shared/widgets/web_content_embed.dart
+++ b/lib/shared/widgets/web_content_embed.dart
@@ -129,6 +129,17 @@ class WebContentEmbed extends StatefulWidget {
   static bool debugShouldAllowInlineFragmentNavigation(String targetUrl) =>
       _WebContentEmbedState._shouldAllowInlineFragmentNavigation(targetUrl);
 
+  @visibleForTesting
+  static bool debugShouldSurfaceLoadFailure({
+    required bool isForMainFrame,
+    required String? remoteEmbedUrl,
+    required String requestUrl,
+  }) => _WebContentEmbedState._shouldSurfaceLoadFailure(
+    isForMainFrame: isForMainFrame,
+    remoteEmbedUrl: remoteEmbedUrl,
+    requestUrl: requestUrl,
+  );
+
   @override
   State<WebContentEmbed> createState() => _WebContentEmbedState();
 }
@@ -526,6 +537,18 @@ class _WebContentEmbedState extends State<WebContentEmbed> {
     return true;
   }
 
+  void _surfaceLoadError(int requestId, String description) {
+    if (!mounted || requestId != _loadRequestId) {
+      return;
+    }
+    setState(() {
+      _controller = null;
+      _shouldRenderWebView = false;
+      _isLoading = false;
+      _loadError = description;
+    });
+  }
+
   void _scheduleHeightUpdates(
     InAppWebViewController controller,
     int requestId,
@@ -647,17 +670,30 @@ class _WebContentEmbedState extends State<WebContentEmbed> {
               _scheduleHeightUpdates(controller, requestId);
             },
             onReceivedError: (controller, request, error) {
-              if (requestId != _loadRequestId ||
-                  !(request.isForMainFrame ?? false) ||
-                  !mounted) {
+              if (!_shouldSurfaceLoadFailure(
+                isForMainFrame: request.isForMainFrame ?? false,
+                remoteEmbedUrl: _resolvedRemoteUri?.toString(),
+                requestUrl: request.url.toString(),
+              )) {
                 return;
               }
-              setState(() {
-                _controller = null;
-                _shouldRenderWebView = false;
-                _isLoading = false;
-                _loadError = error.description;
-              });
+              _surfaceLoadError(requestId, error.description);
+            },
+            onReceivedHttpError: (controller, request, errorResponse) {
+              if (!_shouldSurfaceLoadFailure(
+                isForMainFrame: request.isForMainFrame ?? false,
+                remoteEmbedUrl: _resolvedRemoteUri?.toString(),
+                requestUrl: request.url.toString(),
+              )) {
+                return;
+              }
+              final statusCode = errorResponse.statusCode;
+              _surfaceLoadError(
+                requestId,
+                statusCode == null
+                    ? 'Unable to load embedded content.'
+                    : 'Unable to load embedded content (HTTP $statusCode).',
+              );
             },
             shouldOverrideUrlLoading: (controller, navigationAction) =>
                 _handleNavigationAction(
@@ -915,6 +951,14 @@ ${_frameBootstrapScript(argsText)}
         uri.scheme.toLowerCase() == 'about' &&
         const {'blank', 'srcdoc'}.contains(uri.path.toLowerCase());
   }
+
+  static bool _shouldSurfaceLoadFailure({
+    required bool isForMainFrame,
+    required String? remoteEmbedUrl,
+    required String requestUrl,
+  }) =>
+      isForMainFrame ||
+      (remoteEmbedUrl != null && requestUrl == remoteEmbedUrl);
 
   static bool _shouldHandleCreateWindow({
     required bool requestIsCurrent,

--- a/lib/shared/widgets/web_content_embed.dart
+++ b/lib/shared/widgets/web_content_embed.dart
@@ -93,6 +93,15 @@ class WebContentEmbed extends StatefulWidget {
     targetUrl: targetUrl,
   );
 
+  @visibleForTesting
+  static bool debugHasUserActivationEvidence({
+    required bool? hasGesture,
+    required bool linkActivated,
+  }) => _WebContentEmbedState._hasUserActivationEvidence(
+    hasGesture: hasGesture,
+    linkActivated: linkActivated,
+  );
+
   @override
   State<WebContentEmbed> createState() => _WebContentEmbedState();
 }
@@ -727,8 +736,20 @@ class _WebContentEmbedState extends State<WebContentEmbed> {
   }
 
   static bool _isUserActivatedNavigation(NavigationAction action) =>
-      action.hasGesture == true ||
-      action.navigationType == NavigationType.LINK_ACTIVATED;
+      _hasUserActivationEvidence(
+        hasGesture: action.hasGesture,
+        linkActivated: action.navigationType == NavigationType.LINK_ACTIVATED,
+      );
+
+  static bool _hasUserActivationEvidence({
+    required bool? hasGesture,
+    required bool linkActivated,
+  }) {
+    // Android reports hasGesture, so an explicit false must stay authoritative
+    // for scripted anchor clicks. iOS reports null and exposes only the
+    // navigation type, which remains the fallback for genuine link taps there.
+    return hasGesture == true || (hasGesture == null && linkActivated);
+  }
 
   static bool _shouldAllowAutomaticNavigation(String targetUrl) {
     final uri = Uri.tryParse(targetUrl.trim());

--- a/lib/shared/widgets/web_content_embed.dart
+++ b/lib/shared/widgets/web_content_embed.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:collection';
 import 'dart:convert';
 
 import 'package:flutter/foundation.dart';
@@ -68,6 +69,10 @@ class WebContentEmbed extends StatefulWidget {
     Uri.parse(source),
     fillAvailableHeight: fillAvailableHeight,
   );
+
+  @visibleForTesting
+  static String debugFrameBootstrapScript(String argsText) =>
+      _WebContentEmbedState._frameBootstrapScript(argsText);
 
   @visibleForTesting
   static Future<bool> debugOpenExternalLink(
@@ -614,6 +619,14 @@ class _WebContentEmbedState extends State<WebContentEmbed> {
           child: InAppWebView(
             key: ValueKey<int>(requestId),
             gestureRecognizers: _gestureRecognizers,
+            initialUserScripts: UnmodifiableListView([
+              UserScript(
+                source: _frameBootstrapScript(widget.argsText),
+                injectionTime: UserScriptInjectionTime.AT_DOCUMENT_START,
+                forMainFrameOnly: false,
+                allowedOriginRules: const {'*'},
+              ),
+            ]),
             initialSettings: InAppWebViewSettings(
               javaScriptEnabled: true,
               // Keep script-created popups disabled. onCreateWindow therefore
@@ -784,39 +797,10 @@ class _WebContentEmbedState extends State<WebContentEmbed> {
     String source, {
     required String argsText,
   }) {
-    final assignments = <String>[];
-    if (argsText.trim().isNotEmpty) {
-      assignments.add('window.args = ${_jsonForInlineScript(argsText)};');
-    }
-
     final bootstrap =
         '''
 <script>
-  ${assignments.join('\n  ')}
-  (() => {
-    const reportHeight = () => {
-      const body = document.body;
-      const html = document.documentElement;
-      const height = Math.ceil(Math.max(
-        body?.scrollHeight || 0,
-        body?.offsetHeight || 0,
-        html?.clientHeight || 0,
-        html?.scrollHeight || 0,
-        html?.offsetHeight || 0
-      ));
-      parent.postMessage({ type: 'conduit-embed-height', height }, '*');
-    };
-
-    window.addEventListener('load', reportHeight);
-    if (typeof ResizeObserver !== 'undefined') {
-      const observer = new ResizeObserver(reportHeight);
-      observer.observe(document.documentElement);
-      if (document.body) observer.observe(document.body);
-    }
-    setTimeout(reportHeight, 0);
-    setTimeout(reportHeight, 250);
-    setTimeout(reportHeight, 1000);
-  })();
+${_frameBootstrapScript(argsText)}
 </script>
 ''';
 
@@ -837,6 +821,46 @@ class _WebContentEmbedState extends State<WebContentEmbed> {
     }
 
     return '$bootstrap$source';
+  }
+
+  static String _frameBootstrapScript(String argsText) {
+    final argsAssignment = argsText.trim().isEmpty
+        ? ''
+        : 'window.args = ${_jsonForInlineScript(argsText)};';
+    return '''
+  $argsAssignment
+  (() => {
+    const reportHeight = () => {
+      const body = document.body;
+      const html = document.documentElement;
+      const height = Math.ceil(Math.max(
+        body?.scrollHeight || 0,
+        body?.offsetHeight || 0,
+        html?.clientHeight || 0,
+        html?.scrollHeight || 0,
+        html?.offsetHeight || 0
+      ));
+      parent.postMessage({ type: 'conduit-embed-height', height }, '*');
+    };
+
+    window.addEventListener('load', reportHeight);
+    if (typeof ResizeObserver !== 'undefined') {
+      const observer = new ResizeObserver(reportHeight);
+      const observeDocument = () => {
+        if (document.documentElement) observer.observe(document.documentElement);
+        if (document.body) observer.observe(document.body);
+      };
+      if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', observeDocument, { once: true });
+      } else {
+        observeDocument();
+      }
+    }
+    setTimeout(reportHeight, 0);
+    setTimeout(reportHeight, 250);
+    setTimeout(reportHeight, 1000);
+  })();
+''';
   }
 
   static String _jsonForInlineScript(String value) {

--- a/lib/shared/widgets/web_content_embed.dart
+++ b/lib/shared/widgets/web_content_embed.dart
@@ -84,6 +84,15 @@ class WebContentEmbed extends StatefulWidget {
   static bool debugShouldAllowAutomaticNavigation(String targetUrl) =>
       _WebContentEmbedState._shouldAllowAutomaticNavigation(targetUrl);
 
+  @visibleForTesting
+  static bool debugShouldHandleCreateWindow({
+    required bool requestIsCurrent,
+    required String? targetUrl,
+  }) => _WebContentEmbedState._shouldHandleCreateWindow(
+    requestIsCurrent: requestIsCurrent,
+    targetUrl: targetUrl,
+  );
+
   @override
   State<WebContentEmbed> createState() => _WebContentEmbedState();
 }
@@ -390,16 +399,14 @@ class _WebContentEmbedState extends State<WebContentEmbed> {
     CreateWindowAction createWindowAction,
     int requestId,
   ) async {
-    if (requestId != _loadRequestId ||
-        !_isUserActivatedNavigation(createWindowAction)) {
-      return false;
-    }
-
     final targetUrl = createWindowAction.request.url?.toString();
-    if (targetUrl == null || targetUrl.isEmpty) {
+    if (!_shouldHandleCreateWindow(
+      requestIsCurrent: requestId == _loadRequestId,
+      targetUrl: targetUrl,
+    )) {
       return false;
     }
-    await _openAllowedExternalLink(targetUrl);
+    await _openAllowedExternalLink(targetUrl!);
     return false;
   }
 
@@ -498,6 +505,10 @@ class _WebContentEmbedState extends State<WebContentEmbed> {
             gestureRecognizers: _gestureRecognizers,
             initialSettings: InAppWebViewSettings(
               javaScriptEnabled: true,
+              // Keep script-created popups disabled. onCreateWindow therefore
+              // represents a platform-approved user popup request even when
+              // Android omits its gesture/navigation metadata.
+              javaScriptCanOpenWindowsAutomatically: false,
               supportMultipleWindows: true,
               transparentBackground: true,
               useShouldOverrideUrlLoading: true,
@@ -731,6 +742,15 @@ class _WebContentEmbedState extends State<WebContentEmbed> {
         (scheme == 'about' &&
             const {'blank', 'srcdoc'}.contains(uri.path.toLowerCase()));
   }
+
+  static bool _shouldHandleCreateWindow({
+    required bool requestIsCurrent,
+    required String? targetUrl,
+  }) =>
+      requestIsCurrent &&
+      targetUrl != null &&
+      targetUrl.isNotEmpty &&
+      parseAllowedExternalLink(targetUrl) != null;
 
   static bool _shouldOpenNavigationExternally({
     required String targetUrl,

--- a/lib/shared/widgets/web_content_embed.dart
+++ b/lib/shared/widgets/web_content_embed.dart
@@ -8,6 +8,7 @@ import 'package:flutter_inappwebview/flutter_inappwebview.dart';
 import 'package:conduit/l10n/app_localizations.dart';
 
 import '../theme/theme_extensions.dart';
+import '../utils/external_link_launcher.dart';
 import 'webview_content_height.dart';
 
 const _embedDefaultHeight = 360.0;
@@ -58,6 +59,30 @@ class WebContentEmbed extends StatefulWidget {
       fillAvailableHeight: fillAvailableHeight,
     );
   }
+
+  @visibleForTesting
+  static Future<bool> debugOpenExternalLink(
+    String rawUrl, {
+    required Future<bool> Function(String url) launcher,
+  }) => _WebContentEmbedState._openAllowedExternalLink(
+    rawUrl,
+    launcher: launcher,
+  );
+
+  @visibleForTesting
+  static bool debugShouldOpenNavigationExternally({
+    required String targetUrl,
+    String? currentUrl,
+    required bool userActivated,
+  }) => _WebContentEmbedState._shouldOpenNavigationExternally(
+    targetUrl: targetUrl,
+    currentUrl: currentUrl,
+    userActivated: userActivated,
+  );
+
+  @visibleForTesting
+  static bool debugShouldAllowAutomaticNavigation(String targetUrl) =>
+      _WebContentEmbedState._shouldAllowAutomaticNavigation(targetUrl);
 
   @override
   State<WebContentEmbed> createState() => _WebContentEmbedState();
@@ -318,6 +343,66 @@ class _WebContentEmbedState extends State<WebContentEmbed> {
     } catch (_) {}
   }
 
+  Future<NavigationActionPolicy> _handleNavigationAction(
+    InAppWebViewController controller,
+    NavigationAction navigationAction,
+    int requestId,
+  ) async {
+    if (requestId != _loadRequestId) {
+      return NavigationActionPolicy.CANCEL;
+    }
+
+    final targetUrl = navigationAction.request.url?.toString();
+    if (targetUrl == null || targetUrl.isEmpty) {
+      return NavigationActionPolicy.CANCEL;
+    }
+
+    final userActivated = _isUserActivatedNavigation(navigationAction);
+    if (!userActivated) {
+      return _shouldAllowAutomaticNavigation(targetUrl)
+          ? NavigationActionPolicy.ALLOW
+          : NavigationActionPolicy.CANCEL;
+    }
+    if (parseAllowedExternalLink(targetUrl) == null) {
+      return NavigationActionPolicy.CANCEL;
+    }
+
+    String? currentUrl;
+    try {
+      currentUrl = (await controller.getUrl())?.toString();
+    } catch (_) {}
+    if (!mounted || requestId != _loadRequestId) {
+      return NavigationActionPolicy.CANCEL;
+    }
+    if (!_shouldOpenNavigationExternally(
+      targetUrl: targetUrl,
+      currentUrl: currentUrl,
+      userActivated: userActivated,
+    )) {
+      return NavigationActionPolicy.ALLOW;
+    }
+
+    await _openAllowedExternalLink(targetUrl);
+    return NavigationActionPolicy.CANCEL;
+  }
+
+  Future<bool> _handleCreateWindow(
+    CreateWindowAction createWindowAction,
+    int requestId,
+  ) async {
+    if (requestId != _loadRequestId ||
+        !_isUserActivatedNavigation(createWindowAction)) {
+      return false;
+    }
+
+    final targetUrl = createWindowAction.request.url?.toString();
+    if (targetUrl == null || targetUrl.isEmpty) {
+      return false;
+    }
+    await _openAllowedExternalLink(targetUrl);
+    return false;
+  }
+
   void _scheduleHeightUpdates(
     InAppWebViewController controller,
     int requestId,
@@ -413,7 +498,9 @@ class _WebContentEmbedState extends State<WebContentEmbed> {
             gestureRecognizers: _gestureRecognizers,
             initialSettings: InAppWebViewSettings(
               javaScriptEnabled: true,
+              supportMultipleWindows: true,
               transparentBackground: true,
+              useShouldOverrideUrlLoading: true,
             ),
             onWebViewCreated: (controller) {
               unawaited(_handleWebViewCreated(controller, requestId));
@@ -440,6 +527,14 @@ class _WebContentEmbedState extends State<WebContentEmbed> {
                 _loadError = error.description;
               });
             },
+            shouldOverrideUrlLoading: (controller, navigationAction) =>
+                _handleNavigationAction(
+                  controller,
+                  navigationAction,
+                  requestId,
+                ),
+            onCreateWindow: (controller, createWindowAction) =>
+                _handleCreateWindow(createWindowAction, requestId),
           ),
         ),
         if (_isLoading)
@@ -517,13 +612,14 @@ class _WebContentEmbedState extends State<WebContentEmbed> {
         const fillAvailableHeight = $fillAvailableHeight;
         window.addEventListener('message', (event) => {
           const data = event.data || {};
+          const frame = document.getElementById('embed-frame');
+          if (!frame || event.source !== frame.contentWindow) return;
+
           if (data.type !== 'conduit-embed-height') return;
 
           const height = Number(data.height);
           if (!Number.isFinite(height) || height <= 0) return;
 
-          const frame = document.getElementById('embed-frame');
-          if (!frame) return;
           if (fillAvailableHeight) return;
 
           const clamped = Math.min(Math.max(height, minHeight), maxHeight);
@@ -535,7 +631,7 @@ class _WebContentEmbedState extends State<WebContentEmbed> {
   <body>
     <iframe
       id="embed-frame"
-      sandbox="allow-scripts allow-forms"
+      sandbox="allow-scripts allow-forms allow-popups"
       referrerpolicy="no-referrer"
       srcdoc="$encodedSource"
     ></iframe>
@@ -617,6 +713,58 @@ class _WebContentEmbedState extends State<WebContentEmbed> {
         .replaceAll('>', '&gt;')
         .replaceAll('"', '&quot;')
         .replaceAll("'", '&#39;');
+  }
+
+  static bool _isUserActivatedNavigation(NavigationAction action) =>
+      action.hasGesture == true ||
+      action.navigationType == NavigationType.LINK_ACTIVATED;
+
+  static bool _shouldAllowAutomaticNavigation(String targetUrl) {
+    final uri = Uri.tryParse(targetUrl.trim());
+    if (uri == null) {
+      return false;
+    }
+
+    final scheme = uri.scheme.toLowerCase();
+    return scheme == 'http' ||
+        scheme == 'https' ||
+        (scheme == 'about' &&
+            const {'blank', 'srcdoc'}.contains(uri.path.toLowerCase()));
+  }
+
+  static bool _shouldOpenNavigationExternally({
+    required String targetUrl,
+    required String? currentUrl,
+    required bool userActivated,
+  }) {
+    if (!userActivated || parseAllowedExternalLink(targetUrl) == null) {
+      return false;
+    }
+
+    final target = Uri.tryParse(targetUrl);
+    final current = currentUrl == null ? null : Uri.tryParse(currentUrl);
+    if (target == null || current == null) {
+      return true;
+    }
+
+    final targetWithoutFragment = target.replace(fragment: '');
+    final currentWithoutFragment = current.replace(fragment: '');
+    return targetWithoutFragment != currentWithoutFragment;
+  }
+
+  static Future<bool> _openAllowedExternalLink(
+    String rawUrl, {
+    Future<bool> Function(String url)? launcher,
+  }) async {
+    final uri = parseAllowedExternalLink(rawUrl);
+    if (uri == null) {
+      return false;
+    }
+    final normalizedUrl = uri.toString();
+    if (launcher != null) {
+      return launcher(normalizedUrl);
+    }
+    return launchExternalLink(normalizedUrl, scope: 'embeds/navigation');
   }
 }
 

--- a/lib/shared/widgets/web_content_embed.dart
+++ b/lib/shared/widgets/web_content_embed.dart
@@ -75,6 +75,10 @@ class WebContentEmbed extends StatefulWidget {
       _WebContentEmbedState._frameBootstrapScript(argsText);
 
   @visibleForTesting
+  static String debugAllFrameBootstrapScript() =>
+      _WebContentEmbedState._allFrameBootstrapScript;
+
+  @visibleForTesting
   static Future<bool> debugOpenExternalLink(
     String rawUrl, {
     required Future<bool> Function(String url) launcher,
@@ -132,11 +136,11 @@ class WebContentEmbed extends StatefulWidget {
   @visibleForTesting
   static bool debugShouldSurfaceLoadFailure({
     required bool isForMainFrame,
-    required String? remoteEmbedUrl,
+    required Iterable<String> remoteEmbedUrls,
     required String requestUrl,
   }) => _WebContentEmbedState._shouldSurfaceLoadFailure(
     isForMainFrame: isForMainFrame,
-    remoteEmbedUrl: remoteEmbedUrl,
+    remoteEmbedUrls: remoteEmbedUrls,
     requestUrl: requestUrl,
   );
 
@@ -152,6 +156,7 @@ class _WebContentEmbedState extends State<WebContentEmbed> {
 
   InAppWebViewController? _controller;
   final Set<HeadlessInAppWebView> _popupWebViews = {};
+  final Set<String> _remoteFrameDocumentUrls = {};
   double _height = _embedDefaultHeight;
   bool _isLoading = true;
   bool _loadScheduled = false;
@@ -216,6 +221,7 @@ class _WebContentEmbedState extends State<WebContentEmbed> {
   @override
   void initState() {
     super.initState();
+    _resetRemoteFrameDocumentUrls();
     _isExpanded = widget.initiallyExpanded || !widget.deferUntilExpanded;
     if (widget.debugSeedControllerForTesting) {
       _debugHasSeededController = true;
@@ -243,6 +249,7 @@ class _WebContentEmbedState extends State<WebContentEmbed> {
 
   void _resetControllerState({required bool isLoading}) {
     _disposePopupWebViews();
+    _resetRemoteFrameDocumentUrls();
     final hadController = _hasController;
     if (mounted) {
       setState(() {
@@ -265,6 +272,14 @@ class _WebContentEmbedState extends State<WebContentEmbed> {
     }
     if (hadController) {
       widget.debugOnControllerReset?.call();
+    }
+  }
+
+  void _resetRemoteFrameDocumentUrls() {
+    _remoteFrameDocumentUrls.clear();
+    final remoteUri = _resolvedRemoteUri;
+    if (remoteUri != null) {
+      _remoteFrameDocumentUrls.add(remoteUri.toString());
     }
   }
 
@@ -420,9 +435,11 @@ class _WebContentEmbedState extends State<WebContentEmbed> {
 
     final userActivated = _isUserActivatedNavigation(navigationAction);
     if (!userActivated) {
-      return _shouldAllowAutomaticNavigation(targetUrl)
-          ? NavigationActionPolicy.ALLOW
-          : NavigationActionPolicy.CANCEL;
+      if (!_shouldAllowAutomaticNavigation(targetUrl)) {
+        return NavigationActionPolicy.CANCEL;
+      }
+      _rememberRemoteFrameDocumentUrl(navigationAction, targetUrl);
+      return NavigationActionPolicy.ALLOW;
     }
     if (_shouldAllowInlineFragmentNavigation(targetUrl)) {
       return NavigationActionPolicy.ALLOW;
@@ -443,11 +460,21 @@ class _WebContentEmbedState extends State<WebContentEmbed> {
       currentUrl: currentUrl,
       userActivated: userActivated,
     )) {
+      _rememberRemoteFrameDocumentUrl(navigationAction, targetUrl);
       return NavigationActionPolicy.ALLOW;
     }
 
     await _openAllowedExternalLink(targetUrl);
     return NavigationActionPolicy.CANCEL;
+  }
+
+  void _rememberRemoteFrameDocumentUrl(
+    NavigationAction navigationAction,
+    String targetUrl,
+  ) {
+    if (_isRemoteUrl && !navigationAction.isForMainFrame) {
+      _remoteFrameDocumentUrls.add(targetUrl);
+    }
   }
 
   Future<bool> _handleCreateWindow(
@@ -644,7 +671,10 @@ class _WebContentEmbedState extends State<WebContentEmbed> {
             gestureRecognizers: _gestureRecognizers,
             initialUserScripts: UnmodifiableListView([
               UserScript(
-                source: _frameBootstrapScript(widget.argsText),
+                // This script reaches remote frames too, so it must not contain
+                // tool arguments. Inline srcdoc content receives its private
+                // argument bootstrap from _injectSandboxBootstrap instead.
+                source: _allFrameBootstrapScript,
                 injectionTime: UserScriptInjectionTime.AT_DOCUMENT_START,
                 forMainFrameOnly: false,
                 allowedOriginRules: const {'*'},
@@ -672,7 +702,7 @@ class _WebContentEmbedState extends State<WebContentEmbed> {
             onReceivedError: (controller, request, error) {
               if (!_shouldSurfaceLoadFailure(
                 isForMainFrame: request.isForMainFrame ?? false,
-                remoteEmbedUrl: _resolvedRemoteUri?.toString(),
+                remoteEmbedUrls: _remoteFrameDocumentUrls,
                 requestUrl: request.url.toString(),
               )) {
                 return;
@@ -682,7 +712,7 @@ class _WebContentEmbedState extends State<WebContentEmbed> {
             onReceivedHttpError: (controller, request, errorResponse) {
               if (!_shouldSurfaceLoadFailure(
                 isForMainFrame: request.isForMainFrame ?? false,
-                remoteEmbedUrl: _resolvedRemoteUri?.toString(),
+                remoteEmbedUrls: _remoteFrameDocumentUrls,
                 requestUrl: request.url.toString(),
               )) {
                 return;
@@ -899,6 +929,8 @@ ${_frameBootstrapScript(argsText)}
 ''';
   }
 
+  static final String _allFrameBootstrapScript = _frameBootstrapScript('');
+
   static String _jsonForInlineScript(String value) {
     return jsonEncode(value)
         .replaceAll('&', r'\u0026')
@@ -954,11 +986,34 @@ ${_frameBootstrapScript(argsText)}
 
   static bool _shouldSurfaceLoadFailure({
     required bool isForMainFrame,
-    required String? remoteEmbedUrl,
+    required Iterable<String> remoteEmbedUrls,
     required String requestUrl,
-  }) =>
-      isForMainFrame ||
-      (remoteEmbedUrl != null && requestUrl == remoteEmbedUrl);
+  }) {
+    if (isForMainFrame) {
+      return true;
+    }
+    final normalizedRequest = _normalizedDocumentUrl(requestUrl);
+    if (normalizedRequest == null) {
+      return false;
+    }
+    return remoteEmbedUrls.any(
+      (url) => _normalizedDocumentUrl(url) == normalizedRequest,
+    );
+  }
+
+  static String? _normalizedDocumentUrl(String rawUrl) {
+    final uri = Uri.tryParse(rawUrl.trim());
+    if (uri == null || !uri.hasScheme || uri.host.isEmpty) {
+      return null;
+    }
+    final scheme = uri.scheme.toLowerCase();
+    if (scheme != 'http' && scheme != 'https') {
+      return null;
+    }
+    final path = uri.path.isEmpty ? '/' : uri.path;
+    return '$scheme|${uri.userInfo}|${uri.host.toLowerCase()}|${uri.port}|'
+        '$path|${uri.query}';
+  }
 
   static bool _shouldHandleCreateWindow({
     required bool requestIsCurrent,

--- a/lib/shared/widgets/web_content_embed.dart
+++ b/lib/shared/widgets/web_content_embed.dart
@@ -79,6 +79,10 @@ class WebContentEmbed extends StatefulWidget {
       _WebContentEmbedState._allFrameBootstrapScript;
 
   @visibleForTesting
+  static String debugInlineArgumentsScript(String argsText) =>
+      _WebContentEmbedState._inlineArgumentsScript(argsText);
+
+  @visibleForTesting
   static Future<bool> debugOpenExternalLink(
     String rawUrl, {
     required Future<bool> Function(String url) launcher,
@@ -863,10 +867,14 @@ class _WebContentEmbedState extends State<WebContentEmbed> {
     String source, {
     required String argsText,
   }) {
+    final argumentsScript = _inlineArgumentsScript(argsText);
+    if (argumentsScript.isEmpty) {
+      return source;
+    }
     final bootstrap =
         '''
 <script>
-${_frameBootstrapScript(argsText)}
+$argumentsScript
 </script>
 ''';
 
@@ -890,11 +898,19 @@ ${_frameBootstrapScript(argsText)}
   }
 
   static String _frameBootstrapScript(String argsText) {
-    final argsAssignment = argsText.trim().isEmpty
+    return '''
+${_inlineArgumentsScript(argsText)}
+$_allFrameBootstrapScript
+''';
+  }
+
+  static String _inlineArgumentsScript(String argsText) {
+    return argsText.trim().isEmpty
         ? ''
         : 'window.args = ${_jsonForInlineScript(argsText)};';
-    return '''
-  $argsAssignment
+  }
+
+  static const String _allFrameBootstrapScript = '''
   (() => {
     const reportHeight = () => {
       const body = document.body;
@@ -927,9 +943,6 @@ ${_frameBootstrapScript(argsText)}
     setTimeout(reportHeight, 1000);
   })();
 ''';
-  }
-
-  static final String _allFrameBootstrapScript = _frameBootstrapScript('');
 
   static String _jsonForInlineScript(String value) {
     return jsonEncode(value)

--- a/lib/shared/widgets/web_content_embed.dart
+++ b/lib/shared/widgets/web_content_embed.dart
@@ -94,6 +94,17 @@ class WebContentEmbed extends StatefulWidget {
   );
 
   @visibleForTesting
+  static bool debugShouldResolveMissingPopupUrl({
+    required bool requestIsCurrent,
+    required String? targetUrl,
+    required bool? hasGesture,
+  }) => _WebContentEmbedState._shouldResolveMissingPopupUrl(
+    requestIsCurrent: requestIsCurrent,
+    targetUrl: targetUrl,
+    hasGesture: hasGesture,
+  );
+
+  @visibleForTesting
   static bool debugHasUserActivationEvidence({
     required bool? hasGesture,
     required bool linkActivated,
@@ -117,6 +128,7 @@ class _WebContentEmbedState extends State<WebContentEmbed> {
       };
 
   InAppWebViewController? _controller;
+  final Set<HeadlessInAppWebView> _popupWebViews = {};
   double _height = _embedDefaultHeight;
   bool _isLoading = true;
   bool _loadScheduled = false;
@@ -207,6 +219,7 @@ class _WebContentEmbedState extends State<WebContentEmbed> {
   }
 
   void _resetControllerState({required bool isLoading}) {
+    _disposePopupWebViews();
     final hadController = _hasController;
     if (mounted) {
       setState(() {
@@ -230,6 +243,20 @@ class _WebContentEmbedState extends State<WebContentEmbed> {
     if (hadController) {
       widget.debugOnControllerReset?.call();
     }
+  }
+
+  void _disposePopupWebViews() {
+    final popupWebViews = _popupWebViews.toList(growable: false);
+    _popupWebViews.clear();
+    for (final popupWebView in popupWebViews) {
+      unawaited(popupWebView.dispose());
+    }
+  }
+
+  @override
+  void dispose() {
+    _disposePopupWebViews();
+    super.dispose();
   }
 
   void _scheduleControllerInitialization(BuildContext context) {
@@ -416,14 +443,80 @@ class _WebContentEmbedState extends State<WebContentEmbed> {
     int requestId,
   ) async {
     final targetUrl = createWindowAction.request.url?.toString();
-    if (!_shouldHandleCreateWindow(
+    if (_shouldHandleCreateWindow(
       requestIsCurrent: requestId == _loadRequestId,
       targetUrl: targetUrl,
     )) {
+      await _openAllowedExternalLink(targetUrl!);
       return false;
     }
-    await _openAllowedExternalLink(targetUrl!);
-    return false;
+
+    if (!_shouldResolveMissingPopupUrl(
+      requestIsCurrent: requestId == _loadRequestId,
+      targetUrl: targetUrl,
+      hasGesture: createWindowAction.hasGesture,
+    )) {
+      return false;
+    }
+
+    // Android's WebChromeClient omits request.url for JavaScript window.open
+    // calls. Attach a non-scriptable headless WebView to the pending window so
+    // its first URL can be recovered, cancelled, and validated before launch.
+    late final HeadlessInAppWebView popupWebView;
+    var resolved = false;
+
+    Future<void> disposePopup() async {
+      if (_popupWebViews.remove(popupWebView)) {
+        await popupWebView.dispose();
+      }
+    }
+
+    Future<void> resolvePopupUrl(WebUri? url) async {
+      final rawUrl = url?.toString();
+      if (resolved || rawUrl == null || rawUrl.isEmpty) {
+        return;
+      }
+      final uri = Uri.tryParse(rawUrl);
+      if (uri?.scheme.toLowerCase() == 'about') {
+        return;
+      }
+
+      resolved = true;
+      try {
+        if (mounted && requestId == _loadRequestId) {
+          await _openAllowedExternalLink(rawUrl);
+        }
+      } finally {
+        await disposePopup();
+      }
+    }
+
+    popupWebView = HeadlessInAppWebView(
+      windowId: createWindowAction.windowId,
+      initialSettings: InAppWebViewSettings(
+        javaScriptEnabled: false,
+        supportMultipleWindows: false,
+        useShouldOverrideUrlLoading: true,
+      ),
+      shouldOverrideUrlLoading: (controller, navigationAction) async {
+        unawaited(resolvePopupUrl(navigationAction.request.url));
+        return NavigationActionPolicy.CANCEL;
+      },
+      onLoadStart: (controller, url) {
+        unawaited(resolvePopupUrl(url));
+      },
+    );
+    _popupWebViews.add(popupWebView);
+
+    try {
+      await popupWebView.run();
+    } catch (_) {
+      await disposePopup();
+      return false;
+    }
+
+    Future<void>.delayed(const Duration(seconds: 5), disposePopup);
+    return true;
   }
 
   void _scheduleHeightUpdates(
@@ -787,6 +880,15 @@ class _WebContentEmbedState extends State<WebContentEmbed> {
       targetUrl != null &&
       targetUrl.isNotEmpty &&
       parseAllowedExternalLink(targetUrl) != null;
+
+  static bool _shouldResolveMissingPopupUrl({
+    required bool requestIsCurrent,
+    required String? targetUrl,
+    required bool? hasGesture,
+  }) =>
+      requestIsCurrent &&
+      (targetUrl == null || targetUrl.isEmpty) &&
+      hasGesture == true;
 
   static bool _shouldOpenNavigationExternally({
     required String targetUrl,

--- a/test/features/chat/widgets/chat_timeline_viewport_test.dart
+++ b/test/features/chat/widgets/chat_timeline_viewport_test.dart
@@ -13,6 +13,7 @@ import 'package:conduit/shared/theme/app_theme.dart';
 import 'package:conduit/shared/theme/tweakcn_themes.dart';
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 
@@ -92,6 +93,60 @@ class _MountedRowProbeState extends State<_MountedRowProbe> {
   @override
   Widget build(BuildContext context) =>
       SizedBox(height: 52, child: Text(widget.messageId));
+}
+
+class _TransformAvailability extends SingleChildRenderObjectWidget {
+  const _TransformAvailability({
+    required this.available,
+    required super.child,
+    super.key,
+  });
+
+  final bool available;
+
+  @override
+  RenderObject createRenderObject(BuildContext context) =>
+      _RenderTransformAvailability(available);
+
+  @override
+  void updateRenderObject(
+    BuildContext context,
+    covariant _RenderTransformAvailability renderObject,
+  ) {
+    renderObject.available = available;
+  }
+}
+
+class _RenderTransformAvailability extends RenderProxyBox {
+  _RenderTransformAvailability(this._available);
+
+  bool _available;
+  int unavailableSizeReads = 0;
+  int unavailableTransformReads = 0;
+
+  @override
+  bool get hasSize {
+    if (!_available) {
+      unavailableSizeReads += 1;
+      return false;
+    }
+    return super.hasSize;
+  }
+
+  set available(bool value) {
+    if (_available == value) return;
+    _available = value;
+    markNeedsPaint();
+  }
+
+  @override
+  void applyPaintTransform(RenderBox child, Matrix4 transform) {
+    if (!_available) {
+      unavailableTransformReads += 1;
+      throw StateError('Ancestor paint transform is not laid out');
+    }
+    super.applyPaintTransform(child, transform);
+  }
 }
 
 Future<_TrackedGesture> _startTrackedGesture(
@@ -177,6 +232,79 @@ void main() {
 
     check(controller.rowRect(anchorId)!.top).isCloseTo(before, 1);
   });
+
+  _viewportTest(
+    'route transition transform outage preserves the visible anchor',
+    (tester) async {
+      final controller = _controller(tester);
+      var ids = List<String>.generate(50, (index) => 'message-${index + 50}');
+      var transformAvailable = true;
+      final transformKey = GlobalKey();
+      late StateSetter rebuild;
+
+      await tester.pumpWidget(
+        _viewportHost(
+          StatefulBuilder(
+            builder: (context, setState) {
+              rebuild = setState;
+              return _TransformAvailability(
+                key: transformKey,
+                available: transformAvailable,
+                child: _viewport(
+                  controller: controller,
+                  ids: ids,
+                  maintainVisibleAnchor: true,
+                  followLatest: false,
+                ),
+              );
+            },
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      await tester.fling(
+        find.byType(CustomScrollView),
+        const Offset(0, 420),
+        900,
+      );
+      await tester.pumpAndSettle();
+      final anchor = controller.captureTopVisibleAnchor(
+        loadedCount: ids.length,
+      );
+      check(anchor).isNotNull();
+      final anchorId = anchor!.messageId;
+      final before = controller.rowRect(anchorId)!.top;
+
+      rebuild(() {
+        transformAvailable = false;
+        ids = [
+          ...List<String>.generate(50, (index) => 'message-$index'),
+          ...ids,
+        ];
+      });
+      await tester.pump(const Duration(), EnginePhase.build);
+      final transform =
+          transformKey.currentContext!.findRenderObject()
+              as _RenderTransformAvailability;
+      check(transform.unavailableSizeReads).isGreaterThan(0);
+      check(transform.unavailableTransformReads).equals(0);
+      check(tester.takeException()).isNull();
+
+      // Let the deferred maintenance callbacks observe the unavailable
+      // geometry. Recovery must resume them once the transform is valid.
+      await tester.pump(const Duration(), EnginePhase.paint);
+      check(transform.unavailableTransformReads).equals(0);
+      check(tester.takeException()).isNull();
+
+      rebuild(() => transformAvailable = true);
+      await tester.pump();
+      await tester.pump();
+
+      check(tester.takeException()).isNull();
+      check(controller.rowRect(anchorId)!.top).isCloseTo(before, 1);
+    },
+  );
 
   _viewportTest('oldest edge reserves the toolbar content inset', (
     tester,

--- a/test/features/chat/widgets/modern_chat_input_direct_test.dart
+++ b/test/features/chat/widgets/modern_chat_input_direct_test.dart
@@ -18,6 +18,20 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
+  test('composer measurement style matches recording typography', () {
+    final recordingStyle = ModernChatInput.debugComposerInputTextStyle(
+      isRecording: true,
+    );
+    final idleStyle = ModernChatInput.debugComposerInputTextStyle(
+      isRecording: false,
+    );
+
+    expect(recordingStyle.fontWeight, FontWeight.w500);
+    expect(recordingStyle.fontStyle, FontStyle.italic);
+    expect(idleStyle.fontWeight, FontWeight.w400);
+    expect(idleStyle.fontStyle, FontStyle.normal);
+  });
+
   test('OpenWebUI explicit attachment capability denials fail closed', () {
     final model = Model.fromJson({
       'id': 'text-only',

--- a/test/features/chat/widgets/modern_chat_input_direct_test.dart
+++ b/test/features/chat/widgets/modern_chat_input_direct_test.dart
@@ -5,10 +5,12 @@ import 'package:conduit/core/services/api_service.dart';
 import 'package:conduit/core/services/settings_service.dart';
 import 'package:conduit/core/services/worker_manager.dart';
 import 'package:conduit/features/chat/providers/chat_providers.dart';
+import 'package:conduit/features/chat/services/voice_input_service.dart';
 import 'package:conduit/features/chat/widgets/composer_overflow_menu.dart';
 import 'package:conduit/features/chat/widgets/modern_chat_input.dart';
 import 'package:conduit/features/direct_connections/direct_connections.dart';
 import 'package:conduit/l10n/app_localizations.dart';
+import 'package:conduit/shared/theme/theme_extensions.dart';
 import 'package:conduit/shared/widgets/themed_sheets.dart';
 import 'package:adaptive_platform_ui/adaptive_platform_ui.dart';
 import 'package:flutter/material.dart';
@@ -717,7 +719,7 @@ void main() {
     expect(ThemedSheets.hasActiveSheet, isFalse);
   });
 
-  testWidgets('focus uses two-tier composer without unselected quick pills', (
+  testWidgets('focus stays compact until the composer becomes multiline', (
     tester,
   ) async {
     await tester.pumpWidget(
@@ -747,6 +749,13 @@ void main() {
 
     final composerField = tester.widget<TextField>(find.byType(TextField));
     expect(composerField.focusNode?.hasFocus, isTrue);
+    expect(find.byKey(compactShellKey), findsOneWidget);
+    expect(find.byKey(expandedShellKey), findsNothing);
+
+    await tester.enterText(find.byType(TextField), 'first line\nsecond line');
+    await tester.pump();
+    await tester.pump();
+
     expect(find.byKey(compactShellKey), findsNothing);
     expect(find.byKey(expandedShellKey), findsOneWidget);
     expect(find.byKey(expandedInputKey), findsOneWidget);
@@ -766,12 +775,61 @@ void main() {
     expect(actionInsets.left, 8);
     expect(actionInsets.right, 8);
 
-    composerField.focusNode?.unfocus();
+    await tester.enterText(find.byType(TextField), 'single line');
     await tester.pump();
     await tester.pump();
 
     expect(find.byKey(compactShellKey), findsOneWidget);
     expect(find.byKey(expandedShellKey), findsNothing);
+    expect(
+      tester.widget<TextField>(find.byType(TextField)).focusNode?.hasFocus,
+      isTrue,
+    );
+  });
+
+  testWidgets('a visually wrapped second line expands the composer', (
+    tester,
+  ) async {
+    tester.view.devicePixelRatio = 1;
+    tester.view.physicalSize = const Size(320, 800);
+    addTearDown(tester.view.resetDevicePixelRatio);
+    addTearDown(tester.view.resetPhysicalSize);
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [apiServiceProvider.overrideWithValue(null)],
+        child: MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: Scaffold(body: ModernChatInput(onSendMessage: (_) {})),
+        ),
+      ),
+    );
+    await tester.pump();
+
+    const wrappedText = 'A focused message wraps onto line two';
+    expect(wrappedText.length, lessThan(51));
+
+    final editable = tester.widget<EditableText>(find.byType(EditableText));
+    final editableContext = tester.element(find.byType(EditableText));
+    final textPainter = TextPainter(
+      text: TextSpan(text: wrappedText, style: editable.style),
+      textDirection: Directionality.of(editableContext),
+      textScaler: MediaQuery.textScalerOf(editableContext),
+      maxLines: 2,
+    )..layout(maxWidth: tester.getSize(find.byType(EditableText)).width);
+    expect(textPainter.computeLineMetrics().length, 2);
+
+    await tester.tap(find.byType(TextField));
+    await tester.enterText(find.byType(TextField), wrappedText);
+    await tester.pump();
+    await tester.pump();
+
+    expect(find.byKey(const ValueKey('compact-composer-shell')), findsNothing);
+    expect(
+      find.byKey(const ValueKey('expanded-composer-shell')),
+      findsOneWidget,
+    );
   });
 
   testWidgets('compact composer uses symmetric horizontal insets', (
@@ -827,6 +885,17 @@ void main() {
       overflowCenter.dx - shellRect.left,
       closeTo(shellRect.right - primaryCenter.dx, 0.01),
     );
+
+    await tester.enterText(find.byType(TextField), 'Hi');
+    await tester.pump();
+
+    final fieldRect = tester.getRect(find.byType(TextField));
+    final overflowRect = tester.getRect(overflowButton);
+    final activePrimaryRect = tester.getRect(
+      find.byKey(const ValueKey('primary-btn-send')),
+    );
+    expect(fieldRect.left - overflowRect.right, Spacing.xs);
+    expect(activePrimaryRect.left - fieldRect.right, Spacing.xs);
   });
 
   testWidgets('secondary composer actions use plain icon buttons', (
@@ -866,7 +935,7 @@ void main() {
     );
 
     await tester.tap(find.byType(TextField));
-    await tester.enterText(find.byType(TextField), 'Draft note');
+    await tester.enterText(find.byType(TextField), 'Draft\nnote');
     await tester.pump();
     await tester.pump();
 
@@ -877,6 +946,92 @@ void main() {
           )
           .style,
       AdaptiveButtonStyle.plain,
+    );
+  });
+
+  testWidgets('Android add icon is optically balanced with the mic', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          apiServiceProvider.overrideWithValue(null),
+          voiceInputAvailableProvider.overrideWith((_) async => true),
+        ],
+        child: MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: Scaffold(
+            body: ModernChatInput(
+              onSendMessage: (_) {},
+              onFileAttachment: _noop,
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.pump();
+
+    final addIcon = tester.widget<Icon>(find.byIcon(Icons.add));
+    final micIcon = tester.widget<Icon>(find.byIcon(Icons.mic));
+    expect(addIcon.size, 28);
+    expect(micIcon.size, IconSize.large);
+
+    final addButton = find.byKey(
+      const ValueKey<String>('composer-overflow-button'),
+    );
+    final micButton = find.byKey(
+      const ValueKey<String>('composer-dictation-start'),
+    );
+    expect(tester.getSize(addButton), tester.getSize(micButton));
+  });
+
+  testWidgets('overflow close control keeps its compact size when expanded', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [apiServiceProvider.overrideWithValue(null)],
+        child: MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: Scaffold(
+            body: ModernChatInput(
+              onSendMessage: (_) {},
+              onFileAttachment: _noop,
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.pump();
+
+    final overflowButton = find.byKey(
+      const ValueKey<String>('composer-overflow-button'),
+    );
+    final addControlSize = tester.getSize(overflowButton);
+
+    await tester.tap(find.byIcon(Icons.add));
+    await tester.pumpAndSettle();
+
+    final compactCloseControlSize = tester.getSize(overflowButton);
+    final compactCloseGlyphSize = tester
+        .widget<Icon>(find.byIcon(Icons.close))
+        .size;
+    expect(compactCloseControlSize, addControlSize);
+
+    await tester.enterText(find.byType(TextField), 'first line\nsecond line');
+    await tester.pump();
+    await tester.pump();
+
+    expect(
+      find.byKey(const ValueKey('expanded-composer-shell')),
+      findsOneWidget,
+    );
+    expect(tester.getSize(overflowButton), compactCloseControlSize);
+    expect(
+      tester.widget<Icon>(find.byIcon(Icons.close)).size,
+      compactCloseGlyphSize,
     );
   });
 

--- a/test/features/chat/widgets/modern_chat_input_direct_test.dart
+++ b/test/features/chat/widgets/modern_chat_input_direct_test.dart
@@ -855,8 +855,15 @@ void main() {
       textDirection: Directionality.of(editableContext),
       textScaler: MediaQuery.textScalerOf(editableContext),
       maxLines: 2,
-    )..layout(maxWidth: tester.getSize(find.byType(EditableText)).width);
-    expect(textPainter.computeLineMetrics().length, 2);
+    );
+    try {
+      textPainter.layout(
+        maxWidth: tester.getSize(find.byType(EditableText)).width,
+      );
+      expect(textPainter.computeLineMetrics().length, 2);
+    } finally {
+      textPainter.dispose();
+    }
 
     await tester.tap(find.byType(TextField));
     await tester.enterText(find.byType(TextField), wrappedText);

--- a/test/features/chat/widgets/modern_chat_input_direct_test.dart
+++ b/test/features/chat/widgets/modern_chat_input_direct_test.dart
@@ -1,3 +1,5 @@
+import 'dart:io';
+
 import 'package:conduit/core/models/model.dart';
 import 'package:conduit/core/models/server_config.dart';
 import 'package:conduit/core/providers/app_providers.dart';
@@ -1053,7 +1055,8 @@ void main() {
 
     final addIcon = tester.widget<Icon>(find.byIcon(Icons.add));
     final micIcon = tester.widget<Icon>(find.byIcon(Icons.mic));
-    expect(addIcon.size, IconSize.large);
+    final expectedAddIconSize = Platform.isAndroid ? 28 : IconSize.large;
+    expect(addIcon.size, expectedAddIconSize);
     expect(micIcon.size, IconSize.large);
 
     final addButton = find.byKey(

--- a/test/features/chat/widgets/modern_chat_input_direct_test.dart
+++ b/test/features/chat/widgets/modern_chat_input_direct_test.dart
@@ -832,6 +832,49 @@ void main() {
     );
   });
 
+  testWidgets('unchanged draft reflows when the composer width changes', (
+    tester,
+  ) async {
+    tester.view.devicePixelRatio = 1;
+    tester.view.physicalSize = const Size(1000, 800);
+    addTearDown(tester.view.resetDevicePixelRatio);
+    addTearDown(tester.view.resetPhysicalSize);
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [apiServiceProvider.overrideWithValue(null)],
+        child: MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: Scaffold(body: ModernChatInput(onSendMessage: (_) {})),
+        ),
+      ),
+    );
+    await tester.pump();
+
+    const compactShellKey = ValueKey('compact-composer-shell');
+    const expandedShellKey = ValueKey('expanded-composer-shell');
+    const wrappedText = 'A focused message wraps onto line two';
+
+    await tester.enterText(find.byType(TextField), wrappedText);
+    await tester.pump();
+    await tester.pump();
+    expect(find.byKey(compactShellKey), findsOneWidget);
+    expect(find.byKey(expandedShellKey), findsNothing);
+
+    tester.view.physicalSize = const Size(320, 800);
+    await tester.pump();
+    await tester.pump();
+    expect(find.byKey(compactShellKey), findsNothing);
+    expect(find.byKey(expandedShellKey), findsOneWidget);
+
+    tester.view.physicalSize = const Size(1000, 800);
+    await tester.pump();
+    await tester.pump();
+    expect(find.byKey(compactShellKey), findsOneWidget);
+    expect(find.byKey(expandedShellKey), findsNothing);
+  });
+
   testWidgets('compact composer uses symmetric horizontal insets', (
     tester,
   ) async {

--- a/test/features/chat/widgets/modern_chat_input_direct_test.dart
+++ b/test/features/chat/widgets/modern_chat_input_direct_test.dart
@@ -13,6 +13,7 @@ import 'package:conduit/l10n/app_localizations.dart';
 import 'package:conduit/shared/theme/theme_extensions.dart';
 import 'package:conduit/shared/widgets/themed_sheets.dart';
 import 'package:adaptive_platform_ui/adaptive_platform_ui.dart';
+import 'package:checks/checks.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -26,10 +27,31 @@ void main() {
       isRecording: false,
     );
 
-    expect(recordingStyle.fontWeight, FontWeight.w500);
-    expect(recordingStyle.fontStyle, FontStyle.italic);
-    expect(idleStyle.fontWeight, FontWeight.w400);
-    expect(idleStyle.fontStyle, FontStyle.normal);
+    check(recordingStyle.fontWeight).equals(FontWeight.w500);
+    check(recordingStyle.fontStyle).equals(FontStyle.italic);
+    check(idleStyle.fontWeight).equals(FontWeight.w400);
+    check(idleStyle.fontStyle).equals(FontStyle.normal);
+  });
+
+  test('only Android enlarges the compact overflow add glyph', () {
+    check(
+      ModernChatInput.debugOverflowIconSize(
+        isAndroid: true,
+        attachmentPanelVisible: false,
+      ),
+    ).equals(28);
+    check(
+      ModernChatInput.debugOverflowIconSize(
+        isAndroid: false,
+        attachmentPanelVisible: false,
+      ),
+    ).equals(IconSize.large);
+    check(
+      ModernChatInput.debugOverflowIconSize(
+        isAndroid: true,
+        attachmentPanelVisible: true,
+      ),
+    ).equals(IconSize.large);
   });
 
   test('OpenWebUI explicit attachment capability denials fail closed', () {
@@ -1006,7 +1028,7 @@ void main() {
     );
   });
 
-  testWidgets('Android add icon is optically balanced with the mic', (
+  testWidgets('non-Android add icon matches the standard mic glyph', (
     tester,
   ) async {
     await tester.pumpWidget(
@@ -1031,7 +1053,7 @@ void main() {
 
     final addIcon = tester.widget<Icon>(find.byIcon(Icons.add));
     final micIcon = tester.widget<Icon>(find.byIcon(Icons.mic));
-    expect(addIcon.size, 28);
+    expect(addIcon.size, IconSize.large);
     expect(micIcon.size, IconSize.large);
 
     final addButton = find.byKey(

--- a/test/shared/widgets/markdown/renderer/streaming_markdown_widget_test.dart
+++ b/test/shared/widgets/markdown/renderer/streaming_markdown_widget_test.dart
@@ -4134,6 +4134,36 @@ Tail keeps growing
     expect(find.text('Output'), findsNothing);
   });
 
+  testWidgets('hides pending tool call embeds until completion', (
+    tester,
+  ) async {
+    const pendingContent = '''
+<details type="tool_calls" done="false" name="browser" embeds="[&quot;https://example.com/embed&quot;]">
+<summary>Tool Executing</summary>
+</details>
+<details type="tool_calls" done="true" name="search" result="&quot;done&quot;">
+<summary>Tool Executed</summary>
+</details>
+''';
+    const completedContent = '''
+<details type="tool_calls" done="true" name="browser" embeds="[&quot;https://example.com/embed&quot;]">
+<summary>Tool Executed</summary>
+</details>
+<details type="tool_calls" done="true" name="search" result="&quot;done&quot;">
+<summary>Tool Executed</summary>
+</details>
+''';
+
+    await tester.pumpWidget(buildHarness(pendingContent));
+
+    expect(find.text('Exploring browser, search'), findsOneWidget);
+    expect(find.byKey(const ValueKey('tool-call-embed-0')), findsNothing);
+
+    await tester.pumpWidget(buildHarness(completedContent));
+
+    expect(find.byKey(const ValueKey('tool-call-embed-0')), findsOneWidget);
+  });
+
   testWidgets('does not surface raw html text for tool call embeds', (
     tester,
   ) async {

--- a/test/shared/widgets/markdown/renderer/streaming_markdown_widget_test.dart
+++ b/test/shared/widgets/markdown/renderer/streaming_markdown_widget_test.dart
@@ -2172,6 +2172,33 @@ After
     expect(find.text('View Result from browser'), findsOneWidget);
   });
 
+  testWidgets(
+    'keeps grouped tool call embeds visible while details are closed',
+    (tester) async {
+      const content = '''
+<details type="tool_calls" done="true" name="search" result="&quot;one&quot;">
+<summary>Tool Executed</summary>
+</details>
+<details type="tool_calls" done="true" name="browser" embeds="[&quot;https://example.com/embed&quot;]">
+<summary>Tool Executed</summary>
+</details>
+''';
+
+      await tester.pumpWidget(buildHarness(content));
+
+      expect(find.text('Explored search, browser'), findsOneWidget);
+      expect(find.byKey(const ValueKey('tool-call-embed-0')), findsOneWidget);
+      expect(find.text('View Result from search'), findsNothing);
+      expect(find.text('View Result from browser'), findsNothing);
+
+      await tester.tap(find.text('Explored search, browser'));
+      await tester.pumpAndSettle();
+
+      expect(find.byKey(const ValueKey('tool-call-embed-0')), findsOneWidget);
+      expect(find.text('View Result from search'), findsOneWidget);
+    },
+  );
+
   testWidgets('localizes grouped tool call titles', (tester) async {
     const content = '''
 <details type="tool_calls" done="true" name="search" result="&quot;one&quot;">
@@ -4089,7 +4116,7 @@ Tail keeps growing
     );
   });
 
-  testWidgets('defers tool call embeds until the details view opens', (
+  testWidgets('shows completed tool call embeds without opening details', (
     tester,
   ) async {
     const content = '''
@@ -4100,15 +4127,11 @@ Tail keeps growing
 
     await tester.pumpWidget(buildHarness(content));
 
-    expect(find.text('View Result from browser'), findsOneWidget);
-    expect(find.byKey(const ValueKey('tool-call-embed-0')), findsNothing);
+    expect(find.text('browser'), findsOneWidget);
+    expect(find.text('View Result from browser'), findsNothing);
+    expect(find.byKey(const ValueKey('tool-call-embed-0')), findsOneWidget);
     expect(find.text('Input'), findsNothing);
     expect(find.text('Output'), findsNothing);
-
-    await tester.tap(find.text('View Result from browser'));
-    await tester.pumpAndSettle();
-
-    expect(find.byKey(const ValueKey('tool-call-embed-0')), findsOneWidget);
   });
 
   testWidgets('does not surface raw html text for tool call embeds', (
@@ -4122,13 +4145,10 @@ Tail keeps growing
 
     await tester.pumpWidget(buildHarness(content));
 
-    expect(find.byKey(const ValueKey('tool-call-embed-0')), findsNothing);
-    await tester.tap(find.text('View Result from browser'));
-    await tester.pumpAndSettle();
+    expect(find.byKey(const ValueKey('tool-call-embed-0')), findsOneWidget);
     expect(find.textContaining('<div>hello</div>'), findsNothing);
     expect(find.text('Input'), findsNothing);
     expect(find.text('Output'), findsNothing);
-    expect(find.byKey(const ValueKey('tool-call-embed-0')), findsOneWidget);
   });
 
   testWidgets(
@@ -4142,16 +4162,8 @@ Tail keeps growing
 
       await tester.pumpWidget(buildHarness(content, isStreaming: true));
 
-      expect(find.text('View Result from browser'), findsOneWidget);
-      expect(find.byKey(const ValueKey('tool-call-embed-0')), findsNothing);
-
-      await tester.tap(find.text('View Result from browser'));
-      await tester.pumpAndSettle();
-
-      expect(
-        find.text('Preview will be available after streaming completes.'),
-        findsOneWidget,
-      );
+      expect(find.text('browser'), findsOneWidget);
+      expect(find.text('View Result from browser'), findsNothing);
       expect(find.byKey(const ValueKey('tool-call-embed-0')), findsNothing);
     },
   );

--- a/test/shared/widgets/themed_sheets_test.dart
+++ b/test/shared/widgets/themed_sheets_test.dart
@@ -211,10 +211,19 @@ void main() {
       find.descendant(of: header, matching: find.byType(Divider)),
       findsOneWidget,
     );
-    expect(
-      find.descendant(of: header, matching: find.byType(AdaptiveButton)),
-      findsOneWidget,
-    );
+    if (conduitSupportsNativeGlass()) {
+      expect(
+        find.descendant(of: header, matching: find.byType(AdaptiveButton)),
+        findsOneWidget,
+      );
+    } else {
+      final closeButton = find.descendant(
+        of: header,
+        matching: find.byType(IconButton),
+      );
+      expect(closeButton, findsOneWidget);
+      expect(tester.getSize(closeButton), const Size.square(36));
+    }
   });
 
   testWidgets('root sheets remove native toolbar chrome beneath their edges', (

--- a/test/shared/widgets/web_content_embed_test.dart
+++ b/test/shared/widgets/web_content_embed_test.dart
@@ -89,6 +89,27 @@ void main() {
     ).isFalse();
   });
 
+  test('keeps inline document fragments inside the embed', () {
+    check(
+      WebContentEmbed.debugShouldAllowInlineFragmentNavigation(
+        'about:srcdoc#forecast',
+      ),
+    ).isTrue();
+    check(
+      WebContentEmbed.debugShouldAllowInlineFragmentNavigation(
+        'about:blank#forecast',
+      ),
+    ).isTrue();
+    check(
+      WebContentEmbed.debugShouldAllowInlineFragmentNavigation('about:srcdoc'),
+    ).isFalse();
+    check(
+      WebContentEmbed.debugShouldAllowInlineFragmentNavigation(
+        'javascript:#forecast',
+      ),
+    ).isFalse();
+  });
+
   test(
     'requires positive activation evidence when gesture data is present',
     () {

--- a/test/shared/widgets/web_content_embed_test.dart
+++ b/test/shared/widgets/web_content_embed_test.dart
@@ -206,6 +206,17 @@ void main() {
     check(WebContentEmbed.debugFrameBootstrapScript(secret)).contains(secret);
   });
 
+  test('inline argument bootstrap does not duplicate height observers', () {
+    final argumentsScript = WebContentEmbed.debugInlineArgumentsScript(
+      'private-tool-argument',
+    );
+
+    check(argumentsScript).contains('window.args =');
+    check(argumentsScript).contains('private-tool-argument');
+    check(argumentsScript).not((it) => it.contains('ResizeObserver'));
+    check(argumentsScript).not((it) => it.contains('postMessage'));
+  });
+
   test(
     'requires positive activation evidence when gesture data is present',
     () {

--- a/test/shared/widgets/web_content_embed_test.dart
+++ b/test/shared/widgets/web_content_embed_test.dart
@@ -65,6 +65,22 @@ void main() {
     check(document).not((it) => it.contains('allow-same-origin'));
   });
 
+  test('keeps remote tool URLs inside the sandboxed frame', () {
+    final document = WebContentEmbed.debugWrapRemoteDocument(
+      'https://example.com/widget?city=New%20York&units=metric',
+    );
+
+    check(document).contains(
+      'src="https://example.com/widget?city=New%20York&amp;units=metric"',
+    );
+    check(
+      document,
+    ).contains('sandbox="allow-scripts allow-forms allow-popups"');
+    check(document).contains('referrerpolicy="no-referrer"');
+    check(document).not((it) => it.contains('allow-same-origin'));
+    check(document).not((it) => it.contains('srcdoc="https://example.com'));
+  });
+
   test('opens only user-activated external navigations', () {
     check(
       WebContentEmbed.debugShouldOpenNavigationExternally(

--- a/test/shared/widgets/web_content_embed_test.dart
+++ b/test/shared/widgets/web_content_embed_test.dart
@@ -185,6 +185,37 @@ void main() {
     ).isFalse();
   });
 
+  test('resolves only user-activated popups whose URL Android omits', () {
+    check(
+      WebContentEmbed.debugShouldResolveMissingPopupUrl(
+        requestIsCurrent: true,
+        targetUrl: null,
+        hasGesture: true,
+      ),
+    ).isTrue();
+    check(
+      WebContentEmbed.debugShouldResolveMissingPopupUrl(
+        requestIsCurrent: true,
+        targetUrl: null,
+        hasGesture: false,
+      ),
+    ).isFalse();
+    check(
+      WebContentEmbed.debugShouldResolveMissingPopupUrl(
+        requestIsCurrent: true,
+        targetUrl: 'https://example.com/story',
+        hasGesture: true,
+      ),
+    ).isFalse();
+    check(
+      WebContentEmbed.debugShouldResolveMissingPopupUrl(
+        requestIsCurrent: false,
+        targetUrl: null,
+        hasGesture: true,
+      ),
+    ).isFalse();
+  });
+
   test('rejects disallowed embed links before invoking the launcher', () async {
     final launcher = _MockExternalLinkLauncher();
     when(() => launcher(any())).thenAnswer((_) async => true);

--- a/test/shared/widgets/web_content_embed_test.dart
+++ b/test/shared/widgets/web_content_embed_test.dart
@@ -4,6 +4,7 @@ import 'package:conduit/shared/theme/tweakcn_themes.dart';
 import 'package:conduit/shared/widgets/web_content_embed.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:html_unescape/html_unescape.dart';
 
 Widget _buildHarness({
   required String source,
@@ -34,11 +35,108 @@ void main() {
       '<div>chart</div><script>renderChart()</script>',
     );
 
-    expect(document, contains('sandbox="allow-scripts allow-forms"'));
+    expect(
+      document,
+      contains('sandbox="allow-scripts allow-forms allow-popups"'),
+    );
     expect(document, contains('referrerpolicy="no-referrer"'));
     expect(document, contains('srcdoc="'));
     expect(document, contains('&lt;script&gt;renderChart()&lt;/script&gt;'));
     expect(document, isNot(contains('<script>renderChart()</script>')));
+  });
+
+  test('allows popup links without granting same-origin access', () {
+    final document = WebContentEmbed.debugWrapHtmlDocument(
+      '<a href="https://example.com/story" target="_blank">Read more</a>',
+    );
+    final decodedDocument = HtmlUnescape().convert(document);
+
+    expect(decodedDocument, contains('target="_blank"'));
+    expect(
+      document,
+      contains('sandbox="allow-scripts allow-forms allow-popups"'),
+    );
+    expect(document, isNot(contains('allow-same-origin')));
+  });
+
+  test('opens only user-activated external navigations', () {
+    expect(
+      WebContentEmbed.debugShouldOpenNavigationExternally(
+        targetUrl: 'https://example.com/story',
+        currentUrl: 'https://embed.example.com/widget',
+        userActivated: true,
+      ),
+      isTrue,
+    );
+    expect(
+      WebContentEmbed.debugShouldOpenNavigationExternally(
+        targetUrl: 'https://example.com/story',
+        currentUrl: 'https://embed.example.com/widget',
+        userActivated: false,
+      ),
+      isFalse,
+    );
+    expect(
+      WebContentEmbed.debugShouldOpenNavigationExternally(
+        targetUrl: 'https://embed.example.com/widget#forecast',
+        currentUrl: 'https://embed.example.com/widget',
+        userActivated: true,
+      ),
+      isFalse,
+    );
+  });
+
+  test('automatic embed navigation is limited to web redirects', () {
+    expect(
+      WebContentEmbed.debugShouldAllowAutomaticNavigation(
+        'https://example.com/redirect',
+      ),
+      isTrue,
+    );
+    expect(
+      WebContentEmbed.debugShouldAllowAutomaticNavigation('about:blank'),
+      isTrue,
+    );
+    expect(
+      WebContentEmbed.debugShouldAllowAutomaticNavigation('about:srcdoc'),
+      isTrue,
+    );
+    expect(
+      WebContentEmbed.debugShouldAllowAutomaticNavigation(
+        'mailto:reader@example.com',
+      ),
+      isFalse,
+    );
+    expect(
+      WebContentEmbed.debugShouldAllowAutomaticNavigation(
+        'javascript:alert(1)',
+      ),
+      isFalse,
+    );
+  });
+
+  test('rejects disallowed embed links before invoking the launcher', () async {
+    var launches = 0;
+    Future<bool> launcher(String url) async {
+      launches += 1;
+      return true;
+    }
+
+    expect(
+      await WebContentEmbed.debugOpenExternalLink(
+        'javascript:alert(1)',
+        launcher: launcher,
+      ),
+      isFalse,
+    );
+    expect(
+      await WebContentEmbed.debugOpenExternalLink(
+        'https://example.com/story',
+        launcher: launcher,
+      ),
+      isTrue,
+    );
+    expect(launches, 1);
   });
 
   test('escapes injected arguments before adding them to sandbox HTML', () {

--- a/test/shared/widgets/web_content_embed_test.dart
+++ b/test/shared/widgets/web_content_embed_test.dart
@@ -81,6 +81,21 @@ void main() {
     check(document).not((it) => it.contains('srcdoc="https://example.com'));
   });
 
+  test('injects arguments and height reporting into remote frames', () {
+    final bootstrap = WebContentEmbed.debugFrameBootstrapScript(
+      '</script><script>steal()</script>',
+    );
+
+    check(bootstrap).contains(
+      r'window.args = "\u003C/script\u003E\u003Cscript\u003Esteal()\u003C/script\u003E";',
+    );
+    check(bootstrap).contains(
+      "parent.postMessage({ type: 'conduit-embed-height', height }, '*')",
+    );
+    check(bootstrap).contains('new ResizeObserver(reportHeight)');
+    check(bootstrap).not((it) => it.contains('</script><script>steal()'));
+  });
+
   test('opens only user-activated external navigations', () {
     check(
       WebContentEmbed.debugShouldOpenNavigationExternally(

--- a/test/shared/widgets/web_content_embed_test.dart
+++ b/test/shared/widgets/web_content_embed_test.dart
@@ -115,6 +115,30 @@ void main() {
     );
   });
 
+  test('popup handling does not depend on platform gesture metadata', () {
+    expect(
+      WebContentEmbed.debugShouldHandleCreateWindow(
+        requestIsCurrent: true,
+        targetUrl: 'https://example.com/story',
+      ),
+      isTrue,
+    );
+    expect(
+      WebContentEmbed.debugShouldHandleCreateWindow(
+        requestIsCurrent: false,
+        targetUrl: 'https://example.com/story',
+      ),
+      isFalse,
+    );
+    expect(
+      WebContentEmbed.debugShouldHandleCreateWindow(
+        requestIsCurrent: true,
+        targetUrl: 'javascript:alert(1)',
+      ),
+      isFalse,
+    );
+  });
+
   test('rejects disallowed embed links before invoking the launcher', () async {
     var launches = 0;
     Future<bool> launcher(String url) async {

--- a/test/shared/widgets/web_content_embed_test.dart
+++ b/test/shared/widgets/web_content_embed_test.dart
@@ -185,33 +185,23 @@ void main() {
     ).isFalse();
   });
 
-  test('resolves only user-activated popups whose URL Android omits', () {
+  test('resolves platform-approved popups whose URL Android omits', () {
     check(
       WebContentEmbed.debugShouldResolveMissingPopupUrl(
         requestIsCurrent: true,
         targetUrl: null,
-        hasGesture: true,
       ),
     ).isTrue();
     check(
       WebContentEmbed.debugShouldResolveMissingPopupUrl(
         requestIsCurrent: true,
-        targetUrl: null,
-        hasGesture: false,
-      ),
-    ).isFalse();
-    check(
-      WebContentEmbed.debugShouldResolveMissingPopupUrl(
-        requestIsCurrent: true,
         targetUrl: 'https://example.com/story',
-        hasGesture: true,
       ),
     ).isFalse();
     check(
       WebContentEmbed.debugShouldResolveMissingPopupUrl(
         requestIsCurrent: false,
         targetUrl: null,
-        hasGesture: true,
       ),
     ).isFalse();
   });

--- a/test/shared/widgets/web_content_embed_test.dart
+++ b/test/shared/widgets/web_content_embed_test.dart
@@ -2,9 +2,17 @@ import 'package:conduit/l10n/app_localizations.dart';
 import 'package:conduit/shared/theme/app_theme.dart';
 import 'package:conduit/shared/theme/tweakcn_themes.dart';
 import 'package:conduit/shared/widgets/web_content_embed.dart';
+import 'package:checks/checks.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:html_unescape/html_unescape.dart';
+import 'package:mocktail/mocktail.dart';
+
+abstract interface class _ExternalLinkLauncher {
+  Future<bool> call(String url);
+}
+
+class _MockExternalLinkLauncher extends Mock implements _ExternalLinkLauncher {}
 
 Widget _buildHarness({
   required String source,
@@ -35,14 +43,13 @@ void main() {
       '<div>chart</div><script>renderChart()</script>',
     );
 
-    expect(
+    check(
       document,
-      contains('sandbox="allow-scripts allow-forms allow-popups"'),
-    );
-    expect(document, contains('referrerpolicy="no-referrer"'));
-    expect(document, contains('srcdoc="'));
-    expect(document, contains('&lt;script&gt;renderChart()&lt;/script&gt;'));
-    expect(document, isNot(contains('<script>renderChart()</script>')));
+    ).contains('sandbox="allow-scripts allow-forms allow-popups"');
+    check(document).contains('referrerpolicy="no-referrer"');
+    check(document).contains('srcdoc="');
+    check(document).contains('&lt;script&gt;renderChart()&lt;/script&gt;');
+    check(document).not((it) => it.contains('<script>renderChart()</script>'));
   });
 
   test('allows popup links without granting same-origin access', () {
@@ -51,116 +58,131 @@ void main() {
     );
     final decodedDocument = HtmlUnescape().convert(document);
 
-    expect(decodedDocument, contains('target="_blank"'));
-    expect(
+    check(decodedDocument).contains('target="_blank"');
+    check(
       document,
-      contains('sandbox="allow-scripts allow-forms allow-popups"'),
-    );
-    expect(document, isNot(contains('allow-same-origin')));
+    ).contains('sandbox="allow-scripts allow-forms allow-popups"');
+    check(document).not((it) => it.contains('allow-same-origin'));
   });
 
   test('opens only user-activated external navigations', () {
-    expect(
+    check(
       WebContentEmbed.debugShouldOpenNavigationExternally(
         targetUrl: 'https://example.com/story',
         currentUrl: 'https://embed.example.com/widget',
         userActivated: true,
       ),
-      isTrue,
-    );
-    expect(
+    ).isTrue();
+    check(
       WebContentEmbed.debugShouldOpenNavigationExternally(
         targetUrl: 'https://example.com/story',
         currentUrl: 'https://embed.example.com/widget',
         userActivated: false,
       ),
-      isFalse,
-    );
-    expect(
+    ).isFalse();
+    check(
       WebContentEmbed.debugShouldOpenNavigationExternally(
         targetUrl: 'https://embed.example.com/widget#forecast',
         currentUrl: 'https://embed.example.com/widget',
         userActivated: true,
       ),
-      isFalse,
-    );
+    ).isFalse();
   });
 
+  test(
+    'requires positive activation evidence when gesture data is present',
+    () {
+      check(
+        WebContentEmbed.debugHasUserActivationEvidence(
+          hasGesture: true,
+          linkActivated: false,
+        ),
+      ).isTrue();
+      check(
+        WebContentEmbed.debugHasUserActivationEvidence(
+          hasGesture: false,
+          linkActivated: true,
+        ),
+      ).isFalse();
+      check(
+        WebContentEmbed.debugHasUserActivationEvidence(
+          hasGesture: null,
+          linkActivated: true,
+        ),
+      ).isTrue();
+      check(
+        WebContentEmbed.debugHasUserActivationEvidence(
+          hasGesture: null,
+          linkActivated: false,
+        ),
+      ).isFalse();
+    },
+  );
+
   test('automatic embed navigation is limited to web redirects', () {
-    expect(
+    check(
       WebContentEmbed.debugShouldAllowAutomaticNavigation(
         'https://example.com/redirect',
       ),
-      isTrue,
-    );
-    expect(
+    ).isTrue();
+    check(
       WebContentEmbed.debugShouldAllowAutomaticNavigation('about:blank'),
-      isTrue,
-    );
-    expect(
+    ).isTrue();
+    check(
       WebContentEmbed.debugShouldAllowAutomaticNavigation('about:srcdoc'),
-      isTrue,
-    );
-    expect(
+    ).isTrue();
+    check(
       WebContentEmbed.debugShouldAllowAutomaticNavigation(
         'mailto:reader@example.com',
       ),
-      isFalse,
-    );
-    expect(
+    ).isFalse();
+    check(
       WebContentEmbed.debugShouldAllowAutomaticNavigation(
         'javascript:alert(1)',
       ),
-      isFalse,
-    );
+    ).isFalse();
   });
 
   test('popup handling does not depend on platform gesture metadata', () {
-    expect(
+    check(
       WebContentEmbed.debugShouldHandleCreateWindow(
         requestIsCurrent: true,
         targetUrl: 'https://example.com/story',
       ),
-      isTrue,
-    );
-    expect(
+    ).isTrue();
+    check(
       WebContentEmbed.debugShouldHandleCreateWindow(
         requestIsCurrent: false,
         targetUrl: 'https://example.com/story',
       ),
-      isFalse,
-    );
-    expect(
+    ).isFalse();
+    check(
       WebContentEmbed.debugShouldHandleCreateWindow(
         requestIsCurrent: true,
         targetUrl: 'javascript:alert(1)',
       ),
-      isFalse,
-    );
+    ).isFalse();
   });
 
   test('rejects disallowed embed links before invoking the launcher', () async {
-    var launches = 0;
-    Future<bool> launcher(String url) async {
-      launches += 1;
-      return true;
-    }
+    final launcher = _MockExternalLinkLauncher();
+    when(() => launcher(any())).thenAnswer((_) async => true);
 
-    expect(
+    check(
       await WebContentEmbed.debugOpenExternalLink(
         'javascript:alert(1)',
-        launcher: launcher,
+        launcher: launcher.call,
       ),
-      isFalse,
-    );
-    expect(
+    ).isFalse();
+    verifyNever(() => launcher(any()));
+
+    check(
       await WebContentEmbed.debugOpenExternalLink(
         'https://example.com/story',
-        launcher: launcher,
+        launcher: launcher.call,
       ),
-      isTrue,
-    );
-    expect(launches, 1);
+    ).isTrue();
+    verify(() => launcher('https://example.com/story')).called(1);
   });
 
   test('escapes injected arguments before adding them to sandbox HTML', () {
@@ -169,13 +191,12 @@ void main() {
       argsText: '</script><script>steal()</script>',
     );
 
-    expect(
-      document,
-      contains(
-        r'window.args = &quot;\u003C/script\u003E\u003Cscript\u003Esteal()\u003C/script\u003E&quot;;',
-      ),
+    check(document).contains(
+      r'window.args = &quot;\u003C/script\u003E\u003Cscript\u003Esteal()\u003C/script\u003E&quot;;',
     );
-    expect(document, isNot(contains('</script><script>steal()</script>')));
+    check(
+      document,
+    ).not((it) => it.contains('</script><script>steal()</script>'));
   });
 
   test('full-height documents ignore sandbox resize messages', () {
@@ -184,17 +205,17 @@ void main() {
       fillAvailableHeight: true,
     );
 
-    expect(document, contains('height: 100vh'));
-    expect(document, contains('const fillAvailableHeight = true;'));
-    expect(document, contains('if (fillAvailableHeight) return;'));
+    check(document).contains('height: 100vh');
+    check(document).contains('const fillAvailableHeight = true;');
+    check(document).contains('if (fillAvailableHeight) return;');
   });
 
   test('intrinsic-height documents retain sandbox resize handling', () {
     final document = WebContentEmbed.debugWrapHtmlDocument('<div>chart</div>');
 
-    expect(document, contains('height: 360.0px'));
-    expect(document, contains('const fillAvailableHeight = false;'));
-    expect(document, contains(r'frame.style.height = `${clamped}px`;'));
+    check(document).contains('height: 360.0px');
+    check(document).contains('const fillAvailableHeight = false;');
+    check(document).contains(r'frame.style.height = `${clamped}px`;');
   });
 
   testWidgets('collapsed source changes clear stale controllers', (

--- a/test/shared/widgets/web_content_embed_test.dart
+++ b/test/shared/widgets/web_content_embed_test.dart
@@ -81,7 +81,7 @@ void main() {
     check(document).not((it) => it.contains('srcdoc="https://example.com'));
   });
 
-  test('injects arguments and height reporting into remote frames', () {
+  test('builds a script-safe inline frame bootstrap', () {
     final bootstrap = WebContentEmbed.debugFrameBootstrapScript(
       '</script><script>steal()</script>',
     );
@@ -145,31 +145,65 @@ void main() {
     check(
       WebContentEmbed.debugShouldSurfaceLoadFailure(
         isForMainFrame: true,
-        remoteEmbedUrl: null,
+        remoteEmbedUrls: const [],
         requestUrl: 'https://embed.conduit.local/',
       ),
     ).isTrue();
     check(
       WebContentEmbed.debugShouldSurfaceLoadFailure(
         isForMainFrame: false,
-        remoteEmbedUrl: 'https://example.com/widget',
+        remoteEmbedUrls: const ['https://example.com/widget'],
         requestUrl: 'https://example.com/widget',
       ),
     ).isTrue();
     check(
       WebContentEmbed.debugShouldSurfaceLoadFailure(
         isForMainFrame: false,
-        remoteEmbedUrl: 'https://example.com/widget',
+        remoteEmbedUrls: const ['https://example.com/widget'],
         requestUrl: 'https://example.com/broken-image.png',
       ),
     ).isFalse();
     check(
       WebContentEmbed.debugShouldSurfaceLoadFailure(
         isForMainFrame: false,
-        remoteEmbedUrl: null,
+        remoteEmbedUrls: const [],
         requestUrl: 'https://example.com/script.js',
       ),
     ).isFalse();
+  });
+
+  test('normalizes and tracks remote-frame document failure URLs', () {
+    check(
+      WebContentEmbed.debugShouldSurfaceLoadFailure(
+        isForMainFrame: false,
+        remoteEmbedUrls: const ['https://EXAMPLE.com:443'],
+        requestUrl: 'https://example.com/',
+      ),
+    ).isTrue();
+    check(
+      WebContentEmbed.debugShouldSurfaceLoadFailure(
+        isForMainFrame: false,
+        remoteEmbedUrls: const [
+          'https://example.com/widget',
+          'https://cdn.example.net/redirected-widget',
+        ],
+        requestUrl: 'https://cdn.example.net/redirected-widget',
+      ),
+    ).isTrue();
+  });
+
+  test('all-frame bootstrap never exposes tool arguments', () {
+    const secret = 'tool-argument-secret';
+    check(
+      WebContentEmbed.debugAllFrameBootstrapScript(),
+    ).not((it) => it.contains(secret));
+    check(
+      WebContentEmbed.debugAllFrameBootstrapScript(),
+    ).not((it) => it.contains('window.args ='));
+    check(WebContentEmbed.debugAllFrameBootstrapScript()).contains(
+      "parent.postMessage({ type: 'conduit-embed-height', height }, '*')",
+    );
+    check(WebContentEmbed.debugFrameBootstrapScript(secret)).contains(secret);
   });
 
   test(

--- a/test/shared/widgets/web_content_embed_test.dart
+++ b/test/shared/widgets/web_content_embed_test.dart
@@ -141,6 +141,37 @@ void main() {
     ).isFalse();
   });
 
+  test('surfaces only main-document or configured remote-frame failures', () {
+    check(
+      WebContentEmbed.debugShouldSurfaceLoadFailure(
+        isForMainFrame: true,
+        remoteEmbedUrl: null,
+        requestUrl: 'https://embed.conduit.local/',
+      ),
+    ).isTrue();
+    check(
+      WebContentEmbed.debugShouldSurfaceLoadFailure(
+        isForMainFrame: false,
+        remoteEmbedUrl: 'https://example.com/widget',
+        requestUrl: 'https://example.com/widget',
+      ),
+    ).isTrue();
+    check(
+      WebContentEmbed.debugShouldSurfaceLoadFailure(
+        isForMainFrame: false,
+        remoteEmbedUrl: 'https://example.com/widget',
+        requestUrl: 'https://example.com/broken-image.png',
+      ),
+    ).isFalse();
+    check(
+      WebContentEmbed.debugShouldSurfaceLoadFailure(
+        isForMainFrame: false,
+        remoteEmbedUrl: null,
+        requestUrl: 'https://example.com/script.js',
+      ),
+    ).isFalse();
+  });
+
   test(
     'requires positive activation evidence when gesture data is present',
     () {


### PR DESCRIPTION
## Summary
- render completed HTML and iframe tool output inline without requiring users to expand tool details
- make user-activated embed links interactive while preserving iframe sandbox restrictions and URL scheme validation
- keep the composer compact until its text wraps, align compact and expanded controls across iOS and Android, and unify modal close-button theming

## Verification
- flutter analyze
- flutter test: 4,999 passed, 4 skipped
- iPhone 17 Pro simulator on iOS 26.5: verified compact-to-multiline composer transitions, focus retention, consistent control geometry, and repeatable fullscreen inline PDF expansion
- Android-specific composer geometry and icon sizing covered by widget tests; no Android AVD was configured locally

## Security
- embedded HTML remains sandboxed without same-origin access or popup escape
- external navigation requires a user action and an allowlisted URL scheme
- iframe resize messages are accepted only from the embedded frame

Closes #599

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Enable inline interactive HTML tool embeds in chat responses
> - Remote tool-call embeds are now loaded inside a sandboxed iframe wrapper instead of navigating the WebView directly, enabling safer inline HTML rendering in chat.
> - JavaScript-initiated popups are intercepted and launched externally; user-activated navigations to allowed external URLs are opened outside the embed while scripted/disallowed navigations are blocked.
> - The markdown details group now renders a separate previews-only pass so embed widgets appear inline beneath grouped tool calls without requiring the details view to be expanded.
> - Tool-call headers with embeds show just the tool name instead of execution/result status text; pending embeds are hidden until the tool call completes.
> - The chat composer now uses `TextPainter`-based measurement to determine multiline state accurately, keeping the capsule shell for single-line input and switching to the full shell only on real wrapping.
> - Viewport geometry guards in `chat_timeline_viewport.dart` defer metrics and layout work during transient render states and recover automatically once geometry is available.
> - Risk: Loading remote embeds via sandboxed iframe changes referrer, sandboxing, and navigation behavior relative to direct WebView URL loading.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized da86be1.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved chat composer behavior for wrapped and multiline messages, with consistent spacing and touch targets.
  * Added richer grouped previews for tool-call results, including images and embedded outputs.
  * Improved embedded web content handling for external links, popups, and permitted automatic navigation.
  * Added adaptive close controls for modal sheets across supported platforms.

* **Bug Fixes**
  * Preserved compact composer mode for single-line text, including while focused.
  * Improved model selector navigation and close behavior.
  * Improved reliability when loading embedded content and handling popup links.
  * Completed tool-call previews now appear without requiring expansion.
  * Improved chat timeline stability during temporary layout or navigation transitions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This change renders completed tool embeds inline, keeps remote content inside sandboxed frames, limits external navigation to approved links, and improves chat composer and timeline layout behavior.

The grouped embed implementation separates the persistent preview from expanded tool details, so completed embeds are intended to remain single-rendered and pending tool calls remain hidden until completion.

## T-Rex validation blocked

- **Missing tool:** `flutter` is not available on PATH. The focused widget test for grouped completed and pending tool embeds could not start and exited with `flutter: not found` (exit code 127).

[Configure VMs](https://app.greptile.com/-/settings/trex#environments)

<details><summary><h3>Confidence Score: 5/5</h3></summary>

</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex prepared a focused Flutter widget harness for grouped embeds and attempted to run it, but flutter was not found, so no runtime result.
- Static inspection notes that the after-state test is blocked and not yet confirmed; the runnable test source and observed output are available as uploaded artifacts, showing flutter not found and exit code 127.

<a href="https://app.greptile.com/trex/runs/16793656/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (13): Last reviewed commit: ["fix(markdown): defer embeds until tool c..."](https://github.com/cogwheel0/conduit/commit/da86be1c3307665cf4d214f477db93d57408b9d9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49018909)</sub>

<!-- /greptile_comment -->