### PR TITLE
Enable optimized R8 resource shrinking with AGP 9

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -3,8 +3,7 @@ import java.io.FileInputStream
 
 plugins {
     id("com.android.application")
-    id("kotlin-android")
-    // The Flutter Gradle Plugin must be applied after the Android and Kotlin Gradle plugins.
+    // The Flutter Gradle Plugin must be applied after the Android Gradle plugin.
     id("dev.flutter.flutter-gradle-plugin")
 }
 
@@ -35,11 +34,6 @@ android {
         isCoreLibraryDesugaringEnabled = true
     }
 
-    kotlinOptions {
-        // Generate JVM bytecode targeting Java 17
-        jvmTarget = JavaVersion.VERSION_17.toString()
-    }
-
     signingConfigs {
         if (keystorePropertiesFile.exists()) {
             create("release") {
@@ -67,6 +61,13 @@ android {
             // signingConfig = signingConfigs.getByName("debug")
             applicationIdSuffix = ".debug"
         }
+    }
+}
+
+kotlin {
+    compilerOptions {
+        // Generate JVM bytecode targeting Java 17.
+        jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17
     }
 }
 

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.1.0-all.zip

--- a/android/settings.gradle.kts
+++ b/android/settings.gradle.kts
@@ -18,8 +18,8 @@ pluginManagement {
 
 plugins {
     id("dev.flutter.flutter-plugin-loader") version "1.0.0"
-    id("com.android.application") version "8.11.1" apply false
-    id("org.jetbrains.kotlin.android") version "2.2.20" apply false
+    id("com.android.application") version "9.0.1" apply false
+    id("org.jetbrains.kotlin.android") version "2.3.20" apply false
 }
 
 include(":app")

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -20,10 +20,10 @@ PODS:
   - flutter_inappwebview_ios (0.0.1):
     - Flutter
     - flutter_inappwebview_ios/Core (= 0.0.1)
-    - OrderedSet (~> 6.0.3)
+    - swift-collections (~> 1.1.1)
   - flutter_inappwebview_ios/Core (0.0.1):
     - Flutter
-    - OrderedSet (~> 6.0.3)
+    - swift-collections (~> 1.1.1)
   - flutter_local_notifications (0.0.1):
     - Flutter
   - flutter_secure_storage_darwin (10.0.0):
@@ -40,6 +40,7 @@ PODS:
     - Flutter
   - image_picker_ios (0.0.1):
     - Flutter
+  - InternalCollectionsUtilities (1.1.1)
   - just_audio (0.0.1):
     - Flutter
     - FlutterMacOS
@@ -60,7 +61,6 @@ PODS:
     - onnxruntime-objc/Core (= 1.22.0)
   - onnxruntime-objc/Core (1.22.0):
     - onnxruntime-c (= 1.22.0)
-  - OrderedSet (6.0.3)
   - package_info_plus (0.4.5):
     - Flutter
   - pdfium_flutter (0.1.5):
@@ -86,6 +86,22 @@ PODS:
   - sqflite_darwin (0.0.4):
     - Flutter
     - FlutterMacOS
+  - swift-collections (1.1.1):
+    - swift-collections/BitCollections (= 1.1.1)
+    - swift-collections/DequeModule (= 1.1.1)
+    - swift-collections/HashTreeCollections (= 1.1.1)
+    - swift-collections/HeapModule (= 1.1.1)
+    - swift-collections/OrderedCollections (= 1.1.1)
+  - swift-collections/BitCollections (1.1.1):
+    - InternalCollectionsUtilities (= 1.1.1)
+  - swift-collections/DequeModule (1.1.1):
+    - InternalCollectionsUtilities (= 1.1.1)
+  - swift-collections/HashTreeCollections (1.1.1):
+    - InternalCollectionsUtilities (= 1.1.1)
+  - swift-collections/HeapModule (1.1.1):
+    - InternalCollectionsUtilities (= 1.1.1)
+  - swift-collections/OrderedCollections (1.1.1):
+    - InternalCollectionsUtilities (= 1.1.1)
   - url_launcher_ios (0.0.1):
     - Flutter
   - vad (0.0.6):
@@ -130,12 +146,13 @@ DEPENDENCIES:
 SPEC REPOS:
   trunk:
     - CryptoSwift
+    - InternalCollectionsUtilities
     - libwebp
     - onnxruntime-c
     - onnxruntime-objc
-    - OrderedSet
     - SDWebImage
     - SDWebImageWebPCoder
+    - swift-collections
 
 EXTERNAL SOURCES:
   adaptive_platform_ui:
@@ -196,41 +213,42 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/webview_flutter_wkwebview/darwin"
 
 SPEC CHECKSUMS:
-  adaptive_platform_ui: cd3c5a2997126f138a1e7f12e8376d3ca3fdbfad
-  audio_session: 9bb7f6c970f21241b19f5a3658097ae459681ba0
-  connectivity_plus: cb623214f4e1f6ef8fe7403d580fdad517d2f7dd
+  adaptive_platform_ui: 76b089c653197e733139d9774b97a90e50275cbe
+  audio_session: 19e9480dbdd4e5f6c4543826b2e8b0e4ab6145fe
+  connectivity_plus: 2a701ffec2c0ae28a48cf7540e279787e77c447d
   CryptoSwift: e64e11850ede528a02a0f3e768cec8e9d92ecb90
-  file_picker: 70164d9778c42c47218d6cd79ce435de0856b11a
+  file_picker: e81e2d2db6261a4e98febeae383bd2173ba8b396
   Flutter: cabc95a1d2626b1b06e7179b784ebcf0c0cde467
-  flutter_callkit_incoming: a143995975818a3717524decd3566d5ca7a8c608
-  flutter_image_compress_common: 11d5dcfb36f4ded92320bfa896261813a073240e
-  flutter_inappwebview_ios: b89ba3482b96fb25e00c967aae065701b66e9b99
-  flutter_local_notifications: 643a3eda1ce1c0599413ca31672536d423dee214
-  flutter_secure_storage_darwin: acdb3f316ed05a3e68f856e0353b133eec373a23
-  flutter_sharing_intent: 0c1e53949f09fa8df8ac2268505687bde8ff264c
-  gaimon: 1979ed07cdcfd0bf0d208f255f550936a196cf5a
-  geolocator_apple: ab36aa0e8b7d7a2d7639b3b4e48308394e8cef5e
-  home_widget: 54b4f6b36ed8d64cfee594a476225c35c3e45091
-  image_picker_ios: e0ece4aa2a75771a7de3fa735d26d90817041326
-  just_audio: 4e391f57b79cad2b0674030a00453ca5ce817eed
+  flutter_callkit_incoming: 139fb358c785e109854158086fd399aa64d77891
+  flutter_image_compress_common: d1d827ee42025290fc9e3203ece582e4c74182ed
+  flutter_inappwebview_ios: 4ba92d0d329027e39735ff0c5d5dc8bd4d1ada99
+  flutter_local_notifications: eda81afddbf18f8589f6ec069ce593c4c6378769
+  flutter_secure_storage_darwin: 557817588b80e60213cbecb573c45c76b788018d
+  flutter_sharing_intent: ea3bb5ac2838e6700a5a8506804c08a78a1ef316
+  gaimon: d47cb3bc6226329cf6c6730c0d2e8062f05d1527
+  geolocator_apple: 66b711889fd333205763b83c9dcf0a57a28c7afd
+  home_widget: fdbbfaa90f06f3022cb57f79678d4d58b9c5e140
+  image_picker_ios: 4f2f91b01abdb52842a8e277617df877e40f905b
+  InternalCollectionsUtilities: af3f471602c4a67cbcb0bee0a80f6f55a33ae453
+  just_audio: a42c63806f16995daf5b219ae1d679deb76e6a79
   libwebp: 02b23773aedb6ff1fd38cec7a77b81414c6842a8
   onnxruntime-c: 7f778680e96145956c0a31945f260321eed2611a
   onnxruntime-objc: 83d28b87525bd971259a66e153ea32b5d023de19
-  OrderedSet: e539b66b644ff081c73a262d24ad552a69be3a94
-  package_info_plus: af8e2ca6888548050f16fa2f1938db7b5a5df499
-  pdfium_flutter: e5a6e881af0b182d5b0465ebad23a8a20caa28d4
-  permission_handler_apple: 92d754bbaa7361d436db2d6c3c1c2a0fdcec462e
-  quick_actions_ios: 500fcc11711d9f646739093395c4ae8eec25f779
-  record_ios: 980fd386a97a35987d0fce3dfda4b26a38c90f4c
+  package_info_plus: c0502532a26c7662a62a356cebe2692ec5fe4ec4
+  pdfium_flutter: 814416ae1e24618fc80353aacbf17c7229373559
+  permission_handler_apple: ee2fe0fd04551b304eb002714ff067c371c822ed
+  quick_actions_ios: b49ed09d6362da1bf520dacc204661978a8fc5c2
+  record_ios: 3b171007ae5de51221a3a76d2b379a7105ca98b5
   SDWebImage: e9c98383c7572d713c1a0d7dd2783b10599b9838
   SDWebImageWebPCoder: 0e06e365080397465cc73a7a9b472d8a3bd0f377
-  share_plus: 50da8cb520a8f0f65671c6c6a99b3617ed10a58a
-  shared_preferences_foundation: 7036424c3d8ec98dfe75ff1667cb0cd531ec82bb
-  sqflite_darwin: 20b2a3a3b70e43edae938624ce550a3cbf66a3d0
-  url_launcher_ios: 7a95fa5b60cc718a708b8f2966718e93db0cef1b
-  vad: 7934867589afe53567f492df66fb1615f2185822
-  wakelock_plus: e29112ab3ef0b318e58cfa5c32326458be66b556
-  webview_flutter_wkwebview: 8ebf4fded22593026f7dbff1fbff31ea98573c8d
+  share_plus: 8b6f8b3447e494cca5317c8c3073de39b3600d1f
+  shared_preferences_foundation: 5086985c1d43c5ba4d5e69a4e8083a389e2909e6
+  sqflite_darwin: 5a7236e3b501866c1c9befc6771dfd73ffb8702d
+  swift-collections: ba248ecaf44ef500b27d5cf94d304218c89892ff
+  url_launcher_ios: bb13df5870e8c4234ca12609d04010a21be43dfa
+  vad: adfd9a29558d39cffd94fead982ceb8347b6fb86
+  wakelock_plus: 76957ab028e12bfa4e66813c99e46637f367fc7e
+  webview_flutter_wkwebview: 29eb20d43355b48fe7d07113835b9128f84e3af4
 
 PODFILE CHECKSUM: 1bed8b2262b594f89f58bee2826557447173bc56
 

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -574,18 +574,18 @@ packages:
     dependency: "direct main"
     description:
       name: flutter_inappwebview
-      sha256: "80092d13d3e29b6227e25b67973c67c7210bd5e35c4b747ca908e31eb71a46d5"
+      sha256: "3952d116ee93bad2946401377e7ade87b5ef200e95ecb5ba1affa1b6329a6867"
       url: "https://pub.dev"
     source: hosted
-    version: "6.1.5"
+    version: "6.2.0-beta.3"
   flutter_inappwebview_android:
     dependency: transitive
     description:
       name: flutter_inappwebview_android
-      sha256: "62557c15a5c2db5d195cb3892aab74fcaec266d7b86d59a6f0027abd672cddba"
+      sha256: "8dfb76bd4e507112c3942c2272eeb01fab2e42be11374e5eb226f58698e7a04b"
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.3"
+    version: "1.2.0-beta.3"
   flutter_inappwebview_internal_annotations:
     dependency: transitive
     description:
@@ -598,42 +598,50 @@ packages:
     dependency: transitive
     description:
       name: flutter_inappwebview_ios
-      sha256: "5818cf9b26cf0cbb0f62ff50772217d41ea8d3d9cc00279c45f8aabaa1b4025d"
+      sha256: ae8a78829398771be863aa3c8804a9d40728e1815e66c9c966f86d2cc3ae4fd9
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.2"
+    version: "1.2.0-beta.3"
+  flutter_inappwebview_linux:
+    dependency: transitive
+    description:
+      name: flutter_inappwebview_linux
+      sha256: "2e1a3b09bb911fb5a8bb155cb7f1eb1428a19b6e20363b9db48beef428b8cef5"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.1.0-beta.1"
   flutter_inappwebview_macos:
     dependency: transitive
     description:
       name: flutter_inappwebview_macos
-      sha256: c1fbb86af1a3738e3541364d7d1866315ffb0468a1a77e34198c9be571287da1
+      sha256: "545148cb5c46475ce669ab21621e9f2ad66e05f8e80b2cf49d4018879ab52393"
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.2"
+    version: "1.2.0-beta.3"
   flutter_inappwebview_platform_interface:
     dependency: transitive
     description:
       name: flutter_inappwebview_platform_interface
-      sha256: cf5323e194096b6ede7a1ca808c3e0a078e4b33cc3f6338977d75b4024ba2500
+      sha256: e3522c76e6760d1c0a9ff690e30e1503f226783d3277fa4d26675911977e9766
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.0+1"
+    version: "1.4.0-beta.3"
   flutter_inappwebview_web:
     dependency: transitive
     description:
       name: flutter_inappwebview_web
-      sha256: "55f89c83b0a0d3b7893306b3bb545ba4770a4df018204917148ebb42dc14a598"
+      sha256: e98b8875ccb6a3fd255873318db45c18ab135ed0ed22d20169abad9f5c810eb9
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.2"
+    version: "1.2.0-beta.3"
   flutter_inappwebview_windows:
     dependency: transitive
     description:
       name: flutter_inappwebview_windows
-      sha256: "8b4d3a46078a2cdc636c4a3d10d10f2a16882f6be607962dbfff8874d1642055"
+      sha256: "902edd6f6326952af822e21aa928f7426d723d45c94c15e6ce3c2d5640d28ad7"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.0"
+    version: "0.7.0-beta.3"
   flutter_lints:
     dependency: "direct dev"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -39,7 +39,7 @@ dependencies:
   pdfrx: ^2.4.7
   archive: ^4.0.9
   xml: ^7.0.1
-  flutter_inappwebview: ^6.1.5
+  flutter_inappwebview: ^6.2.0-beta.3
   flutter_svg: ^2.3.0
   # Native Mermaid renderer. These unpublished workspace packages are pinned
   # as submodules under third_party/.


### PR DESCRIPTION
## Summary

- upgrade Android Gradle Plugin to 9.0.1, Gradle to 9.1.0, and Kotlin to 2.3.20
- migrate the app module to the current Kotlin compiler DSL
- upgrade flutter_inappwebview to 6.2.0-beta.3 because the stable Android implementation references a ProGuard configuration removed by AGP 9
- refresh the iOS CocoaPods lock for the beta WebView implementation and its Swift Collections dependency
- preserve release minification and resource shrinking while enabling the optimized resource shrinker reported by Play Console

## Verification

- flutter pub get
- dart run build_runner build
- flutter analyze
- 84 focused SSO, proxy-auth, cookie, origin, and WebView tests passed
- full suite: 5,103 passed and 4 skipped; the two release-notes golden failures reproduce on untouched origin/main
- release bundle built successfully with bounded Gradle and Kotlin memory
- CocoaPods 1.17 resolved and generated the widened iOS dependency graph
- AAB metadata reports AGP 9.0.1, R8 shrinking/optimization enabled, and isOptimizedShrinkingEnabled true

## Follow-up

- migrate remaining third-party plugins to built-in Kotlin before AGP 10 enforcement
- move flutter_inappwebview back to a stable release once 6.2 is published

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Updated Android build tooling and Kotlin support to newer versions.
  * Improved Kotlin compilation compatibility with JVM 17.
  * Updated in-app web view support to a newer release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Enable optimized R8 resource shrinking by upgrading to AGP 9 and Gradle 9
> - Upgrades Android Gradle Plugin from 8.11.1 to 9.0.1 in [settings.gradle.kts](https://github.com/cogwheel0/conduit/pull/607/files#diff-b846529d3b9af5e34dfb0174742f9dc3d52bcd97761555bc61271a7a868870b9), enabling R8 resource shrinking optimizations available in AGP 9
> - Upgrades the Gradle wrapper from 8.14.3 to 9.1.0 in [gradle-wrapper.properties](https://github.com/cogwheel0/conduit/pull/607/files#diff-4c5ffadbdf6016477a1c3768e0b7381cc298bd558b1784871f407cbcb0efacce)
> - Upgrades Kotlin plugin from 2.2.20 to 2.3.20 and migrates `jvmTarget` configuration from `kotlinOptions` to the `kotlin { compilerOptions {} }` block in [build.gradle.kts](https://github.com/cogwheel0/conduit/pull/607/files#diff-852897104c5cf350a945bb63cd9836c04ab5209a74900a1e8938092f6b9d68fb)
> - Bumps `flutter_inappwebview` to `^6.2.0-beta.3` in [pubspec.yaml](https://github.com/cogwheel0/conduit/pull/607/files#diff-8b7e9df87668ffa6a04b32e1769a33434999e54ae081c52e5d943c541d4c0d25)
> - Risk: AGP 9 and Gradle 9 are major version bumps that may introduce breaking changes in plugin compatibility or build behavior
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized fa0478e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This change refreshes the iOS WebView pod lock, replacing OrderedSet with swift-collections 1.1.1 and recording its transitive collection dependencies. The committed lockfile was checked against the prior revision and has a consistent swift-collections dependency closure with no stale OrderedSet entry.

## T-Rex validation blocked
CocoaPods deployment installation could not be executed because the CocoaPods `pod` tool is not installed in this environment. The attempted installation path stopped with `pod: not found`; Flutter-generated iOS configuration and plugin podspec inputs were also unavailable.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge.

No blocking failure remains. The updated dependency closure was checked for consistency and no defect was found.
</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran an executable validator against both the previous and updated Podfile.lock files to parse the WebView dependency closure.
- Verified that the updated lockfile resolves swift-collections 1.1.1 through OrderedCollections to InternalCollectionsUtilities 1.1.1 and contains no stale OrderedSet entry.
- Tried to run pod install --deployment to exercise CocoaPods, but the CocoaPods executable was unavailable, so native installation could not be performed.
- Saved the validation script and both before/after captured command outputs for review in trex-artifacts.
- Noted that there is no real lockfile inconsistency evidenced in ios/Podfile.lock and that the install failure hypothesis remains unproven.

<a href="https://app.greptile.com/trex/runs/16880757/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (2): Last reviewed commit: ["build: refresh iOS WebView pod lock"](https://github.com/cogwheel0/conduit/commit/fa0478e654e5b558ee1bcd62bf3fa679e60a16fe) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49301967)</sub>

<!-- /greptile_comment -->