### PR TITLE
Fix voice calls for Hermes-only setups

### DIFF
--- a/lib/core/services/app_intents_service.dart
+++ b/lib/core/services/app_intents_service.dart
@@ -827,29 +827,6 @@ class AppIntentCoordinator extends _$AppIntentCoordinator
       return {'success': false, 'error': 'App not ready'};
     }
 
-    // Check authentication state
-    final navState = ref.read(authNavigationStateProvider);
-    if (navState != AuthNavigationState.authenticated) {
-      DebugLogger.log(
-        'Not authenticated for voice call',
-        scope: 'app-intents/voice',
-      );
-      return {
-        'success': false,
-        'error': 'Please sign in to start a voice call',
-      };
-    }
-
-    // Check if a model is selected
-    final model = ref.read(selectedModelProvider);
-    if (model == null) {
-      DebugLogger.log(
-        'No model selected for voice call',
-        scope: 'app-intents/voice',
-      );
-      return {'success': false, 'error': 'Please select a model first'};
-    }
-
     try {
       await _startVoiceCall();
       DebugLogger.log(

--- a/lib/core/services/carplay_service.dart
+++ b/lib/core/services/carplay_service.dart
@@ -100,7 +100,7 @@ final class CarPlayCoordinator {
         .start(
           startNewConversation: true,
           shouldStart: () => _isCurrentScene(sceneGeneration),
-          readinessResolved: true,
+          admittedModel: eligibility.model!,
         );
     if (!_isCurrentScene(sceneGeneration)) {
       final snapshot = _ref.read(chatVoiceModeControllerProvider);

--- a/lib/core/services/carplay_service.dart
+++ b/lib/core/services/carplay_service.dart
@@ -118,11 +118,14 @@ final class CarPlayCoordinator {
         );
     if (!_isCurrentScene(sceneGeneration)) {
       final snapshot = _ref.read(chatVoiceModeControllerProvider);
-      if (startResult == ChatVoiceModeStartResult.started &&
+      final claimedOwnership = startResult == ChatVoiceModeStartResult.started;
+      if (claimedOwnership &&
           (snapshot.isActive || snapshot.phase == ChatVoiceModePhase.error)) {
         await _ref.read(chatVoiceModeControllerProvider.notifier).stop();
       }
-      _startedByCarPlay = false;
+      if (claimedOwnership) {
+        _startedByCarPlay = false;
+      }
       return _failure('CarPlay disconnected.');
     }
 

--- a/lib/core/services/carplay_service.dart
+++ b/lib/core/services/carplay_service.dart
@@ -5,7 +5,7 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
-import '../../features/auth/providers/unified_auth_providers.dart';
+import '../../features/chat/voice_call/voice_call_eligibility.dart';
 import '../../features/chat/voice_mode/chat_voice_mode_controller.dart';
 import '../providers/app_providers.dart';
 import '../utils/debug_logger.dart';
@@ -86,29 +86,26 @@ final class CarPlayCoordinator {
       return _success();
     }
 
-    final authState = await _waitForAuthReady();
+    final eligibility = await resolveVoiceCallEligibility(_ref);
     if (!_isCurrentScene(sceneGeneration)) {
       return _failure('CarPlay disconnected.');
     }
-    if (authState != AuthNavigationState.authenticated) {
-      return _failure('Please sign in to Conduit on iPhone first.');
+
+    if (!eligibility.canStart) {
+      return _failure(eligibility.errorMessage!);
     }
 
-    await _ensureModelSelected();
-    if (!_isCurrentScene(sceneGeneration)) {
-      return _failure('CarPlay disconnected.');
-    }
-    if (_ref.read(selectedModelProvider) == null) {
-      return _failure('Please select a model in Conduit on iPhone first.');
-    }
-
-    _startedByCarPlay = true;
-    await _ref
+    final startResult = await _ref
         .read(chatVoiceModeControllerProvider.notifier)
-        .start(startNewConversation: true);
+        .start(
+          startNewConversation: true,
+          shouldStart: () => _isCurrentScene(sceneGeneration),
+          readinessResolved: true,
+        );
     if (!_isCurrentScene(sceneGeneration)) {
       final snapshot = _ref.read(chatVoiceModeControllerProvider);
-      if (snapshot.isActive || snapshot.phase == ChatVoiceModePhase.error) {
+      if (startResult == ChatVoiceModeStartResult.started &&
+          (snapshot.isActive || snapshot.phase == ChatVoiceModePhase.error)) {
         await _ref.read(chatVoiceModeControllerProvider.notifier).stop();
       }
       _startedByCarPlay = false;
@@ -116,6 +113,7 @@ final class CarPlayCoordinator {
     }
 
     final next = _ref.read(chatVoiceModeControllerProvider);
+    _startedByCarPlay = startResult == ChatVoiceModeStartResult.started;
     if (next.phase == ChatVoiceModePhase.error) {
       _startedByCarPlay = false;
       return _failure(
@@ -243,37 +241,6 @@ final class CarPlayCoordinator {
     } catch (error, stackTrace) {
       DebugLogger.error(
         'carplay-state-update',
-        scope: 'carplay',
-        error: error,
-        stackTrace: stackTrace,
-      );
-    }
-  }
-
-  Future<AuthNavigationState> _waitForAuthReady() async {
-    for (var attempt = 0; attempt < 50; attempt++) {
-      final state = _ref.read(authNavigationStateProvider);
-      if (state != AuthNavigationState.loading) {
-        return state;
-      }
-      await Future<void>.delayed(const Duration(milliseconds: 100));
-    }
-
-    return _ref.read(authNavigationStateProvider);
-  }
-
-  Future<void> _ensureModelSelected() async {
-    if (_ref.read(selectedModelProvider) != null) {
-      return;
-    }
-
-    try {
-      await _ref
-          .read(defaultModelProvider.future)
-          .timeout(const Duration(seconds: 3), onTimeout: () => null);
-    } catch (error, stackTrace) {
-      DebugLogger.error(
-        'carplay-default-model',
         scope: 'carplay',
         error: error,
         stackTrace: stackTrace,

--- a/lib/core/services/carplay_service.dart
+++ b/lib/core/services/carplay_service.dart
@@ -28,6 +28,7 @@ final class CarPlayCoordinator {
   bool _startedByCarPlay = false;
   bool _sceneConnected = false;
   int _sceneGeneration = 0;
+  Completer<void>? _sceneDisconnectSignal;
   String? _lastSentStateKey;
 
   void initialize() {
@@ -86,7 +87,20 @@ final class CarPlayCoordinator {
       return _success();
     }
 
-    final eligibility = await resolveVoiceCallEligibility(_ref);
+    final disconnectSignal = _sceneDisconnectSignal!;
+    late final VoiceCallEligibility eligibility;
+    try {
+      eligibility = await resolveVoiceCallEligibility(
+        _ref,
+        cancellationSignal: disconnectSignal.future,
+        cancellationRequested: () => !_isCurrentScene(sceneGeneration),
+      );
+    } on VoiceCallEligibilityResolutionCancelled {
+      if (!_isCurrentScene(sceneGeneration)) {
+        return _failure('CarPlay disconnected.');
+      }
+      rethrow;
+    }
     if (!_isCurrentScene(sceneGeneration)) {
       return _failure('CarPlay disconnected.');
     }
@@ -176,6 +190,7 @@ final class CarPlayCoordinator {
     if (!_sceneConnected) {
       _sceneConnected = true;
       _sceneGeneration++;
+      _sceneDisconnectSignal = Completer<void>();
     }
     return _sceneGeneration;
   }
@@ -184,6 +199,11 @@ final class CarPlayCoordinator {
     if (_sceneConnected) {
       _sceneConnected = false;
       _sceneGeneration++;
+      final disconnectSignal = _sceneDisconnectSignal;
+      _sceneDisconnectSignal = null;
+      if (disconnectSignal != null && !disconnectSignal.isCompleted) {
+        disconnectSignal.complete();
+      }
     }
   }
 

--- a/lib/core/services/carplay_service.dart
+++ b/lib/core/services/carplay_service.dart
@@ -127,7 +127,9 @@ final class CarPlayCoordinator {
     }
 
     final next = _ref.read(chatVoiceModeControllerProvider);
-    _startedByCarPlay = startResult == ChatVoiceModeStartResult.started;
+    if (startResult == ChatVoiceModeStartResult.started) {
+      _startedByCarPlay = true;
+    }
     if (next.phase == ChatVoiceModePhase.error) {
       _startedByCarPlay = false;
       return _failure(

--- a/lib/core/services/home_widget_service.dart
+++ b/lib/core/services/home_widget_service.dart
@@ -2,8 +2,8 @@ import 'dart:async';
 import 'dart:io';
 
 import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
-import 'package:flutter/widgets.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:home_widget/home_widget.dart';
 import 'package:image_picker/image_picker.dart';
@@ -13,6 +13,8 @@ import 'package:riverpod_annotation/riverpod_annotation.dart';
 import '../../features/auth/providers/unified_auth_providers.dart';
 import '../../features/chat/providers/chat_providers.dart';
 import '../../features/chat/services/file_attachment_service.dart';
+import '../../features/chat/voice_call/voice_call_eligibility.dart';
+import '../../l10n/app_localizations.dart';
 import '../utils/debug_logger.dart';
 import 'app_intents_service.dart';
 import 'media_upload_controller.dart';
@@ -139,7 +141,18 @@ class HomeWidgetCoordinator extends _$HomeWidgetCoordinator {
     // Check if action was already processed by stream handler while waiting
     if (_pendingWidgetAction == null) return;
 
-    // Now wait for authentication to complete (up to 30 seconds for login flow)
+    final pendingUri = _pendingWidgetAction;
+    if (pendingUri != null &&
+        homeWidgetVoiceActionCanDispatch(
+          pendingUri,
+          canBypassOpenWebUiAuth: voiceCallCanResolveWithoutOpenWebUiAuth(ref),
+        )) {
+      _pendingWidgetAction = null;
+      await _handleWidgetClick(pendingUri);
+      return;
+    }
+
+    // Non-voice actions retain their existing authentication wait.
     for (var i = 0; i < 300; i++) {
       await Future<void>.delayed(const Duration(milliseconds: 100));
 
@@ -253,6 +266,15 @@ class HomeWidgetCoordinator extends _$HomeWidgetCoordinator {
       await ref
           .read(appIntentCoordinatorProvider.notifier)
           .openChatFromExternal(focusComposer: true, resetChat: true);
+      final context = NavigationService.context;
+      if (context == null || !context.mounted) return;
+      final message = error is StateError
+          ? error.message.toString()
+          : AppLocalizations.of(context)?.errorMessage ??
+                'Unable to start a voice call.';
+      ScaffoldMessenger.maybeOf(
+        context,
+      )?.showSnackBar(SnackBar(content: Text(message)));
     }
   }
 
@@ -453,6 +475,15 @@ class HomeWidgetCoordinator extends _$HomeWidgetCoordinator {
       );
     }
   }
+}
+
+@visibleForTesting
+bool homeWidgetVoiceActionCanDispatch(
+  Uri uri, {
+  required bool canBypassOpenWebUiAuth,
+}) {
+  final action = uri.host.isNotEmpty ? uri.host : uri.pathSegments.firstOrNull;
+  return action == WidgetActions.mic && canBypassOpenWebUiAuth;
 }
 
 /// Provider to trigger home widget initialization at app startup.

--- a/lib/core/services/home_widget_service.dart
+++ b/lib/core/services/home_widget_service.dart
@@ -165,6 +165,19 @@ class HomeWidgetCoordinator extends _$HomeWidgetCoordinator {
         return;
       }
 
+      final pendingUri = _pendingWidgetAction;
+      if (pendingUri != null &&
+          homeWidgetVoiceActionCanDispatch(
+            pendingUri,
+            canBypassOpenWebUiAuth: voiceCallCanResolveWithoutOpenWebUiAuth(
+              ref,
+            ),
+          )) {
+        _pendingWidgetAction = null;
+        await _handleWidgetClick(pendingUri);
+        return;
+      }
+
       final authState = ref.read(authNavigationStateProvider);
       if (authState == AuthNavigationState.authenticated) {
         DebugLogger.log(
@@ -207,9 +220,7 @@ class HomeWidgetCoordinator extends _$HomeWidgetCoordinator {
       return;
     }
 
-    final action = uri.host.isNotEmpty
-        ? uri.host
-        : uri.pathSegments.firstOrNull;
+    final action = homeWidgetActionOf(uri);
     if (action == null || action.isEmpty) {
       // Default action: open new chat
       await _handleNewChat();
@@ -478,12 +489,15 @@ class HomeWidgetCoordinator extends _$HomeWidgetCoordinator {
 }
 
 @visibleForTesting
+String? homeWidgetActionOf(Uri uri) =>
+    uri.host.isNotEmpty ? uri.host : uri.pathSegments.firstOrNull;
+
+@visibleForTesting
 bool homeWidgetVoiceActionCanDispatch(
   Uri uri, {
   required bool canBypassOpenWebUiAuth,
 }) {
-  final action = uri.host.isNotEmpty ? uri.host : uri.pathSegments.firstOrNull;
-  return action == WidgetActions.mic && canBypassOpenWebUiAuth;
+  return homeWidgetActionOf(uri) == WidgetActions.mic && canBypassOpenWebUiAuth;
 }
 
 /// Provider to trigger home widget initialization at app startup.

--- a/lib/core/services/quick_actions_service.dart
+++ b/lib/core/services/quick_actions_service.dart
@@ -13,6 +13,7 @@ import '../utils/debug_logger.dart';
 import 'app_intents_service.dart';
 import 'navigation_service.dart';
 import '../../features/auth/providers/unified_auth_providers.dart';
+import '../../features/chat/voice_call/voice_call_eligibility.dart';
 
 part 'quick_actions_service.g.dart';
 
@@ -71,7 +72,6 @@ class QuickActionsCoordinator extends _$QuickActionsCoordinator {
   Timer? _shortcutRefreshTimer;
   Timer? _actionRetryTimer;
   bool _isProcessing = false;
-  bool _isResolvingVoiceCallModel = false;
 
   @override
   FutureOr<void> build() {
@@ -178,31 +178,24 @@ class QuickActionsCoordinator extends _$QuickActionsCoordinator {
         }
 
         final authState = ref.read(authNavigationStateProvider);
-        if (authState == AuthNavigationState.loading) {
-          _scheduleRetry();
-          return;
-        }
-        if (authState != AuthNavigationState.authenticated) {
-          return;
-        }
-
-        final event = _pendingEvents.first;
-        if (event.type == _quickActionVoiceCall) {
-          await _ensureVoiceCallModelReady();
-          if (ref.read(selectedModelProvider) == null) {
-            _pendingEvents.removeFirst();
-            DebugLogger.warning(
-              'quick-actions-voice-model-unavailable',
-              scope: 'platform',
-            );
-            await ref
-                .read(appIntentCoordinatorProvider.notifier)
-                .openChatFromExternal(focusComposer: true, resetChat: true);
-            continue;
+        final dispatchIndex = quickActionDispatchIndex(
+          queuedTypes: _pendingEvents
+              .map((event) => event.type)
+              .toList(growable: false),
+          authState: authState,
+          voiceCanBypassAuthLoading: voiceCallCanResolveWithoutOpenWebUiAuth(
+            ref,
+          ),
+        );
+        if (dispatchIndex == null) {
+          if (authState == AuthNavigationState.loading) {
+            _scheduleRetry();
           }
+          return;
         }
 
-        _pendingEvents.removeFirst();
+        final event = _pendingEvents.elementAt(dispatchIndex);
+        _pendingEvents.remove(event);
         await _dispatch(event.type);
       }
     } finally {
@@ -216,27 +209,6 @@ class QuickActionsCoordinator extends _$QuickActionsCoordinator {
       if (!ref.mounted) return;
       unawaited(_maybeProcessPendingActions());
     });
-  }
-
-  Future<void> _ensureVoiceCallModelReady() async {
-    if (_isResolvingVoiceCallModel) return;
-    if (ref.read(selectedModelProvider) != null) return;
-
-    _isResolvingVoiceCallModel = true;
-    try {
-      await ref
-          .read(defaultModelProvider.future)
-          .timeout(const Duration(seconds: 3), onTimeout: () => null);
-    } catch (error, stackTrace) {
-      DebugLogger.error(
-        'quick-actions-voice-model',
-        scope: 'platform',
-        error: error,
-        stackTrace: stackTrace,
-      );
-    } finally {
-      _isResolvingVoiceCallModel = false;
-    }
   }
 
   Future<void> _dispatch(String type) async {
@@ -261,6 +233,15 @@ class QuickActionsCoordinator extends _$QuickActionsCoordinator {
           await ref
               .read(appIntentCoordinatorProvider.notifier)
               .openChatFromExternal(focusComposer: true, resetChat: true);
+          final context = NavigationService.context;
+          if (context == null || !context.mounted) return;
+          final message = error is StateError
+              ? error.message.toString()
+              : AppLocalizations.of(context)?.errorMessage ??
+                    'Unable to start a voice call.';
+          ScaffoldMessenger.maybeOf(
+            context,
+          )?.showSnackBar(SnackBar(content: Text(message)));
         }
         return;
       default:
@@ -268,6 +249,26 @@ class QuickActionsCoordinator extends _$QuickActionsCoordinator {
         return;
     }
   }
+}
+
+@visibleForTesting
+int? quickActionDispatchIndex({
+  required List<String> queuedTypes,
+  required AuthNavigationState authState,
+  required bool voiceCanBypassAuthLoading,
+}) {
+  if (queuedTypes.isEmpty) return null;
+  if (authState == AuthNavigationState.authenticated) return 0;
+
+  final voiceIndex = queuedTypes.indexOf(_quickActionVoiceCall);
+  if (voiceIndex < 0) return null;
+  if (voiceIndex > 0 && !voiceCanBypassAuthLoading) {
+    return null;
+  }
+  if (authState == AuthNavigationState.loading && !voiceCanBypassAuthLoading) {
+    return null;
+  }
+  return voiceIndex;
 }
 
 class _QuickActionEvent {

--- a/lib/core/services/quick_actions_service.dart
+++ b/lib/core/services/quick_actions_service.dart
@@ -262,12 +262,7 @@ int? quickActionDispatchIndex({
 
   final voiceIndex = queuedTypes.indexOf(_quickActionVoiceCall);
   if (voiceIndex < 0) return null;
-  if (voiceIndex > 0 && !voiceCanBypassAuthLoading) {
-    return null;
-  }
-  if (authState == AuthNavigationState.loading && !voiceCanBypassAuthLoading) {
-    return null;
-  }
+  if (!voiceCanBypassAuthLoading) return null;
   return voiceIndex;
 }
 

--- a/lib/core/utils/android_assistant_handler.dart
+++ b/lib/core/utils/android_assistant_handler.dart
@@ -1,5 +1,7 @@
 import 'dart:async';
 import 'dart:io';
+
+import 'package:conduit/l10n/app_localizations.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -145,7 +147,8 @@ class AndroidAssistantHandler {
       if (context == null || !context.mounted) return;
       final message = error is StateError
           ? error.message.toString()
-          : 'Unable to start a voice call.';
+          : AppLocalizations.of(context)?.errorMessage ??
+                'Unable to start a voice call.';
       ScaffoldMessenger.maybeOf(
         context,
       )?.showSnackBar(SnackBar(content: Text(message)));

--- a/lib/core/utils/android_assistant_handler.dart
+++ b/lib/core/utils/android_assistant_handler.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 import 'dart:io';
+import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:path/path.dart' as path;
@@ -127,22 +128,27 @@ class AndroidAssistantHandler {
   Future<void> _startVoiceCall() async {
     try {
       DebugLogger.log('Starting voice call from assistant', scope: 'assistant');
-
-      // Wait for app to be ready (authenticated and model available)
-      final navState = _ref.read(authNavigationStateProvider);
-      final model = _ref.read(selectedModelProvider);
-
-      if (navState != AuthNavigationState.authenticated || model == null) {
-        DebugLogger.log('App not ready for voice call', scope: 'assistant');
-        return;
-      }
       await _ref
           .read(voiceCallLauncherProvider)
           .launch(startNewConversation: true);
 
       DebugLogger.log('Voice call page launched', scope: 'assistant');
-    } catch (e) {
-      DebugLogger.log('Failed to start voice call: $e', scope: 'assistant');
+    } catch (error, stackTrace) {
+      DebugLogger.error(
+        'voice-call-failed',
+        scope: 'assistant',
+        error: error,
+        stackTrace: stackTrace,
+      );
+      await NavigationService.navigateToChat();
+      final context = NavigationService.context;
+      if (context == null || !context.mounted) return;
+      final message = error is StateError
+          ? error.message.toString()
+          : 'Unable to start a voice call.';
+      ScaffoldMessenger.maybeOf(
+        context,
+      )?.showSnackBar(SnackBar(content: Text(message)));
     }
   }
 

--- a/lib/features/chat/providers/chat_providers.dart
+++ b/lib/features/chat/providers/chat_providers.dart
@@ -7034,7 +7034,7 @@ List<String> selectedFilterIdsForModel(dynamic ref, Model model) {
 }
 
 // Start a new chat (unified function for both "New Chat" button and home screen)
-void startNewChat(dynamic ref) {
+void startNewChat(dynamic ref, {Model? modelForNewConversation}) {
   resetHermesForNewChat(ref);
   resetDirectRunsForNewChat(ref);
   clearSelectedFiltersForConversationBoundary(ref);
@@ -7051,8 +7051,18 @@ void startNewChat(dynamic ref) {
   // Clear any pending folder selection
   ref.read(pendingFolderIdProvider.notifier).clear();
 
-  // Reset to default model for new conversations (fixes #296)
-  restoreDefaultModel(ref);
+  if (modelForNewConversation != null) {
+    // Voice startup admits a concrete transport before this reset. Keep that
+    // exact model pinned so the asynchronous default restore cannot switch the
+    // first voice turn to a different, potentially unauthenticated backend.
+    ref.read(isManualModelSelectionProvider.notifier).set(true);
+    ref
+        .read(selectedModelProvider.notifier)
+        .set(modelForNewConversation, allowHidden: true);
+  } else {
+    // Reset to default model for new conversations (fixes #296)
+    restoreDefaultModel(ref);
+  }
 
   final settings = ref.read(appSettingsProvider);
   ref

--- a/lib/features/chat/views/chat_page.dart
+++ b/lib/features/chat/views/chat_page.dart
@@ -1637,10 +1637,26 @@ class _ChatPageState extends ConsumerState<ChatPage> {
     await Future.delayed(const Duration(milliseconds: 300));
   }
 
-  void _handleVoiceCall() {
-    unawaited(
-      ref.read(voiceCallLauncherProvider).launch(startNewConversation: false),
-    );
+  Future<void> _handleVoiceCall() async {
+    try {
+      await ref
+          .read(voiceCallLauncherProvider)
+          .launch(startNewConversation: false);
+    } catch (error, stackTrace) {
+      DebugLogger.error(
+        'launch-failed',
+        scope: 'chat/voice_call',
+        error: error,
+        stackTrace: stackTrace,
+      );
+      if (!mounted) return;
+      final message = error is StateError
+          ? error.message.toString()
+          : AppLocalizations.of(context)!.errorMessage;
+      ScaffoldMessenger.maybeOf(
+        context,
+      )?.showSnackBar(SnackBar(content: Text(message)));
+    }
   }
 
   void _prewarmVisibleMarkdownRows() {

--- a/lib/features/chat/voice_call/presentation/voice_call_launcher.dart
+++ b/lib/features/chat/voice_call/presentation/voice_call_launcher.dart
@@ -3,8 +3,8 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../../../../core/providers/app_providers.dart';
 import '../../../../../core/services/navigation_service.dart';
-import '../../../auth/providers/unified_auth_providers.dart';
 import '../../voice_mode/chat_voice_mode_controller.dart';
+import '../voice_call_eligibility.dart';
 
 /// Unified launcher for all voice-call entry points.
 class VoiceCallLauncher {
@@ -13,14 +13,9 @@ class VoiceCallLauncher {
   final Ref _ref;
 
   Future<void> launch({required bool startNewConversation}) async {
-    final navState = _ref.read(authNavigationStateProvider);
-    if (navState != AuthNavigationState.authenticated) {
-      throw StateError('Sign in to start a voice call.');
-    }
-
-    final model = _ref.read(selectedModelProvider);
-    if (model == null) {
-      throw StateError('Choose a model before starting a voice call.');
+    final eligibility = await resolveVoiceCallEligibility(_ref);
+    if (!eligibility.canStart) {
+      throw StateError(eligibility.errorMessage!);
     }
 
     final socketService = _ref.read(socketServiceProvider);
@@ -33,9 +28,18 @@ class VoiceCallLauncher {
       await Future<void>.delayed(const Duration(milliseconds: 50));
     }
 
-    await _ref
+    final result = await _ref
         .read(chatVoiceModeControllerProvider.notifier)
-        .start(startNewConversation: startNewConversation);
+        .start(
+          startNewConversation: startNewConversation,
+          readinessResolved: true,
+        );
+    final snapshot = _ref.read(chatVoiceModeControllerProvider);
+    if (result == ChatVoiceModeStartResult.failed || !snapshot.isActive) {
+      throw StateError(
+        snapshot.errorMessage ?? 'Unable to start a voice call.',
+      );
+    }
   }
 }
 

--- a/lib/features/chat/voice_call/presentation/voice_call_launcher.dart
+++ b/lib/features/chat/voice_call/presentation/voice_call_launcher.dart
@@ -32,7 +32,7 @@ class VoiceCallLauncher {
         .read(chatVoiceModeControllerProvider.notifier)
         .start(
           startNewConversation: startNewConversation,
-          readinessResolved: true,
+          admittedModel: eligibility.model!,
         );
     final snapshot = _ref.read(chatVoiceModeControllerProvider);
     if (result == ChatVoiceModeStartResult.failed || !snapshot.isActive) {

--- a/lib/features/chat/voice_call/voice_call_eligibility.dart
+++ b/lib/features/chat/voice_call/voice_call_eligibility.dart
@@ -110,13 +110,14 @@ final voiceCallEligibilityProvider = Provider<VoiceCallEligibility>((ref) {
   );
 });
 
-const _voiceCallReadinessTimeout = Duration(seconds: 3);
-
 /// Resolves transient startup state before returning the current admission
 /// decision. Native entry points can arrive before secure storage, auth, or
 /// default-model selection has finished hydrating.
-Future<VoiceCallEligibility> resolveVoiceCallEligibility(Ref ref) async {
-  final deadline = DateTime.now().add(_voiceCallReadinessTimeout);
+Future<VoiceCallEligibility> resolveVoiceCallEligibility(
+  Ref ref, {
+  Duration readinessTimeout = const Duration(seconds: 3),
+}) async {
+  final deadline = DateTime.now().add(readinessTimeout);
 
   while (true) {
     if (_voiceCallNeedsHermesHydration(ref)) {
@@ -142,15 +143,26 @@ Future<VoiceCallEligibility> resolveVoiceCallEligibility(Ref ref) async {
               'Hermes is unavailable. Check its server URL and API key.',
         );
       }
+      if (_remainingReadinessTime(deadline) == Duration.zero) {
+        return ref.read(voiceCallEligibilityProvider);
+      }
       // Hermes selection is independent from optional OpenWebUI auth. Restore
       // it directly so a slow OWUI secure-storage read cannot block a valid
       // Hermes-only native launch.
       await Future<void>.delayed(Duration.zero);
+      if (_remainingReadinessTime(deadline) == Duration.zero) {
+        return ref.read(voiceCallEligibilityProvider);
+      }
       if (ref.read(selectedModelProvider) == null &&
           ref.read(preferredBackendProvider) == PreferredBackend.hermes &&
           ref.read(hermesConfigProvider).isUsable) {
         ref.read(isManualModelSelectionProvider.notifier).set(false);
         ref.read(selectedModelProvider.notifier).set(hermesSyntheticModel());
+      }
+      if (ref.read(selectedModelProvider) == null &&
+          ref.read(preferredBackendProvider) == PreferredBackend.hermes &&
+          ref.read(hermesConfigProvider).isUsable) {
+        return ref.read(voiceCallEligibilityProvider);
       }
       continue;
     }

--- a/lib/features/chat/voice_call/voice_call_eligibility.dart
+++ b/lib/features/chat/voice_call/voice_call_eligibility.dart
@@ -1,0 +1,346 @@
+import 'dart:async';
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../core/models/model.dart';
+import '../../../core/providers/app_providers.dart';
+import '../../../core/providers/backend_mode_providers.dart';
+import '../../../core/services/settings_service.dart';
+import '../../auth/providers/unified_auth_providers.dart';
+import '../../direct_connections/providers/direct_connection_providers.dart';
+import '../../direct_connections/services/direct_model_registry.dart';
+import '../../hermes/models/hermes_model.dart';
+import '../../hermes/providers/hermes_providers.dart';
+
+enum VoiceCallEligibilityReason {
+  eligible,
+  modelRequired,
+  backendInitializing,
+  authenticationRequired,
+  backendUnavailable,
+}
+
+@immutable
+class VoiceCallEligibility {
+  const VoiceCallEligibility._({
+    required this.reason,
+    required this.model,
+    this.errorMessage,
+  });
+
+  const VoiceCallEligibility.eligible(Model model)
+    : this._(reason: VoiceCallEligibilityReason.eligible, model: model);
+
+  const VoiceCallEligibility.blocked({
+    required VoiceCallEligibilityReason reason,
+    required String errorMessage,
+    Model? model,
+  }) : this._(reason: reason, model: model, errorMessage: errorMessage);
+
+  final VoiceCallEligibilityReason reason;
+  final Model? model;
+  final String? errorMessage;
+
+  bool get canStart => reason == VoiceCallEligibilityReason.eligible;
+}
+
+/// Resolves voice eligibility from the selected model's trusted transport.
+///
+/// OpenWebUI models still require an authenticated session. Hermes and
+/// device-owned Direct models use app-owned transports and are admitted from
+/// their concrete runtime provenance instead of OpenWebUI navigation state.
+final voiceCallEligibilityProvider = Provider<VoiceCallEligibility>((ref) {
+  final model = ref.watch(selectedModelProvider);
+  if (model == null) {
+    return const VoiceCallEligibility.blocked(
+      reason: VoiceCallEligibilityReason.modelRequired,
+      errorMessage: 'Choose a model before starting a voice call.',
+    );
+  }
+
+  if (ref.watch(reviewerModeProvider)) {
+    return VoiceCallEligibility.eligible(model);
+  }
+
+  if (isHermesModel(model)) {
+    if (ref.watch(hermesSecretsLoadingProvider)) {
+      return VoiceCallEligibility.blocked(
+        reason: VoiceCallEligibilityReason.backendInitializing,
+        model: model,
+        errorMessage: 'Hermes is still loading. Try again in a moment.',
+      );
+    }
+    if (ref.watch(hermesConfigProvider).isUsable) {
+      return VoiceCallEligibility.eligible(model);
+    }
+    return VoiceCallEligibility.blocked(
+      reason: VoiceCallEligibilityReason.backendUnavailable,
+      model: model,
+      errorMessage: 'Hermes is unavailable. Check its server URL and API key.',
+    );
+  }
+
+  if (isLocallyMintedDirectModel(model)) {
+    // The registry mutates in place. Discovery is its reactive invalidation
+    // signal when a profile is replaced, disabled, or removed.
+    ref.watch(directModelDiscoveryProvider);
+    final binding = ref.watch(directModelRegistryProvider).resolve(model);
+    if (binding == null) {
+      return VoiceCallEligibility.blocked(
+        reason: VoiceCallEligibilityReason.backendUnavailable,
+        model: model,
+        errorMessage: 'The selected direct connection is unavailable.',
+      );
+    }
+    if (binding.source == DirectModelSource.device) {
+      return VoiceCallEligibility.eligible(model);
+    }
+  }
+
+  if (ref.watch(authNavigationStateProvider) ==
+      AuthNavigationState.authenticated) {
+    return VoiceCallEligibility.eligible(model);
+  }
+
+  return VoiceCallEligibility.blocked(
+    reason: VoiceCallEligibilityReason.authenticationRequired,
+    model: model,
+    errorMessage: 'Sign in to start a voice call.',
+  );
+});
+
+const _voiceCallReadinessTimeout = Duration(seconds: 3);
+
+/// Resolves transient startup state before returning the current admission
+/// decision. Native entry points can arrive before secure storage, auth, or
+/// default-model selection has finished hydrating.
+Future<VoiceCallEligibility> resolveVoiceCallEligibility(Ref ref) async {
+  final deadline = DateTime.now().add(_voiceCallReadinessTimeout);
+
+  while (true) {
+    if (_voiceCallNeedsHermesHydration(ref)) {
+      final changed = await _waitForHermesStateChange(ref, deadline);
+      if (!changed && _voiceCallNeedsHermesHydration(ref)) {
+        return const VoiceCallEligibility.blocked(
+          reason: VoiceCallEligibilityReason.backendInitializing,
+          errorMessage: 'Hermes is still loading. Try again in a moment.',
+        );
+      }
+      // Re-evaluate selection as well as hydration. The user may have changed
+      // backends while native startup was waiting.
+      continue;
+    }
+
+    final model = ref.read(selectedModelProvider);
+    final preferredBackend = ref.read(preferredBackendProvider);
+    if (model == null && preferredBackend == PreferredBackend.hermes) {
+      if (!ref.read(hermesConfigProvider).isUsable) {
+        return const VoiceCallEligibility.blocked(
+          reason: VoiceCallEligibilityReason.backendUnavailable,
+          errorMessage:
+              'Hermes is unavailable. Check its server URL and API key.',
+        );
+      }
+      // Hermes selection is independent from optional OpenWebUI auth. Restore
+      // it directly so a slow OWUI secure-storage read cannot block a valid
+      // Hermes-only native launch.
+      await Future<void>.delayed(Duration.zero);
+      if (ref.read(selectedModelProvider) == null &&
+          ref.read(preferredBackendProvider) == PreferredBackend.hermes &&
+          ref.read(hermesConfigProvider).isUsable) {
+        ref.read(isManualModelSelectionProvider.notifier).set(false);
+        ref.read(selectedModelProvider.notifier).set(hermesSyntheticModel());
+      }
+      continue;
+    }
+    if (model == null && preferredBackend == PreferredBackend.direct) {
+      final restored = await _restorePreferredDeviceDirectModel(ref, deadline);
+      if (restored) continue;
+    }
+
+    if (ref.read(authNavigationStateProvider) == AuthNavigationState.loading &&
+        !voiceCallCanResolveWithoutOpenWebUiAuth(ref)) {
+      final changed = await _waitForOpenWebUiStateChange(ref, deadline);
+      if (changed) continue;
+      return ref.read(voiceCallEligibilityProvider);
+    }
+
+    await _resolveDefaultModelIfNeeded(ref, deadline);
+    final eligibility = ref.read(voiceCallEligibilityProvider);
+    if (eligibility.canStart ||
+        ref.read(authNavigationStateProvider) != AuthNavigationState.loading ||
+        voiceCallCanResolveWithoutOpenWebUiAuth(ref)) {
+      return eligibility;
+    }
+
+    final changed = await _waitForOpenWebUiStateChange(ref, deadline);
+    if (!changed) return ref.read(voiceCallEligibilityProvider);
+  }
+}
+
+/// Whether the current voice launch can become ready without OpenWebUI auth.
+///
+/// This is also used by cold-start quick actions so accountless transports can
+/// proceed while an unrelated OpenWebUI session is still hydrating.
+bool voiceCallCanResolveWithoutOpenWebUiAuth(Ref ref) {
+  if (ref.read(reviewerModeProvider)) return true;
+
+  final model = ref.read(selectedModelProvider);
+  if (model == null) {
+    final preferredBackend = ref.read(preferredBackendProvider);
+    if (preferredBackend == PreferredBackend.hermes) return true;
+    if (preferredBackend != PreferredBackend.direct) return false;
+
+    final discovery = ref.read(directModelDiscoveryProvider);
+    if (discovery.isLoading && !discovery.hasValue) return true;
+    final registry = ref.read(directModelRegistryProvider);
+    return discovery.value?.models.any((candidate) {
+          if (candidate.isHidden) return false;
+          return registry.resolve(candidate)?.source ==
+              DirectModelSource.device;
+        }) ??
+        false;
+  }
+  if (isHermesModel(model)) return true;
+  if (!isLocallyMintedDirectModel(model)) return false;
+
+  final binding = ref.read(directModelRegistryProvider).resolve(model);
+  return binding?.source == DirectModelSource.device;
+}
+
+bool _voiceCallNeedsHermesHydration(Ref ref) {
+  if (!ref.read(hermesSecretsLoadingProvider)) return false;
+  final model = ref.read(selectedModelProvider);
+  return model != null
+      ? isHermesModel(model)
+      : ref.read(preferredBackendProvider) == PreferredBackend.hermes;
+}
+
+Duration _remainingReadinessTime(DateTime deadline) {
+  final remaining = deadline.difference(DateTime.now());
+  return remaining.isNegative ? Duration.zero : remaining;
+}
+
+Future<void> _resolveDefaultModelIfNeeded(Ref ref, DateTime deadline) async {
+  if (ref.read(selectedModelProvider) != null) return;
+  final remaining = _remainingReadinessTime(deadline);
+  if (remaining == Duration.zero) return;
+  try {
+    await ref
+        .read(defaultModelProvider.future)
+        .timeout(remaining, onTimeout: () => null);
+  } catch (_) {
+    // The eligibility result below provides the user-facing failure.
+  }
+}
+
+Future<bool> _restorePreferredDeviceDirectModel(
+  Ref ref,
+  DateTime deadline,
+) async {
+  final remaining = _remainingReadinessTime(deadline);
+  if (remaining == Duration.zero) return false;
+
+  DirectModelDiscoveryState discovery;
+  try {
+    discovery = await ref
+        .read(directModelDiscoveryProvider.future)
+        .timeout(remaining);
+  } catch (_) {
+    return false;
+  }
+
+  final registry = ref.read(directModelRegistryProvider);
+  final candidates = discovery.models
+      .where((candidate) {
+        if (candidate.isHidden) return false;
+        return registry.resolve(candidate)?.source == DirectModelSource.device;
+      })
+      .toList(growable: false);
+  if (candidates.isEmpty) return false;
+
+  final configuredId = ref.read(appSettingsProvider).defaultModel;
+  final selected = candidates.firstWhere(
+    (candidate) => candidate.id == configuredId,
+    orElse: () => candidates.first,
+  );
+  await Future<void>.delayed(Duration.zero);
+  if (ref.read(selectedModelProvider) != null ||
+      ref.read(preferredBackendProvider) != PreferredBackend.direct ||
+      ref.read(directModelRegistryProvider).resolve(selected)?.source !=
+          DirectModelSource.device) {
+    return false;
+  }
+  ref.read(isManualModelSelectionProvider.notifier).set(false);
+  ref.read(selectedModelProvider.notifier).set(selected);
+  return ref.read(selectedModelProvider)?.id == selected.id;
+}
+
+Future<bool> _waitForHermesStateChange(Ref ref, DateTime deadline) async {
+  if (!_voiceCallNeedsHermesHydration(ref)) return true;
+
+  final completer = Completer<bool>();
+  void completeOnChange(Object? previous, Object? next) {
+    if (!completer.isCompleted) completer.complete(true);
+  }
+
+  final subscriptions = <ProviderSubscription<Object?>>[
+    ref.listen<bool>(hermesSecretsLoadingProvider, completeOnChange),
+    ref.listen<Model?>(selectedModelProvider, completeOnChange),
+    ref.listen<PreferredBackend>(preferredBackendProvider, completeOnChange),
+  ];
+  final timer = Timer(_remainingReadinessTime(deadline), () {
+    if (!completer.isCompleted) completer.complete(false);
+  });
+  if (!_voiceCallNeedsHermesHydration(ref) && !completer.isCompleted) {
+    completer.complete(true);
+  }
+
+  try {
+    return await completer.future;
+  } finally {
+    timer.cancel();
+    for (final subscription in subscriptions) {
+      subscription.close();
+    }
+  }
+}
+
+Future<bool> _waitForOpenWebUiStateChange(Ref ref, DateTime deadline) async {
+  if (ref.read(authNavigationStateProvider) != AuthNavigationState.loading ||
+      voiceCallCanResolveWithoutOpenWebUiAuth(ref)) {
+    return true;
+  }
+
+  final completer = Completer<bool>();
+  void completeOnChange(Object? previous, Object? next) {
+    if (!completer.isCompleted) completer.complete(true);
+  }
+
+  final subscriptions = <ProviderSubscription<Object?>>[
+    ref.listen<AuthNavigationState>(
+      authNavigationStateProvider,
+      completeOnChange,
+    ),
+    ref.listen<Model?>(selectedModelProvider, completeOnChange),
+    ref.listen<PreferredBackend>(preferredBackendProvider, completeOnChange),
+  ];
+  final timer = Timer(_remainingReadinessTime(deadline), () {
+    if (!completer.isCompleted) completer.complete(false);
+  });
+  if ((ref.read(authNavigationStateProvider) != AuthNavigationState.loading ||
+          voiceCallCanResolveWithoutOpenWebUiAuth(ref)) &&
+      !completer.isCompleted) {
+    completer.complete(true);
+  }
+
+  try {
+    return await completer.future;
+  } finally {
+    timer.cancel();
+    for (final subscription in subscriptions) {
+      subscription.close();
+    }
+  }
+}

--- a/lib/features/chat/voice_call/voice_call_eligibility.dart
+++ b/lib/features/chat/voice_call/voice_call_eligibility.dart
@@ -45,6 +45,10 @@ class VoiceCallEligibility {
   bool get canStart => reason == VoiceCallEligibilityReason.eligible;
 }
 
+final class VoiceCallEligibilityResolutionCancelled implements Exception {
+  const VoiceCallEligibilityResolutionCancelled();
+}
+
 /// Resolves voice eligibility from the selected model's trusted transport.
 ///
 /// OpenWebUI models still require an authenticated session. Hermes and
@@ -116,12 +120,24 @@ final voiceCallEligibilityProvider = Provider<VoiceCallEligibility>((ref) {
 Future<VoiceCallEligibility> resolveVoiceCallEligibility(
   Ref ref, {
   Duration readinessTimeout = const Duration(seconds: 3),
+  Future<void>? cancellationSignal,
+  bool Function()? cancellationRequested,
 }) async {
   final deadline = DateTime.now().add(readinessTimeout);
+  final cancellation = _VoiceCallEligibilityCancellation(
+    signal: cancellationSignal,
+    requested: cancellationRequested,
+  );
 
   while (true) {
+    cancellation.throwIfRequested();
     if (_voiceCallNeedsHermesHydration(ref)) {
-      final changed = await _waitForHermesStateChange(ref, deadline);
+      final changed = await _waitForHermesStateChange(
+        ref,
+        deadline,
+        cancellation,
+      );
+      cancellation.throwIfRequested();
       if (!changed && _voiceCallNeedsHermesHydration(ref)) {
         return const VoiceCallEligibility.blocked(
           reason: VoiceCallEligibilityReason.backendInitializing,
@@ -149,7 +165,8 @@ Future<VoiceCallEligibility> resolveVoiceCallEligibility(
       // Hermes selection is independent from optional OpenWebUI auth. Restore
       // it directly so a slow OWUI secure-storage read cannot block a valid
       // Hermes-only native launch.
-      await Future<void>.delayed(Duration.zero);
+      await cancellation.wait(Future<void>.delayed(Duration.zero));
+      cancellation.throwIfRequested();
       if (_remainingReadinessTime(deadline) == Duration.zero) {
         return ref.read(voiceCallEligibilityProvider);
       }
@@ -167,18 +184,29 @@ Future<VoiceCallEligibility> resolveVoiceCallEligibility(
       continue;
     }
     if (model == null && preferredBackend == PreferredBackend.direct) {
-      final restored = await _restorePreferredDeviceDirectModel(ref, deadline);
+      final restored = await _restorePreferredDeviceDirectModel(
+        ref,
+        deadline,
+        cancellation,
+      );
+      cancellation.throwIfRequested();
       if (restored) continue;
     }
 
     if (ref.read(authNavigationStateProvider) == AuthNavigationState.loading &&
         !voiceCallCanResolveWithoutOpenWebUiAuth(ref)) {
-      final changed = await _waitForOpenWebUiStateChange(ref, deadline);
+      final changed = await _waitForOpenWebUiStateChange(
+        ref,
+        deadline,
+        cancellation,
+      );
+      cancellation.throwIfRequested();
       if (changed) continue;
       return ref.read(voiceCallEligibilityProvider);
     }
 
-    await _resolveDefaultModelIfNeeded(ref, deadline);
+    await _resolveDefaultModelIfNeeded(ref, deadline, cancellation);
+    cancellation.throwIfRequested();
     final eligibility = ref.read(voiceCallEligibilityProvider);
     if (eligibility.canStart ||
         ref.read(authNavigationStateProvider) != AuthNavigationState.loading ||
@@ -186,7 +214,12 @@ Future<VoiceCallEligibility> resolveVoiceCallEligibility(
       return eligibility;
     }
 
-    final changed = await _waitForOpenWebUiStateChange(ref, deadline);
+    final changed = await _waitForOpenWebUiStateChange(
+      ref,
+      deadline,
+      cancellation,
+    );
+    cancellation.throwIfRequested();
     if (!changed) return ref.read(voiceCallEligibilityProvider);
   }
 }
@@ -234,14 +267,23 @@ Duration _remainingReadinessTime(DateTime deadline) {
   return remaining.isNegative ? Duration.zero : remaining;
 }
 
-Future<void> _resolveDefaultModelIfNeeded(Ref ref, DateTime deadline) async {
+Future<void> _resolveDefaultModelIfNeeded(
+  Ref ref,
+  DateTime deadline,
+  _VoiceCallEligibilityCancellation cancellation,
+) async {
+  cancellation.throwIfRequested();
   if (ref.read(selectedModelProvider) != null) return;
   final remaining = _remainingReadinessTime(deadline);
   if (remaining == Duration.zero) return;
   try {
-    await ref
-        .read(defaultModelProvider.future)
-        .timeout(remaining, onTimeout: () => null);
+    await cancellation.wait(
+      ref
+          .read(defaultModelProvider.future)
+          .timeout(remaining, onTimeout: () => null),
+    );
+  } on VoiceCallEligibilityResolutionCancelled {
+    rethrow;
   } catch (_) {
     // The eligibility result below provides the user-facing failure.
   }
@@ -250,19 +292,24 @@ Future<void> _resolveDefaultModelIfNeeded(Ref ref, DateTime deadline) async {
 Future<bool> _restorePreferredDeviceDirectModel(
   Ref ref,
   DateTime deadline,
+  _VoiceCallEligibilityCancellation cancellation,
 ) async {
+  cancellation.throwIfRequested();
   final remaining = _remainingReadinessTime(deadline);
   if (remaining == Duration.zero) return false;
 
   DirectModelDiscoveryState discovery;
   try {
-    discovery = await ref
-        .read(directModelDiscoveryProvider.future)
-        .timeout(remaining);
+    discovery = await cancellation.wait(
+      ref.read(directModelDiscoveryProvider.future).timeout(remaining),
+    );
+  } on VoiceCallEligibilityResolutionCancelled {
+    rethrow;
   } catch (_) {
     return false;
   }
 
+  cancellation.throwIfRequested();
   final registry = ref.read(directModelRegistryProvider);
   final candidates = discovery.models
       .where((candidate) {
@@ -277,7 +324,8 @@ Future<bool> _restorePreferredDeviceDirectModel(
     (candidate) => candidate.id == configuredId,
     orElse: () => candidates.first,
   );
-  await Future<void>.delayed(Duration.zero);
+  await cancellation.wait(Future<void>.delayed(Duration.zero));
+  cancellation.throwIfRequested();
   if (ref.read(selectedModelProvider) != null ||
       ref.read(preferredBackendProvider) != PreferredBackend.direct ||
       ref.read(directModelRegistryProvider).resolve(selected)?.source !=
@@ -289,7 +337,12 @@ Future<bool> _restorePreferredDeviceDirectModel(
   return ref.read(selectedModelProvider)?.id == selected.id;
 }
 
-Future<bool> _waitForHermesStateChange(Ref ref, DateTime deadline) async {
+Future<bool> _waitForHermesStateChange(
+  Ref ref,
+  DateTime deadline,
+  _VoiceCallEligibilityCancellation cancellation,
+) async {
+  cancellation.throwIfRequested();
   if (!_voiceCallNeedsHermesHydration(ref)) return true;
 
   final completer = Completer<bool>();
@@ -310,7 +363,7 @@ Future<bool> _waitForHermesStateChange(Ref ref, DateTime deadline) async {
   }
 
   try {
-    return await completer.future;
+    return await cancellation.wait(completer.future);
   } finally {
     timer.cancel();
     for (final subscription in subscriptions) {
@@ -319,7 +372,12 @@ Future<bool> _waitForHermesStateChange(Ref ref, DateTime deadline) async {
   }
 }
 
-Future<bool> _waitForOpenWebUiStateChange(Ref ref, DateTime deadline) async {
+Future<bool> _waitForOpenWebUiStateChange(
+  Ref ref,
+  DateTime deadline,
+  _VoiceCallEligibilityCancellation cancellation,
+) async {
+  cancellation.throwIfRequested();
   if (ref.read(authNavigationStateProvider) != AuthNavigationState.loading ||
       voiceCallCanResolveWithoutOpenWebUiAuth(ref)) {
     return true;
@@ -348,11 +406,36 @@ Future<bool> _waitForOpenWebUiStateChange(Ref ref, DateTime deadline) async {
   }
 
   try {
-    return await completer.future;
+    return await cancellation.wait(completer.future);
   } finally {
     timer.cancel();
     for (final subscription in subscriptions) {
       subscription.close();
     }
+  }
+}
+
+final class _VoiceCallEligibilityCancellation {
+  const _VoiceCallEligibilityCancellation({this.signal, this.requested});
+
+  final Future<void>? signal;
+  final bool Function()? requested;
+
+  void throwIfRequested() {
+    if (requested?.call() ?? false) {
+      throw const VoiceCallEligibilityResolutionCancelled();
+    }
+  }
+
+  Future<T> wait<T>(Future<T> operation) async {
+    throwIfRequested();
+    final cancellationSignal = signal;
+    if (cancellationSignal == null) return operation;
+    return Future.any<T>([
+      operation,
+      cancellationSignal.then<T>(
+        (_) => throw const VoiceCallEligibilityResolutionCancelled(),
+      ),
+    ]);
   }
 }

--- a/lib/features/chat/voice_mode/chat_voice_mode_controller.dart
+++ b/lib/features/chat/voice_mode/chat_voice_mode_controller.dart
@@ -253,8 +253,10 @@ class ChatVoiceModeController extends Notifier<ChatVoiceModeSnapshot> {
 
   Future<void> _serial = Future<void>.value();
   int _token = 0;
+  int _stopRequestGeneration = 0;
   int _emptyTranscriptRestarts = 0;
   bool _disposed = false;
+  Completer<void>? _pendingStartReadinessCancellation;
 
   StreamSubscription<VoiceTranscriptEvent>? _transcriptSub;
   StreamSubscription<int>? _intensitySub;
@@ -319,6 +321,8 @@ class ChatVoiceModeController extends Notifier<ChatVoiceModeSnapshot> {
       // down its subscriptions. Async work must use only dependencies captured
       // while the provider was alive; reading Ref from this point is invalid.
       _disposed = true;
+      ++_stopRequestGeneration;
+      _cancelPendingStartReadiness();
       ++_token;
       _elapsedTimer?.cancel();
       _backgroundKeepAliveTimer?.cancel();
@@ -371,20 +375,47 @@ class ChatVoiceModeController extends Notifier<ChatVoiceModeSnapshot> {
     bool Function()? shouldStart,
     bool readinessResolved = false,
   }) async {
+    final stopGenerationAtRequest = _stopRequestGeneration;
     var result = ChatVoiceModeStartResult.failed;
     await _enqueue(() async {
+      if (stopGenerationAtRequest != _stopRequestGeneration) {
+        result = ChatVoiceModeStartResult.cancelled;
+        return;
+      }
+
       int? token;
+      final readinessCancellation = readinessResolved
+          ? null
+          : Completer<void>();
+      if (readinessCancellation != null) {
+        _pendingStartReadinessCancellation = readinessCancellation;
+      }
 
       try {
         await _serviceLifecycleGate.runExclusive(() async {
+          if (stopGenerationAtRequest != _stopRequestGeneration) {
+            result = ChatVoiceModeStartResult.cancelled;
+            return;
+          }
           if (state.isActive) {
             result = ChatVoiceModeStartResult.alreadyActive;
             return;
           }
 
-          final eligibility = readinessResolved
-              ? ref.read(voiceCallEligibilityProvider)
-              : await resolveVoiceCallEligibility(ref);
+          final VoiceCallEligibility? eligibility;
+          if (readinessCancellation == null) {
+            eligibility = ref.read(voiceCallEligibilityProvider);
+          } else {
+            eligibility = await Future.any<VoiceCallEligibility?>([
+              resolveVoiceCallEligibility(ref),
+              readinessCancellation.future.then((_) => null),
+            ]);
+          }
+          if (eligibility == null ||
+              stopGenerationAtRequest != _stopRequestGeneration) {
+            result = ChatVoiceModeStartResult.cancelled;
+            return;
+          }
           if (!eligibility.canStart) {
             _setError(eligibility.errorMessage!);
             return;
@@ -453,7 +484,7 @@ class ChatVoiceModeController extends Notifier<ChatVoiceModeSnapshot> {
           if (!_isCurrent(startToken)) return;
           cancelIfRequested();
           if (startNewConversation) {
-            startNewChat(ref);
+            startNewChat(ref, modelForNewConversation: model);
           }
           if (_isCurrent(startToken) && state.isActive) {
             result = ChatVoiceModeStartResult.started;
@@ -490,6 +521,13 @@ class ChatVoiceModeController extends Notifier<ChatVoiceModeSnapshot> {
         }
         if (startToken == null) return;
         await _fail(error.toString(), startToken);
+      } finally {
+        if (identical(
+          _pendingStartReadinessCancellation,
+          readinessCancellation,
+        )) {
+          _pendingStartReadinessCancellation = null;
+        }
       }
     });
     return result;
@@ -525,6 +563,8 @@ class ChatVoiceModeController extends Notifier<ChatVoiceModeSnapshot> {
   }
 
   Future<void> stop() {
+    ++_stopRequestGeneration;
+    _cancelPendingStartReadiness();
     return _enqueue(() => _stopInternal(endCallKit: true));
   }
 
@@ -1633,6 +1673,13 @@ class ChatVoiceModeController extends Notifier<ChatVoiceModeSnapshot> {
     });
     _serial = next.catchError((_) {});
     return next;
+  }
+
+  void _cancelPendingStartReadiness() {
+    final cancellation = _pendingStartReadinessCancellation;
+    if (cancellation != null && !cancellation.isCompleted) {
+      cancellation.complete();
+    }
   }
 
   bool _isCurrent(int token) => !_disposed && token == _token;

--- a/lib/features/chat/voice_mode/chat_voice_mode_controller.dart
+++ b/lib/features/chat/voice_mode/chat_voice_mode_controller.dart
@@ -482,12 +482,17 @@ class ChatVoiceModeController extends Notifier<ChatVoiceModeSnapshot> {
           if (!_isCurrent(startToken)) return;
           cancelIfRequested();
           _startElapsedTimer(startToken);
-          await _startListening(startToken);
+          await _startListening(
+            startToken,
+            beforeAcceptingTranscripts: startNewConversation
+                ? () {
+                    cancelIfRequested();
+                    startNewChat(ref, modelForNewConversation: model);
+                  }
+                : null,
+          );
           if (!_isCurrent(startToken)) return;
           cancelIfRequested();
-          if (startNewConversation) {
-            startNewChat(ref, modelForNewConversation: model);
-          }
           if (_isCurrent(startToken) && state.isActive) {
             result = ChatVoiceModeStartResult.started;
           }
@@ -885,9 +890,51 @@ class ChatVoiceModeController extends Notifier<ChatVoiceModeSnapshot> {
     await background.setExternalAudioSessionOwner(false);
   }
 
-  Future<void> _startListening(int token) async {
+  Future<void> _startListening(
+    int token, {
+    VoidCallback? beforeAcceptingTranscripts,
+  }) async {
     if (!_isCurrent(token) || state.isMuted) {
       return;
+    }
+
+    final bufferedEvents = <VoiceTranscriptEvent>[];
+    Object? bufferedError;
+    StackTrace? bufferedErrorStackTrace;
+    var bufferedDone = false;
+    var acceptingTranscripts = beforeAcceptingTranscripts == null;
+
+    void onTranscriptEvent(VoiceTranscriptEvent event) {
+      if (!acceptingTranscripts) {
+        bufferedEvents.add(event);
+        return;
+      }
+      _handleTranscriptEvent(event, token);
+    }
+
+    void onTranscriptError(Object error, StackTrace stackTrace) {
+      if (!acceptingTranscripts) {
+        bufferedError ??= error;
+        bufferedErrorStackTrace ??= stackTrace;
+        return;
+      }
+      if (!_isCurrent(token)) return;
+      DebugLogger.error(
+        'listen-failed',
+        scope: 'chat/voice_mode',
+        error: error,
+        stackTrace: stackTrace,
+      );
+      unawaited(_fail(error.toString(), token));
+    }
+
+    void onTranscriptDone() {
+      if (!acceptingTranscripts) {
+        bufferedDone = true;
+        return;
+      }
+      _transcriptSub = null;
+      unawaited(_handleListeningDone(token));
     }
 
     final input = _voiceInput!;
@@ -925,23 +972,9 @@ class ChatVoiceModeController extends Notifier<ChatVoiceModeSnapshot> {
 
       await _transcriptSub?.cancel();
       _transcriptSub = stream.listen(
-        (event) {
-          _handleTranscriptEvent(event, token);
-        },
-        onError: (Object error, StackTrace stackTrace) {
-          if (!_isCurrent(token)) return;
-          DebugLogger.error(
-            'listen-failed',
-            scope: 'chat/voice_mode',
-            error: error,
-            stackTrace: stackTrace,
-          );
-          unawaited(_fail(error.toString(), token));
-        },
-        onDone: () {
-          _transcriptSub = null;
-          unawaited(_handleListeningDone(token));
-        },
+        onTranscriptEvent,
+        onError: onTranscriptError,
+        onDone: onTranscriptDone,
       );
     }
 
@@ -952,6 +985,31 @@ class ChatVoiceModeController extends Notifier<ChatVoiceModeSnapshot> {
         state = state.copyWith(intensity: intensity);
       }
     });
+
+    final startupError = bufferedError;
+    if (startupError != null) {
+      final stackTrace = bufferedErrorStackTrace ?? StackTrace.current;
+      DebugLogger.error(
+        'listen-failed',
+        scope: 'chat/voice_mode',
+        error: startupError,
+        stackTrace: stackTrace,
+      );
+      Error.throwWithStackTrace(startupError, stackTrace);
+    }
+
+    beforeAcceptingTranscripts?.call();
+    if (!_isCurrent(token)) return;
+    acceptingTranscripts = true;
+    for (final event in bufferedEvents) {
+      if (!_isCurrent(token)) return;
+      _handleTranscriptEvent(event, token);
+    }
+    bufferedEvents.clear();
+    if (bufferedDone && _isCurrent(token)) {
+      _transcriptSub = null;
+      unawaited(_handleListeningDone(token));
+    }
   }
 
   void _handleTranscriptEvent(VoiceTranscriptEvent event, int token) {

--- a/lib/features/chat/voice_mode/chat_voice_mode_controller.dart
+++ b/lib/features/chat/voice_mode/chat_voice_mode_controller.dart
@@ -8,6 +8,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:permission_handler/permission_handler.dart';
 
 import '../../../core/models/chat_message.dart';
+import '../../../core/models/model.dart';
 import '../../../core/services/background_streaming_handler.dart';
 import '../../../core/services/callkit_service.dart';
 import '../../../core/services/settings_service.dart';
@@ -373,7 +374,7 @@ class ChatVoiceModeController extends Notifier<ChatVoiceModeSnapshot> {
   Future<ChatVoiceModeStartResult> start({
     required bool startNewConversation,
     bool Function()? shouldStart,
-    bool readinessResolved = false,
+    Model? admittedModel,
   }) async {
     final stopGenerationAtRequest = _stopRequestGeneration;
     bool cancellationRequested() =>
@@ -387,9 +388,9 @@ class ChatVoiceModeController extends Notifier<ChatVoiceModeSnapshot> {
       }
 
       int? token;
-      final readinessCancellation = readinessResolved
-          ? null
-          : Completer<void>();
+      final readinessCancellation = admittedModel == null
+          ? Completer<void>()
+          : null;
 
       try {
         await _serviceLifecycleGate.runExclusive(() async {
@@ -403,13 +404,13 @@ class ChatVoiceModeController extends Notifier<ChatVoiceModeSnapshot> {
           }
 
           final VoiceCallEligibility eligibility;
-          if (readinessCancellation == null) {
-            eligibility = ref.read(voiceCallEligibilityProvider);
+          if (admittedModel != null) {
+            eligibility = VoiceCallEligibility.eligible(admittedModel);
           } else {
             _pendingStartReadinessCancellation = readinessCancellation;
             eligibility = await resolveVoiceCallEligibility(
               ref,
-              cancellationSignal: readinessCancellation.future,
+              cancellationSignal: readinessCancellation!.future,
               cancellationRequested: cancellationRequested,
             );
           }
@@ -527,7 +528,10 @@ class ChatVoiceModeController extends Notifier<ChatVoiceModeSnapshot> {
           _setError('Voice services timed out. Try again.');
           return;
         }
-        if (startToken == null) return;
+        if (startToken == null) {
+          _setError(error.toString());
+          return;
+        }
         await _fail(error.toString(), startToken);
       } finally {
         if (identical(
@@ -1485,6 +1489,7 @@ class ChatVoiceModeController extends Notifier<ChatVoiceModeSnapshot> {
     state = state.copyWith(
       phase: ChatVoiceModePhase.error,
       errorMessage: message,
+      clearActiveCallId: true,
       clearSpokenResponse: true,
       intensity: 0,
     );

--- a/lib/features/chat/voice_mode/chat_voice_mode_controller.dart
+++ b/lib/features/chat/voice_mode/chat_voice_mode_controller.dart
@@ -450,6 +450,7 @@ class ChatVoiceModeController extends Notifier<ChatVoiceModeSnapshot> {
           cancelIfRequested();
           _startElapsedTimer(startToken);
           await _startListening(startToken);
+          if (!_isCurrent(startToken)) return;
           cancelIfRequested();
           if (startNewConversation) {
             startNewChat(ref);

--- a/lib/features/chat/voice_mode/chat_voice_mode_controller.dart
+++ b/lib/features/chat/voice_mode/chat_voice_mode_controller.dart
@@ -8,16 +8,15 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:permission_handler/permission_handler.dart';
 
 import '../../../core/models/chat_message.dart';
-import '../../../core/providers/app_providers.dart';
 import '../../../core/services/background_streaming_handler.dart';
 import '../../../core/services/callkit_service.dart';
 import '../../../core/services/settings_service.dart';
 import '../../../core/utils/debug_logger.dart';
-import '../../auth/providers/unified_auth_providers.dart';
 import '../providers/chat_providers.dart';
 import '../providers/text_to_speech_provider.dart';
 import '../services/text_to_speech_service.dart';
 import '../services/voice_input_service.dart';
+import '../voice_call/voice_call_eligibility.dart';
 import 'chat_voice_audio_session_coordinator.dart';
 import '../../tools/providers/tools_providers.dart';
 
@@ -32,6 +31,12 @@ enum ChatVoiceModePhase {
   ending,
   ended,
   error,
+}
+
+enum ChatVoiceModeStartResult { started, alreadyActive, cancelled, failed }
+
+final class _ChatVoiceModeStartCancelled implements Exception {
+  const _ChatVoiceModeStartCancelled();
 }
 
 @immutable
@@ -361,31 +366,45 @@ class ChatVoiceModeController extends Notifier<ChatVoiceModeSnapshot> {
     return const ChatVoiceModeSnapshot();
   }
 
-  Future<void> start({required bool startNewConversation}) {
-    return _enqueue(() async {
+  Future<ChatVoiceModeStartResult> start({
+    required bool startNewConversation,
+    bool Function()? shouldStart,
+    bool readinessResolved = false,
+  }) async {
+    var result = ChatVoiceModeStartResult.failed;
+    await _enqueue(() async {
       int? token;
 
       try {
         await _serviceLifecycleGate.runExclusive(() async {
           if (state.isActive) {
+            result = ChatVoiceModeStartResult.alreadyActive;
             return;
           }
 
-          final authState = ref.read(authNavigationStateProvider);
-          if (authState != AuthNavigationState.authenticated) {
-            _setError('Sign in to start a voice call.');
+          final eligibility = readinessResolved
+              ? ref.read(voiceCallEligibilityProvider)
+              : await resolveVoiceCallEligibility(ref);
+          if (!eligibility.canStart) {
+            _setError(eligibility.errorMessage!);
+            return;
+          }
+          if (shouldStart != null && !shouldStart()) {
+            result = ChatVoiceModeStartResult.cancelled;
             return;
           }
 
-          final model = ref.read(selectedModelProvider);
-          if (model == null) {
-            _setError('Choose a model before starting a voice call.');
-            return;
-          }
+          final model = eligibility.model!;
 
           final startToken = ++_token;
           token = startToken;
           _resetRuntime();
+
+          void cancelIfRequested() {
+            if (shouldStart != null && !shouldStart()) {
+              throw const _ChatVoiceModeStartCancelled();
+            }
+          }
 
           // Keep the inactive overlay lightweight. These services can reach
           // authenticated storage and platform channels, so capture them only
@@ -409,31 +428,47 @@ class ChatVoiceModeController extends Notifier<ChatVoiceModeSnapshot> {
             isMuted: false,
           );
 
-          if (startNewConversation) {
-            startNewChat(ref);
-          }
-
           final inputReady = await input.initialize();
           if (!_isCurrent(startToken)) return;
+          cancelIfRequested();
           if (!inputReady) {
             throw StateError('Voice input initialization failed.');
           }
 
           await _requestAndroidVoiceRoutingPermission();
           if (!_isCurrent(startToken)) return;
+          cancelIfRequested();
           await _initializeTts(tts, settings);
           if (!_isCurrent(startToken)) return;
+          cancelIfRequested();
           _listenForTtsEvents(tts, startToken);
           await _startCallKit(model.name, startToken);
           if (!_isCurrent(startToken)) return;
+          cancelIfRequested();
           await _startBackgroundVoiceLease(input, startToken);
           if (!_isCurrent(startToken)) return;
+          cancelIfRequested();
           _startElapsedTimer(startToken);
           await _startListening(startToken);
+          cancelIfRequested();
+          if (startNewConversation) {
+            startNewChat(ref);
+          }
+          if (_isCurrent(startToken) && state.isActive) {
+            result = ChatVoiceModeStartResult.started;
+          }
         });
       } catch (error, stackTrace) {
         final startToken = token;
         if (_disposed || (startToken != null && !_isCurrent(startToken))) {
+          result = ChatVoiceModeStartResult.cancelled;
+          return;
+        }
+        if (error is _ChatVoiceModeStartCancelled) {
+          result = ChatVoiceModeStartResult.cancelled;
+          if (startToken != null) {
+            await _stopInternal(endCallKit: true);
+          }
           return;
         }
         DebugLogger.error(
@@ -456,6 +491,7 @@ class ChatVoiceModeController extends Notifier<ChatVoiceModeSnapshot> {
         await _fail(error.toString(), startToken);
       }
     });
+    return result;
   }
 
   Future<void> _requestAndroidVoiceRoutingPermission() async {

--- a/lib/features/chat/voice_mode/chat_voice_mode_controller.dart
+++ b/lib/features/chat/voice_mode/chat_voice_mode_controller.dart
@@ -440,6 +440,12 @@ class ChatVoiceModeController extends Notifier<ChatVoiceModeSnapshot> {
             }
           }
 
+          bool lostOwnership() {
+            if (_isCurrent(startToken)) return false;
+            result = ChatVoiceModeStartResult.cancelled;
+            return true;
+          }
+
           // Keep the inactive overlay lightweight. These services can reach
           // authenticated storage and platform channels, so capture them only
           // when a voice session actually starts. The retained references also
@@ -463,24 +469,24 @@ class ChatVoiceModeController extends Notifier<ChatVoiceModeSnapshot> {
           );
 
           final inputReady = await input.initialize();
-          if (!_isCurrent(startToken)) return;
+          if (lostOwnership()) return;
           cancelIfRequested();
           if (!inputReady) {
             throw StateError('Voice input initialization failed.');
           }
 
           await _requestAndroidVoiceRoutingPermission();
-          if (!_isCurrent(startToken)) return;
+          if (lostOwnership()) return;
           cancelIfRequested();
           await _initializeTts(tts, settings);
-          if (!_isCurrent(startToken)) return;
+          if (lostOwnership()) return;
           cancelIfRequested();
           _listenForTtsEvents(tts, startToken);
           await _startCallKit(model.name, startToken);
-          if (!_isCurrent(startToken)) return;
+          if (lostOwnership()) return;
           cancelIfRequested();
           await _startBackgroundVoiceLease(input, startToken);
-          if (!_isCurrent(startToken)) return;
+          if (lostOwnership()) return;
           cancelIfRequested();
           _startElapsedTimer(startToken);
           await _startListening(
@@ -492,7 +498,7 @@ class ChatVoiceModeController extends Notifier<ChatVoiceModeSnapshot> {
                   }
                 : null,
           );
-          if (!_isCurrent(startToken)) return;
+          if (lostOwnership()) return;
           cancelIfRequested();
           if (_isCurrent(startToken) && state.isActive) {
             result = ChatVoiceModeStartResult.started;

--- a/lib/features/chat/voice_mode/chat_voice_mode_controller.dart
+++ b/lib/features/chat/voice_mode/chat_voice_mode_controller.dart
@@ -376,9 +376,12 @@ class ChatVoiceModeController extends Notifier<ChatVoiceModeSnapshot> {
     bool readinessResolved = false,
   }) async {
     final stopGenerationAtRequest = _stopRequestGeneration;
+    bool cancellationRequested() =>
+        _disposed || stopGenerationAtRequest != _stopRequestGeneration;
+
     var result = ChatVoiceModeStartResult.failed;
     await _enqueue(() async {
-      if (stopGenerationAtRequest != _stopRequestGeneration) {
+      if (cancellationRequested()) {
         result = ChatVoiceModeStartResult.cancelled;
         return;
       }
@@ -387,13 +390,10 @@ class ChatVoiceModeController extends Notifier<ChatVoiceModeSnapshot> {
       final readinessCancellation = readinessResolved
           ? null
           : Completer<void>();
-      if (readinessCancellation != null) {
-        _pendingStartReadinessCancellation = readinessCancellation;
-      }
 
       try {
         await _serviceLifecycleGate.runExclusive(() async {
-          if (stopGenerationAtRequest != _stopRequestGeneration) {
+          if (cancellationRequested()) {
             result = ChatVoiceModeStartResult.cancelled;
             return;
           }
@@ -402,17 +402,18 @@ class ChatVoiceModeController extends Notifier<ChatVoiceModeSnapshot> {
             return;
           }
 
-          final VoiceCallEligibility? eligibility;
+          final VoiceCallEligibility eligibility;
           if (readinessCancellation == null) {
             eligibility = ref.read(voiceCallEligibilityProvider);
           } else {
-            eligibility = await Future.any<VoiceCallEligibility?>([
-              resolveVoiceCallEligibility(ref),
-              readinessCancellation.future.then((_) => null),
-            ]);
+            _pendingStartReadinessCancellation = readinessCancellation;
+            eligibility = await resolveVoiceCallEligibility(
+              ref,
+              cancellationSignal: readinessCancellation.future,
+              cancellationRequested: cancellationRequested,
+            );
           }
-          if (eligibility == null ||
-              stopGenerationAtRequest != _stopRequestGeneration) {
+          if (cancellationRequested()) {
             result = ChatVoiceModeStartResult.cancelled;
             return;
           }
@@ -432,7 +433,8 @@ class ChatVoiceModeController extends Notifier<ChatVoiceModeSnapshot> {
           _resetRuntime();
 
           void cancelIfRequested() {
-            if (shouldStart != null && !shouldStart()) {
+            if (cancellationRequested() ||
+                (shouldStart != null && !shouldStart())) {
               throw const _ChatVoiceModeStartCancelled();
             }
           }
@@ -496,7 +498,8 @@ class ChatVoiceModeController extends Notifier<ChatVoiceModeSnapshot> {
           result = ChatVoiceModeStartResult.cancelled;
           return;
         }
-        if (error is _ChatVoiceModeStartCancelled) {
+        if (error is _ChatVoiceModeStartCancelled ||
+            error is VoiceCallEligibilityResolutionCancelled) {
           result = ChatVoiceModeStartResult.cancelled;
           if (startToken != null) {
             await _stopInternal(endCallKit: true);
@@ -561,6 +564,10 @@ class ChatVoiceModeController extends Notifier<ChatVoiceModeSnapshot> {
       );
     }
   }
+
+  @visibleForTesting
+  bool get isWaitingForStartReadiness =>
+      _pendingStartReadinessCancellation != null;
 
   Future<void> stop() {
     ++_stopRequestGeneration;

--- a/lib/features/navigation/views/folder_page.dart
+++ b/lib/features/navigation/views/folder_page.dart
@@ -758,10 +758,26 @@ class _FolderPageState extends ConsumerState<FolderPage> {
     );
   }
 
-  void _handleVoiceCall() {
-    unawaited(
-      ref.read(voiceCallLauncherProvider).launch(startNewConversation: false),
-    );
+  Future<void> _handleVoiceCall() async {
+    try {
+      await ref
+          .read(voiceCallLauncherProvider)
+          .launch(startNewConversation: false);
+    } catch (error, stackTrace) {
+      DebugLogger.error(
+        'launch-failed',
+        scope: 'navigation/folder/voice_call',
+        error: error,
+        stackTrace: stackTrace,
+      );
+      if (!mounted) return;
+      final message = error is StateError
+          ? error.message.toString()
+          : AppLocalizations.of(context)!.errorMessage;
+      ScaffoldMessenger.maybeOf(
+        context,
+      )?.showSnackBar(SnackBar(content: Text(message)));
+    }
   }
 
   void _dismissComposerFocus() {

--- a/test/core/services/carplay_service_test.dart
+++ b/test/core/services/carplay_service_test.dart
@@ -77,6 +77,7 @@ void main() {
         expect(result['success'], isTrue);
         expect(voice.startCalls, 1);
         expect(voice.startedByStartNewConversation.single, isTrue);
+        expect(voice.admittedModels.single?.id, hermesSyntheticModel().id);
       },
     );
 
@@ -266,6 +267,7 @@ final class _FakeVoiceCallController extends ChatVoiceModeController {
   final Completer<void>? startCompleter;
   final ChatVoiceModeStartResult startResult;
   final startedByStartNewConversation = <bool>[];
+  final admittedModels = <Model?>[];
   int startCalls = 0;
   int stopCalls = 0;
   int pauseCalls = 0;
@@ -278,10 +280,11 @@ final class _FakeVoiceCallController extends ChatVoiceModeController {
   Future<ChatVoiceModeStartResult> start({
     required bool startNewConversation,
     bool Function()? shouldStart,
-    bool readinessResolved = false,
+    Model? admittedModel,
   }) async {
     startCalls += 1;
     startedByStartNewConversation.add(startNewConversation);
+    admittedModels.add(admittedModel);
     await startCompleter?.future;
     if (shouldStart != null && !shouldStart()) {
       return ChatVoiceModeStartResult.cancelled;

--- a/test/core/services/carplay_service_test.dart
+++ b/test/core/services/carplay_service_test.dart
@@ -179,6 +179,41 @@ void main() {
       },
     );
 
+    test(
+      'disconnect stops an owned call while an overlapping start is pending',
+      () async {
+        final firstStart = Completer<void>();
+        final secondStart = Completer<void>();
+        final voice = _FakeVoiceCallController(
+          startCompleters: [firstStart, secondStart],
+          startResults: const [
+            ChatVoiceModeStartResult.started,
+            ChatVoiceModeStartResult.alreadyActive,
+          ],
+        );
+        final container = _buildContainer(voice: voice);
+        addTearDown(container.dispose);
+
+        final firstResult = _invokeNative('startVoiceConversation');
+        await _until(() => voice.startCalls == 1);
+        final secondResult = _invokeNative('startVoiceConversation');
+        await _until(() => voice.startCalls == 2);
+
+        firstStart.complete();
+        expect((await firstResult)['success'], isTrue);
+
+        final disconnect = await _invokeNative('carPlaySceneDidDisconnect');
+        expect(disconnect['success'], isTrue);
+        expect(voice.stopCalls, 1);
+
+        secondStart.complete();
+        final cancelledOverlap = await secondResult;
+        expect(cancelledOverlap['success'], isFalse);
+        expect(cancelledOverlap['error'], contains('disconnected'));
+        expect(voice.stopCalls, 1);
+      },
+    );
+
     test('does not take ownership of an already-active phone call', () async {
       final voice = _FakeVoiceCallController(
         startResult: ChatVoiceModeStartResult.alreadyActive,

--- a/test/core/services/carplay_service_test.dart
+++ b/test/core/services/carplay_service_test.dart
@@ -120,6 +120,33 @@ void main() {
       },
     );
 
+    test(
+      'disconnect cancels eligibility readiness without waiting for timeout',
+      () async {
+        final authRead = Completer<void>();
+        final voice = _FakeVoiceCallController();
+        final container = _buildContainer(
+          voice: voice,
+          authState: AuthNavigationState.loading,
+          onAuthRead: () {
+            if (!authRead.isCompleted) authRead.complete();
+          },
+        );
+        addTearDown(container.dispose);
+
+        final startFuture = _invokeNative('startVoiceConversation');
+        await authRead.future.timeout(const Duration(seconds: 1));
+
+        final disconnect = await _invokeNative('carPlaySceneDidDisconnect');
+        final result = await startFuture.timeout(const Duration(seconds: 1));
+
+        expect(disconnect['success'], isTrue);
+        expect(result['success'], isFalse);
+        expect(result['error'], contains('disconnected'));
+        expect(voice.startCalls, 0);
+      },
+    );
+
     test('does not take ownership of an already-active phone call', () async {
       final voice = _FakeVoiceCallController(
         startResult: ChatVoiceModeStartResult.alreadyActive,
@@ -187,11 +214,15 @@ ProviderContainer _buildContainer({
   AuthNavigationState authState = AuthNavigationState.authenticated,
   Model? selectedModel = _model,
   HermesConfig? hermesConfig,
+  VoidCallback? onAuthRead,
 }) {
   final container = ProviderContainer(
     overrides: [
       chatVoiceModeControllerProvider.overrideWith(() => voice),
-      authNavigationStateProvider.overrideWithValue(authState),
+      authNavigationStateProvider.overrideWith((ref) {
+        onAuthRead?.call();
+        return authState;
+      }),
       reviewerModeProvider.overrideWithValue(false),
       selectedModelProvider.overrideWithValue(selectedModel),
       defaultModelProvider.overrideWith((ref) => selectedModel),

--- a/test/core/services/carplay_service_test.dart
+++ b/test/core/services/carplay_service_test.dart
@@ -147,6 +147,38 @@ void main() {
       },
     );
 
+    test(
+      'overlapping starts preserve CarPlay ownership through disconnect',
+      () async {
+        final firstStart = Completer<void>();
+        final secondStart = Completer<void>();
+        final voice = _FakeVoiceCallController(
+          startCompleters: [firstStart, secondStart],
+          startResults: const [
+            ChatVoiceModeStartResult.started,
+            ChatVoiceModeStartResult.alreadyActive,
+          ],
+        );
+        final container = _buildContainer(voice: voice);
+        addTearDown(container.dispose);
+
+        final firstResult = _invokeNative('startVoiceConversation');
+        await _until(() => voice.startCalls == 1);
+        final secondResult = _invokeNative('startVoiceConversation');
+        await _until(() => voice.startCalls == 2);
+
+        firstStart.complete();
+        expect((await firstResult)['success'], isTrue);
+        secondStart.complete();
+        expect((await secondResult)['success'], isTrue);
+
+        final disconnect = await _invokeNative('carPlaySceneDidDisconnect');
+
+        expect(disconnect['success'], isTrue);
+        expect(voice.stopCalls, 1);
+      },
+    );
+
     test('does not take ownership of an already-active phone call', () async {
       final voice = _FakeVoiceCallController(
         startResult: ChatVoiceModeStartResult.alreadyActive,
@@ -292,11 +324,15 @@ Future<void> _until(bool Function() condition) async {
 final class _FakeVoiceCallController extends ChatVoiceModeController {
   _FakeVoiceCallController({
     this.startCompleter,
+    this.startCompleters = const <Completer<void>>[],
     this.startResult = ChatVoiceModeStartResult.started,
+    this.startResults = const <ChatVoiceModeStartResult>[],
   });
 
   final Completer<void>? startCompleter;
+  final List<Completer<void>> startCompleters;
   final ChatVoiceModeStartResult startResult;
+  final List<ChatVoiceModeStartResult> startResults;
   final startedByStartNewConversation = <bool>[];
   final admittedModels = <Model?>[];
   int startCalls = 0;
@@ -313,23 +349,30 @@ final class _FakeVoiceCallController extends ChatVoiceModeController {
     bool Function()? shouldStart,
     Model? admittedModel,
   }) async {
+    final callIndex = startCalls;
     startCalls += 1;
     startedByStartNewConversation.add(startNewConversation);
     admittedModels.add(admittedModel);
-    await startCompleter?.future;
+    final gate = callIndex < startCompleters.length
+        ? startCompleters[callIndex]
+        : startCompleter;
+    await gate?.future;
     if (shouldStart != null && !shouldStart()) {
       return ChatVoiceModeStartResult.cancelled;
     }
-    if (startResult == ChatVoiceModeStartResult.started ||
-        startResult == ChatVoiceModeStartResult.alreadyActive) {
+    final result = callIndex < startResults.length
+        ? startResults[callIndex]
+        : startResult;
+    if (result == ChatVoiceModeStartResult.started ||
+        result == ChatVoiceModeStartResult.alreadyActive) {
       state = const ChatVoiceModeSnapshot(phase: ChatVoiceModePhase.listening);
-    } else if (startResult == ChatVoiceModeStartResult.failed) {
+    } else if (result == ChatVoiceModeStartResult.failed) {
       state = const ChatVoiceModeSnapshot(
         phase: ChatVoiceModePhase.error,
         errorMessage: 'Unable to start test voice call.',
       );
     }
-    return startResult;
+    return result;
   }
 
   @override

--- a/test/core/services/carplay_service_test.dart
+++ b/test/core/services/carplay_service_test.dart
@@ -5,6 +5,9 @@ import 'package:conduit/core/providers/app_providers.dart';
 import 'package:conduit/core/services/carplay_service.dart';
 import 'package:conduit/features/auth/providers/unified_auth_providers.dart';
 import 'package:conduit/features/chat/voice_mode/chat_voice_mode_controller.dart';
+import 'package:conduit/features/hermes/models/hermes_config.dart';
+import 'package:conduit/features/hermes/models/hermes_model.dart';
+import 'package:conduit/features/hermes/providers/hermes_providers.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -52,8 +55,28 @@ void main() {
         final result = await _invokeNative('startVoiceConversation');
 
         expect(result['success'], isFalse);
-        expect(result['error'], contains('sign in'));
+        expect(result['error'], contains('Sign in'));
         expect(voice.startCalls, 0);
+      },
+    );
+
+    test(
+      'startVoiceConversation starts signed-out Hermes voice mode',
+      () async {
+        final voice = _FakeVoiceCallController();
+        final container = _buildContainer(
+          voice: voice,
+          authState: AuthNavigationState.needsLogin,
+          selectedModel: hermesSyntheticModel(),
+          hermesConfig: _usableHermesConfig,
+        );
+        addTearDown(container.dispose);
+
+        final result = await _invokeNative('startVoiceConversation');
+
+        expect(result['success'], isTrue);
+        expect(voice.startCalls, 1);
+        expect(voice.startedByStartNewConversation.single, isTrue);
       },
     );
 
@@ -67,30 +90,48 @@ void main() {
         final result = await _invokeNative('startVoiceConversation');
 
         expect(result['success'], isFalse);
-        expect(result['error'], contains('select a model'));
+        expect(result['error'], contains('Choose a model'));
         expect(voice.startCalls, 0);
       },
     );
 
-    test('disconnect during in-flight start stops the native call', () async {
-      final startCompleter = Completer<void>();
-      final voice = _FakeVoiceCallController(startCompleter: startCompleter);
+    test(
+      'disconnect during in-flight readiness cancels native start',
+      () async {
+        final startCompleter = Completer<void>();
+        final voice = _FakeVoiceCallController(startCompleter: startCompleter);
+        final container = _buildContainer(voice: voice);
+        addTearDown(container.dispose);
+
+        final startFuture = _invokeNative('startVoiceConversation');
+        await _until(() => voice.startCalls == 1);
+
+        final disconnect = await _invokeNative('carPlaySceneDidDisconnect');
+        expect(disconnect['success'], isTrue);
+
+        startCompleter.complete();
+        final result = await startFuture;
+
+        expect(result['success'], isFalse);
+        expect(result['error'], contains('disconnected'));
+        expect(voice.stopCalls, 0);
+        expect(voice.startedByStartNewConversation.single, isTrue);
+      },
+    );
+
+    test('does not take ownership of an already-active phone call', () async {
+      final voice = _FakeVoiceCallController(
+        startResult: ChatVoiceModeStartResult.alreadyActive,
+      );
       final container = _buildContainer(voice: voice);
       addTearDown(container.dispose);
 
-      final startFuture = _invokeNative('startVoiceConversation');
-      await _until(() => voice.startCalls == 1);
-
+      final start = await _invokeNative('startVoiceConversation');
       final disconnect = await _invokeNative('carPlaySceneDidDisconnect');
+
+      expect(start['success'], isTrue);
       expect(disconnect['success'], isTrue);
-
-      startCompleter.complete();
-      final result = await startFuture;
-
-      expect(result['success'], isFalse);
-      expect(result['error'], contains('disconnected'));
-      expect(voice.stopCalls, 1);
-      expect(voice.startedByStartNewConversation.single, isTrue);
+      expect(voice.stopCalls, 0);
     });
 
     test(
@@ -144,17 +185,45 @@ ProviderContainer _buildContainer({
   required _FakeVoiceCallController voice,
   AuthNavigationState authState = AuthNavigationState.authenticated,
   Model? selectedModel = _model,
+  HermesConfig? hermesConfig,
 }) {
   final container = ProviderContainer(
     overrides: [
       chatVoiceModeControllerProvider.overrideWith(() => voice),
       authNavigationStateProvider.overrideWithValue(authState),
+      reviewerModeProvider.overrideWithValue(false),
       selectedModelProvider.overrideWithValue(selectedModel),
       defaultModelProvider.overrideWith((ref) => selectedModel),
+      if (hermesConfig != null)
+        hermesConfigProvider.overrideWith(
+          () => _FixedHermesConfig(hermesConfig),
+        ),
+      if (hermesConfig != null)
+        hermesSecretsLoadingProvider.overrideWith(_SettledHermesSecrets.new),
     ],
   );
   container.read(_testCarPlayCoordinatorProvider);
   return container;
+}
+
+const _usableHermesConfig = HermesConfig(
+  enabled: true,
+  baseUrl: 'https://hermes.example/v1',
+  apiKey: 'hermes-key',
+);
+
+final class _FixedHermesConfig extends HermesConfigController {
+  _FixedHermesConfig(this._config);
+
+  final HermesConfig _config;
+
+  @override
+  HermesConfig build() => _config;
+}
+
+final class _SettledHermesSecrets extends HermesSecretsLoading {
+  @override
+  bool build() => false;
 }
 
 Future<Map<String, Object?>> _invokeNative(String method) async {
@@ -189,9 +258,13 @@ Future<void> _until(bool Function() condition) async {
 }
 
 final class _FakeVoiceCallController extends ChatVoiceModeController {
-  _FakeVoiceCallController({this.startCompleter});
+  _FakeVoiceCallController({
+    this.startCompleter,
+    this.startResult = ChatVoiceModeStartResult.started,
+  });
 
   final Completer<void>? startCompleter;
+  final ChatVoiceModeStartResult startResult;
   final startedByStartNewConversation = <bool>[];
   int startCalls = 0;
   int stopCalls = 0;
@@ -202,11 +275,27 @@ final class _FakeVoiceCallController extends ChatVoiceModeController {
   ChatVoiceModeSnapshot build() => const ChatVoiceModeSnapshot();
 
   @override
-  Future<void> start({required bool startNewConversation}) async {
+  Future<ChatVoiceModeStartResult> start({
+    required bool startNewConversation,
+    bool Function()? shouldStart,
+    bool readinessResolved = false,
+  }) async {
     startCalls += 1;
     startedByStartNewConversation.add(startNewConversation);
     await startCompleter?.future;
-    state = const ChatVoiceModeSnapshot(phase: ChatVoiceModePhase.listening);
+    if (shouldStart != null && !shouldStart()) {
+      return ChatVoiceModeStartResult.cancelled;
+    }
+    if (startResult == ChatVoiceModeStartResult.started ||
+        startResult == ChatVoiceModeStartResult.alreadyActive) {
+      state = const ChatVoiceModeSnapshot(phase: ChatVoiceModePhase.listening);
+    } else if (startResult == ChatVoiceModeStartResult.failed) {
+      state = const ChatVoiceModeSnapshot(
+        phase: ChatVoiceModePhase.error,
+        errorMessage: 'Unable to start test voice call.',
+      );
+    }
+    return startResult;
   }
 
   @override

--- a/test/core/services/external_voice_entrypoints_test.dart
+++ b/test/core/services/external_voice_entrypoints_test.dart
@@ -61,6 +61,14 @@ void main() {
   test('voice quick action bypasses a signed-out queue head', () {
     expect(
       quickActionDispatchIndex(
+        queuedTypes: const ['conduit_voice_call'],
+        authState: AuthNavigationState.needsLogin,
+        voiceCanBypassAuthLoading: false,
+      ),
+      isNull,
+    );
+    expect(
+      quickActionDispatchIndex(
         queuedTypes: const ['conduit_new_chat', 'conduit_voice_call'],
         authState: AuthNavigationState.needsLogin,
         voiceCanBypassAuthLoading: false,
@@ -78,6 +86,14 @@ void main() {
     expect(
       quickActionDispatchIndex(
         queuedTypes: const ['conduit_voice_call'],
+        authState: AuthNavigationState.needsLogin,
+        voiceCanBypassAuthLoading: true,
+      ),
+      0,
+    );
+    expect(
+      quickActionDispatchIndex(
+        queuedTypes: const ['conduit_voice_call'],
         authState: AuthNavigationState.loading,
         voiceCanBypassAuthLoading: false,
       ),
@@ -90,6 +106,14 @@ void main() {
         voiceCanBypassAuthLoading: true,
       ),
       1,
+    );
+    expect(
+      quickActionDispatchIndex(
+        queuedTypes: const ['conduit_voice_call'],
+        authState: AuthNavigationState.authenticated,
+        voiceCanBypassAuthLoading: false,
+      ),
+      0,
     );
   });
 
@@ -115,6 +139,9 @@ void main() {
       ),
       isFalse,
     );
+    expect(homeWidgetActionOf(Uri.parse('conduit://mic')), WidgetActions.mic);
+    expect(homeWidgetActionOf(Uri.parse('conduit:///mic')), WidgetActions.mic);
+    expect(homeWidgetActionOf(Uri.parse('conduit:///')), isNull);
   });
 }
 

--- a/test/core/services/external_voice_entrypoints_test.dart
+++ b/test/core/services/external_voice_entrypoints_test.dart
@@ -1,0 +1,157 @@
+import 'dart:async';
+
+import 'package:conduit/core/persistence/preferences_store.dart';
+import 'package:conduit/core/providers/app_providers.dart';
+import 'package:conduit/core/services/app_intents_service.dart';
+import 'package:conduit/core/services/home_widget_service.dart';
+import 'package:conduit/core/services/quick_actions_service.dart';
+import 'package:conduit/core/utils/android_assistant_handler.dart';
+import 'package:conduit/features/auth/providers/unified_auth_providers.dart';
+import 'package:conduit/features/chat/voice_call/presentation/voice_call_launcher.dart';
+import 'package:conduit/features/hermes/models/hermes_model.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+const _assistantChannel = 'app.cogwheel.conduit/assistant';
+const _codec = StandardMethodCodec();
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() async {
+    SharedPreferences.setMockInitialValues({});
+    PreferencesStore.debugOverride(await SharedPreferences.getInstance());
+  });
+
+  tearDown(() {
+    AndroidAssistantHandler.platform.setMethodCallHandler(null);
+    PreferencesStore.debugReset();
+  });
+
+  test('Android Assistant delegates signed-out Hermes voice calls', () async {
+    late _RecordingVoiceCallLauncher launcher;
+    final container = _buildContainer((ref) {
+      return launcher = _RecordingVoiceCallLauncher(ref);
+    });
+    addTearDown(container.dispose);
+    container.read(androidAssistantProvider);
+
+    await _invokeAndroidAssistant('startVoiceCall');
+
+    expect(launcher.startNewConversationCalls, [isTrue]);
+  });
+
+  test('Siri intent delegates signed-out Hermes voice calls', () async {
+    late _RecordingVoiceCallLauncher launcher;
+    final container = _buildContainer((ref) {
+      return launcher = _RecordingVoiceCallLauncher(ref);
+    });
+    addTearDown(container.dispose);
+
+    final response = await container
+        .read(appIntentCoordinatorProvider.notifier)
+        .startVoiceCall('signed-out-hermes-voice');
+
+    expect(response.success, isTrue);
+    expect(launcher.startNewConversationCalls, [isTrue]);
+  });
+
+  test('voice quick action bypasses a signed-out queue head', () {
+    expect(
+      quickActionDispatchIndex(
+        queuedTypes: const ['conduit_new_chat', 'conduit_voice_call'],
+        authState: AuthNavigationState.needsLogin,
+        voiceCanBypassAuthLoading: false,
+      ),
+      isNull,
+    );
+    expect(
+      quickActionDispatchIndex(
+        queuedTypes: const ['conduit_new_chat', 'conduit_voice_call'],
+        authState: AuthNavigationState.needsLogin,
+        voiceCanBypassAuthLoading: true,
+      ),
+      1,
+    );
+    expect(
+      quickActionDispatchIndex(
+        queuedTypes: const ['conduit_voice_call'],
+        authState: AuthNavigationState.loading,
+        voiceCanBypassAuthLoading: false,
+      ),
+      isNull,
+    );
+    expect(
+      quickActionDispatchIndex(
+        queuedTypes: const ['conduit_new_chat', 'conduit_voice_call'],
+        authState: AuthNavigationState.loading,
+        voiceCanBypassAuthLoading: true,
+      ),
+      1,
+    );
+  });
+
+  test('voice home widget is not gated by OpenWebUI auth', () {
+    expect(
+      homeWidgetVoiceActionCanDispatch(
+        Uri.parse('conduit://mic'),
+        canBypassOpenWebUiAuth: true,
+      ),
+      isTrue,
+    );
+    expect(
+      homeWidgetVoiceActionCanDispatch(
+        Uri.parse('conduit://mic'),
+        canBypassOpenWebUiAuth: false,
+      ),
+      isFalse,
+    );
+    expect(
+      homeWidgetVoiceActionCanDispatch(
+        Uri.parse('conduit://new_chat'),
+        canBypassOpenWebUiAuth: true,
+      ),
+      isFalse,
+    );
+  });
+}
+
+ProviderContainer _buildContainer(
+  VoiceCallLauncher Function(Ref ref) createLauncher,
+) {
+  return ProviderContainer(
+    overrides: [
+      authNavigationStateProvider.overrideWithValue(
+        AuthNavigationState.needsLogin,
+      ),
+      selectedModelProvider.overrideWithValue(hermesSyntheticModel()),
+      voiceCallLauncherProvider.overrideWith(createLauncher),
+    ],
+  );
+}
+
+Future<void> _invokeAndroidAssistant(String method) async {
+  final messenger =
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger;
+  final data = _codec.encodeMethodCall(MethodCall(method));
+  final completer = Completer<ByteData?>();
+  await messenger.handlePlatformMessage(
+    _assistantChannel,
+    data,
+    completer.complete,
+  );
+  await completer.future;
+}
+
+final class _RecordingVoiceCallLauncher extends VoiceCallLauncher {
+  _RecordingVoiceCallLauncher(super.ref);
+
+  final startNewConversationCalls = <bool>[];
+
+  @override
+  Future<void> launch({required bool startNewConversation}) async {
+    startNewConversationCalls.add(startNewConversation);
+  }
+}

--- a/test/features/chat/voice_mode/chat_voice_mode_controller_test.dart
+++ b/test/features/chat/voice_mode/chat_voice_mode_controller_test.dart
@@ -35,6 +35,12 @@ const _model = Model(id: 'test-model', name: 'Test Model');
 final _voiceReadinessTestProvider = FutureProvider<VoiceCallEligibility>(
   resolveVoiceCallEligibility,
 );
+final _boundedVoiceReadinessTestProvider = FutureProvider<VoiceCallEligibility>(
+  (ref) => resolveVoiceCallEligibility(
+    ref,
+    readinessTimeout: const Duration(milliseconds: 10),
+  ),
+);
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
@@ -376,6 +382,39 @@ void main() {
       check(eligibility.canStart).isTrue();
       check(eligibility.model?.id).equals(model.id);
       check(container.read(isManualModelSelectionProvider)).isFalse();
+    },
+  );
+
+  test(
+    'voice readiness stops when Hermes model restoration is rejected',
+    () async {
+      final container = ProviderContainer(
+        overrides: [
+          authNavigationStateProvider.overrideWithValue(
+            AuthNavigationState.loading,
+          ),
+          reviewerModeProvider.overrideWithValue(false),
+          preferredBackendProvider.overrideWith(_HermesPreferredBackend.new),
+          selectedModelProvider.overrideWith(_IgnoringSelectedModel.new),
+          isManualModelSelectionProvider.overrideWith(
+            _ManualModelSelection.new,
+          ),
+          hermesConfigProvider.overrideWith(
+            () => _FixedHermesConfig(_usableHermesConfig),
+          ),
+          hermesSecretsLoadingProvider.overrideWith(_SettledHermesSecrets.new),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      final eligibility = await container
+          .read(_boundedVoiceReadinessTestProvider.future)
+          .timeout(const Duration(seconds: 1));
+
+      check(eligibility.canStart).isFalse();
+      check(
+        eligibility.reason,
+      ).equals(VoiceCallEligibilityReason.modelRequired);
     },
   );
 
@@ -962,60 +1001,75 @@ void main() {
     },
   );
 
-  test('listen failure ignores a buffered final transcript', () async {
-    final input = _FakeVoiceInputService()
-      ..bufferedErrorWhenIntensityStarts = StateError('recognizer failed')
-      ..bufferedFinalWhenIntensityStarts = 'must not be sent after failure';
-    final tts = _FakeTextToSpeechService();
-    final uncaught = <Object>[];
-    late List<ChatMessage> messages;
-    late ChatVoiceModeSnapshot snapshot;
-
-    await runZonedGuarded(() async {
-      final container = ProviderContainer(
-        overrides: [
-          ...openWebUiStorageOpenOverrides(),
-          authNavigationStateProvider.overrideWithValue(
-            AuthNavigationState.authenticated,
-          ),
-          selectedModelProvider.overrideWithValue(_model),
-          appSettingsProvider.overrideWithValue(const AppSettings()),
-          reviewerModeProvider.overrideWithValue(true),
-          voiceInputServiceProvider.overrideWithValue(input),
-          textToSpeechServiceProvider.overrideWithValue(tts),
-          callKitServiceProvider.overrideWithValue(
-            _UnavailableCallKitService(),
-          ),
-          chatVoiceModeBackgroundCoordinatorProvider.overrideWithValue(
-            _FakeChatVoiceBackgroundCoordinator(),
-          ),
-          chatVoiceAudioSessionCoordinatorProvider.overrideWithValue(
-            _FakeChatVoiceAudioSessionCoordinator(),
-          ),
-        ],
+  test(
+    'listen failure ignores buffered input and preserves the active chat',
+    () async {
+      final input = _FakeVoiceInputService()
+        ..bufferedErrorWhenIntensityStarts = StateError('recognizer failed')
+        ..bufferedFinalWhenIntensityStarts = 'must not be sent after failure';
+      final tts = _FakeTextToSpeechService();
+      final uncaught = <Object>[];
+      final existingConversation = Conversation(
+        id: 'existing-chat',
+        title: 'Existing chat',
+        createdAt: DateTime(2024),
+        updatedAt: DateTime(2024),
       );
-      final controller = container.read(
-        chatVoiceModeControllerProvider.notifier,
-      );
-      await controller.start(startNewConversation: false);
-      await _until(
-        () =>
-            container.read(chatVoiceModeControllerProvider).phase ==
-            ChatVoiceModePhase.error,
-      );
-      await Future<void>.delayed(Duration.zero);
+      late List<ChatMessage> messages;
+      late ChatVoiceModeSnapshot snapshot;
+      late Conversation? activeConversation;
 
-      messages = container.read(chatMessagesProvider);
-      snapshot = container.read(chatVoiceModeControllerProvider);
-      container.dispose();
-      await Future<void>.delayed(Duration.zero);
-    }, (error, stackTrace) => uncaught.add(error));
+      await runZonedGuarded(() async {
+        final container = ProviderContainer(
+          overrides: [
+            ...openWebUiStorageOpenOverrides(),
+            authNavigationStateProvider.overrideWithValue(
+              AuthNavigationState.authenticated,
+            ),
+            selectedModelProvider.overrideWithValue(_model),
+            appSettingsProvider.overrideWithValue(const AppSettings()),
+            reviewerModeProvider.overrideWithValue(true),
+            voiceInputServiceProvider.overrideWithValue(input),
+            textToSpeechServiceProvider.overrideWithValue(tts),
+            callKitServiceProvider.overrideWithValue(
+              _UnavailableCallKitService(),
+            ),
+            chatVoiceModeBackgroundCoordinatorProvider.overrideWithValue(
+              _FakeChatVoiceBackgroundCoordinator(),
+            ),
+            chatVoiceAudioSessionCoordinatorProvider.overrideWithValue(
+              _FakeChatVoiceAudioSessionCoordinator(),
+            ),
+          ],
+        );
+        final controller = container.read(
+          chatVoiceModeControllerProvider.notifier,
+        );
+        container
+            .read(activeConversationProvider.notifier)
+            .set(existingConversation);
+        await controller.start(startNewConversation: true);
+        await _until(
+          () =>
+              container.read(chatVoiceModeControllerProvider).phase ==
+              ChatVoiceModePhase.error,
+        );
+        await Future<void>.delayed(Duration.zero);
 
-    check(uncaught).isEmpty();
-    check(messages).isEmpty();
-    check(tts.startedStreaming).isFalse();
-    check(snapshot.errorMessage).isNotNull().contains('recognizer failed');
-  });
+        messages = container.read(chatMessagesProvider);
+        snapshot = container.read(chatVoiceModeControllerProvider);
+        activeConversation = container.read(activeConversationProvider);
+        container.dispose();
+        await Future<void>.delayed(Duration.zero);
+      }, (error, stackTrace) => uncaught.add(error));
+
+      check(uncaught).isEmpty();
+      check(messages).isEmpty();
+      check(tts.startedStreaming).isFalse();
+      check(snapshot.errorMessage).isNotNull().contains('recognizer failed');
+      check(activeConversation?.id).equals(existingConversation.id);
+    },
+  );
 
   test('replacement waits for stale teardown and keeps services live', () async {
     final input = _FakeVoiceInputService();
@@ -1294,6 +1348,11 @@ class _FixedDirectDiscovery extends DirectModelDiscoveryController {
 class _NullSelectedModel extends SelectedModel {
   @override
   Model? build() => null;
+}
+
+class _IgnoringSelectedModel extends _NullSelectedModel {
+  @override
+  void set(Model? model, {bool allowHidden = false}) {}
 }
 
 class _ManualModelSelection extends IsManualModelSelection {

--- a/test/features/chat/voice_mode/chat_voice_mode_controller_test.dart
+++ b/test/features/chat/voice_mode/chat_voice_mode_controller_test.dart
@@ -4,11 +4,13 @@ import 'package:checks/checks.dart';
 import 'package:conduit/core/models/chat_message.dart';
 import 'package:conduit/core/models/conversation.dart';
 import 'package:conduit/core/models/model.dart';
+import 'package:conduit/core/models/server_config.dart';
 import 'package:conduit/core/providers/app_providers.dart';
 import 'package:conduit/core/providers/backend_mode_providers.dart';
 import 'package:conduit/core/services/callkit_service.dart';
 import 'package:conduit/core/services/optimized_storage_service.dart';
 import 'package:conduit/core/services/settings_service.dart';
+import 'package:conduit/core/services/socket_service.dart';
 import 'package:conduit/features/auth/providers/unified_auth_providers.dart';
 import 'package:conduit/features/chat/providers/chat_providers.dart';
 import 'package:conduit/features/chat/providers/text_to_speech_provider.dart';
@@ -114,6 +116,37 @@ void main() {
       container.read(chatVoiceModeControllerProvider).phase,
     ).equals(ChatVoiceModePhase.listening);
     await container.read(chatVoiceModeControllerProvider.notifier).stop();
+  });
+
+  test('launcher retains the model admitted before startup', () async {
+    final controller = _RecordingVoiceStartController();
+    late ProviderContainer container;
+    final socket = _SelectionChangingSocketService(() {
+      container
+          .read(selectedModelProvider.notifier)
+          .set(_fallbackModel, allowHidden: true);
+    });
+    container = ProviderContainer(
+      overrides: [
+        authNavigationStateProvider.overrideWithValue(
+          AuthNavigationState.authenticated,
+        ),
+        reviewerModeProvider.overrideWithValue(true),
+        selectedModelProvider.overrideWith(() => _SeededSelectedModel(_model)),
+        socketServiceProvider.overrideWithValue(socket),
+        chatVoiceModeControllerProvider.overrideWith(() => controller),
+      ],
+    );
+    addTearDown(container.dispose);
+    addTearDown(socket.dispose);
+
+    await container
+        .read(voiceCallLauncherProvider)
+        .launch(startNewConversation: true);
+
+    check(container.read(selectedModelProvider)).identicalTo(_fallbackModel);
+    check(controller.admittedModels.single).identicalTo(_model);
+    check(controller.startedByStartNewConversation.single).isTrue();
   });
 
   test('launcher propagates controller-side start failure', () async {
@@ -238,6 +271,76 @@ void main() {
     ).equals(ChatVoiceModePhase.idle);
   });
 
+  test(
+    'start surfaces eligibility failures before services initialize',
+    () async {
+      final container = ProviderContainer(
+        overrides: [
+          authNavigationStateProvider.overrideWithValue(
+            AuthNavigationState.authenticated,
+          ),
+          reviewerModeProvider.overrideWithValue(true),
+          selectedModelProvider.overrideWithValue(_model),
+          voiceCallEligibilityProvider.overrideWith((ref) {
+            throw StateError('eligibility exploded');
+          }),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      final result = await container
+          .read(chatVoiceModeControllerProvider.notifier)
+          .start(startNewConversation: false);
+      final snapshot = container.read(chatVoiceModeControllerProvider);
+
+      check(result).equals(ChatVoiceModeStartResult.failed);
+      check(snapshot.phase).equals(ChatVoiceModePhase.error);
+      check(snapshot.errorMessage).isNotNull().contains('eligibility exploded');
+      check(snapshot.activeCallId).isNull();
+    },
+  );
+
+  test('timeout clears the active CallKit call from error state', () async {
+    final input = _FakeVoiceInputService()
+      ..beginListeningError = TimeoutException('voice input timed out');
+    final callKit = _AvailableCallKitService();
+    final container = ProviderContainer(
+      overrides: [
+        ...openWebUiStorageOpenOverrides(),
+        authNavigationStateProvider.overrideWithValue(
+          AuthNavigationState.authenticated,
+        ),
+        reviewerModeProvider.overrideWithValue(true),
+        selectedModelProvider.overrideWithValue(_model),
+        appSettingsProvider.overrideWithValue(const AppSettings()),
+        voiceInputServiceProvider.overrideWithValue(input),
+        textToSpeechServiceProvider.overrideWithValue(
+          _FakeTextToSpeechService(),
+        ),
+        callKitServiceProvider.overrideWithValue(callKit),
+        chatVoiceModeBackgroundCoordinatorProvider.overrideWithValue(
+          _FakeChatVoiceBackgroundCoordinator(),
+        ),
+        chatVoiceAudioSessionCoordinatorProvider.overrideWithValue(
+          _FakeChatVoiceAudioSessionCoordinator(),
+        ),
+      ],
+    );
+    addTearDown(container.dispose);
+    addTearDown(callKit.dispose);
+
+    final result = await container
+        .read(chatVoiceModeControllerProvider.notifier)
+        .start(startNewConversation: false);
+    await _until(() => callKit.endedCallIds.contains('call-1'));
+    final snapshot = container.read(chatVoiceModeControllerProvider);
+
+    check(result).equals(ChatVoiceModeStartResult.failed);
+    check(snapshot.phase).equals(ChatVoiceModePhase.error);
+    check(snapshot.errorMessage).equals('Voice services timed out. Try again.');
+    check(snapshot.activeCallId).isNull();
+  });
+
   test('stop cancels a start during voice input initialization', () async {
     final input = _FakeVoiceInputService()..initializeGate = Completer<bool>();
     final container = ProviderContainer(
@@ -281,49 +384,60 @@ void main() {
     ).equals(ChatVoiceModePhase.ended);
   });
 
-  test('new voice conversation preserves the admitted model', () async {
-    final input = _FakeVoiceInputService();
-    final container = ProviderContainer(
-      overrides: [
-        ...openWebUiStorageOpenOverrides(),
-        authNavigationStateProvider.overrideWithValue(
-          AuthNavigationState.authenticated,
-        ),
-        reviewerModeProvider.overrideWithValue(true),
-        selectedModelProvider.overrideWith(() => _SeededSelectedModel(_model)),
-        isManualModelSelectionProvider.overrideWith(_ManualModelSelection.new),
-        modelsProvider.overrideWith(() => _FixedModels(const [_fallbackModel])),
-        optimizedStorageServiceProvider.overrideWithValue(
-          _FakeOptimizedStorageService(),
-        ),
-        appSettingsProvider.overrideWithValue(
-          const AppSettings(defaultModel: 'fallback-model'),
-        ),
-        voiceInputServiceProvider.overrideWithValue(input),
-        textToSpeechServiceProvider.overrideWithValue(
-          _FakeTextToSpeechService(),
-        ),
-        callKitServiceProvider.overrideWithValue(_UnavailableCallKitService()),
-        chatVoiceModeBackgroundCoordinatorProvider.overrideWithValue(
-          _FakeChatVoiceBackgroundCoordinator(),
-        ),
-        chatVoiceAudioSessionCoordinatorProvider.overrideWithValue(
-          _FakeChatVoiceAudioSessionCoordinator(),
-        ),
-      ],
-    );
-    addTearDown(container.dispose);
+  test(
+    'new voice conversation preserves an admitted model after selection changes',
+    () async {
+      final input = _FakeVoiceInputService();
+      final container = ProviderContainer(
+        overrides: [
+          ...openWebUiStorageOpenOverrides(),
+          authNavigationStateProvider.overrideWithValue(
+            AuthNavigationState.authenticated,
+          ),
+          reviewerModeProvider.overrideWithValue(true),
+          selectedModelProvider.overrideWith(
+            () => _SeededSelectedModel(_fallbackModel),
+          ),
+          isManualModelSelectionProvider.overrideWith(
+            _ManualModelSelection.new,
+          ),
+          modelsProvider.overrideWith(
+            () => _FixedModels(const [_fallbackModel]),
+          ),
+          optimizedStorageServiceProvider.overrideWithValue(
+            _FakeOptimizedStorageService(),
+          ),
+          appSettingsProvider.overrideWithValue(
+            const AppSettings(defaultModel: 'fallback-model'),
+          ),
+          voiceInputServiceProvider.overrideWithValue(input),
+          textToSpeechServiceProvider.overrideWithValue(
+            _FakeTextToSpeechService(),
+          ),
+          callKitServiceProvider.overrideWithValue(
+            _UnavailableCallKitService(),
+          ),
+          chatVoiceModeBackgroundCoordinatorProvider.overrideWithValue(
+            _FakeChatVoiceBackgroundCoordinator(),
+          ),
+          chatVoiceAudioSessionCoordinatorProvider.overrideWithValue(
+            _FakeChatVoiceAudioSessionCoordinator(),
+          ),
+        ],
+      );
+      addTearDown(container.dispose);
 
-    final result = await container
-        .read(chatVoiceModeControllerProvider.notifier)
-        .start(startNewConversation: true);
-    final resolvedDefault = await container.read(defaultModelProvider.future);
+      final result = await container
+          .read(chatVoiceModeControllerProvider.notifier)
+          .start(startNewConversation: true, admittedModel: _model);
+      final resolvedDefault = await container.read(defaultModelProvider.future);
 
-    check(result).equals(ChatVoiceModeStartResult.started);
-    check(resolvedDefault).identicalTo(_model);
-    check(container.read(selectedModelProvider)).identicalTo(_model);
-    check(container.read(isManualModelSelectionProvider)).isTrue();
-  });
+      check(result).equals(ChatVoiceModeStartResult.started);
+      check(resolvedDefault).identicalTo(_model);
+      check(container.read(selectedModelProvider)).identicalTo(_model);
+      check(container.read(isManualModelSelectionProvider)).isTrue();
+    },
+  );
 
   test(
     'new voice conversation owns a transcript emitted during listener startup',
@@ -366,23 +480,56 @@ void main() {
         title: 'Existing chat',
         createdAt: DateTime(2024),
         updatedAt: DateTime(2024),
+        messages: [
+          ChatMessage(
+            id: 'existing-message',
+            role: 'user',
+            content: 'existing words',
+            timestamp: DateTime(2024),
+          ),
+        ],
       );
       container
           .read(activeConversationProvider.notifier)
           .set(existingConversation);
+      final existingConversationSnapshots = <Conversation>[];
+      final activeConversationSubscription = container.listen(
+        activeConversationProvider,
+        (_, next) {
+          if (next?.id == existingConversation.id) {
+            existingConversationSnapshots.add(next!);
+          }
+        },
+        fireImmediately: true,
+      );
+      addTearDown(activeConversationSubscription.close);
 
       final result = await container
           .read(chatVoiceModeControllerProvider.notifier)
           .start(startNewConversation: true);
-      await _until(() => container.read(chatMessagesProvider).isNotEmpty);
+      await _until(() {
+        final active = container.read(activeConversationProvider);
+        return active != null &&
+            active.id != existingConversation.id &&
+            active.messages.any((message) => message.content == 'first words');
+      });
 
       final messages = container.read(chatMessagesProvider);
+      final activeConversation = container.read(activeConversationProvider)!;
       check(result).equals(ChatVoiceModeStartResult.started);
       check(messages.first.content).equals('first words');
       check(messages.first.role).equals('user');
-      final activeConversationId = container
-          .read(activeConversationProvider)
-          ?.id;
+      final persistedTranscript = activeConversation.messages.firstWhere(
+        (message) => message.content == 'first words',
+      );
+      check(persistedTranscript.role).equals('user');
+      final oldConversationTranscripts = existingConversationSnapshots.expand(
+        (conversation) => conversation.messages.where(
+          (message) => message.content == 'first words',
+        ),
+      );
+      check(oldConversationTranscripts).isEmpty();
+      final activeConversationId = activeConversation.id;
       check(activeConversationId).isNotNull();
       check(
         activeConversationId,
@@ -1584,13 +1731,56 @@ class _RejectedVoiceStartController extends ChatVoiceModeController {
   Future<ChatVoiceModeStartResult> start({
     required bool startNewConversation,
     bool Function()? shouldStart,
-    bool readinessResolved = false,
+    Model? admittedModel,
   }) async {
     state = const ChatVoiceModeSnapshot(
       phase: ChatVoiceModePhase.error,
       errorMessage: 'Rejected test voice start.',
     );
     return ChatVoiceModeStartResult.failed;
+  }
+}
+
+class _RecordingVoiceStartController extends ChatVoiceModeController {
+  final admittedModels = <Model?>[];
+  final startedByStartNewConversation = <bool>[];
+
+  @override
+  ChatVoiceModeSnapshot build() => const ChatVoiceModeSnapshot();
+
+  @override
+  Future<ChatVoiceModeStartResult> start({
+    required bool startNewConversation,
+    bool Function()? shouldStart,
+    Model? admittedModel,
+  }) async {
+    admittedModels.add(admittedModel);
+    startedByStartNewConversation.add(startNewConversation);
+    state = const ChatVoiceModeSnapshot(phase: ChatVoiceModePhase.listening);
+    return ChatVoiceModeStartResult.started;
+  }
+}
+
+class _SelectionChangingSocketService extends SocketService {
+  _SelectionChangingSocketService(this._onConnectionRead)
+    : super(
+        serverConfig: const ServerConfig(
+          id: 'selection-changing',
+          name: 'Selection changing',
+          url: 'https://example.com',
+        ),
+      );
+
+  final void Function() _onConnectionRead;
+  bool _selectionChanged = false;
+
+  @override
+  bool get isConnected {
+    if (!_selectionChanged) {
+      _selectionChanged = true;
+      _onConnectionRead();
+    }
+    return true;
   }
 }
 
@@ -1643,6 +1833,7 @@ class _FakeVoiceInputService extends VoiceInputService {
   bool listening = false;
   int stopCalls = 0;
   Completer<void>? nextStopListeningGate;
+  Object? beginListeningError;
   Object? bufferedErrorWhenIntensityStarts;
   String? bufferedFinalWhenIntensityStarts;
   bool _emittedBufferedTranscriptSignal = false;
@@ -1685,6 +1876,10 @@ class _FakeVoiceInputService extends VoiceInputService {
     bool iosAudioSessionManagedExternally = false,
   }) async {
     beginCalls += 1;
+    final error = beginListeningError;
+    if (error != null) {
+      Error.throwWithStackTrace(error, StackTrace.current);
+    }
     listening = true;
     completedTranscriptSendable = false;
     managedAudioFlags.add(iosAudioSessionManagedExternally);

--- a/test/features/chat/voice_mode/chat_voice_mode_controller_test.dart
+++ b/test/features/chat/voice_mode/chat_voice_mode_controller_test.dart
@@ -2,8 +2,10 @@ import 'dart:async';
 
 import 'package:checks/checks.dart';
 import 'package:conduit/core/models/chat_message.dart';
+import 'package:conduit/core/models/conversation.dart';
 import 'package:conduit/core/models/model.dart';
 import 'package:conduit/core/providers/app_providers.dart';
+import 'package:conduit/core/providers/backend_mode_providers.dart';
 import 'package:conduit/core/services/callkit_service.dart';
 import 'package:conduit/core/services/settings_service.dart';
 import 'package:conduit/features/auth/providers/unified_auth_providers.dart';
@@ -11,8 +13,17 @@ import 'package:conduit/features/chat/providers/chat_providers.dart';
 import 'package:conduit/features/chat/providers/text_to_speech_provider.dart';
 import 'package:conduit/features/chat/services/text_to_speech_service.dart';
 import 'package:conduit/features/chat/services/voice_input_service.dart';
+import 'package:conduit/features/chat/voice_call/voice_call_eligibility.dart';
+import 'package:conduit/features/chat/voice_call/presentation/voice_call_launcher.dart';
 import 'package:conduit/features/chat/voice_mode/chat_voice_audio_session_coordinator.dart';
 import 'package:conduit/features/chat/voice_mode/chat_voice_mode_controller.dart';
+import 'package:conduit/features/direct_connections/models/direct_connection_profile.dart';
+import 'package:conduit/features/direct_connections/models/direct_remote_model.dart';
+import 'package:conduit/features/direct_connections/providers/direct_connection_providers.dart';
+import 'package:conduit/features/direct_connections/services/direct_model_registry.dart';
+import 'package:conduit/features/hermes/models/hermes_config.dart';
+import 'package:conduit/features/hermes/models/hermes_model.dart';
+import 'package:conduit/features/hermes/providers/hermes_providers.dart';
 import 'package:flutter_callkit_incoming/entities/call_event.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -20,6 +31,10 @@ import 'package:flutter_test/flutter_test.dart';
 import '../../../support/openwebui_storage_test_overrides.dart';
 
 const _model = Model(id: 'test-model', name: 'Test Model');
+
+final _voiceReadinessTestProvider = FutureProvider<VoiceCallEligibility>(
+  resolveVoiceCallEligibility,
+);
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
@@ -49,6 +64,320 @@ void main() {
     check(tts.stopStreamingCalls).equals(0);
     check(tts.stopCalls).equals(0);
   });
+
+  test('launcher starts voice mode for signed-out Hermes', () async {
+    final input = _FakeVoiceInputService();
+    final tts = _FakeTextToSpeechService();
+    final audioSession = _FakeChatVoiceAudioSessionCoordinator();
+    final container = ProviderContainer(
+      overrides: [
+        ...openWebUiStorageOpenOverrides(),
+        authNavigationStateProvider.overrideWithValue(
+          AuthNavigationState.needsLogin,
+        ),
+        reviewerModeProvider.overrideWithValue(false),
+        selectedModelProvider.overrideWithValue(hermesSyntheticModel()),
+        hermesConfigProvider.overrideWith(
+          () => _FixedHermesConfig(_usableHermesConfig),
+        ),
+        hermesSecretsLoadingProvider.overrideWith(_SettledHermesSecrets.new),
+        socketServiceProvider.overrideWithValue(null),
+        appSettingsProvider.overrideWithValue(const AppSettings()),
+        voiceInputServiceProvider.overrideWithValue(input),
+        textToSpeechServiceProvider.overrideWithValue(tts),
+        callKitServiceProvider.overrideWithValue(_UnavailableCallKitService()),
+        chatVoiceModeBackgroundCoordinatorProvider.overrideWithValue(
+          _FakeChatVoiceBackgroundCoordinator(),
+        ),
+        chatVoiceAudioSessionCoordinatorProvider.overrideWithValue(
+          audioSession,
+        ),
+      ],
+    );
+    addTearDown(container.dispose);
+
+    await container
+        .read(voiceCallLauncherProvider)
+        .launch(startNewConversation: false);
+
+    check(input.beginCalls).equals(1);
+    check(audioSession.listeningCalls).equals(1);
+    check(
+      container.read(chatVoiceModeControllerProvider).phase,
+    ).equals(ChatVoiceModePhase.listening);
+    await container.read(chatVoiceModeControllerProvider.notifier).stop();
+  });
+
+  test('launcher propagates controller-side start failure', () async {
+    final container = ProviderContainer(
+      overrides: [
+        authNavigationStateProvider.overrideWithValue(
+          AuthNavigationState.authenticated,
+        ),
+        reviewerModeProvider.overrideWithValue(false),
+        selectedModelProvider.overrideWithValue(_model),
+        socketServiceProvider.overrideWithValue(null),
+        chatVoiceModeControllerProvider.overrideWith(
+          _RejectedVoiceStartController.new,
+        ),
+      ],
+    );
+    addTearDown(container.dispose);
+
+    await expectLater(
+      container
+          .read(voiceCallLauncherProvider)
+          .launch(startNewConversation: false),
+      throwsA(
+        isA<StateError>().having(
+          (error) => error.message,
+          'message',
+          'Rejected test voice start.',
+        ),
+      ),
+    );
+  });
+
+  test('start cancels cleanly when its external owner disconnects', () async {
+    final input = _FakeVoiceInputService()..initializeGate = Completer<bool>();
+    final container = ProviderContainer(
+      overrides: [
+        ...openWebUiStorageOpenOverrides(),
+        authNavigationStateProvider.overrideWithValue(
+          AuthNavigationState.authenticated,
+        ),
+        reviewerModeProvider.overrideWithValue(true),
+        selectedModelProvider.overrideWithValue(_model),
+        appSettingsProvider.overrideWithValue(const AppSettings()),
+        voiceInputServiceProvider.overrideWithValue(input),
+        textToSpeechServiceProvider.overrideWithValue(
+          _FakeTextToSpeechService(),
+        ),
+        callKitServiceProvider.overrideWithValue(_UnavailableCallKitService()),
+        chatVoiceModeBackgroundCoordinatorProvider.overrideWithValue(
+          _FakeChatVoiceBackgroundCoordinator(),
+        ),
+        chatVoiceAudioSessionCoordinatorProvider.overrideWithValue(
+          _FakeChatVoiceAudioSessionCoordinator(),
+        ),
+      ],
+    );
+    addTearDown(container.dispose);
+
+    final conversation = Conversation(
+      id: 'existing-chat',
+      title: 'Existing chat',
+      createdAt: DateTime(2024),
+      updatedAt: DateTime(2024),
+    );
+    container.read(activeConversationProvider.notifier).set(conversation);
+    var connected = true;
+    final start = container
+        .read(chatVoiceModeControllerProvider.notifier)
+        .start(startNewConversation: true, shouldStart: () => connected);
+    await _until(() => input.initializeCalls == 1);
+    connected = false;
+    input.initializeGate!.complete(true);
+
+    check(await start).equals(ChatVoiceModeStartResult.cancelled);
+    check(input.beginCalls).equals(0);
+    check(
+      container.read(chatVoiceModeControllerProvider).phase,
+    ).equals(ChatVoiceModePhase.ended);
+    check(
+      container.read(activeConversationProvider)?.id,
+    ).equals(conversation.id);
+  });
+
+  test('voice eligibility allows trusted device Direct while signed out', () {
+    final registry = DirectModelRegistry();
+    final model = registry.replaceProfileModels(_directProfile, [
+      DirectRemoteModel(id: 'voice-model'),
+    ]).single;
+    final container = ProviderContainer(
+      overrides: [
+        authNavigationStateProvider.overrideWithValue(
+          AuthNavigationState.needsLogin,
+        ),
+        reviewerModeProvider.overrideWithValue(false),
+        selectedModelProvider.overrideWithValue(model),
+        directModelRegistryProvider.overrideWithValue(registry),
+        directModelDiscoveryProvider.overrideWith(_DirectDiscoverySignal.new),
+      ],
+    );
+    addTearDown(container.dispose);
+
+    final eligibility = container.read(voiceCallEligibilityProvider);
+
+    check(eligibility.canStart).isTrue();
+    check(eligibility.model).identicalTo(model);
+  });
+
+  test('voice eligibility still rejects signed-out OpenWebUI', () {
+    final container = ProviderContainer(
+      overrides: [
+        authNavigationStateProvider.overrideWithValue(
+          AuthNavigationState.needsLogin,
+        ),
+        reviewerModeProvider.overrideWithValue(false),
+        selectedModelProvider.overrideWithValue(_model),
+      ],
+    );
+    addTearDown(container.dispose);
+
+    final eligibility = container.read(voiceCallEligibilityProvider);
+
+    check(eligibility.canStart).isFalse();
+    check(
+      eligibility.reason,
+    ).equals(VoiceCallEligibilityReason.authenticationRequired);
+    check(eligibility.errorMessage).equals('Sign in to start a voice call.');
+  });
+
+  test('voice eligibility explains incomplete Hermes configuration', () {
+    final container = ProviderContainer(
+      overrides: [
+        authNavigationStateProvider.overrideWithValue(
+          AuthNavigationState.needsLogin,
+        ),
+        reviewerModeProvider.overrideWithValue(false),
+        selectedModelProvider.overrideWithValue(hermesSyntheticModel()),
+        hermesConfigProvider.overrideWith(
+          () => _FixedHermesConfig(
+            const HermesConfig(
+              enabled: true,
+              baseUrl: 'https://hermes.example/v1',
+            ),
+          ),
+        ),
+        hermesSecretsLoadingProvider.overrideWith(_SettledHermesSecrets.new),
+      ],
+    );
+    addTearDown(container.dispose);
+
+    final eligibility = container.read(voiceCallEligibilityProvider);
+
+    check(eligibility.canStart).isFalse();
+    check(
+      eligibility.reason,
+    ).equals(VoiceCallEligibilityReason.backendUnavailable);
+    check(eligibility.errorMessage).isNotNull().contains('Hermes');
+  });
+
+  test('voice readiness waits for Hermes secrets to hydrate', () async {
+    final container = ProviderContainer(
+      overrides: [
+        authNavigationStateProvider.overrideWithValue(
+          AuthNavigationState.needsLogin,
+        ),
+        reviewerModeProvider.overrideWithValue(false),
+        selectedModelProvider.overrideWithValue(hermesSyntheticModel()),
+        hermesConfigProvider.overrideWith(_HydratingHermesConfig.new),
+        hermesSecretsLoadingProvider.overrideWith(_LoadingHermesSecrets.new),
+      ],
+    );
+    addTearDown(container.dispose);
+
+    var completed = false;
+    final readiness = container.read(_voiceReadinessTestProvider.future).then((
+      value,
+    ) {
+      completed = true;
+      return value;
+    });
+    await Future<void>.delayed(Duration.zero);
+    check(completed).isFalse();
+
+    (container.read(hermesConfigProvider.notifier) as _HydratingHermesConfig)
+        .finishHydration();
+    container.read(hermesSecretsLoadingProvider.notifier).set(false);
+    final eligibility = await readiness;
+
+    check(eligibility.canStart).isTrue();
+  });
+
+  test(
+    'voice readiness restores Hermes model after cold-start hydration',
+    () async {
+      final container = ProviderContainer(
+        overrides: [
+          authNavigationStateProvider.overrideWithValue(
+            AuthNavigationState.loading,
+          ),
+          reviewerModeProvider.overrideWithValue(false),
+          preferredBackendProvider.overrideWith(_HermesPreferredBackend.new),
+          selectedModelProvider.overrideWith(_NullSelectedModel.new),
+          isManualModelSelectionProvider.overrideWith(
+            _ManualModelSelection.new,
+          ),
+          hermesConfigProvider.overrideWith(_HydratingHermesConfig.new),
+          hermesSecretsLoadingProvider.overrideWith(_LoadingHermesSecrets.new),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      var completed = false;
+      final readiness = container.read(_voiceReadinessTestProvider.future).then(
+        (value) {
+          completed = true;
+          return value;
+        },
+      );
+      await Future<void>.delayed(Duration.zero);
+      check(completed).isFalse();
+
+      (container.read(hermesConfigProvider.notifier) as _HydratingHermesConfig)
+          .finishHydration();
+      container.read(hermesSecretsLoadingProvider.notifier).set(false);
+      final eligibility = await readiness;
+
+      check(eligibility.canStart).isTrue();
+      check(eligibility.model)
+          .isNotNull()
+          .has((model) => model.id, 'id')
+          .equals(hermesSyntheticModel().id);
+      check(container.read(isManualModelSelectionProvider)).isFalse();
+    },
+  );
+
+  test(
+    'voice readiness restores device Direct model while OWUI auth loads',
+    () async {
+      final registry = DirectModelRegistry();
+      final model = registry.replaceProfileModels(_directProfile, [
+        DirectRemoteModel(id: 'cold-start-voice-model'),
+      ]).single;
+      final container = ProviderContainer(
+        overrides: [
+          authNavigationStateProvider.overrideWithValue(
+            AuthNavigationState.loading,
+          ),
+          reviewerModeProvider.overrideWithValue(false),
+          preferredBackendProvider.overrideWith(_DirectPreferredBackend.new),
+          selectedModelProvider.overrideWith(_NullSelectedModel.new),
+          isManualModelSelectionProvider.overrideWith(
+            _ManualModelSelection.new,
+          ),
+          directModelRegistryProvider.overrideWithValue(registry),
+          directModelDiscoveryProvider.overrideWith(
+            () => _FixedDirectDiscovery(model),
+          ),
+          appSettingsProvider.overrideWithValue(
+            AppSettings(defaultModel: model.id),
+          ),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      final eligibility = await container.read(
+        _voiceReadinessTestProvider.future,
+      );
+
+      check(eligibility.canStart).isTrue();
+      check(eligibility.model?.id).equals(model.id);
+      check(container.read(isManualModelSelectionProvider)).isFalse();
+    },
+  );
 
   test(
     'sends transcript through chat voice mode and resumes listening',
@@ -924,10 +1253,108 @@ void main() {
   );
 }
 
+const _usableHermesConfig = HermesConfig(
+  enabled: true,
+  baseUrl: 'https://hermes.example/v1',
+  apiKey: 'hermes-key',
+);
+
+final _directProfile = DirectConnectionProfile(
+  id: 'voice-direct-profile',
+  name: 'Voice Direct',
+  adapterKey: 'ollama',
+  baseUrl: 'http://localhost:11434',
+);
+
+class _FixedHermesConfig extends HermesConfigController {
+  _FixedHermesConfig(this._config);
+
+  final HermesConfig _config;
+
+  @override
+  HermesConfig build() => _config;
+}
+
+class _DirectDiscoverySignal extends DirectModelDiscoveryController {
+  @override
+  Future<DirectModelDiscoveryState> build() async =>
+      DirectModelDiscoveryState();
+}
+
+class _FixedDirectDiscovery extends DirectModelDiscoveryController {
+  _FixedDirectDiscovery(this.model);
+
+  final Model model;
+
+  @override
+  Future<DirectModelDiscoveryState> build() async =>
+      DirectModelDiscoveryState(models: [model]);
+}
+
+class _NullSelectedModel extends SelectedModel {
+  @override
+  Model? build() => null;
+}
+
+class _ManualModelSelection extends IsManualModelSelection {
+  @override
+  bool build() => true;
+}
+
+class _RejectedVoiceStartController extends ChatVoiceModeController {
+  @override
+  ChatVoiceModeSnapshot build() => const ChatVoiceModeSnapshot();
+
+  @override
+  Future<ChatVoiceModeStartResult> start({
+    required bool startNewConversation,
+    bool Function()? shouldStart,
+    bool readinessResolved = false,
+  }) async {
+    state = const ChatVoiceModeSnapshot(
+      phase: ChatVoiceModePhase.error,
+      errorMessage: 'Rejected test voice start.',
+    );
+    return ChatVoiceModeStartResult.failed;
+  }
+}
+
+class _HermesPreferredBackend extends PreferredBackendController {
+  @override
+  PreferredBackend build() => PreferredBackend.hermes;
+}
+
+class _DirectPreferredBackend extends PreferredBackendController {
+  @override
+  PreferredBackend build() => PreferredBackend.direct;
+}
+
+class _HydratingHermesConfig extends HermesConfigController {
+  @override
+  HermesConfig build() =>
+      const HermesConfig(enabled: true, baseUrl: 'https://hermes.example/v1');
+
+  void finishHydration() {
+    state = _usableHermesConfig;
+  }
+}
+
+class _LoadingHermesSecrets extends HermesSecretsLoading {
+  @override
+  bool build() => true;
+}
+
+class _SettledHermesSecrets extends HermesSecretsLoading {
+  @override
+  bool build() => false;
+}
+
 class _FakeVoiceInputService extends VoiceInputService {
   _FakeVoiceInputService() : super();
 
   int beginCalls = 0;
+  int initializeCalls = 0;
+  Completer<bool>? initializeGate;
   bool localSttAvailable = true;
   bool serverSttAvailable = false;
   SttPreference sttPreference = SttPreference.deviceOnly;
@@ -968,7 +1395,10 @@ class _FakeVoiceInputService extends VoiceInputService {
   bool get isListening => listening;
 
   @override
-  Future<bool> initialize({bool forceLocalStt = false}) async => true;
+  Future<bool> initialize({bool forceLocalStt = false}) async {
+    initializeCalls += 1;
+    return await initializeGate?.future ?? true;
+  }
 
   @override
   Future<Stream<VoiceTranscriptEvent>> beginListeningEvents({

--- a/test/features/chat/voice_mode/chat_voice_mode_controller_test.dart
+++ b/test/features/chat/voice_mode/chat_voice_mode_controller_test.dart
@@ -7,6 +7,7 @@ import 'package:conduit/core/models/model.dart';
 import 'package:conduit/core/providers/app_providers.dart';
 import 'package:conduit/core/providers/backend_mode_providers.dart';
 import 'package:conduit/core/services/callkit_service.dart';
+import 'package:conduit/core/services/optimized_storage_service.dart';
 import 'package:conduit/core/services/settings_service.dart';
 import 'package:conduit/features/auth/providers/unified_auth_providers.dart';
 import 'package:conduit/features/chat/providers/chat_providers.dart';
@@ -31,6 +32,7 @@ import 'package:flutter_test/flutter_test.dart';
 import '../../../support/openwebui_storage_test_overrides.dart';
 
 const _model = Model(id: 'test-model', name: 'Test Model');
+const _fallbackModel = Model(id: 'fallback-model', name: 'Fallback Model');
 
 final _voiceReadinessTestProvider = FutureProvider<VoiceCallEligibility>(
   resolveVoiceCallEligibility,
@@ -193,6 +195,92 @@ void main() {
     check(
       container.read(activeConversationProvider)?.id,
     ).equals(conversation.id);
+  });
+
+  test('stop cancels a start waiting for voice readiness', () async {
+    final input = _FakeVoiceInputService();
+    final container = ProviderContainer(
+      overrides: [
+        ...openWebUiStorageOpenOverrides(),
+        authNavigationStateProvider.overrideWithValue(
+          AuthNavigationState.loading,
+        ),
+        reviewerModeProvider.overrideWithValue(false),
+        preferredBackendProvider.overrideWith(_OwuiPreferredBackend.new),
+        selectedModelProvider.overrideWith(_NullSelectedModel.new),
+        voiceInputServiceProvider.overrideWithValue(input),
+        textToSpeechServiceProvider.overrideWithValue(
+          _FakeTextToSpeechService(),
+        ),
+        callKitServiceProvider.overrideWithValue(_UnavailableCallKitService()),
+        chatVoiceModeBackgroundCoordinatorProvider.overrideWithValue(
+          _FakeChatVoiceBackgroundCoordinator(),
+        ),
+        chatVoiceAudioSessionCoordinatorProvider.overrideWithValue(
+          _FakeChatVoiceAudioSessionCoordinator(),
+        ),
+      ],
+    );
+    addTearDown(container.dispose);
+
+    final controller = container.read(chatVoiceModeControllerProvider.notifier);
+    final start = controller.start(startNewConversation: false);
+    await Future<void>.delayed(Duration.zero);
+    await Future<void>.delayed(Duration.zero);
+
+    await controller.stop().timeout(const Duration(seconds: 1));
+
+    check(
+      await start.timeout(const Duration(seconds: 1)),
+    ).equals(ChatVoiceModeStartResult.cancelled);
+    check(input.initializeCalls).equals(0);
+    check(
+      container.read(chatVoiceModeControllerProvider).phase,
+    ).equals(ChatVoiceModePhase.idle);
+  });
+
+  test('new voice conversation preserves the admitted model', () async {
+    final input = _FakeVoiceInputService();
+    final container = ProviderContainer(
+      overrides: [
+        ...openWebUiStorageOpenOverrides(),
+        authNavigationStateProvider.overrideWithValue(
+          AuthNavigationState.authenticated,
+        ),
+        reviewerModeProvider.overrideWithValue(true),
+        selectedModelProvider.overrideWith(() => _SeededSelectedModel(_model)),
+        isManualModelSelectionProvider.overrideWith(_ManualModelSelection.new),
+        modelsProvider.overrideWith(() => _FixedModels(const [_fallbackModel])),
+        optimizedStorageServiceProvider.overrideWithValue(
+          _FakeOptimizedStorageService(),
+        ),
+        appSettingsProvider.overrideWithValue(
+          const AppSettings(defaultModel: 'fallback-model'),
+        ),
+        voiceInputServiceProvider.overrideWithValue(input),
+        textToSpeechServiceProvider.overrideWithValue(
+          _FakeTextToSpeechService(),
+        ),
+        callKitServiceProvider.overrideWithValue(_UnavailableCallKitService()),
+        chatVoiceModeBackgroundCoordinatorProvider.overrideWithValue(
+          _FakeChatVoiceBackgroundCoordinator(),
+        ),
+        chatVoiceAudioSessionCoordinatorProvider.overrideWithValue(
+          _FakeChatVoiceAudioSessionCoordinator(),
+        ),
+      ],
+    );
+    addTearDown(container.dispose);
+
+    final result = await container
+        .read(chatVoiceModeControllerProvider.notifier)
+        .start(startNewConversation: true);
+    final resolvedDefault = await container.read(defaultModelProvider.future);
+
+    check(result).equals(ChatVoiceModeStartResult.started);
+    check(resolvedDefault).identicalTo(_model);
+    check(container.read(selectedModelProvider)).identicalTo(_model);
+    check(container.read(isManualModelSelectionProvider)).isTrue();
   });
 
   test('voice eligibility allows trusted device Direct while signed out', () {
@@ -1350,10 +1438,31 @@ class _NullSelectedModel extends SelectedModel {
   Model? build() => null;
 }
 
+class _SeededSelectedModel extends SelectedModel {
+  _SeededSelectedModel(this._model);
+
+  final Model _model;
+
+  @override
+  Model build() => _model;
+}
+
 class _IgnoringSelectedModel extends _NullSelectedModel {
   @override
   void set(Model? model, {bool allowHidden = false}) {}
 }
+
+class _FixedModels extends Models {
+  _FixedModels(this._models);
+
+  final List<Model> _models;
+
+  @override
+  Future<List<Model>> build() async => _models;
+}
+
+class _FakeOptimizedStorageService extends Fake
+    implements OptimizedStorageService {}
 
 class _ManualModelSelection extends IsManualModelSelection {
   @override
@@ -1386,6 +1495,11 @@ class _HermesPreferredBackend extends PreferredBackendController {
 class _DirectPreferredBackend extends PreferredBackendController {
   @override
   PreferredBackend build() => PreferredBackend.direct;
+}
+
+class _OwuiPreferredBackend extends PreferredBackendController {
+  @override
+  PreferredBackend build() => PreferredBackend.owui;
 }
 
 class _HydratingHermesConfig extends HermesConfigController {

--- a/test/features/chat/voice_mode/chat_voice_mode_controller_test.dart
+++ b/test/features/chat/voice_mode/chat_voice_mode_controller_test.dart
@@ -225,8 +225,7 @@ void main() {
 
     final controller = container.read(chatVoiceModeControllerProvider.notifier);
     final start = controller.start(startNewConversation: false);
-    await Future<void>.delayed(Duration.zero);
-    await Future<void>.delayed(Duration.zero);
+    await _until(() => controller.isWaitingForStartReadiness);
 
     await controller.stop().timeout(const Duration(seconds: 1));
 
@@ -237,6 +236,49 @@ void main() {
     check(
       container.read(chatVoiceModeControllerProvider).phase,
     ).equals(ChatVoiceModePhase.idle);
+  });
+
+  test('stop cancels a start during voice input initialization', () async {
+    final input = _FakeVoiceInputService()..initializeGate = Completer<bool>();
+    final container = ProviderContainer(
+      overrides: [
+        ...openWebUiStorageOpenOverrides(),
+        authNavigationStateProvider.overrideWithValue(
+          AuthNavigationState.authenticated,
+        ),
+        reviewerModeProvider.overrideWithValue(true),
+        selectedModelProvider.overrideWithValue(_model),
+        appSettingsProvider.overrideWithValue(const AppSettings()),
+        voiceInputServiceProvider.overrideWithValue(input),
+        textToSpeechServiceProvider.overrideWithValue(
+          _FakeTextToSpeechService(),
+        ),
+        callKitServiceProvider.overrideWithValue(_UnavailableCallKitService()),
+        chatVoiceModeBackgroundCoordinatorProvider.overrideWithValue(
+          _FakeChatVoiceBackgroundCoordinator(),
+        ),
+        chatVoiceAudioSessionCoordinatorProvider.overrideWithValue(
+          _FakeChatVoiceAudioSessionCoordinator(),
+        ),
+      ],
+    );
+    addTearDown(container.dispose);
+
+    final controller = container.read(chatVoiceModeControllerProvider.notifier);
+    final start = controller.start(startNewConversation: false);
+    await _until(() => input.initializeCalls == 1);
+
+    final stop = controller.stop();
+    input.initializeGate!.complete(true);
+
+    check(
+      await start.timeout(const Duration(seconds: 1)),
+    ).equals(ChatVoiceModeStartResult.cancelled);
+    await stop.timeout(const Duration(seconds: 1));
+    check(input.beginCalls).equals(0);
+    check(
+      container.read(chatVoiceModeControllerProvider).phase,
+    ).equals(ChatVoiceModePhase.ended);
   });
 
   test('new voice conversation preserves the admitted model', () async {

--- a/test/features/chat/voice_mode/chat_voice_mode_controller_test.dart
+++ b/test/features/chat/voice_mode/chat_voice_mode_controller_test.dart
@@ -384,6 +384,44 @@ void main() {
     ).equals(ChatVoiceModePhase.ended);
   });
 
+  test('provider disposal cancels a start during initialization', () async {
+    final input = _FakeVoiceInputService()..initializeGate = Completer<bool>();
+    final container = ProviderContainer(
+      overrides: [
+        ...openWebUiStorageOpenOverrides(),
+        authNavigationStateProvider.overrideWithValue(
+          AuthNavigationState.authenticated,
+        ),
+        reviewerModeProvider.overrideWithValue(true),
+        selectedModelProvider.overrideWithValue(_model),
+        appSettingsProvider.overrideWithValue(const AppSettings()),
+        voiceInputServiceProvider.overrideWithValue(input),
+        textToSpeechServiceProvider.overrideWithValue(
+          _FakeTextToSpeechService(),
+        ),
+        callKitServiceProvider.overrideWithValue(_UnavailableCallKitService()),
+        chatVoiceModeBackgroundCoordinatorProvider.overrideWithValue(
+          _FakeChatVoiceBackgroundCoordinator(),
+        ),
+        chatVoiceAudioSessionCoordinatorProvider.overrideWithValue(
+          _FakeChatVoiceAudioSessionCoordinator(),
+        ),
+      ],
+    );
+
+    final start = container
+        .read(chatVoiceModeControllerProvider.notifier)
+        .start(startNewConversation: false);
+    await _until(() => input.initializeCalls == 1);
+
+    container.dispose();
+    input.initializeGate!.complete(true);
+
+    check(
+      await start.timeout(const Duration(seconds: 1)),
+    ).equals(ChatVoiceModeStartResult.cancelled);
+  });
+
   test(
     'new voice conversation preserves an admitted model after selection changes',
     () async {

--- a/test/features/chat/voice_mode/chat_voice_mode_controller_test.dart
+++ b/test/features/chat/voice_mode/chat_voice_mode_controller_test.dart
@@ -325,6 +325,71 @@ void main() {
     check(container.read(isManualModelSelectionProvider)).isTrue();
   });
 
+  test(
+    'new voice conversation owns a transcript emitted during listener startup',
+    () async {
+      final input = _FakeVoiceInputService()
+        ..bufferedFinalWhenIntensityStarts = 'first words';
+      final container = ProviderContainer(
+        overrides: [
+          ...openWebUiStorageOpenOverrides(),
+          authNavigationStateProvider.overrideWithValue(
+            AuthNavigationState.authenticated,
+          ),
+          reviewerModeProvider.overrideWithValue(true),
+          selectedModelProvider.overrideWith(
+            () => _SeededSelectedModel(_model),
+          ),
+          isManualModelSelectionProvider.overrideWith(
+            _ManualModelSelection.new,
+          ),
+          appSettingsProvider.overrideWithValue(const AppSettings()),
+          voiceInputServiceProvider.overrideWithValue(input),
+          textToSpeechServiceProvider.overrideWithValue(
+            _FakeTextToSpeechService(),
+          ),
+          callKitServiceProvider.overrideWithValue(
+            _UnavailableCallKitService(),
+          ),
+          chatVoiceModeBackgroundCoordinatorProvider.overrideWithValue(
+            _FakeChatVoiceBackgroundCoordinator(),
+          ),
+          chatVoiceAudioSessionCoordinatorProvider.overrideWithValue(
+            _FakeChatVoiceAudioSessionCoordinator(),
+          ),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      final existingConversation = Conversation(
+        id: 'existing-chat',
+        title: 'Existing chat',
+        createdAt: DateTime(2024),
+        updatedAt: DateTime(2024),
+      );
+      container
+          .read(activeConversationProvider.notifier)
+          .set(existingConversation);
+
+      final result = await container
+          .read(chatVoiceModeControllerProvider.notifier)
+          .start(startNewConversation: true);
+      await _until(() => container.read(chatMessagesProvider).isNotEmpty);
+
+      final messages = container.read(chatMessagesProvider);
+      check(result).equals(ChatVoiceModeStartResult.started);
+      check(messages.first.content).equals('first words');
+      check(messages.first.role).equals('user');
+      final activeConversationId = container
+          .read(activeConversationProvider)
+          ?.id;
+      check(activeConversationId).isNotNull();
+      check(
+        activeConversationId,
+      ).not((id) => id.equals(existingConversation.id));
+    },
+  );
+
   test('voice eligibility allows trusted device Direct while signed out', () {
     final registry = DirectModelRegistry();
     final model = registry.replaceProfileModels(_directProfile, [
@@ -1580,7 +1645,7 @@ class _FakeVoiceInputService extends VoiceInputService {
   Completer<void>? nextStopListeningGate;
   Object? bufferedErrorWhenIntensityStarts;
   String? bufferedFinalWhenIntensityStarts;
-  bool _emittedBufferedFailure = false;
+  bool _emittedBufferedTranscriptSignal = false;
   final managedAudioFlags = <bool>[];
   StreamController<VoiceTranscriptEvent>? _transcriptController;
   StreamController<int>? _intensityController;
@@ -1624,7 +1689,9 @@ class _FakeVoiceInputService extends VoiceInputService {
     completedTranscriptSendable = false;
     managedAudioFlags.add(iosAudioSessionManagedExternally);
     _transcriptController = StreamController<VoiceTranscriptEvent>.broadcast(
-      sync: bufferedErrorWhenIntensityStarts != null,
+      sync:
+          bufferedErrorWhenIntensityStarts != null ||
+          bufferedFinalWhenIntensityStarts != null,
     );
     _intensityController = StreamController<int>.broadcast();
     return _transcriptController!.stream;
@@ -1633,11 +1700,14 @@ class _FakeVoiceInputService extends VoiceInputService {
   @override
   Stream<int> get intensityStream {
     final error = bufferedErrorWhenIntensityStarts;
-    if (!_emittedBufferedFailure && error != null) {
-      _emittedBufferedFailure = true;
+    final finalTranscript = bufferedFinalWhenIntensityStarts;
+    if (!_emittedBufferedTranscriptSignal &&
+        (error != null || finalTranscript != null)) {
+      _emittedBufferedTranscriptSignal = true;
       final controller = _transcriptController;
-      controller?.addError(error, StackTrace.current);
-      final finalTranscript = bufferedFinalWhenIntensityStarts;
+      if (error != null) {
+        controller?.addError(error, StackTrace.current);
+      }
       if (controller != null && finalTranscript != null) {
         controller.add(
           VoiceTranscriptEvent(text: finalTranscript, isFinal: true),


### PR DESCRIPTION
## Summary

- replace OWUI-session-only admission with shared backend-aware eligibility for Hermes, trusted Direct, and OWUI
- make chat UI and all external entry points await startup and surface clear errors
- harden lifecycle ownership and cancellation so CarPlay and concurrent launchers cannot claim or stop another voice session

## Testing

- flutter analyze
- flutter test (5105 passed, 4 skipped)
- repeated both gates in a fresh detached worktree rebased onto origin/main

Fixes #604

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added consistent voice-call eligibility handling across supported connection types.
  - Enabled eligible calls from CarPlay, quick actions, home widgets, Android Assistant, and Siri.
  - Added readiness checks, cancellation support, and already-active call detection.
  - Preserved selected models when starting new conversations.

- **Bug Fixes**
  - Voice-call failures now show clear, localized error messages.
  - Prevented incomplete startup when configuration or connections are unavailable.
  - Preserved active conversations when voice listening fails.
  - Improved voice-call access during authentication loading when eligible.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix voice calls for Hermes-only and device-direct setups by removing auth/model preflight checks
> - Introduces [`VoiceCallEligibility`](https://github.com/cogwheel0/conduit/pull/605/files#diff-171419432d0164ce14c6477424e6f98c31214be5e54d69409f1f7b43f8615fb7) — a structured eligibility resolver that replaces scattered auth/model preflight checks across all voice call entrypoints (CarPlay, home widget, quick actions, Android assistant, Siri intents, folder page, chat page).
> - `resolveVoiceCallEligibility` waits for transient cold-start conditions (Hermes hydration, direct model discovery, OpenWebUI auth) with timeout and cancellation support, then returns a structured result including the admitted model.
> - [`ChatVoiceModeController.start`](https://github.com/cogwheel0/conduit/pull/605/files#diff-30b1e784ef03be0b545f508369ccc3861dd91644aa510983cca23bed93264adc) now returns a `ChatVoiceModeStartResult` enum, supports cooperative cancellation via a generation counter, and delays transcript handling until an optional precondition (e.g. starting a new conversation) completes atomically.
> - Voice call entrypoints that previously blocked on `authenticated` state or a pre-selected model now attempt to start immediately, falling back to a localized SnackBar error on failure.
> - Behavioral Change: Hermes and device-owned direct models can now start a voice call without OpenWebUI authentication; OpenWebUI-backed calls still require auth.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e70b571.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This change centralizes voice-call admission, improves voice-start cancellation and lifecycle ownership, and ensures a new voice conversation stores its admitted model before it accepts spoken transcripts.

The reported **Admitted model remains mutable** issue was disproved by an executed comparison of the parent revision and current implementation. The current code calls `startNewChat(ref, modelForNewConversation: model)` before accepting buffered transcript events, and that function writes the admitted model to `selectedModelProvider` before message dispatch reads it. A later model reconciliation therefore cannot redirect the first voice turn to a different backend.

### T-Rex validation blocked
A focused Flutter voice-controller test could not run because the required `flutter` tool is not installed in the environment. The executable source-path comparison completed successfully and provided the disproof above. [Configure VMs](https://app.greptile.com/-/settings/trex#environments)

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The reviewed first-turn voice dispatch path preserves the model approved at call start before any transcript can be submitted.

The only reported issue was disproved by an executed comparison that observed model pinning before transcript acceptance and dispatch on the current code.

**Files Needing Attention:** No remaining defect was found in `lib/features/chat/voice_mode/chat_voice_mode_controller.dart` or the associated chat-provider dispatch path.
</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran an executable source-path comparison against the parent revision and the current head for the start-new-conversation, transcript-acceptance, and message-dispatch sequence.
- Observed that the parent revision lacked a transcript-acceptance gate before dispatch, and that the current code invokes startNewChat before beforeAcceptingTranscripts?.call(), while startNewChat writes the admitted model to selectedModelProvider before \_sendMessageInternal reads it, preventing the first-turn backend switch.
- Conducted a follow-up probe to compare pre- and post-change behavior; after the probe, the current head still calls startNewChat before beforeAcceptingTranscripts?.call(), and the admitted model is re-read after being written, so the alleged switch is prevented; runtime Flutter execution remains blocked by the missing SDK.
- Reviewed the artifacts (a Python diff and three logs) to validate findings and enable reviewers to inspect the test run details.

<a href="https://app.greptile.com/trex/runs/16840469/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (10): Last reviewed commit: ["fix(carplay): scope disconnect ownership..."](https://github.com/cogwheel0/conduit/commit/e70b5714e1c001a54bd3ff3186bd0cc32b647497) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49164783)</sub>

<!-- /greptile_comment -->