### PR TITLE
fix: polish iOS 26 native glass controls

### DIFF
--- a/ios/Runner/AppDelegate.swift
+++ b/ios/Runner/AppDelegate.swift
@@ -2318,9 +2318,12 @@ private final class ConduitNativeModelSelectorButtonView:
     configuration.baseForegroundColor = foreground
     configuration.contentInsets = NSDirectionalEdgeInsets(
       top: 8,
-      leading: 16,
+      // The downward chevron's trailing side bearing reads wider than its
+      // leading edge. Shift the content group one point right optically while
+      // preserving the 32-point inset budget used by Dart's width resolver.
+      leading: 17,
       bottom: 8,
-      trailing: 16
+      trailing: 15
     )
     configuration.imagePlacement = .trailing
     configuration.imagePadding = symbolPadding
@@ -2352,6 +2355,175 @@ private final class ConduitNativeModelSelectorButtonView:
 
   @objc private func handlePress() {
     channel.invokeMethod("pressed", arguments: nil)
+  }
+
+  private static func color(fromARGB number: NSNumber?) -> UIColor? {
+    guard let number else { return nil }
+    let value = number.uint32Value
+    return UIColor(
+      red: CGFloat((value >> 16) & 0xff) / 255,
+      green: CGFloat((value >> 8) & 0xff) / 255,
+      blue: CGFloat(value & 0xff) / 255,
+      alpha: CGFloat((value >> 24) & 0xff) / 255
+    )
+  }
+}
+
+private final class ConduitNativeToolbarActionGroupFactory:
+  NSObject, FlutterPlatformViewFactory
+{
+  private let messenger: FlutterBinaryMessenger
+
+  init(messenger: FlutterBinaryMessenger) {
+    self.messenger = messenger
+    super.init()
+  }
+
+  func create(
+    withFrame frame: CGRect,
+    viewIdentifier viewId: Int64,
+    arguments args: Any?
+  ) -> FlutterPlatformView {
+    ConduitNativeToolbarActionGroupView(
+      frame: frame,
+      viewId: viewId,
+      arguments: args,
+      messenger: messenger
+    )
+  }
+
+  func createArgsCodec() -> FlutterMessageCodec & NSObjectProtocol {
+    FlutterStandardMessageCodec.sharedInstance()
+  }
+}
+
+private final class ConduitNativeToolbarActionGroupView:
+  NSObject, FlutterPlatformView
+{
+  private let container: UIView
+  private let toolbar: UIToolbar
+  private let channel: FlutterMethodChannel
+
+  init(
+    frame: CGRect,
+    viewId: Int64,
+    arguments: Any?,
+    messenger: FlutterBinaryMessenger
+  ) {
+    container = UIView(frame: frame)
+    toolbar = UIToolbar(frame: frame)
+    channel = FlutterMethodChannel(
+      name: "app.cogwheel.conduit/native_toolbar_action_group_\(viewId)",
+      binaryMessenger: messenger
+    )
+    super.init()
+
+    container.backgroundColor = .clear
+    container.clipsToBounds = false
+    toolbar.translatesAutoresizingMaskIntoConstraints = false
+    toolbar.clipsToBounds = false
+
+    let appearance = UIToolbarAppearance()
+    appearance.configureWithTransparentBackground()
+    toolbar.standardAppearance = appearance
+    if #available(iOS 15.0, *) {
+      toolbar.scrollEdgeAppearance = appearance
+    }
+
+    let values = arguments as? [String: Any]
+    let actions = values?["actions"] as? [[String: Any]] ?? []
+    let symbolSize =
+      (values?["symbolSize"] as? NSNumber)?.doubleValue ?? 20
+    let items = actions.enumerated().compactMap { index, action in
+      Self.makeBarButtonItem(
+        action,
+        actionIndex: index,
+        symbolSize: symbolSize,
+        channel: channel
+      )
+    }
+    toolbar.items = [.flexibleSpace()] + items + [.flexibleSpace()]
+
+    container.addSubview(toolbar)
+    NSLayoutConstraint.activate([
+      toolbar.leadingAnchor.constraint(equalTo: container.leadingAnchor),
+      toolbar.trailingAnchor.constraint(equalTo: container.trailingAnchor),
+      toolbar.topAnchor.constraint(equalTo: container.topAnchor),
+      toolbar.bottomAnchor.constraint(equalTo: container.bottomAnchor),
+    ])
+  }
+
+  func view() -> UIView { container }
+
+  private static func makeBarButtonItem(
+    _ action: [String: Any],
+    actionIndex: Int,
+    symbolSize: Double,
+    channel: FlutterMethodChannel
+  ) -> UIBarButtonItem? {
+    guard let symbolName = action["iosSymbol"] as? String,
+          let image = UIImage(systemName: symbolName)?
+            .applyingSymbolConfiguration(
+              UIImage.SymbolConfiguration(
+                pointSize: symbolSize,
+                weight: .regular
+              )
+            ) else {
+      return nil
+    }
+
+    let menuValues = action["menuItems"] as? [[String: Any]] ?? []
+    let menu = menuValues.isEmpty ? nil : UIMenu(
+      children: menuValues.enumerated().map { itemIndex, item in
+        var attributes: UIMenuElement.Attributes = []
+        if item["isDestructive"] as? Bool == true {
+          attributes.insert(.destructive)
+        }
+        if item["enabled"] as? Bool == false {
+          attributes.insert(.disabled)
+        }
+        let state: UIMenuElement.State =
+          item["isChecked"] as? Bool == true ? .on : .off
+        let itemImage = (item["iosSymbol"] as? String).flatMap {
+          UIImage(systemName: $0)
+        }
+        return UIAction(
+          title: item["label"] as? String ?? "",
+          image: itemImage,
+          attributes: attributes,
+          state: state
+        ) { _ in
+          channel.invokeMethod(
+            "menuItemSelected",
+            arguments: [
+              "actionIndex": actionIndex,
+              "itemIndex": itemIndex,
+            ]
+          )
+        }
+      }
+    )
+
+    let primaryAction: UIAction? = menu == nil
+      ? UIAction { _ in
+          channel.invokeMethod(
+            "actionTapped",
+            arguments: ["actionIndex": actionIndex]
+          )
+        }
+      : nil
+    let item = UIBarButtonItem(
+      image: image,
+      primaryAction: primaryAction,
+      menu: menu
+    )
+    item.accessibilityLabel = action["accessibilityLabel"] as? String
+    item.isEnabled = action["enabled"] as? Bool ?? true
+    item.tintColor = color(fromARGB: action["tintColor"] as? NSNumber)
+    if #available(iOS 26.0, *) {
+      item.sharesBackground = true
+    }
+    return item
   }
 
   private static func color(fromARGB number: NSNumber?) -> UIColor? {
@@ -2493,6 +2665,16 @@ private final class ConduitNativeModelSelectorButtonView:
         withId: "app.cogwheel.conduit/native_model_selector_button"
       )
     }
+    if let registrar = engineBridge.pluginRegistry.registrar(
+      forPlugin: "ConduitNativeToolbarActionGroup"
+    ) {
+      registrar.register(
+        ConduitNativeToolbarActionGroupFactory(
+          messenger: registrar.messenger()
+        ),
+        withId: "app.cogwheel.conduit/native_toolbar_action_group"
+      )
+    }
     configureApplicationFlutterChannels(
       messenger: engineBridge.applicationRegistrar.messenger()
     )
@@ -2552,6 +2734,16 @@ private final class ConduitNativeModelSelectorButtonView:
           messenger: registrar.messenger()
         ),
         withId: "app.cogwheel.conduit/native_model_selector_button"
+      )
+    }
+    if let registrar = engine.registrar(
+      forPlugin: "ConduitNativeToolbarActionGroup"
+    ) {
+      registrar.register(
+        ConduitNativeToolbarActionGroupFactory(
+          messenger: registrar.messenger()
+        ),
+        withId: "app.cogwheel.conduit/native_toolbar_action_group"
       )
     }
     configureApplicationFlutterChannels(messenger: engine.binaryMessenger)

--- a/ios/Runner/AppDelegate.swift
+++ b/ios/Runner/AppDelegate.swift
@@ -2269,6 +2269,8 @@ private final class ConduitNativeModelSelectorButtonFactory:
   func createArgsCodec() -> FlutterMessageCodec & NSObjectProtocol {
     FlutterStandardMessageCodec.sharedInstance()
   }
+
+  deinit {}
 }
 
 private final class ConduitNativeModelSelectorButtonView:
@@ -2298,6 +2300,8 @@ private final class ConduitNativeModelSelectorButtonView:
     let symbolSize = (values?["symbolSize"] as? NSNumber)?.doubleValue ?? 13
     let symbolPadding =
       (values?["symbolPadding"] as? NSNumber)?.doubleValue ?? 6
+    let titleFontSize =
+      (values?["titleFontSize"] as? NSNumber)?.doubleValue ?? 17
     let enabled = (values?["enabled"] as? NSNumber)?.boolValue ?? true
     let foreground = Self.color(
       fromARGB: values?["foregroundColor"] as? NSNumber
@@ -2329,7 +2333,10 @@ private final class ConduitNativeModelSelectorButtonView:
     configuration.imagePadding = symbolPadding
 
     var attributedTitle = AttributedString(label)
-    attributedTitle.font = .systemFont(ofSize: 17, weight: .semibold)
+    attributedTitle.font = .systemFont(
+      ofSize: titleFontSize,
+      weight: .semibold
+    )
     configuration.attributedTitle = attributedTitle
 
     if let symbolName,
@@ -2367,6 +2374,8 @@ private final class ConduitNativeModelSelectorButtonView:
       alpha: CGFloat((value >> 24) & 0xff) / 255
     )
   }
+
+  deinit {}
 }
 
 private final class ConduitNativeToolbarActionGroupFactory:
@@ -2395,6 +2404,8 @@ private final class ConduitNativeToolbarActionGroupFactory:
   func createArgsCodec() -> FlutterMessageCodec & NSObjectProtocol {
     FlutterStandardMessageCodec.sharedInstance()
   }
+
+  deinit {}
 }
 
 private final class ConduitNativeToolbarActionGroupView:
@@ -2536,6 +2547,8 @@ private final class ConduitNativeToolbarActionGroupView:
       alpha: CGFloat((value >> 24) & 0xff) / 255
     )
   }
+
+  deinit {}
 }
 
 @main
@@ -2655,25 +2668,8 @@ private final class ConduitNativeToolbarActionGroupView:
     guard sharedFlutterEngine == nil else { return }
 
     GeneratedPluginRegistrant.register(with: engineBridge.pluginRegistry)
-    if let registrar = engineBridge.pluginRegistry.registrar(
-      forPlugin: "ConduitNativeModelSelectorButton"
-    ) {
-      registrar.register(
-        ConduitNativeModelSelectorButtonFactory(
-          messenger: registrar.messenger()
-        ),
-        withId: "app.cogwheel.conduit/native_model_selector_button"
-      )
-    }
-    if let registrar = engineBridge.pluginRegistry.registrar(
-      forPlugin: "ConduitNativeToolbarActionGroup"
-    ) {
-      registrar.register(
-        ConduitNativeToolbarActionGroupFactory(
-          messenger: registrar.messenger()
-        ),
-        withId: "app.cogwheel.conduit/native_toolbar_action_group"
-      )
+    registerConduitNativeToolbarPlatformViews { pluginName in
+      engineBridge.pluginRegistry.registrar(forPlugin: pluginName)
     }
     configureApplicationFlutterChannels(
       messenger: engineBridge.applicationRegistrar.messenger()
@@ -2726,8 +2722,18 @@ private final class ConduitNativeToolbarActionGroupView:
     guard !didConfigureSharedFlutterEngine else { return }
 
     GeneratedPluginRegistrant.register(with: engine)
-    if let registrar = engine.registrar(
-      forPlugin: "ConduitNativeModelSelectorButton"
+    registerConduitNativeToolbarPlatformViews { pluginName in
+      engine.registrar(forPlugin: pluginName)
+    }
+    configureApplicationFlutterChannels(messenger: engine.binaryMessenger)
+    didConfigureSharedFlutterEngine = true
+  }
+
+  private func registerConduitNativeToolbarPlatformViews(
+    registrarForPlugin: (String) -> FlutterPluginRegistrar?
+  ) {
+    if let registrar = registrarForPlugin(
+      "ConduitNativeModelSelectorButton"
     ) {
       registrar.register(
         ConduitNativeModelSelectorButtonFactory(
@@ -2736,8 +2742,8 @@ private final class ConduitNativeToolbarActionGroupView:
         withId: "app.cogwheel.conduit/native_model_selector_button"
       )
     }
-    if let registrar = engine.registrar(
-      forPlugin: "ConduitNativeToolbarActionGroup"
+    if let registrar = registrarForPlugin(
+      "ConduitNativeToolbarActionGroup"
     ) {
       registrar.register(
         ConduitNativeToolbarActionGroupFactory(
@@ -2746,8 +2752,6 @@ private final class ConduitNativeToolbarActionGroupView:
         withId: "app.cogwheel.conduit/native_toolbar_action_group"
       )
     }
-    configureApplicationFlutterChannels(messenger: engine.binaryMessenger)
-    didConfigureSharedFlutterEngine = true
   }
 
   private func configureApplicationFlutterChannels(

--- a/ios/Runner/AppDelegate.swift
+++ b/ios/Runner/AppDelegate.swift
@@ -2472,11 +2472,13 @@ private final class ConduitNativeToolbarActionGroupView:
     symbolSize: Double,
     channel: FlutterMethodChannel
   ) -> UIBarButtonItem? {
+    let actionSymbolSize =
+      (action["symbolSize"] as? NSNumber)?.doubleValue ?? symbolSize
     guard let symbolName = action["iosSymbol"] as? String,
           let image = UIImage(systemName: symbolName)?
             .applyingSymbolConfiguration(
               UIImage.SymbolConfiguration(
-                pointSize: symbolSize,
+                pointSize: actionSymbolSize,
                 weight: .regular
               )
             ) else {

--- a/ios/Runner/AppDelegate.swift
+++ b/ios/Runner/AppDelegate.swift
@@ -2243,6 +2243,129 @@ private func cookieIsPreferred(
     return candidate.value < current.value
 }
 
+private final class ConduitNativeModelSelectorButtonFactory:
+  NSObject, FlutterPlatformViewFactory
+{
+  private let messenger: FlutterBinaryMessenger
+
+  init(messenger: FlutterBinaryMessenger) {
+    self.messenger = messenger
+    super.init()
+  }
+
+  func create(
+    withFrame frame: CGRect,
+    viewIdentifier viewId: Int64,
+    arguments args: Any?
+  ) -> FlutterPlatformView {
+    ConduitNativeModelSelectorButtonView(
+      frame: frame,
+      viewId: viewId,
+      arguments: args,
+      messenger: messenger
+    )
+  }
+
+  func createArgsCodec() -> FlutterMessageCodec & NSObjectProtocol {
+    FlutterStandardMessageCodec.sharedInstance()
+  }
+}
+
+private final class ConduitNativeModelSelectorButtonView:
+  NSObject, FlutterPlatformView
+{
+  private let container: UIView
+  private let button: UIButton
+  private let channel: FlutterMethodChannel
+
+  init(
+    frame: CGRect,
+    viewId: Int64,
+    arguments: Any?,
+    messenger: FlutterBinaryMessenger
+  ) {
+    container = UIView(frame: frame)
+    button = UIButton(type: .system)
+    channel = FlutterMethodChannel(
+      name: "app.cogwheel.conduit/native_model_selector_button_\(viewId)",
+      binaryMessenger: messenger
+    )
+    super.init()
+
+    let values = arguments as? [String: Any]
+    let label = values?["label"] as? String ?? ""
+    let symbolName = values?["symbolName"] as? String
+    let symbolSize = (values?["symbolSize"] as? NSNumber)?.doubleValue ?? 17
+    let symbolPadding =
+      (values?["symbolPadding"] as? NSNumber)?.doubleValue ?? 6
+    let enabled = (values?["enabled"] as? NSNumber)?.boolValue ?? true
+    let foreground = Self.color(
+      fromARGB: values?["foregroundColor"] as? NSNumber
+    ) ?? .label
+
+    container.backgroundColor = .clear
+    button.translatesAutoresizingMaskIntoConstraints = false
+    button.isEnabled = enabled
+    button.isAccessibilityElement = false
+
+    var configuration: UIButton.Configuration
+    if #available(iOS 26.0, *) {
+      configuration = .glass()
+    } else {
+      configuration = .plain()
+    }
+    configuration.cornerStyle = .capsule
+    configuration.baseForegroundColor = foreground
+    configuration.contentInsets = NSDirectionalEdgeInsets(
+      top: 8,
+      leading: 16,
+      bottom: 8,
+      trailing: 16
+    )
+    configuration.imagePlacement = .trailing
+    configuration.imagePadding = symbolPadding
+
+    var attributedTitle = AttributedString(label)
+    attributedTitle.font = .systemFont(ofSize: 17, weight: .semibold)
+    configuration.attributedTitle = attributedTitle
+
+    if let symbolName,
+       let image = UIImage(systemName: symbolName)?.applyingSymbolConfiguration(
+         UIImage.SymbolConfiguration(pointSize: symbolSize)
+       ) {
+      configuration.image = image
+    }
+
+    button.configuration = configuration
+    button.addTarget(self, action: #selector(handlePress), for: .touchUpInside)
+
+    container.addSubview(button)
+    NSLayoutConstraint.activate([
+      button.leadingAnchor.constraint(equalTo: container.leadingAnchor),
+      button.trailingAnchor.constraint(equalTo: container.trailingAnchor),
+      button.topAnchor.constraint(equalTo: container.topAnchor),
+      button.bottomAnchor.constraint(equalTo: container.bottomAnchor),
+    ])
+  }
+
+  func view() -> UIView { container }
+
+  @objc private func handlePress() {
+    channel.invokeMethod("pressed", arguments: nil)
+  }
+
+  private static func color(fromARGB number: NSNumber?) -> UIColor? {
+    guard let number else { return nil }
+    let value = number.uint32Value
+    return UIColor(
+      red: CGFloat((value >> 16) & 0xff) / 255,
+      green: CGFloat((value >> 8) & 0xff) / 255,
+      blue: CGFloat(value & 0xff) / 255,
+      alpha: CGFloat((value >> 24) & 0xff) / 255
+    )
+  }
+}
+
 @main
 @objc class AppDelegate: FlutterAppDelegate, FlutterImplicitEngineDelegate {
   private var backgroundStreamingHandler: BackgroundStreamingHandler?
@@ -2360,6 +2483,16 @@ private func cookieIsPreferred(
     guard sharedFlutterEngine == nil else { return }
 
     GeneratedPluginRegistrant.register(with: engineBridge.pluginRegistry)
+    if let registrar = engineBridge.pluginRegistry.registrar(
+      forPlugin: "ConduitNativeModelSelectorButton"
+    ) {
+      registrar.register(
+        ConduitNativeModelSelectorButtonFactory(
+          messenger: registrar.messenger()
+        ),
+        withId: "app.cogwheel.conduit/native_model_selector_button"
+      )
+    }
     configureApplicationFlutterChannels(
       messenger: engineBridge.applicationRegistrar.messenger()
     )
@@ -2411,6 +2544,16 @@ private func cookieIsPreferred(
     guard !didConfigureSharedFlutterEngine else { return }
 
     GeneratedPluginRegistrant.register(with: engine)
+    if let registrar = engine.registrar(
+      forPlugin: "ConduitNativeModelSelectorButton"
+    ) {
+      registrar.register(
+        ConduitNativeModelSelectorButtonFactory(
+          messenger: registrar.messenger()
+        ),
+        withId: "app.cogwheel.conduit/native_model_selector_button"
+      )
+    }
     configureApplicationFlutterChannels(messenger: engine.binaryMessenger)
     didConfigureSharedFlutterEngine = true
   }

--- a/ios/Runner/AppDelegate.swift
+++ b/ios/Runner/AppDelegate.swift
@@ -2295,7 +2295,7 @@ private final class ConduitNativeModelSelectorButtonView:
     let values = arguments as? [String: Any]
     let label = values?["label"] as? String ?? ""
     let symbolName = values?["symbolName"] as? String
-    let symbolSize = (values?["symbolSize"] as? NSNumber)?.doubleValue ?? 17
+    let symbolSize = (values?["symbolSize"] as? NSNumber)?.doubleValue ?? 13
     let symbolPadding =
       (values?["symbolPadding"] as? NSNumber)?.doubleValue ?? 6
     let enabled = (values?["enabled"] as? NSNumber)?.boolValue ?? true

--- a/lib/features/channels/views/channel_page.dart
+++ b/lib/features/channels/views/channel_page.dart
@@ -19,6 +19,7 @@ import '../../../core/services/navigation_service.dart';
 import '../../../core/utils/model_icon_utils.dart';
 import '../../../core/utils/user_avatar_utils.dart';
 import '../../../shared/theme/theme_extensions.dart';
+import '../../../shared/utils/adaptive_glass.dart';
 import '../../../shared/widgets/adaptive_route_shell.dart';
 import '../../../shared/widgets/adaptive_toolbar_components.dart';
 import '../../../shared/utils/conversation_context_menu.dart';
@@ -1177,11 +1178,42 @@ class _ChannelPageState extends ConsumerState<ChannelPage> {
     );
   }
 
+  List<AdaptivePopupMenuEntry> _buildChannelToolbarMenuItems(
+    AppLocalizations? l10n,
+  ) => [
+    AdaptivePopupMenuItem<String>(
+      value: 'edit',
+      label: l10n?.channelEdit ?? 'Edit Channel',
+      icon: conduitAdaptivePopupMenuIcon(
+        iosSymbol: 'pencil',
+        materialIcon: Icons.edit_outlined,
+      ),
+    ),
+    AdaptivePopupMenuItem<String>(
+      value: 'leave',
+      label: l10n?.channelLeave ?? 'Leave Channel',
+      isDestructive: true,
+      icon: conduitAdaptivePopupMenuIcon(
+        iosSymbol: 'rectangle.portrait.and.arrow.right',
+        materialIcon: Icons.logout_outlined,
+      ),
+    ),
+    AdaptivePopupMenuItem<String>(
+      value: 'delete',
+      label: l10n?.channelDelete ?? 'Delete Channel',
+      isDestructive: true,
+      icon: conduitAdaptivePopupMenuIcon(
+        iosSymbol: 'trash',
+        materialIcon: Icons.delete_outline,
+      ),
+    ),
+  ];
+
   List<Widget> _buildChannelToolbarActionWidgets(
-    BuildContext context,
     ConduitThemeExtension theme,
     Channel? channel,
-    AppLocalizations? l10n,
+    List<AdaptivePopupMenuEntry> menuItems,
+    ValueChanged<String> onMenuSelected,
   ) {
     return buildConduitAdaptiveToolbarActionWidgets([
       if (channel?.userCount != null)
@@ -1191,9 +1223,9 @@ class _ChannelPageState extends ConsumerState<ChannelPage> {
           onPressed: _showMemberList,
         ),
       _ChannelToolbarPopupButton(
-        l10n: l10n,
         tintColor: theme.textPrimary,
-        onSelected: (action) => _handleChannelToolbarSelection(action, channel),
+        items: menuItems,
+        onSelected: onMenuSelected,
       ),
     ]);
   }
@@ -1211,9 +1243,10 @@ class _ChannelPageState extends ConsumerState<ChannelPage> {
     final textScaler = MediaQuery.textScalerOf(context);
     final controlExtent = conduitScaledControlExtent(context);
     final toolbarHeight = conduitAdaptiveToolbarHeightOf(context);
+    final memberCount = channel?.userCount;
     final maxTitleWidth = resolveConduitAdaptiveLeadingPillWidth(
       context,
-      trailingActionCount: channel?.userCount != null ? 2 : 1,
+      trailingActionCount: memberCount != null ? 2 : 1,
       maxWidth: kConduitAdaptiveToolbarMaxPillWidth,
     );
     final tintColor = theme.textPrimary;
@@ -1229,12 +1262,41 @@ class _ChannelPageState extends ConsumerState<ChannelPage> {
         _buildChannelTitlePill(context, channel, maxWidth: maxTitleWidth),
       ],
     );
+    final menuItems = _buildChannelToolbarMenuItems(l10n);
+    void onMenuSelected(String action) =>
+        _handleChannelToolbarSelection(action, channel);
     final actions = _buildChannelToolbarActionWidgets(
-      context,
       theme,
       channel,
-      l10n,
+      menuItems,
+      onMenuSelected,
     );
+    final nativeMenuAction = buildConduitNativeToolbarMenuAction<String>(
+      iosSymbol: 'ellipsis',
+      accessibilityLabel:
+          l10n?.more ?? MaterialLocalizations.of(context).moreButtonTooltip,
+      tintColor: tintColor,
+      symbolSize: kConduitNativeToolbarSymbolExtent,
+      items: menuItems,
+      onSelected: onMenuSelected,
+    );
+    final useNativeActionGroup =
+        Platform.isIOS &&
+        conduitSupportsNativeGlass() &&
+        nativeMenuAction != null;
+    final nativeActions = <ConduitNativeToolbarAction>[
+      if (memberCount != null)
+        ConduitNativeToolbarAction(
+          iosSymbol: 'person.2',
+          accessibilityLabel:
+              l10n?.channelMembersTitle(memberCount) ??
+              'Members ($memberCount)',
+          tintColor: tintColor,
+          symbolSize: kConduitNativeToolbarSymbolExtent,
+          onPressed: _showMemberList,
+        ),
+      ?nativeMenuAction,
+    ];
     final overlayStyle = Theme.of(context).appBarTheme.systemOverlayStyle;
 
     final scaledLeading = ConduitSystemTextScaling(
@@ -1252,7 +1314,9 @@ class _ChannelPageState extends ConsumerState<ChannelPage> {
       cupertinoNavigationBar: ConduitAdaptiveCupertinoNavigationBar(
         textScaler: textScaler,
         leading: leading,
-        trailing: Row(mainAxisSize: MainAxisSize.min, children: actions),
+        trailing: useNativeActionGroup
+            ? ConduitNativeToolbarActionGroup(actions: nativeActions)
+            : Row(mainAxisSize: MainAxisSize.min, children: actions),
         systemOverlayStyle: overlayStyle,
       ),
       appBar: AppBar(
@@ -1710,13 +1774,13 @@ class _ChannelPageState extends ConsumerState<ChannelPage> {
 
 class _ChannelToolbarPopupButton extends StatelessWidget {
   const _ChannelToolbarPopupButton({
-    required this.l10n,
     required this.tintColor,
+    required this.items,
     required this.onSelected,
   });
 
-  final AppLocalizations? l10n;
   final Color tintColor;
+  final List<AdaptivePopupMenuEntry> items;
   final ValueChanged<String> onSelected;
 
   @override
@@ -1724,34 +1788,7 @@ class _ChannelToolbarPopupButton extends StatelessWidget {
     return ConduitAdaptiveToolbarOverflowButton<String>(
       tintColor: tintColor,
       materialIcon: Icons.more_vert,
-      items: [
-        AdaptivePopupMenuItem<String>(
-          value: 'edit',
-          label: l10n?.channelEdit ?? 'Edit Channel',
-          icon: conduitAdaptivePopupMenuIcon(
-            iosSymbol: 'pencil',
-            materialIcon: Icons.edit_outlined,
-          ),
-        ),
-        AdaptivePopupMenuItem<String>(
-          value: 'leave',
-          label: l10n?.channelLeave ?? 'Leave Channel',
-          isDestructive: true,
-          icon: conduitAdaptivePopupMenuIcon(
-            iosSymbol: 'rectangle.portrait.and.arrow.right',
-            materialIcon: Icons.logout_outlined,
-          ),
-        ),
-        AdaptivePopupMenuItem<String>(
-          value: 'delete',
-          label: l10n?.channelDelete ?? 'Delete Channel',
-          isDestructive: true,
-          icon: conduitAdaptivePopupMenuIcon(
-            iosSymbol: 'trash',
-            materialIcon: Icons.delete_outline,
-          ),
-        ),
-      ],
+      items: items,
       onSelected: onSelected,
     );
   }

--- a/lib/features/chat/views/chat_page.dart
+++ b/lib/features/chat/views/chat_page.dart
@@ -3635,7 +3635,7 @@ class _ChatPageState extends ConsumerState<ChatPage> {
         ConduitAdaptiveAppBarIconButton(
           key: const ValueKey('chat-sidebar-toggle'),
           icon: Platform.isIOS ? CupertinoIcons.line_horizontal_3 : Icons.menu,
-          iosSymbol: 'sidebar.left',
+          iosSymbol: 'line.3.horizontal',
           iosSymbolSize: kConduitNativeGroupedToolbarSymbolExtent,
           onPressed: () => _toggleResponsiveDrawer(context),
           iconColor: context.conduitTheme.textPrimary,

--- a/lib/features/chat/views/chat_page.dart
+++ b/lib/features/chat/views/chat_page.dart
@@ -2316,7 +2316,9 @@ class _ChatPageState extends ConsumerState<ChatPage> {
         ? CupertinoIcons.chevron_down
         : Icons.keyboard_arrow_down;
     const buttonSize = 40.0;
-    const iconSize = IconSize.medium;
+    final iconSize = conduitSupportsNativeGlass()
+        ? kConduitNativeUtilitySymbolExtent
+        : IconSize.medium;
     final theme = context.conduitTheme;
     final usesOpaqueFallback = conduitUsesOpaqueGlassFallback();
     final style = usesOpaqueFallback
@@ -3609,6 +3611,7 @@ class _ChatPageState extends ConsumerState<ChatPage> {
         ConduitAdaptiveAppBarIconButton(
           key: const ValueKey('chat-sidebar-toggle'),
           icon: Platform.isIOS ? CupertinoIcons.line_horizontal_3 : Icons.menu,
+          iosSymbolSize: kConduitNativeToolbarSymbolExtent,
           onPressed: () => _toggleResponsiveDrawer(context),
           iconColor: context.conduitTheme.textPrimary,
         ),
@@ -3648,6 +3651,7 @@ class _ChatPageState extends ConsumerState<ChatPage> {
       actions.add(
         ConduitAdaptiveAppBarIconButton(
           icon: Platform.isIOS ? CupertinoIcons.create : Icons.add_comment,
+          iosSymbolSize: kConduitNativeToolbarSymbolExtent,
           iconColor: defaultTint,
           onPressed: _handleNewChat,
         ),
@@ -3681,6 +3685,7 @@ class _ChatPageState extends ConsumerState<ChatPage> {
     if (isTemporary && hasMessages && activeConversation != null) {
       return ConduitAdaptiveAppBarIconButton(
         icon: Platform.isIOS ? CupertinoIcons.arrow_down_doc : Icons.save_alt,
+        iosSymbolSize: kConduitNativeToolbarSymbolExtent,
         iconColor: tintColor,
         onPressed: _isSavingTemporary ? null : _saveTemporaryChat,
       );
@@ -3690,6 +3695,7 @@ class _ChatPageState extends ConsumerState<ChatPage> {
       icon: isTemporary
           ? (Platform.isIOS ? CupertinoIcons.eye_slash : Icons.visibility_off)
           : (Platform.isIOS ? CupertinoIcons.eye : Icons.visibility_outlined),
+      iosSymbolSize: kConduitNativeToolbarSymbolExtent,
       iconColor: isTemporary ? Colors.blue : tintColor,
       onPressed: () {
         ConduitHaptics.selectionClick();

--- a/lib/features/chat/views/chat_page.dart
+++ b/lib/features/chat/views/chat_page.dart
@@ -3738,7 +3738,7 @@ class _ChatPageState extends ConsumerState<ChatPage> {
     if (isTemporary && hasMessages && activeConversation != null) {
       return _buildChatToolbarIconAction(
         icon: Platform.isIOS ? CupertinoIcons.arrow_down_doc : Icons.save_alt,
-        accessibilityLabel: AppLocalizations.of(context)!.temporaryChat,
+        accessibilityLabel: AppLocalizations.of(context)!.saveChat,
         tintColor: tintColor,
         onPressed: _isSavingTemporary ? null : _saveTemporaryChat,
       );

--- a/lib/features/chat/views/chat_page.dart
+++ b/lib/features/chat/views/chat_page.dart
@@ -2323,6 +2323,23 @@ class _ChatPageState extends ConsumerState<ChatPage> {
         ? AdaptiveButtonStyle.filled
         : AdaptiveButtonStyle.glass;
 
+    if (conduitSupportsNativeGlass()) {
+      return AdaptiveButton.sfSymbol(
+        onPressed: _userScrollToBottom,
+        sfSymbol: SFSymbol(
+          'chevron.down',
+          size: iconSize,
+          color: theme.textPrimary,
+        ),
+        style: style,
+        size: AdaptiveButtonSize.medium,
+        minSize: const Size.square(buttonSize),
+        padding: EdgeInsets.zero,
+        borderRadius: BorderRadius.circular(buttonSize),
+        useSmoothRectangleBorder: false,
+      );
+    }
+
     return AdaptiveButton.child(
       onPressed: _userScrollToBottom,
       style: style,

--- a/lib/features/chat/views/chat_page.dart
+++ b/lib/features/chat/views/chat_page.dart
@@ -3636,7 +3636,7 @@ class _ChatPageState extends ConsumerState<ChatPage> {
           key: const ValueKey('chat-sidebar-toggle'),
           icon: Platform.isIOS ? CupertinoIcons.line_horizontal_3 : Icons.menu,
           iosSymbol: 'line.3.horizontal',
-          iosSymbolSize: kConduitNativeGroupedToolbarSymbolExtent,
+          iosSymbolSize: kConduitNativeSidebarSymbolExtent,
           onPressed: () => _toggleResponsiveDrawer(context),
           iconColor: context.conduitTheme.textPrimary,
         ),
@@ -3701,6 +3701,7 @@ class _ChatPageState extends ConsumerState<ChatPage> {
     required String accessibilityLabel,
     required Color tintColor,
     required VoidCallback? onPressed,
+    double iosSymbolSize = kConduitNativeToolbarSymbolExtent,
   }) {
     final iosSymbol = conduitToolbarSfSymbolForIcon(icon);
     assert(iosSymbol != null);
@@ -3708,7 +3709,7 @@ class _ChatPageState extends ConsumerState<ChatPage> {
       widget: ConduitAdaptiveAppBarIconButton(
         icon: icon,
         iosSymbol: iosSymbol,
-        iosSymbolSize: kConduitNativeToolbarSymbolExtent,
+        iosSymbolSize: iosSymbolSize,
         iconColor: tintColor,
         onPressed: onPressed,
       ),
@@ -3716,6 +3717,7 @@ class _ChatPageState extends ConsumerState<ChatPage> {
         iosSymbol: iosSymbol!,
         accessibilityLabel: accessibilityLabel,
         tintColor: tintColor,
+        symbolSize: iosSymbolSize,
         enabled: onPressed != null,
         onPressed: onPressed,
       ),
@@ -3750,6 +3752,7 @@ class _ChatPageState extends ConsumerState<ChatPage> {
           : (Platform.isIOS ? CupertinoIcons.eye : Icons.visibility_outlined),
       accessibilityLabel: AppLocalizations.of(context)!.temporaryChat,
       tintColor: isTemporary ? Colors.blue : tintColor,
+      iosSymbolSize: kConduitNativeVisibilitySymbolExtent,
       onPressed: () {
         ConduitHaptics.selectionClick();
         final current = ref.read(temporaryChatEnabledProvider);

--- a/lib/features/chat/views/chat_page.dart
+++ b/lib/features/chat/views/chat_page.dart
@@ -96,6 +96,16 @@ Widget _buildArchivedAssistantPlaceholder({Key? key}) =>
 Widget debugBuildArchivedAssistantPlaceholderForTesting({Key? key}) =>
     _buildArchivedAssistantPlaceholder(key: key);
 
+class _ChatToolbarActionDescriptor {
+  const _ChatToolbarActionDescriptor({
+    required this.widget,
+    required this.nativeAction,
+  });
+
+  final Widget widget;
+  final ConduitNativeToolbarAction nativeAction;
+}
+
 @visibleForTesting
 Widget debugBuildChatEmptyStateViewportForTesting({
   required EdgeInsetsGeometry padding,
@@ -3549,13 +3559,27 @@ class _ChatPageState extends ConsumerState<ChatPage> {
       maxModelWidth: maxModelWidth,
       showModelDropdown: showModelDropdown,
     );
-    final actions = _buildAdaptiveToolbarActionWidgets(
+    final actionDescriptors = _buildAdaptiveToolbarActions(
       context: context,
       activeConversation: activeConversation,
       isTemporary: isTemporary,
       hasMessages: hasMessages,
       showNewChatAction: showNewChatAction,
     );
+    final actionWidgets = buildConduitAdaptiveToolbarActionWidgets([
+      for (final action in actionDescriptors) action.widget,
+    ]);
+    final useNativeActionGroup =
+        Platform.isIOS &&
+        conduitSupportsNativeGlass() &&
+        actionDescriptors.length == 2;
+    final cupertinoTrailing = useNativeActionGroup
+        ? ConduitNativeToolbarActionGroup(
+            actions: [
+              for (final action in actionDescriptors) action.nativeAction,
+            ],
+          )
+        : Row(mainAxisSize: MainAxisSize.min, children: actionWidgets);
     final leadingWidth = resolveConduitAdaptiveToolbarLeadingWidth(
       pillWidth: maxModelWidth,
       leadingGap: leadingGap,
@@ -3567,7 +3591,7 @@ class _ChatPageState extends ConsumerState<ChatPage> {
       child: leading,
     );
     final scaledActions = [
-      for (final action in actions)
+      for (final action in actionWidgets)
         ConduitSystemTextScaling(textScaler: textScaler, child: action),
     ];
 
@@ -3577,7 +3601,7 @@ class _ChatPageState extends ConsumerState<ChatPage> {
       cupertinoNavigationBar: ConduitAdaptiveCupertinoNavigationBar(
         textScaler: textScaler,
         leading: leading,
-        trailing: Row(mainAxisSize: MainAxisSize.min, children: actions),
+        trailing: cupertinoTrailing,
         systemOverlayStyle: overlayStyle,
       ),
       appBar: AppBar(
@@ -3611,7 +3635,8 @@ class _ChatPageState extends ConsumerState<ChatPage> {
         ConduitAdaptiveAppBarIconButton(
           key: const ValueKey('chat-sidebar-toggle'),
           icon: Platform.isIOS ? CupertinoIcons.line_horizontal_3 : Icons.menu,
-          iosSymbolSize: kConduitNativeToolbarSymbolExtent,
+          iosSymbol: 'sidebar.left',
+          iosSymbolSize: kConduitNativeGroupedToolbarSymbolExtent,
           onPressed: () => _toggleResponsiveDrawer(context),
           iconColor: context.conduitTheme.textPrimary,
         ),
@@ -3627,17 +3652,18 @@ class _ChatPageState extends ConsumerState<ChatPage> {
     );
   }
 
-  List<Widget> _buildAdaptiveToolbarActionWidgets({
+  List<_ChatToolbarActionDescriptor> _buildAdaptiveToolbarActions({
     required BuildContext context,
     required Conversation? activeConversation,
     required bool isTemporary,
     required bool hasMessages,
     required bool showNewChatAction,
   }) {
-    final actions = <Widget>[];
+    final actions = <_ChatToolbarActionDescriptor>[];
     final defaultTint = context.conduitTheme.textPrimary;
 
     final temporaryAction = _buildTemporaryChatToolbarAction(
+      context: context,
       activeConversation: activeConversation,
       isTemporary: isTemporary,
       hasMessages: hasMessages,
@@ -3649,16 +3675,16 @@ class _ChatPageState extends ConsumerState<ChatPage> {
 
     if (showNewChatAction) {
       actions.add(
-        ConduitAdaptiveAppBarIconButton(
+        _buildChatToolbarIconAction(
           icon: Platform.isIOS ? CupertinoIcons.create : Icons.add_comment,
-          iosSymbolSize: kConduitNativeToolbarSymbolExtent,
-          iconColor: defaultTint,
+          accessibilityLabel: AppLocalizations.of(context)!.newChat,
+          tintColor: defaultTint,
           onPressed: _handleNewChat,
         ),
       );
     }
 
-    final overflowButton = _buildChatToolbarOverflowButton(
+    final overflowButton = _buildChatToolbarOverflowAction(
       context: context,
       activeConversation: activeConversation,
       tintColor: defaultTint,
@@ -3667,10 +3693,37 @@ class _ChatPageState extends ConsumerState<ChatPage> {
       actions.add(overflowButton);
     }
 
-    return buildConduitAdaptiveToolbarActionWidgets(actions);
+    return actions;
   }
 
-  Widget? _buildTemporaryChatToolbarAction({
+  _ChatToolbarActionDescriptor _buildChatToolbarIconAction({
+    required IconData icon,
+    required String accessibilityLabel,
+    required Color tintColor,
+    required VoidCallback? onPressed,
+  }) {
+    final iosSymbol = conduitToolbarSfSymbolForIcon(icon);
+    assert(iosSymbol != null);
+    return _ChatToolbarActionDescriptor(
+      widget: ConduitAdaptiveAppBarIconButton(
+        icon: icon,
+        iosSymbol: iosSymbol,
+        iosSymbolSize: kConduitNativeToolbarSymbolExtent,
+        iconColor: tintColor,
+        onPressed: onPressed,
+      ),
+      nativeAction: ConduitNativeToolbarAction(
+        iosSymbol: iosSymbol!,
+        accessibilityLabel: accessibilityLabel,
+        tintColor: tintColor,
+        enabled: onPressed != null,
+        onPressed: onPressed,
+      ),
+    );
+  }
+
+  _ChatToolbarActionDescriptor? _buildTemporaryChatToolbarAction({
+    required BuildContext context,
     required Conversation? activeConversation,
     required bool isTemporary,
     required bool hasMessages,
@@ -3683,20 +3736,20 @@ class _ChatPageState extends ConsumerState<ChatPage> {
     }
 
     if (isTemporary && hasMessages && activeConversation != null) {
-      return ConduitAdaptiveAppBarIconButton(
+      return _buildChatToolbarIconAction(
         icon: Platform.isIOS ? CupertinoIcons.arrow_down_doc : Icons.save_alt,
-        iosSymbolSize: kConduitNativeToolbarSymbolExtent,
-        iconColor: tintColor,
+        accessibilityLabel: AppLocalizations.of(context)!.temporaryChat,
+        tintColor: tintColor,
         onPressed: _isSavingTemporary ? null : _saveTemporaryChat,
       );
     }
 
-    return ConduitAdaptiveAppBarIconButton(
+    return _buildChatToolbarIconAction(
       icon: isTemporary
           ? (Platform.isIOS ? CupertinoIcons.eye_slash : Icons.visibility_off)
           : (Platform.isIOS ? CupertinoIcons.eye : Icons.visibility_outlined),
-      iosSymbolSize: kConduitNativeToolbarSymbolExtent,
-      iconColor: isTemporary ? Colors.blue : tintColor,
+      accessibilityLabel: AppLocalizations.of(context)!.temporaryChat,
+      tintColor: isTemporary ? Colors.blue : tintColor,
       onPressed: () {
         ConduitHaptics.selectionClick();
         final current = ref.read(temporaryChatEnabledProvider);
@@ -3705,23 +3758,39 @@ class _ChatPageState extends ConsumerState<ChatPage> {
     );
   }
 
-  Widget? _buildChatToolbarOverflowButton({
+  _ChatToolbarActionDescriptor? _buildChatToolbarOverflowAction({
     required BuildContext context,
     required Conversation? activeConversation,
     required Color tintColor,
   }) {
     final items = <AdaptivePopupMenuEntry>[];
     final callbacks = <Future<void> Function()>[];
+    final nativeItems = <ConduitNativeToolbarMenuItem>[];
 
     void addItem({
       required String label,
       required Object icon,
+      String? iosSymbol,
+      bool isDestructive = false,
       required Future<void> Function() onSelected,
     }) {
       final index = callbacks.length;
       callbacks.add(onSelected);
       items.add(
-        AdaptivePopupMenuItem<int>(value: index, label: label, icon: icon),
+        AdaptivePopupMenuItem<int>(
+          value: index,
+          label: label,
+          icon: icon,
+          isDestructive: isDestructive,
+        ),
+      );
+      nativeItems.add(
+        ConduitNativeToolbarMenuItem(
+          label: label,
+          iosSymbol: iosSymbol,
+          isDestructive: isDestructive,
+          onSelected: () => unawaited(onSelected()),
+        ),
       );
     }
 
@@ -3737,6 +3806,8 @@ class _ChatPageState extends ConsumerState<ChatPage> {
       addItem(
         label: action.label,
         icon: _chatToolbarConversationActionIcon(action),
+        iosSymbol: action.sfSymbol,
+        isDestructive: action.destructive,
         onSelected: () async {
           action.onBeforeClose?.call();
           await action.onSelected();
@@ -3748,16 +3819,24 @@ class _ChatPageState extends ConsumerState<ChatPage> {
       return null;
     }
 
-    return ConduitAdaptiveToolbarOverflowButton<int>(
-      tintColor: tintColor,
-      materialIcon: Icons.more_vert,
-      items: items,
-      onSelected: (index) {
-        if (index < 0 || index >= callbacks.length) {
-          return;
-        }
-        unawaited(callbacks[index]());
-      },
+    return _ChatToolbarActionDescriptor(
+      widget: ConduitAdaptiveToolbarOverflowButton<int>(
+        tintColor: tintColor,
+        materialIcon: Icons.more_vert,
+        items: items,
+        onSelected: (index) {
+          if (index < 0 || index >= callbacks.length) {
+            return;
+          }
+          unawaited(callbacks[index]());
+        },
+      ),
+      nativeAction: ConduitNativeToolbarAction(
+        iosSymbol: 'ellipsis',
+        accessibilityLabel: AppLocalizations.of(context)!.more,
+        tintColor: tintColor,
+        menuItems: nativeItems,
+      ),
     );
   }
 

--- a/lib/features/chat/widgets/modern_chat_input.dart
+++ b/lib/features/chat/widgets/modern_chat_input.dart
@@ -70,61 +70,12 @@ import 'prompt_suggestion_overlay.dart';
 bool composerCursorOpacityAnimates({required bool usesNativePlatformView}) =>
     !usesNativePlatformView;
 
-/// Suppresses the remaining discrete caret blink while the selection menu is
-/// visible over an iOS 26 platform view.
+/// Whether the composer should delegate its edit menu to UIKit.
 @visibleForTesting
-bool composerShowsCursor({
-  required bool usesNativePlatformView,
-  required bool selectionMenuVisible,
-}) => !usesNativePlatformView || !selectionMenuVisible;
-
-/// Reports the lifetime of the Flutter-rendered composer selection menu.
-@visibleForTesting
-Widget buildComposerSelectionMenuLifecycle({
-  required Widget child,
-  required ValueChanged<bool> onVisibilityChanged,
-}) => _ComposerSelectionMenuLifecycle(
-  onVisibilityChanged: onVisibilityChanged,
-  child: child,
-);
-
-class _ComposerSelectionMenuLifecycle extends StatefulWidget {
-  const _ComposerSelectionMenuLifecycle({
-    required this.child,
-    required this.onVisibilityChanged,
-  });
-
-  final Widget child;
-  final ValueChanged<bool> onVisibilityChanged;
-
-  @override
-  State<_ComposerSelectionMenuLifecycle> createState() =>
-      _ComposerSelectionMenuLifecycleState();
-}
-
-class _ComposerSelectionMenuLifecycleState
-    extends State<_ComposerSelectionMenuLifecycle> {
-  void _scheduleVisibility(bool visible) {
-    WidgetsBinding.instance.addPostFrameCallback((_) {
-      widget.onVisibilityChanged(visible);
-    });
-  }
-
-  @override
-  void initState() {
-    super.initState();
-    _scheduleVisibility(true);
-  }
-
-  @override
-  void dispose() {
-    _scheduleVisibility(false);
-    super.dispose();
-  }
-
-  @override
-  Widget build(BuildContext context) => widget.child;
-}
+bool composerUsesNativeSystemSelectionMenu({
+  required bool isIOS,
+  required bool systemMenuSupported,
+}) => isIOS && systemMenuSupported;
 
 /// Whether the selected model may accept locally pasted/picked images.
 /// Reserved direct identities fail closed when their mutable registry binding
@@ -394,7 +345,6 @@ class _ModernChatInputState extends ConsumerState<ModernChatInput>
   final MentionTextEditingController _controller =
       MentionTextEditingController();
   final FocusNode _focusNode = FocusNode();
-  final ValueNotifier<bool> _selectionMenuVisible = ValueNotifier<bool>(false);
   late final String _generatedInsertionTargetId =
       'modern-chat-input-${_nextGeneratedInsertionTargetId++}';
   String get _composerTextInsertionTargetId =>
@@ -555,7 +505,6 @@ class _ModernChatInputState extends ConsumerState<ModernChatInput>
     );
     _controller.dispose();
     _focusNode.dispose();
-    _selectionMenuVisible.dispose();
     _pendingFocus = false;
     _voiceStreamSubscription?.cancel();
     if (!kIsWeb && Platform.isIOS) {
@@ -843,10 +792,69 @@ class _ModernChatInputState extends ConsumerState<ModernChatInput>
     BuildContext context,
     EditableTextState editableTextState,
   ) {
-    // iOS 26 can assert when Flutter tries to show overlapping system edit
-    // menus while focus is changing. Use the Flutter-rendered toolbar until
-    // the platform SystemContextMenu path is reliable again.
+    final useSystemMenu = composerUsesNativeSystemSelectionMenu(
+      isIOS: !kIsWeb && Platform.isIOS,
+      systemMenuSupported: SystemContextMenu.isSupportedByField(
+        editableTextState,
+      ),
+    );
+    if (useSystemMenu) {
+      return SystemContextMenu.editableText(
+        editableTextState: editableTextState,
+        items: _buildIosSystemContextMenuItems(editableTextState),
+      );
+    }
+
     return _buildFallbackContextMenu(context, editableTextState);
+  }
+
+  List<IOSSystemContextMenuItem> _buildIosSystemContextMenuItems(
+    EditableTextState editableTextState,
+  ) {
+    final items = List<IOSSystemContextMenuItem>.from(
+      SystemContextMenu.getDefaultItems(editableTextState),
+    );
+
+    if (widget.onPastedAttachments != null &&
+        _selectedModelAcceptsImageInput &&
+        !items.any((item) => item is IOSSystemContextMenuItemPaste)) {
+      final insertionIndex = items.indexWhere(
+        (item) =>
+            item is IOSSystemContextMenuItemSelectAll ||
+            item is IOSSystemContextMenuItemLookUp ||
+            item is IOSSystemContextMenuItemSearchWeb ||
+            item is IOSSystemContextMenuItemShare ||
+            item is IOSSystemContextMenuItemLiveText,
+      );
+      const pasteItem = IOSSystemContextMenuItemPaste();
+      if (insertionIndex >= 0) {
+        items.insert(insertionIndex, pasteItem);
+      } else {
+        items.add(pasteItem);
+      }
+    }
+
+    final selectedText = selectedTextFromEditableTextState(editableTextState);
+    if (selectedText != null &&
+        selectedText.trim().isNotEmpty &&
+        _composerTextInsertionTargetId.isNotEmpty) {
+      items.add(
+        IOSSystemContextMenuItemCustom(
+          title: 'Ask Conduit',
+          onPressed: () {
+            editableTextState.hideToolbar(false);
+            ref
+                .read(composerTextInsertionProvider.notifier)
+                .insert(
+                  targetId: _composerTextInsertionTargetId,
+                  text: selectedText,
+                );
+          },
+        ),
+      );
+    }
+
+    return items;
   }
 
   /// Builds a Flutter-rendered fallback text editing menu.
@@ -858,20 +866,10 @@ class _ModernChatInputState extends ConsumerState<ModernChatInput>
       context,
       editableTextState,
     );
-    return buildComposerSelectionMenuLifecycle(
-      onVisibilityChanged: _handleSelectionMenuVisibilityChanged,
-      child: AdaptiveTextSelectionToolbar.buttonItems(
-        anchors: editableTextState.contextMenuAnchors,
-        buttonItems: buttonItems,
-      ),
+    return AdaptiveTextSelectionToolbar.buttonItems(
+      anchors: editableTextState.contextMenuAnchors,
+      buttonItems: buttonItems,
     );
-  }
-
-  void _handleSelectionMenuVisibilityChanged(bool visible) {
-    if (!mounted || _selectionMenuVisible.value == visible) {
-      return;
-    }
-    _selectionMenuVisible.value = visible;
   }
 
   List<ContextMenuButtonItem> _buildFallbackContextMenuItems(
@@ -3518,68 +3516,53 @@ class _ModernChatInputState extends ConsumerState<ModernChatInput>
               // by keyboard shortcuts (Enter key) instead.
               if (!kIsWeb && Platform.isIOS) {
                 final usesNativePlatformView = conduitSupportsNativeGlass();
-                return ValueListenableBuilder<bool>(
-                  valueListenable: _selectionMenuVisible,
-                  builder: (context, selectionMenuVisible, _) =>
-                      CupertinoTextField(
-                        controller: _controller,
-                        focusNode: _focusNode,
-                        placeholder: inputPlaceholder,
-                        placeholderStyle: baseChatStyle.copyWith(
-                          color: animatedPlaceholder,
-                        ),
-                        enabled: widget.enabled,
-                        autofocus: false,
-                        minLines: 1,
-                        maxLines: null,
-                        textAlignVertical: TextAlignVertical.center,
-                        keyboardType: TextInputType.multiline,
-                        textCapitalization: TextCapitalization.sentences,
-                        textInputAction: TextInputAction.newline,
-                        autofillHints: const <String>[],
-                        showCursor: composerShowsCursor(
-                          usesNativePlatformView: usesNativePlatformView,
-                          selectionMenuVisible: selectionMenuVisible,
-                        ),
-                        cursorOpacityAnimates: composerCursorOpacityAnimates(
-                          usesNativePlatformView: usesNativePlatformView,
-                        ),
-                        cursorColor: Theme.of(
-                          context,
-                        ).textSelectionTheme.cursorColor,
-                        scrollPadding: const EdgeInsets.only(bottom: 80),
-                        keyboardAppearance: brightness,
-                        style: baseChatStyle.copyWith(color: animatedTextColor),
-                        contentInsertionConfiguration:
-                            _selectedModelAcceptsImageInput
-                            ? ContentInsertionConfiguration(
-                                allowedMimeTypes: ClipboardAttachmentService
-                                    .supportedImageMimeTypes
-                                    .toList(),
-                                onContentInserted: _handleContentInserted,
-                              )
-                            : null,
-                        // Transparent decoration, the glass container provides
-                        // the visual frame.
-                        decoration: const BoxDecoration(),
-                        padding: contentPadding,
-                        contextMenuBuilder: (context, editableTextState) {
-                          return _buildIosContextMenu(
-                            context,
-                            editableTextState,
-                          );
-                        },
-                        onSubmitted: (_) {},
-                        onTap: () {
-                          if (!widget.enabled) return;
-                          unawaited(
-                            _hideAttachmentPanels(
-                              restoreFallbackKeyboard: true,
-                            ),
-                          );
-                          _ensureFocusedIfEnabled();
-                        },
-                      ),
+                return CupertinoTextField(
+                  controller: _controller,
+                  focusNode: _focusNode,
+                  placeholder: inputPlaceholder,
+                  placeholderStyle: baseChatStyle.copyWith(
+                    color: animatedPlaceholder,
+                  ),
+                  enabled: widget.enabled,
+                  autofocus: false,
+                  minLines: 1,
+                  maxLines: null,
+                  textAlignVertical: TextAlignVertical.center,
+                  keyboardType: TextInputType.multiline,
+                  textCapitalization: TextCapitalization.sentences,
+                  textInputAction: TextInputAction.newline,
+                  autofillHints: const <String>[],
+                  showCursor: true,
+                  cursorOpacityAnimates: composerCursorOpacityAnimates(
+                    usesNativePlatformView: usesNativePlatformView,
+                  ),
+                  cursorColor: Theme.of(context).textSelectionTheme.cursorColor,
+                  scrollPadding: const EdgeInsets.only(bottom: 80),
+                  keyboardAppearance: brightness,
+                  style: baseChatStyle.copyWith(color: animatedTextColor),
+                  contentInsertionConfiguration: _selectedModelAcceptsImageInput
+                      ? ContentInsertionConfiguration(
+                          allowedMimeTypes: ClipboardAttachmentService
+                              .supportedImageMimeTypes
+                              .toList(),
+                          onContentInserted: _handleContentInserted,
+                        )
+                      : null,
+                  // Transparent decoration, the glass container provides
+                  // the visual frame.
+                  decoration: const BoxDecoration(),
+                  padding: contentPadding,
+                  contextMenuBuilder: (context, editableTextState) {
+                    return _buildIosContextMenu(context, editableTextState);
+                  },
+                  onSubmitted: (_) {},
+                  onTap: () {
+                    if (!widget.enabled) return;
+                    unawaited(
+                      _hideAttachmentPanels(restoreFallbackKeyboard: true),
+                    );
+                    _ensureFocusedIfEnabled();
+                  },
                 );
               }
               return TextField(

--- a/lib/features/chat/widgets/modern_chat_input.dart
+++ b/lib/features/chat/widgets/modern_chat_input.dart
@@ -63,6 +63,13 @@ import 'mention_text_controller.dart';
 import 'model_suggestion_overlay.dart';
 import 'prompt_suggestion_overlay.dart';
 
+/// Native platform views are recomposited for every animated cursor-opacity
+/// frame. Keep the normal animated caret everywhere else, but use the much
+/// cheaper periodic cursor toggle while the iOS 26 glass view is present.
+@visibleForTesting
+bool composerCursorOpacityAnimates({required bool usesNativePlatformView}) =>
+    !usesNativePlatformView;
+
 /// Whether the selected model may accept locally pasted/picked images.
 /// Reserved direct identities fail closed when their mutable registry binding
 /// has been removed or replaced.
@@ -3459,6 +3466,9 @@ class _ModernChatInputState extends ConsumerState<ModernChatInput>
                   textInputAction: TextInputAction.newline,
                   autofillHints: const <String>[],
                   showCursor: true,
+                  cursorOpacityAnimates: composerCursorOpacityAnimates(
+                    usesNativePlatformView: conduitSupportsNativeGlass(),
+                  ),
                   cursorColor: Theme.of(context).textSelectionTheme.cursorColor,
                   scrollPadding: const EdgeInsets.only(bottom: 80),
                   keyboardAppearance: brightness,
@@ -3602,6 +3612,9 @@ class _ModernChatInputState extends ConsumerState<ModernChatInput>
               : null,
           size: buttonSize,
           forcePlain: true,
+          iosSymbol: attachmentPanelVisible ? 'xmark' : 'plus',
+          iosSymbolSize: kConduitNativeUtilitySymbolExtent,
+          iosSymbolColor: iconColor,
           child: ConduitSystemAdaptiveIcon(
             overflowIcon,
             size: iconSize,
@@ -3760,6 +3773,9 @@ class _ModernChatInputState extends ConsumerState<ModernChatInput>
         onPressed: enabled ? _createNoteFromDraft : null,
         size: buttonSize,
         forcePlain: true,
+        iosSymbol: isLoading ? null : 'doc.text',
+        iosSymbolSize: kConduitNativeUtilitySymbolExtent,
+        iosSymbolColor: iconColor,
         child: isLoading
             ? SizedBox(
                 width: iconSize,
@@ -3798,6 +3814,9 @@ class _ModernChatInputState extends ConsumerState<ModernChatInput>
       context,
       dense ? IconSize.large : IconSize.xl,
     );
+    final nativePrimaryIconSize = dense
+        ? kConduitNativeUtilitySymbolExtent
+        : kConduitNativePrimarySymbolExtent;
 
     // Don't allow sending until all uploads are complete
     final enabled =
@@ -3815,6 +3834,9 @@ class _ModernChatInputState extends ConsumerState<ModernChatInput>
           },
           size: buttonSize,
           isProminent: true,
+          iosSymbol: 'stop.fill',
+          iosSymbolSize: nativePrimaryIconSize,
+          iosSymbolColor: context.conduitTheme.buttonPrimaryText,
           child: ConduitSystemAdaptiveIcon(
             Platform.isIOS ? CupertinoIcons.stop_fill : Icons.stop,
             size: primaryIconSize,
@@ -3864,6 +3886,13 @@ class _ModernChatInputState extends ConsumerState<ModernChatInput>
           onPressed: onPressed,
           size: buttonSize,
           isProminent: true,
+          iosSymbol: hasUploadsInProgress ? null : 'arrow.up',
+          iosSymbolSize: kConduitNativeUtilitySymbolExtent,
+          iosSymbolColor: enabled
+              ? context.conduitTheme.buttonPrimaryText
+              : context.conduitTheme.textPrimary.withValues(
+                  alpha: Alpha.disabled,
+                ),
           child: sendChild,
         ),
       );
@@ -3885,6 +3914,13 @@ class _ModernChatInputState extends ConsumerState<ModernChatInput>
               : null,
           size: buttonSize,
           isProminent: true,
+          iosSymbol: 'waveform',
+          iosSymbolSize: nativePrimaryIconSize,
+          iosSymbolColor: enabledVoiceCall
+              ? context.conduitTheme.buttonPrimaryText
+              : context.conduitTheme.textPrimary.withValues(
+                  alpha: Alpha.disabled,
+                ),
           child: ConduitSystemAdaptiveIcon(
             Platform.isIOS ? CupertinoIcons.waveform : Icons.graphic_eq,
             size: primaryIconSize,
@@ -3904,6 +3940,11 @@ class _ModernChatInputState extends ConsumerState<ModernChatInput>
       onPressed: null,
       size: buttonSize,
       isProminent: false,
+      iosSymbol: 'arrow.up',
+      iosSymbolSize: kConduitNativeUtilitySymbolExtent,
+      iosSymbolColor: context.conduitTheme.textPrimary.withValues(
+        alpha: Alpha.disabled,
+      ),
       child: ConduitSystemAdaptiveIcon(
         CupertinoIcons.arrow_up,
         size: largeIconSize,
@@ -4013,6 +4054,9 @@ class _ModernChatInputState extends ConsumerState<ModernChatInput>
     bool androidShowBackground = false,
     bool forcePlain = false,
     Color? color,
+    String? iosSymbol,
+    double? iosSymbolSize,
+    Color? iosSymbolColor,
   }) {
     final theme = context.conduitTheme;
     final effectiveColor = color ?? theme.buttonPrimary;
@@ -4037,6 +4081,46 @@ class _ModernChatInputState extends ConsumerState<ModernChatInput>
               ? AdaptiveButtonStyle.prominentGlass
               : AdaptiveButtonStyle.glass);
 
+    final adaptiveSize = size > 40
+        ? AdaptiveButtonSize.large
+        : AdaptiveButtonSize.medium;
+    final buttonColor =
+        usesOpaqueFallback && androidShowBackground && !isProminent
+        ? androidBackgroundColor
+        : effectiveColor;
+
+    if (conduitSupportsNativeGlass()) {
+      // Loading indicators are transient Flutter content. Keeping them out of
+      // child-mode avoids creating another persistent platform view.
+      if (iosSymbol == null) {
+        return SizedBox.square(
+          key: key,
+          dimension: size,
+          child: Center(child: child),
+        );
+      }
+      return SizedBox.square(
+        dimension: size,
+        child: AdaptiveButton.sfSymbol(
+          key: key,
+          onPressed: onPressed,
+          enabled: onPressed != null,
+          sfSymbol: SFSymbol(
+            iosSymbol,
+            size: iosSymbolSize ?? kConduitNativeUtilitySymbolExtent,
+            color: iosSymbolColor,
+          ),
+          style: buttonStyle,
+          color: buttonColor,
+          size: adaptiveSize,
+          minSize: Size.square(size),
+          padding: EdgeInsets.zero,
+          borderRadius: BorderRadius.circular(size),
+          useSmoothRectangleBorder: false,
+        ),
+      );
+    }
+
     return SizedBox.square(
       dimension: size,
       child: AdaptiveButton.child(
@@ -4044,10 +4128,8 @@ class _ModernChatInputState extends ConsumerState<ModernChatInput>
         onPressed: onPressed,
         enabled: onPressed != null,
         style: buttonStyle,
-        color: usesOpaqueFallback && androidShowBackground && !isProminent
-            ? androidBackgroundColor
-            : effectiveColor,
-        size: size > 40 ? AdaptiveButtonSize.large : AdaptiveButtonSize.medium,
+        color: buttonColor,
+        size: adaptiveSize,
         minSize: Size.square(size),
         padding: EdgeInsets.zero,
         borderRadius: BorderRadius.circular(size),

--- a/lib/features/chat/widgets/modern_chat_input.dart
+++ b/lib/features/chat/widgets/modern_chat_input.dart
@@ -64,11 +64,67 @@ import 'model_suggestion_overlay.dart';
 import 'prompt_suggestion_overlay.dart';
 
 /// Native platform views are recomposited for every animated cursor-opacity
-/// frame. Keep the normal animated caret everywhere else, but use the much
-/// cheaper periodic cursor toggle while the iOS 26 glass view is present.
+/// frame. Keep the normal animated caret everywhere else, but use a discrete
+/// blink while the iOS 26 glass view is present.
 @visibleForTesting
 bool composerCursorOpacityAnimates({required bool usesNativePlatformView}) =>
     !usesNativePlatformView;
+
+/// Suppresses the remaining discrete caret blink while the selection menu is
+/// visible over an iOS 26 platform view.
+@visibleForTesting
+bool composerShowsCursor({
+  required bool usesNativePlatformView,
+  required bool selectionMenuVisible,
+}) => !usesNativePlatformView || !selectionMenuVisible;
+
+/// Reports the lifetime of the Flutter-rendered composer selection menu.
+@visibleForTesting
+Widget buildComposerSelectionMenuLifecycle({
+  required Widget child,
+  required ValueChanged<bool> onVisibilityChanged,
+}) => _ComposerSelectionMenuLifecycle(
+  onVisibilityChanged: onVisibilityChanged,
+  child: child,
+);
+
+class _ComposerSelectionMenuLifecycle extends StatefulWidget {
+  const _ComposerSelectionMenuLifecycle({
+    required this.child,
+    required this.onVisibilityChanged,
+  });
+
+  final Widget child;
+  final ValueChanged<bool> onVisibilityChanged;
+
+  @override
+  State<_ComposerSelectionMenuLifecycle> createState() =>
+      _ComposerSelectionMenuLifecycleState();
+}
+
+class _ComposerSelectionMenuLifecycleState
+    extends State<_ComposerSelectionMenuLifecycle> {
+  void _scheduleVisibility(bool visible) {
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      widget.onVisibilityChanged(visible);
+    });
+  }
+
+  @override
+  void initState() {
+    super.initState();
+    _scheduleVisibility(true);
+  }
+
+  @override
+  void dispose() {
+    _scheduleVisibility(false);
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) => widget.child;
+}
 
 /// Whether the selected model may accept locally pasted/picked images.
 /// Reserved direct identities fail closed when their mutable registry binding
@@ -338,6 +394,7 @@ class _ModernChatInputState extends ConsumerState<ModernChatInput>
   final MentionTextEditingController _controller =
       MentionTextEditingController();
   final FocusNode _focusNode = FocusNode();
+  final ValueNotifier<bool> _selectionMenuVisible = ValueNotifier<bool>(false);
   late final String _generatedInsertionTargetId =
       'modern-chat-input-${_nextGeneratedInsertionTargetId++}';
   String get _composerTextInsertionTargetId =>
@@ -498,6 +555,7 @@ class _ModernChatInputState extends ConsumerState<ModernChatInput>
     );
     _controller.dispose();
     _focusNode.dispose();
+    _selectionMenuVisible.dispose();
     _pendingFocus = false;
     _voiceStreamSubscription?.cancel();
     if (!kIsWeb && Platform.isIOS) {
@@ -800,10 +858,20 @@ class _ModernChatInputState extends ConsumerState<ModernChatInput>
       context,
       editableTextState,
     );
-    return AdaptiveTextSelectionToolbar.buttonItems(
-      anchors: editableTextState.contextMenuAnchors,
-      buttonItems: buttonItems,
+    return buildComposerSelectionMenuLifecycle(
+      onVisibilityChanged: _handleSelectionMenuVisibilityChanged,
+      child: AdaptiveTextSelectionToolbar.buttonItems(
+        anchors: editableTextState.contextMenuAnchors,
+        buttonItems: buttonItems,
+      ),
     );
+  }
+
+  void _handleSelectionMenuVisibilityChanged(bool visible) {
+    if (!mounted || _selectionMenuVisible.value == visible) {
+      return;
+    }
+    _selectionMenuVisible.value = visible;
   }
 
   List<ContextMenuButtonItem> _buildFallbackContextMenuItems(
@@ -3449,53 +3517,69 @@ class _ModernChatInputState extends ConsumerState<ModernChatInput>
               // send messages. The send-on-enter functionality is handled
               // by keyboard shortcuts (Enter key) instead.
               if (!kIsWeb && Platform.isIOS) {
-                return CupertinoTextField(
-                  controller: _controller,
-                  focusNode: _focusNode,
-                  placeholder: inputPlaceholder,
-                  placeholderStyle: baseChatStyle.copyWith(
-                    color: animatedPlaceholder,
-                  ),
-                  enabled: widget.enabled,
-                  autofocus: false,
-                  minLines: 1,
-                  maxLines: null,
-                  textAlignVertical: TextAlignVertical.center,
-                  keyboardType: TextInputType.multiline,
-                  textCapitalization: TextCapitalization.sentences,
-                  textInputAction: TextInputAction.newline,
-                  autofillHints: const <String>[],
-                  showCursor: true,
-                  cursorOpacityAnimates: composerCursorOpacityAnimates(
-                    usesNativePlatformView: conduitSupportsNativeGlass(),
-                  ),
-                  cursorColor: Theme.of(context).textSelectionTheme.cursorColor,
-                  scrollPadding: const EdgeInsets.only(bottom: 80),
-                  keyboardAppearance: brightness,
-                  style: baseChatStyle.copyWith(color: animatedTextColor),
-                  contentInsertionConfiguration: _selectedModelAcceptsImageInput
-                      ? ContentInsertionConfiguration(
-                          allowedMimeTypes: ClipboardAttachmentService
-                              .supportedImageMimeTypes
-                              .toList(),
-                          onContentInserted: _handleContentInserted,
-                        )
-                      : null,
-                  // Transparent decoration — the glass container provides
-                  // the visual frame.
-                  decoration: const BoxDecoration(),
-                  padding: contentPadding,
-                  contextMenuBuilder: (context, editableTextState) {
-                    return _buildIosContextMenu(context, editableTextState);
-                  },
-                  onSubmitted: (_) {},
-                  onTap: () {
-                    if (!widget.enabled) return;
-                    unawaited(
-                      _hideAttachmentPanels(restoreFallbackKeyboard: true),
-                    );
-                    _ensureFocusedIfEnabled();
-                  },
+                final usesNativePlatformView = conduitSupportsNativeGlass();
+                return ValueListenableBuilder<bool>(
+                  valueListenable: _selectionMenuVisible,
+                  builder: (context, selectionMenuVisible, _) =>
+                      CupertinoTextField(
+                        controller: _controller,
+                        focusNode: _focusNode,
+                        placeholder: inputPlaceholder,
+                        placeholderStyle: baseChatStyle.copyWith(
+                          color: animatedPlaceholder,
+                        ),
+                        enabled: widget.enabled,
+                        autofocus: false,
+                        minLines: 1,
+                        maxLines: null,
+                        textAlignVertical: TextAlignVertical.center,
+                        keyboardType: TextInputType.multiline,
+                        textCapitalization: TextCapitalization.sentences,
+                        textInputAction: TextInputAction.newline,
+                        autofillHints: const <String>[],
+                        showCursor: composerShowsCursor(
+                          usesNativePlatformView: usesNativePlatformView,
+                          selectionMenuVisible: selectionMenuVisible,
+                        ),
+                        cursorOpacityAnimates: composerCursorOpacityAnimates(
+                          usesNativePlatformView: usesNativePlatformView,
+                        ),
+                        cursorColor: Theme.of(
+                          context,
+                        ).textSelectionTheme.cursorColor,
+                        scrollPadding: const EdgeInsets.only(bottom: 80),
+                        keyboardAppearance: brightness,
+                        style: baseChatStyle.copyWith(color: animatedTextColor),
+                        contentInsertionConfiguration:
+                            _selectedModelAcceptsImageInput
+                            ? ContentInsertionConfiguration(
+                                allowedMimeTypes: ClipboardAttachmentService
+                                    .supportedImageMimeTypes
+                                    .toList(),
+                                onContentInserted: _handleContentInserted,
+                              )
+                            : null,
+                        // Transparent decoration, the glass container provides
+                        // the visual frame.
+                        decoration: const BoxDecoration(),
+                        padding: contentPadding,
+                        contextMenuBuilder: (context, editableTextState) {
+                          return _buildIosContextMenu(
+                            context,
+                            editableTextState,
+                          );
+                        },
+                        onSubmitted: (_) {},
+                        onTap: () {
+                          if (!widget.enabled) return;
+                          unawaited(
+                            _hideAttachmentPanels(
+                              restoreFallbackKeyboard: true,
+                            ),
+                          );
+                          _ensureFocusedIfEnabled();
+                        },
+                      ),
                 );
               }
               return TextField(

--- a/lib/features/chat/widgets/modern_chat_input.dart
+++ b/lib/features/chat/widgets/modern_chat_input.dart
@@ -46,7 +46,6 @@ import '../../../core/models/knowledge_base_file.dart';
 
 import '../../../shared/utils/platform_utils.dart';
 import '../../../shared/utils/adaptive_glass.dart';
-import '../../../shared/utils/ask_conduit_context_menu.dart';
 import 'package:conduit/l10n/app_localizations.dart';
 import '../../../shared/widgets/modal_safe_area.dart';
 import '../../../shared/widgets/model_avatar.dart';
@@ -76,6 +75,41 @@ bool composerUsesNativeSystemSelectionMenu({
   required bool isIOS,
   required bool systemMenuSupported,
 }) => isIOS && systemMenuSupported;
+
+/// Returns a stable UIKit edit-menu model for the composer.
+///
+/// Keep composer actions limited to operations that mutate the editable field.
+/// In particular, "Ask Conduit" belongs to selected response text: adding it
+/// here both reinserted the selection into the same field and created a fresh
+/// callback identity whenever selection handles moved, forcing UIKit to
+/// re-present the menu.
+@visibleForTesting
+List<IOSSystemContextMenuItem> buildComposerSystemContextMenuItems({
+  required List<IOSSystemContextMenuItem> defaultItems,
+  required bool ensurePaste,
+}) {
+  final items = List<IOSSystemContextMenuItem>.from(defaultItems);
+  if (!ensurePaste ||
+      items.any((item) => item is IOSSystemContextMenuItemPaste)) {
+    return items;
+  }
+
+  final insertionIndex = items.indexWhere(
+    (item) =>
+        item is IOSSystemContextMenuItemSelectAll ||
+        item is IOSSystemContextMenuItemLookUp ||
+        item is IOSSystemContextMenuItemSearchWeb ||
+        item is IOSSystemContextMenuItemShare ||
+        item is IOSSystemContextMenuItemLiveText,
+  );
+  const pasteItem = IOSSystemContextMenuItemPaste();
+  if (insertionIndex >= 0) {
+    items.insert(insertionIndex, pasteItem);
+  } else {
+    items.add(pasteItem);
+  }
+  return items;
+}
 
 /// Whether the selected model may accept locally pasted/picked images.
 /// Reserved direct identities fail closed when their mutable registry binding
@@ -811,50 +845,11 @@ class _ModernChatInputState extends ConsumerState<ModernChatInput>
   List<IOSSystemContextMenuItem> _buildIosSystemContextMenuItems(
     EditableTextState editableTextState,
   ) {
-    final items = List<IOSSystemContextMenuItem>.from(
-      SystemContextMenu.getDefaultItems(editableTextState),
+    return buildComposerSystemContextMenuItems(
+      defaultItems: SystemContextMenu.getDefaultItems(editableTextState),
+      ensurePaste:
+          widget.onPastedAttachments != null && _selectedModelAcceptsImageInput,
     );
-
-    if (widget.onPastedAttachments != null &&
-        _selectedModelAcceptsImageInput &&
-        !items.any((item) => item is IOSSystemContextMenuItemPaste)) {
-      final insertionIndex = items.indexWhere(
-        (item) =>
-            item is IOSSystemContextMenuItemSelectAll ||
-            item is IOSSystemContextMenuItemLookUp ||
-            item is IOSSystemContextMenuItemSearchWeb ||
-            item is IOSSystemContextMenuItemShare ||
-            item is IOSSystemContextMenuItemLiveText,
-      );
-      const pasteItem = IOSSystemContextMenuItemPaste();
-      if (insertionIndex >= 0) {
-        items.insert(insertionIndex, pasteItem);
-      } else {
-        items.add(pasteItem);
-      }
-    }
-
-    final selectedText = selectedTextFromEditableTextState(editableTextState);
-    if (selectedText != null &&
-        selectedText.trim().isNotEmpty &&
-        _composerTextInsertionTargetId.isNotEmpty) {
-      items.add(
-        IOSSystemContextMenuItemCustom(
-          title: 'Ask Conduit',
-          onPressed: () {
-            editableTextState.hideToolbar(false);
-            ref
-                .read(composerTextInsertionProvider.notifier)
-                .insert(
-                  targetId: _composerTextInsertionTargetId,
-                  text: selectedText,
-                );
-          },
-        ),
-      );
-    }
-
-    return items;
   }
 
   /// Builds a Flutter-rendered fallback text editing menu.
@@ -914,13 +909,7 @@ class _ModernChatInputState extends ConsumerState<ModernChatInput>
       }
     }
 
-    return withAskConduitContextMenuItem(
-      items: items,
-      ref: ref,
-      selectedText: selectedTextFromEditableTextState(editableTextState),
-      composerTargetId: _composerTextInsertionTargetId,
-      hideToolbar: () => editableTextState.hideToolbar(false),
-    );
+    return items;
   }
 
   Future<void> _handleFallbackPaste(
@@ -4160,10 +4149,14 @@ class _ModernChatInputState extends ConsumerState<ModernChatInput>
       // Loading indicators are transient Flutter content. Keeping them out of
       // child-mode avoids creating another persistent platform view.
       if (iosSymbol == null) {
-        return SizedBox.square(
+        return Semantics(
           key: key,
-          dimension: size,
-          child: Center(child: child),
+          button: true,
+          enabled: onPressed != null,
+          child: SizedBox.square(
+            dimension: size,
+            child: Center(child: child),
+          ),
         );
       }
       return SizedBox.square(

--- a/lib/features/chat/widgets/modern_chat_input.dart
+++ b/lib/features/chat/widgets/modern_chat_input.dart
@@ -4155,7 +4155,15 @@ class _ModernChatInputState extends ConsumerState<ModernChatInput>
           enabled: onPressed != null,
           child: SizedBox.square(
             dimension: size,
-            child: Center(child: child),
+            child: isProminent
+                ? DecoratedBox(
+                    decoration: BoxDecoration(
+                      color: buttonColor,
+                      shape: BoxShape.circle,
+                    ),
+                    child: Center(child: child),
+                  )
+                : Center(child: child),
           ),
         );
       }

--- a/lib/features/navigation/views/folder_page.dart
+++ b/lib/features/navigation/views/folder_page.dart
@@ -23,6 +23,7 @@ import '../../../core/widgets/error_boundary.dart';
 import '../../../l10n/app_localizations.dart';
 import '../../../shared/theme/conduit_input_styles.dart';
 import '../../../shared/theme/theme_extensions.dart';
+import '../../../shared/utils/adaptive_glass.dart';
 import '../../../shared/utils/platform_scroll_physics.dart';
 import '../../../shared/utils/conversation_context_menu.dart';
 import '../../../shared/utils/ui_utils.dart';
@@ -158,7 +159,54 @@ class _FolderPageState extends ConsumerState<FolderPage> {
       leadingGap: leadingGap,
       maxModelWidth: maxModelWidth,
     );
-    final actions = _buildFolderToolbarActionWidgets(context, folder);
+    final isTemporary = ref.watch(temporaryChatEnabledProvider);
+    final menuItems = folder == null
+        ? const <AdaptivePopupMenuEntry>[]
+        : _buildFolderToolbarMenuItems(l10n);
+    void onMenuSelected(String action) {
+      if (folder != null) {
+        _handleFolderToolbarSelection(folder, action);
+      }
+    }
+
+    final actions = _buildFolderToolbarActionWidgets(
+      context,
+      folder: folder,
+      isTemporary: isTemporary,
+      menuItems: menuItems,
+      onMenuSelected: onMenuSelected,
+    );
+    final nativeMenuAction = folder == null
+        ? null
+        : buildConduitNativeToolbarMenuAction<String>(
+            iosSymbol: 'ellipsis',
+            accessibilityLabel: l10n.more,
+            tintColor: tintColor,
+            symbolSize: kConduitNativeToolbarSymbolExtent,
+            items: menuItems,
+            onSelected: onMenuSelected,
+          );
+    final nativeActions = <ConduitNativeToolbarAction>[
+      ConduitNativeToolbarAction(
+        iosSymbol: isTemporary ? 'eye.slash' : 'eye',
+        accessibilityLabel: l10n.temporaryChat,
+        tintColor: isTemporary ? Colors.blue : tintColor,
+        symbolSize: kConduitNativeVisibilitySymbolExtent,
+        onPressed: _toggleTemporaryChat,
+      ),
+      ConduitNativeToolbarAction(
+        iosSymbol: 'square.and.pencil',
+        accessibilityLabel: l10n.newChat,
+        tintColor: tintColor,
+        symbolSize: kConduitNativeToolbarSymbolExtent,
+        onPressed: _handleNewChat,
+      ),
+      ?nativeMenuAction,
+    ];
+    final useNativeActionGroup =
+        Platform.isIOS &&
+        conduitSupportsNativeGlass() &&
+        (folder == null || nativeMenuAction != null);
     final leadingWidth = resolveConduitAdaptiveToolbarLeadingWidth(
       pillWidth: maxModelWidth,
       leadingGap: leadingGap,
@@ -180,7 +228,9 @@ class _FolderPageState extends ConsumerState<FolderPage> {
       cupertinoNavigationBar: ConduitAdaptiveCupertinoNavigationBar(
         textScaler: textScaler,
         leading: leading,
-        trailing: Row(mainAxisSize: MainAxisSize.min, children: actions),
+        trailing: useNativeActionGroup
+            ? ConduitNativeToolbarActionGroup(actions: nativeActions)
+            : Row(mainAxisSize: MainAxisSize.min, children: actions),
         systemOverlayStyle: overlayStyle,
       ),
       appBar: AppBar(
@@ -232,10 +282,12 @@ class _FolderPageState extends ConsumerState<FolderPage> {
   }
 
   List<Widget> _buildFolderToolbarActionWidgets(
-    BuildContext context,
-    Folder? folder,
-  ) {
-    final isTemporary = ref.watch(temporaryChatEnabledProvider);
+    BuildContext context, {
+    required Folder? folder,
+    required bool isTemporary,
+    required List<AdaptivePopupMenuEntry> menuItems,
+    required ValueChanged<String> onMenuSelected,
+  }) {
     final actions = buildConduitAdaptiveToolbarActionWidgets([
       ConduitAdaptiveAppBarIconButton(
         key: const ValueKey<String>('folder-page-temp-button'),
@@ -243,11 +295,7 @@ class _FolderPageState extends ConsumerState<FolderPage> {
             ? (Platform.isIOS ? CupertinoIcons.eye_slash : Icons.visibility_off)
             : (Platform.isIOS ? CupertinoIcons.eye : Icons.visibility_outlined),
         iconColor: isTemporary ? Colors.blue : context.conduitTheme.textPrimary,
-        onPressed: () {
-          ConduitHaptics.selectionClick();
-          final current = ref.read(temporaryChatEnabledProvider);
-          ref.read(temporaryChatEnabledProvider.notifier).set(!current);
-        },
+        onPressed: _toggleTemporaryChat,
       ),
       ConduitAdaptiveAppBarIconButton(
         key: const ValueKey<String>('folder-page-new-chat-button'),
@@ -258,12 +306,40 @@ class _FolderPageState extends ConsumerState<FolderPage> {
       if (folder != null)
         _FolderToolbarPopupButton(
           tintColor: context.conduitTheme.textPrimary,
-          onSelected: (action) => _handleFolderToolbarSelection(folder, action),
+          items: menuItems,
+          onSelected: onMenuSelected,
         ),
     ]);
 
     return actions;
   }
+
+  void _toggleTemporaryChat() {
+    ConduitHaptics.selectionClick();
+    final current = ref.read(temporaryChatEnabledProvider);
+    ref.read(temporaryChatEnabledProvider.notifier).set(!current);
+  }
+
+  List<AdaptivePopupMenuEntry> _buildFolderToolbarMenuItems(
+    AppLocalizations l10n,
+  ) => [
+    AdaptivePopupMenuItem<String>(
+      value: 'edit-folder',
+      label: l10n.editFolder,
+      icon: conduitAdaptivePopupMenuIcon(
+        iosSymbol: 'pencil',
+        materialIcon: Icons.edit_outlined,
+      ),
+    ),
+    AdaptivePopupMenuItem<String>(
+      value: 'system-prompt',
+      label: l10n.systemPrompt,
+      icon: conduitAdaptivePopupMenuIcon(
+        iosSymbol: 'text.bubble',
+        materialIcon: Icons.notes_outlined,
+      ),
+    ),
+  ];
 
   void _handleFolderToolbarSelection(Folder folder, String action) {
     ConduitHaptics.selectionClick();
@@ -2173,37 +2249,21 @@ class _SectionHeader extends StatelessWidget {
 class _FolderToolbarPopupButton extends StatelessWidget {
   const _FolderToolbarPopupButton({
     required this.tintColor,
+    required this.items,
     required this.onSelected,
   });
 
   final Color tintColor;
+  final List<AdaptivePopupMenuEntry> items;
   final ValueChanged<String> onSelected;
 
   @override
   Widget build(BuildContext context) {
-    final l10n = AppLocalizations.of(context)!;
     return KeyedSubtree(
       key: const ValueKey<String>('folder-page-overflow-button'),
       child: ConduitAdaptiveToolbarOverflowButton<String>(
         tintColor: tintColor,
-        items: [
-          AdaptivePopupMenuItem<String>(
-            value: 'edit-folder',
-            label: l10n.editFolder,
-            icon: conduitAdaptivePopupMenuIcon(
-              iosSymbol: 'pencil',
-              materialIcon: Icons.edit_outlined,
-            ),
-          ),
-          AdaptivePopupMenuItem<String>(
-            value: 'system-prompt',
-            label: l10n.systemPrompt,
-            icon: conduitAdaptivePopupMenuIcon(
-              iosSymbol: 'text.bubble',
-              materialIcon: Icons.notes_outlined,
-            ),
-          ),
-        ],
+        items: items,
         onSelected: onSelected,
       ),
     );

--- a/lib/features/navigation/widgets/sidebar_user_pill.dart
+++ b/lib/features/navigation/widgets/sidebar_user_pill.dart
@@ -4,7 +4,7 @@ import 'dart:typed_data';
 
 import 'package:adaptive_platform_ui/adaptive_platform_ui.dart';
 import 'package:conduit/l10n/app_localizations.dart';
-import 'package:flutter/material.dart';
+import 'package:flutter/cupertino.dart';
 import 'package:flutter/services.dart' show rootBundle;
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
@@ -131,6 +131,46 @@ String sidebarSearchHintForActiveTab(WidgetRef ref, AppLocalizations l10n) {
   return l10n.searchConversations;
 }
 
+/// Builds a compact profile avatar without an iOS 26 child platform view.
+@visibleForTesting
+Widget buildSidebarProfileButton({
+  required bool supportsNativeGlass,
+  required VoidCallback onPressed,
+  required AdaptiveButtonStyle fallbackStyle,
+  Color? fallbackColor,
+  required Widget child,
+}) {
+  const buttonKey = ValueKey<String>('sidebar-profile-button');
+
+  if (supportsNativeGlass) {
+    // AdaptiveButton.child expands to the native toolbar's full leading slot
+    // on iOS 26. Keep the custom avatar Flutter-owned so it remains a compact
+    // tap target and does not add another persistent platform glass surface.
+    return SizedBox.square(
+      dimension: TouchTarget.minimum,
+      child: CupertinoButton(
+        key: buttonKey,
+        onPressed: onPressed,
+        padding: EdgeInsets.zero,
+        minimumSize: const Size.square(TouchTarget.minimum),
+        child: child,
+      ),
+    );
+  }
+
+  return AdaptiveButton.child(
+    key: buttonKey,
+    onPressed: onPressed,
+    style: fallbackStyle,
+    color: fallbackColor,
+    size: AdaptiveButtonSize.large,
+    padding: EdgeInsets.zero,
+    minSize: const Size(TouchTarget.minimum, TouchTarget.minimum),
+    useSmoothRectangleBorder: false,
+    child: child,
+  );
+}
+
 /// Profile button used as the sidebar adaptive app bar leading widget.
 class SidebarProfileAppBarLeading extends ConsumerWidget {
   const SidebarProfileAppBarLeading({super.key});
@@ -178,8 +218,8 @@ class SidebarProfileAppBarLeading extends ConsumerWidget {
     return Semantics(
       label: l10n.manage,
       button: true,
-      child: AdaptiveButton.child(
-        key: const ValueKey<String>('sidebar-profile-button'),
+      child: buildSidebarProfileButton(
+        supportsNativeGlass: conduitSupportsNativeGlass(),
         onPressed: () async {
           await Navigator.of(context).maybePop();
           if (!context.mounted) return;
@@ -214,12 +254,8 @@ class SidebarProfileAppBarLeading extends ConsumerWidget {
             );
           }
         },
-        style: style,
-        color: useOpaqueFallback ? iconColor : null,
-        size: AdaptiveButtonSize.large,
-        padding: EdgeInsets.zero,
-        minSize: const Size(TouchTarget.minimum, TouchTarget.minimum),
-        useSmoothRectangleBorder: false,
+        fallbackStyle: style,
+        fallbackColor: useOpaqueFallback ? iconColor : null,
         child: ClipRRect(
           borderRadius: BorderRadius.circular(AppBorderRadius.avatar),
           child: UserAvatar(

--- a/lib/shared/widgets/adaptive_toolbar_components.dart
+++ b/lib/shared/widgets/adaptive_toolbar_components.dart
@@ -770,7 +770,7 @@ class ConduitAdaptiveAppBarModelSelector extends StatelessWidget {
             // Only reserve chevron space when a chevron is actually rendered.
             trailingWidth: showChevron ? chevronSize + Spacing.xs : 0,
           );
-    final child = SizedBox(
+    Widget buildFallbackChild() => SizedBox(
       width: targetWidth,
       child: ConstrainedBox(
         constraints: BoxConstraints(minHeight: controlExtent),
@@ -820,7 +820,7 @@ class ConduitAdaptiveAppBarModelSelector extends StatelessWidget {
       return FloatingAppBarButton(
         onTap: (isLoading || !showChevron) ? null : onPressed,
         semanticLabel: label,
-        child: child,
+        child: buildFallbackChild(),
       );
     }
 
@@ -859,7 +859,7 @@ class ConduitAdaptiveAppBarModelSelector extends StatelessWidget {
               padding: EdgeInsets.zero,
               minSize: Size(targetWidth, controlExtent),
               useSmoothRectangleBorder: false,
-              child: child,
+              child: buildFallbackChild(),
             ),
     );
   }

--- a/lib/shared/widgets/adaptive_toolbar_components.dart
+++ b/lib/shared/widgets/adaptive_toolbar_components.dart
@@ -963,6 +963,24 @@ ValueKey<Object> conduitNativeModelSelectorViewKey(
   double titleFontSize = 17,
 }) => ValueKey<Object>((foregroundColor.toARGB32(), titleFontSize));
 
+/// Builds the native model-selector payload without truncating accessibility
+/// content that does not participate in UIKit layout measurement.
+Map<String, Object?> encodeConduitNativeModelSelectorParams({
+  required String label,
+  required String? symbolName,
+  required Color foregroundColor,
+  required double titleFontSize,
+  required bool enabled,
+}) => <String, Object?>{
+  'label': label,
+  'symbolName': symbolName,
+  'symbolSize': kConduitNativeModelChevronExtent,
+  'symbolPadding': _kConduitNativeModelChevronPadding,
+  'foregroundColor': foregroundColor.toARGB32(),
+  'titleFontSize': titleFontSize,
+  'enabled': enabled,
+};
+
 class _ConduitNativeModelSelectorButton extends StatefulWidget {
   const _ConduitNativeModelSelectorButton({
     super.key,
@@ -1020,15 +1038,13 @@ class _ConduitNativeModelSelectorButtonState
         widget.enabled,
       )),
       viewType: 'app.cogwheel.conduit/native_model_selector_button',
-      creationParams: <String, Object?>{
-        'label': widget.label,
-        'symbolName': widget.symbolName,
-        'symbolSize': kConduitNativeModelChevronExtent,
-        'symbolPadding': _kConduitNativeModelChevronPadding,
-        'foregroundColor': widget.foregroundColor.toARGB32(),
-        'titleFontSize': widget.titleFontSize,
-        'enabled': widget.enabled,
-      },
+      creationParams: encodeConduitNativeModelSelectorParams(
+        label: widget.label,
+        symbolName: widget.symbolName,
+        foregroundColor: widget.foregroundColor,
+        titleFontSize: widget.titleFontSize,
+        enabled: widget.enabled,
+      ),
       creationParamsCodec: const StandardMessageCodec(),
       onPlatformViewCreated: _handlePlatformViewCreated,
       gestureRecognizers: <Factory<OneSequenceGestureRecognizer>>{

--- a/lib/shared/widgets/adaptive_toolbar_components.dart
+++ b/lib/shared/widgets/adaptive_toolbar_components.dart
@@ -2,6 +2,8 @@ import 'dart:io' show Platform;
 
 import 'package:adaptive_platform_ui/adaptive_platform_ui.dart';
 import 'package:flutter/cupertino.dart';
+import 'package:flutter/foundation.dart' show Factory;
+import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 
@@ -20,10 +22,12 @@ const double kConduitNativeUtilitySymbolExtent = 17;
 const double kConduitNativePrimarySymbolExtent = 17;
 
 const double _kConduitNativeButtonHorizontalInsets = 32;
+const double _kConduitNativeModelChevronPadding = 6;
+const double _kConduitNativeModelChevronReservedWidth =
+    kConduitNativeToolbarSymbolExtent + _kConduitNativeModelChevronPadding;
 // Flutter and UIKit do not produce perfectly identical SF Pro advances. Keep
 // a small optical guard instead of letting UIButton wrap at the measured edge.
 const double _kConduitNativeModelTitleWrapGuard = 8;
-const String _kConduitNativeModelChevronSuffix = '  ⌄';
 const TextStyle _kConduitNativeModelTitleStyle = TextStyle(
   fontSize: 17,
   fontWeight: FontWeight.w600,
@@ -637,6 +641,9 @@ String _middleEllipsizeConduitNativeModelTitle({
 String _normalizedConduitNativeModelLabel(String label) =>
     label.replaceAll(RegExp(r'\s+'), ' ').trim();
 
+String? conduitNativeModelSelectorSymbol({required bool showChevron}) =>
+    showChevron ? 'chevron.down' : null;
+
 /// Width required by the package's native large label button, capped to the
 /// toolbar space Conduit can safely allocate.
 double resolveConduitNativeModelSelectorWidth({
@@ -652,11 +659,10 @@ double resolveConduitNativeModelSelectorWidth({
   if (isLoading) return safeMaxWidth.clamp(0.0, 104.0).toDouble();
 
   final safeMinWidth = minWidth.clamp(0.0, safeMaxWidth).toDouble();
-  final suffix = showChevron ? _kConduitNativeModelChevronSuffix : '';
   final normalizedLabel = _normalizedConduitNativeModelLabel(label);
   final desiredWidth =
       _measureConduitNativeModelTitle(normalizedLabel, textDirection) +
-      _measureConduitNativeModelTitle(suffix, textDirection) +
+      (showChevron ? _kConduitNativeModelChevronReservedWidth : 0) +
       _kConduitNativeButtonHorizontalInsets +
       _kConduitNativeModelTitleWrapGuard;
   return desiredWidth.clamp(safeMinWidth, safeMaxWidth).toDouble();
@@ -673,23 +679,20 @@ String resolveConduitNativeModelSelectorLabel({
 }) {
   if (isLoading) return '…';
 
-  final suffix = showChevron ? _kConduitNativeModelChevronSuffix : '';
   final normalizedLabel = _normalizedConduitNativeModelLabel(label);
-  final suffixWidth = _measureConduitNativeModelTitle(suffix, textDirection);
-  final contentWidth = availableWidth - _kConduitNativeButtonHorizontalInsets;
-  if (_measureConduitNativeModelTitle(normalizedLabel, textDirection) +
-          suffixWidth <=
+  final contentWidth =
+      availableWidth -
+      _kConduitNativeButtonHorizontalInsets -
+      (showChevron ? _kConduitNativeModelChevronReservedWidth : 0);
+  if (_measureConduitNativeModelTitle(normalizedLabel, textDirection) <=
       contentWidth) {
-    return '$normalizedLabel$suffix';
+    return normalizedLabel;
   }
-  final labelWidth =
-      contentWidth - suffixWidth - _kConduitNativeModelTitleWrapGuard;
-  final fittedLabel = _middleEllipsizeConduitNativeModelTitle(
+  return _middleEllipsizeConduitNativeModelTitle(
     value: normalizedLabel,
-    maxWidth: labelWidth,
+    maxWidth: contentWidth - _kConduitNativeModelTitleWrapGuard,
     textDirection: textDirection,
   );
-  return '$fittedLabel$suffix';
 }
 
 /// Forces the package-owned platform view to be recreated when its foreground
@@ -697,6 +700,77 @@ String resolveConduitNativeModelSelectorLabel({
 /// `didUpdateWidget`, so preserving the state would retain the previous theme.
 ValueKey<int> conduitNativeModelSelectorViewKey(Color foregroundColor) =>
     ValueKey<int>(foregroundColor.toARGB32());
+
+class _ConduitNativeModelSelectorButton extends StatefulWidget {
+  const _ConduitNativeModelSelectorButton({
+    super.key,
+    required this.label,
+    required this.symbolName,
+    required this.foregroundColor,
+    required this.enabled,
+    required this.onPressed,
+  });
+
+  final String label;
+  final String? symbolName;
+  final Color foregroundColor;
+  final bool enabled;
+  final VoidCallback onPressed;
+
+  @override
+  State<_ConduitNativeModelSelectorButton> createState() =>
+      _ConduitNativeModelSelectorButtonState();
+}
+
+class _ConduitNativeModelSelectorButtonState
+    extends State<_ConduitNativeModelSelectorButton> {
+  MethodChannel? _channel;
+
+  void _handlePlatformViewCreated(int id) {
+    _channel?.setMethodCallHandler(null);
+    final channel = MethodChannel(
+      'app.cogwheel.conduit/native_model_selector_button_$id',
+    );
+    _channel = channel;
+    channel.setMethodCallHandler((call) async {
+      if (call.method == 'pressed' && widget.enabled) {
+        widget.onPressed();
+      }
+    });
+  }
+
+  @override
+  void dispose() {
+    _channel?.setMethodCallHandler(null);
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return UiKitView(
+      key: ValueKey<Object>((
+        widget.label,
+        widget.symbolName,
+        widget.foregroundColor.toARGB32(),
+        widget.enabled,
+      )),
+      viewType: 'app.cogwheel.conduit/native_model_selector_button',
+      creationParams: <String, Object?>{
+        'label': widget.label,
+        'symbolName': widget.symbolName,
+        'symbolSize': kConduitNativeToolbarSymbolExtent,
+        'symbolPadding': _kConduitNativeModelChevronPadding,
+        'foregroundColor': widget.foregroundColor.toARGB32(),
+        'enabled': widget.enabled,
+      },
+      creationParamsCodec: const StandardMessageCodec(),
+      onPlatformViewCreated: _handlePlatformViewCreated,
+      gestureRecognizers: <Factory<OneSequenceGestureRecognizer>>{
+        Factory<TapGestureRecognizer>(() => TapGestureRecognizer()),
+      },
+    );
+  }
+}
 
 /// Adaptive model-selector control used by floating route toolbars.
 class ConduitAdaptiveAppBarModelSelector extends StatelessWidget {
@@ -832,24 +906,27 @@ class ConduitAdaptiveAppBarModelSelector extends StatelessWidget {
               button: true,
               enabled: !isLoading && showChevron,
               excludeSemantics: true,
-              child: AdaptiveButton(
-                key: conduitNativeModelSelectorViewKey(
-                  context.conduitTheme.textPrimary,
+              child: SizedBox(
+                width: targetWidth,
+                height: controlExtent,
+                child: _ConduitNativeModelSelectorButton(
+                  key: conduitNativeModelSelectorViewKey(
+                    context.conduitTheme.textPrimary,
+                  ),
+                  label: resolveConduitNativeModelSelectorLabel(
+                    label: label,
+                    isLoading: isLoading,
+                    showChevron: showChevron,
+                    availableWidth: targetWidth,
+                    textDirection: textDirection,
+                  ),
+                  symbolName: conduitNativeModelSelectorSymbol(
+                    showChevron: showChevron,
+                  ),
+                  foregroundColor: context.conduitTheme.textPrimary,
+                  enabled: !isLoading && showChevron,
+                  onPressed: onPressed,
                 ),
-                onPressed: (isLoading || !showChevron) ? null : onPressed,
-                label: resolveConduitNativeModelSelectorLabel(
-                  label: label,
-                  isLoading: isLoading,
-                  showChevron: showChevron,
-                  availableWidth: targetWidth,
-                  textDirection: textDirection,
-                ),
-                textColor: context.conduitTheme.textPrimary,
-                style: AdaptiveButtonStyle.glass,
-                size: AdaptiveButtonSize.large,
-                padding: EdgeInsets.zero,
-                minSize: Size(targetWidth, controlExtent),
-                useSmoothRectangleBorder: false,
               ),
             )
           : AdaptiveButton.child(

--- a/lib/shared/widgets/adaptive_toolbar_components.dart
+++ b/lib/shared/widgets/adaptive_toolbar_components.dart
@@ -18,7 +18,7 @@ import 'themed_sheets.dart';
 const double kConduitAdaptiveToolbarLeadingGap = Spacing.sm;
 const double kConduitAdaptiveToolbarMaxPillWidth = 220;
 const double kConduitMaximumSystemControlScale = 1.5;
-const double kConduitNativeToolbarSymbolExtent = 17;
+const double kConduitNativeToolbarSymbolExtent = 20;
 const double kConduitNativeGroupedToolbarSymbolExtent = 20;
 const double kConduitNativeUtilitySymbolExtent = 17;
 const double kConduitNativePrimarySymbolExtent = 17;

--- a/lib/shared/widgets/adaptive_toolbar_components.dart
+++ b/lib/shared/widgets/adaptive_toolbar_components.dart
@@ -18,8 +18,10 @@ import 'themed_sheets.dart';
 const double kConduitAdaptiveToolbarLeadingGap = Spacing.sm;
 const double kConduitAdaptiveToolbarMaxPillWidth = 220;
 const double kConduitMaximumSystemControlScale = 1.5;
-const double kConduitNativeToolbarSymbolExtent = 20;
-const double kConduitNativeGroupedToolbarSymbolExtent = 20;
+const double kConduitNativeSidebarSymbolExtent = 20;
+const double kConduitNativeToolbarSymbolExtent = 22;
+const double kConduitNativeGroupedToolbarSymbolExtent = 22;
+const double kConduitNativeVisibilitySymbolExtent = 18;
 const double kConduitNativeUtilitySymbolExtent = 17;
 const double kConduitNativePrimarySymbolExtent = 17;
 const double kConduitNativeModelChevronExtent = 13;
@@ -617,6 +619,7 @@ class ConduitNativeToolbarAction {
     this.onPressed,
     this.menuItems = const <ConduitNativeToolbarMenuItem>[],
     this.tintColor,
+    this.symbolSize,
     this.enabled = true,
   }) : assert(onPressed != null || menuItems.length > 0 || !enabled);
 
@@ -625,6 +628,7 @@ class ConduitNativeToolbarAction {
   final VoidCallback? onPressed;
   final List<ConduitNativeToolbarMenuItem> menuItems;
   final Color? tintColor;
+  final double? symbolSize;
   final bool enabled;
 }
 
@@ -638,6 +642,7 @@ List<Map<String, Object?>> encodeConduitNativeToolbarActions(
       'accessibilityLabel': action.accessibilityLabel,
       'enabled': action.enabled,
       if (action.tintColor != null) 'tintColor': action.tintColor!.toARGB32(),
+      if (action.symbolSize != null) 'symbolSize': action.symbolSize,
       if (action.menuItems.isNotEmpty)
         'menuItems': <Map<String, Object?>>[
           for (final item in action.menuItems)

--- a/lib/shared/widgets/adaptive_toolbar_components.dart
+++ b/lib/shared/widgets/adaptive_toolbar_components.dart
@@ -507,6 +507,16 @@ final Map<IconData, String> _kConduitToolbarSfSymbolByIcon = {
 String? conduitToolbarSfSymbolForIcon(IconData icon, {String? iosSymbol}) =>
     iosSymbol ?? _kConduitToolbarSfSymbolByIcon[icon];
 
+/// Resolves SF Symbol point sizes by optical footprint rather than applying a
+/// single numeric size to every toolbar glyph.
+double conduitNativeToolbarSymbolExtentFor(String? iosSymbol) =>
+    switch (iosSymbol) {
+      'line.3.horizontal' ||
+      'chevron.left' => kConduitNativeSidebarSymbolExtent,
+      'eye' || 'eye.slash' => kConduitNativeVisibilitySymbolExtent,
+      _ => kConduitNativeToolbarSymbolExtent,
+    };
+
 /// Adaptive floating app-bar icon button for route-level toolbar actions.
 class ConduitAdaptiveAppBarIconButton extends StatelessWidget {
   /// Creates an adaptive toolbar icon button.
@@ -516,7 +526,7 @@ class ConduitAdaptiveAppBarIconButton extends StatelessWidget {
     this.iosSymbol,
     this.onPressed,
     this.iconColor,
-    this.iosSymbolSize = kConduitNativeToolbarSymbolExtent,
+    this.iosSymbolSize,
   });
 
   /// Icon shown inside the control.
@@ -532,7 +542,7 @@ class ConduitAdaptiveAppBarIconButton extends StatelessWidget {
   final Color? iconColor;
 
   /// Native SF Symbol point size on iOS 26+.
-  final double iosSymbolSize;
+  final double? iosSymbolSize;
 
   @override
   Widget build(BuildContext context) {
@@ -543,6 +553,8 @@ class ConduitAdaptiveAppBarIconButton extends StatelessWidget {
       icon,
       iosSymbol: iosSymbol,
     );
+    final nativeSymbolExtent =
+        iosSymbolSize ?? conduitNativeToolbarSymbolExtentFor(nativeSymbol);
 
     if (conduitUsesOpaqueGlassFallback()) {
       return SizedBox.square(
@@ -566,7 +578,7 @@ class ConduitAdaptiveAppBarIconButton extends StatelessWidget {
               onPressed: onPressed,
               sfSymbol: SFSymbol(
                 nativeSymbol,
-                size: iosSymbolSize,
+                size: nativeSymbolExtent,
                 color: effectiveIconColor,
               ),
               style: AdaptiveButtonStyle.glass,
@@ -665,13 +677,10 @@ Map<String, Object?> encodeConduitNativeToolbarActionGroupParams(
   'symbolSize': kConduitNativeGroupedToolbarSymbolExtent,
 };
 
-/// A single native toolbar surface whose adjacent items share Liquid Glass.
-///
-/// This is intentionally used only for the two-action iOS 26 trailing group.
-/// Other action counts and platforms keep their existing Flutter controls.
+/// A native toolbar surface for one action or two adjacent shared actions.
 class ConduitNativeToolbarActionGroup extends StatefulWidget {
   const ConduitNativeToolbarActionGroup({super.key, required this.actions})
-    : assert(actions.length == 2);
+    : assert(actions.length == 1 || actions.length == 2);
 
   final List<ConduitNativeToolbarAction> actions;
 
@@ -690,6 +699,7 @@ class _ConduitNativeToolbarActionGroupState
       action.accessibilityLabel,
       action.enabled,
       action.tintColor?.toARGB32(),
+      action.symbolSize,
       for (final item in action.menuItems) ...[
         item.label,
         item.iosSymbol,
@@ -720,6 +730,7 @@ class _ConduitNativeToolbarActionGroupState
     switch (call.method) {
       case 'actionTapped':
         action.onPressed?.call();
+        return;
       case 'menuItemSelected':
         final itemIndex = arguments['itemIndex'];
         if (itemIndex is int &&
@@ -727,6 +738,7 @@ class _ConduitNativeToolbarActionGroupState
             itemIndex < action.menuItems.length) {
           action.menuItems[itemIndex].onSelected();
         }
+        return;
     }
   }
 
@@ -740,7 +752,9 @@ class _ConduitNativeToolbarActionGroupState
   @override
   Widget build(BuildContext context) {
     final controlExtent = conduitScaledControlExtent(context);
-    final width = (controlExtent * widget.actions.length) + Spacing.sm;
+    final width = widget.actions.length == 1
+        ? controlExtent
+        : (controlExtent * widget.actions.length) + Spacing.sm;
     final size = Size(width, controlExtent);
 
     return _hideNativeToolbarChromeWhileSheetCovered(
@@ -1238,10 +1252,52 @@ class ConduitAdaptiveToolbarOverflowButton<T> extends StatelessWidget {
     }
   }
 
+  List<ConduitNativeToolbarMenuItem>? _nativeMenuItems() {
+    final nativeItems = <ConduitNativeToolbarMenuItem>[];
+    for (final entry in items) {
+      if (entry is! AdaptivePopupMenuItem<T> ||
+          entry.value == null ||
+          entry.subtitle?.isNotEmpty == true ||
+          entry.imageBytes != null ||
+          (entry.icon != null && entry.icon is! String)) {
+        return null;
+      }
+      final value = entry.value as T;
+      nativeItems.add(
+        ConduitNativeToolbarMenuItem(
+          label: entry.label,
+          iosSymbol: entry.icon as String?,
+          isDestructive: entry.isDestructive,
+          enabled: entry.enabled,
+          onSelected: () => onSelected(value),
+        ),
+      );
+    }
+    return nativeItems.isEmpty ? null : nativeItems;
+  }
+
   @override
   Widget build(BuildContext context) {
     final controlExtent = conduitScaledControlExtent(context);
     final iconExtent = conduitScaledIconExtent(context, IconSize.appBar);
+    final nativeMenuItems = conduitSupportsNativeGlass()
+        ? _nativeMenuItems()
+        : null;
+    if (nativeMenuItems != null) {
+      return ConduitNativeToolbarActionGroup(
+        actions: [
+          ConduitNativeToolbarAction(
+            iosSymbol: iosIcon,
+            accessibilityLabel: MaterialLocalizations.of(
+              context,
+            ).moreButtonTooltip,
+            menuItems: nativeMenuItems,
+            tintColor: tintColor,
+            symbolSize: conduitNativeToolbarSymbolExtentFor(iosIcon),
+          ),
+        ],
+      );
+    }
     if (conduitUsesOpaqueGlassFallback()) {
       return AdaptivePopupMenuButton.widget<T>(
         items: items,

--- a/lib/shared/widgets/adaptive_toolbar_components.dart
+++ b/lib/shared/widgets/adaptive_toolbar_components.dart
@@ -1137,7 +1137,7 @@ class ConduitAdaptiveAppBarModelSelector extends StatelessWidget {
                           boundedLabel,
                           style: effectiveTextStyle,
                           textAlign: TextAlign.center,
-                          semanticsLabel: boundedLabel,
+                          semanticsLabel: label,
                           textHeightBehavior: const TextHeightBehavior(
                             applyHeightToFirstAscent: false,
                             applyHeightToLastDescent: false,
@@ -1168,7 +1168,7 @@ class ConduitAdaptiveAppBarModelSelector extends StatelessWidget {
           showChevron: showChevron,
           onPressed: onPressed,
         ),
-        semanticLabel: boundedLabel,
+        semanticLabel: label,
         child: buildFallbackChild(),
       );
     }
@@ -1177,7 +1177,7 @@ class ConduitAdaptiveAppBarModelSelector extends StatelessWidget {
       size: Size(targetWidth, controlExtent),
       child: usesNativeGlass
           ? Semantics(
-              label: boundedLabel,
+              label: label,
               button: true,
               enabled: !isLoading && showChevron,
               onTap: conduitNativeModelSelectorActivation(

--- a/lib/shared/widgets/adaptive_toolbar_components.dart
+++ b/lib/shared/widgets/adaptive_toolbar_components.dart
@@ -5,6 +5,7 @@ import 'package:flutter/cupertino.dart';
 import 'package:flutter/foundation.dart' show Factory;
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart' show PlatformViewHitTestBehavior;
 import 'package:flutter/services.dart';
 
 import '../theme/theme_extensions.dart';
@@ -18,6 +19,7 @@ const double kConduitAdaptiveToolbarLeadingGap = Spacing.sm;
 const double kConduitAdaptiveToolbarMaxPillWidth = 220;
 const double kConduitMaximumSystemControlScale = 1.5;
 const double kConduitNativeToolbarSymbolExtent = 17;
+const double kConduitNativeGroupedToolbarSymbolExtent = 20;
 const double kConduitNativeUtilitySymbolExtent = 17;
 const double kConduitNativePrimarySymbolExtent = 17;
 const double kConduitNativeModelChevronExtent = 13;
@@ -582,6 +584,173 @@ class ConduitAdaptiveAppBarIconButton extends StatelessWidget {
                 color: effectiveIconColor,
               ),
             ),
+    );
+  }
+}
+
+/// One native iOS toolbar menu item shown from a grouped trailing action.
+class ConduitNativeToolbarMenuItem {
+  const ConduitNativeToolbarMenuItem({
+    required this.label,
+    required this.onSelected,
+    this.iosSymbol,
+    this.isDestructive = false,
+    this.isChecked = false,
+    this.enabled = true,
+  });
+
+  final String label;
+  final String? iosSymbol;
+  final VoidCallback onSelected;
+  final bool isDestructive;
+  final bool isChecked;
+  final bool enabled;
+}
+
+/// One action in an iOS 26 toolbar group.
+class ConduitNativeToolbarAction {
+  const ConduitNativeToolbarAction({
+    required this.iosSymbol,
+    required this.accessibilityLabel,
+    this.onPressed,
+    this.menuItems = const <ConduitNativeToolbarMenuItem>[],
+    this.tintColor,
+    this.enabled = true,
+  }) : assert(onPressed != null || menuItems.length > 0 || !enabled);
+
+  final String iosSymbol;
+  final String accessibilityLabel;
+  final VoidCallback? onPressed;
+  final List<ConduitNativeToolbarMenuItem> menuItems;
+  final Color? tintColor;
+  final bool enabled;
+}
+
+/// Serializes native toolbar actions without leaking their Dart callbacks.
+List<Map<String, Object?>> encodeConduitNativeToolbarActions(
+  List<ConduitNativeToolbarAction> actions,
+) => [
+  for (final action in actions)
+    <String, Object?>{
+      'iosSymbol': action.iosSymbol,
+      'accessibilityLabel': action.accessibilityLabel,
+      'enabled': action.enabled,
+      if (action.tintColor != null) 'tintColor': action.tintColor!.toARGB32(),
+      if (action.menuItems.isNotEmpty)
+        'menuItems': <Map<String, Object?>>[
+          for (final item in action.menuItems)
+            <String, Object?>{
+              'label': item.label,
+              if (item.iosSymbol != null) 'iosSymbol': item.iosSymbol,
+              'isDestructive': item.isDestructive,
+              'isChecked': item.isChecked,
+              'enabled': item.enabled,
+            },
+        ],
+    },
+];
+
+/// Builds the native creation payload with navigation-bar optical sizing.
+Map<String, Object?> encodeConduitNativeToolbarActionGroupParams(
+  List<ConduitNativeToolbarAction> actions,
+) => <String, Object?>{
+  'actions': encodeConduitNativeToolbarActions(actions),
+  'symbolSize': kConduitNativeGroupedToolbarSymbolExtent,
+};
+
+/// A single native toolbar surface whose adjacent items share Liquid Glass.
+///
+/// This is intentionally used only for the two-action iOS 26 trailing group.
+/// Other action counts and platforms keep their existing Flutter controls.
+class ConduitNativeToolbarActionGroup extends StatefulWidget {
+  const ConduitNativeToolbarActionGroup({super.key, required this.actions})
+    : assert(actions.length == 2);
+
+  final List<ConduitNativeToolbarAction> actions;
+
+  @override
+  State<ConduitNativeToolbarActionGroup> createState() =>
+      _ConduitNativeToolbarActionGroupState();
+}
+
+class _ConduitNativeToolbarActionGroupState
+    extends State<ConduitNativeToolbarActionGroup> {
+  MethodChannel? _channel;
+
+  Object get _configurationKey => Object.hashAll([
+    for (final action in widget.actions) ...[
+      action.iosSymbol,
+      action.accessibilityLabel,
+      action.enabled,
+      action.tintColor?.toARGB32(),
+      for (final item in action.menuItems) ...[
+        item.label,
+        item.iosSymbol,
+        item.isDestructive,
+        item.isChecked,
+        item.enabled,
+      ],
+    ],
+  ]);
+
+  @override
+  void dispose() {
+    _channel?.setMethodCallHandler(null);
+    super.dispose();
+  }
+
+  Future<void> _handleMethodCall(MethodCall call) async {
+    final arguments = call.arguments;
+    if (arguments is! Map<Object?, Object?>) return;
+    final actionIndex = arguments['actionIndex'];
+    if (actionIndex is! int ||
+        actionIndex < 0 ||
+        actionIndex >= widget.actions.length) {
+      return;
+    }
+
+    final action = widget.actions[actionIndex];
+    switch (call.method) {
+      case 'actionTapped':
+        action.onPressed?.call();
+      case 'menuItemSelected':
+        final itemIndex = arguments['itemIndex'];
+        if (itemIndex is int &&
+            itemIndex >= 0 &&
+            itemIndex < action.menuItems.length) {
+          action.menuItems[itemIndex].onSelected();
+        }
+    }
+  }
+
+  void _onPlatformViewCreated(int id) {
+    _channel?.setMethodCallHandler(null);
+    _channel = MethodChannel(
+      'app.cogwheel.conduit/native_toolbar_action_group_$id',
+    )..setMethodCallHandler(_handleMethodCall);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final controlExtent = conduitScaledControlExtent(context);
+    final width = (controlExtent * widget.actions.length) + Spacing.sm;
+    final size = Size(width, controlExtent);
+
+    return _hideNativeToolbarChromeWhileSheetCovered(
+      size: size,
+      child: SizedBox.fromSize(
+        size: size,
+        child: UiKitView(
+          key: ValueKey<Object>(_configurationKey),
+          viewType: 'app.cogwheel.conduit/native_toolbar_action_group',
+          creationParams: encodeConduitNativeToolbarActionGroupParams(
+            widget.actions,
+          ),
+          creationParamsCodec: const StandardMessageCodec(),
+          onPlatformViewCreated: _onPlatformViewCreated,
+          hitTestBehavior: PlatformViewHitTestBehavior.opaque,
+        ),
+      ),
     );
   }
 }

--- a/lib/shared/widgets/adaptive_toolbar_components.dart
+++ b/lib/shared/widgets/adaptive_toolbar_components.dart
@@ -15,14 +15,15 @@ import 'themed_sheets.dart';
 const double kConduitAdaptiveToolbarLeadingGap = Spacing.sm;
 const double kConduitAdaptiveToolbarMaxPillWidth = 220;
 const double kConduitMaximumSystemControlScale = 1.5;
-const double kConduitNativeUtilitySymbolExtent = 20;
-const double kConduitNativePrimarySymbolExtent = 22;
+const double kConduitNativeToolbarSymbolExtent = 17;
+const double kConduitNativeUtilitySymbolExtent = 17;
+const double kConduitNativePrimarySymbolExtent = 17;
 
 const double _kConduitNativeButtonHorizontalInsets = 32;
 // Flutter and UIKit do not produce perfectly identical SF Pro advances. Keep
 // a small optical guard instead of letting UIButton wrap at the measured edge.
 const double _kConduitNativeModelTitleWrapGuard = 8;
-const String _kConduitNativeModelChevronSuffix = '  ▾';
+const String _kConduitNativeModelChevronSuffix = '  ⌄';
 const TextStyle _kConduitNativeModelTitleStyle = TextStyle(
   fontSize: 17,
   fontWeight: FontWeight.w600,
@@ -472,33 +473,28 @@ Object conduitAdaptivePopupMenuIcon({
 ///
 /// Callers may still provide [iosSymbol] explicitly for icons that do not have
 /// a stable cross-platform mapping.
-String? conduitToolbarSfSymbolForIcon(IconData icon, {String? iosSymbol}) {
-  if (iosSymbol != null) return iosSymbol;
-  if (icon == CupertinoIcons.line_horizontal_3 || icon == Icons.menu) {
-    return 'line.3.horizontal';
-  }
-  if (icon == CupertinoIcons.chevron_back ||
-      icon == CupertinoIcons.back ||
-      icon == Icons.arrow_back) {
-    return 'chevron.left';
-  }
-  if (icon == CupertinoIcons.create || icon == Icons.add_comment) {
-    return 'square.and.pencil';
-  }
-  if (icon == CupertinoIcons.add || icon == Icons.add) return 'plus';
-  if (icon == CupertinoIcons.eye || icon == Icons.visibility_outlined) {
-    return 'eye';
-  }
-  if (icon == CupertinoIcons.eye_slash || icon == Icons.visibility_off) {
-    return 'eye.slash';
-  }
-  if (icon == CupertinoIcons.arrow_down_doc || icon == Icons.save_alt) {
-    return 'arrow.down.doc';
-  }
-  if (icon == Icons.people_outline) return 'person.2';
-  if (icon == Icons.circle) return 'circle';
-  return null;
-}
+final Map<IconData, String> _kConduitToolbarSfSymbolByIcon = {
+  CupertinoIcons.line_horizontal_3: 'line.3.horizontal',
+  Icons.menu: 'line.3.horizontal',
+  CupertinoIcons.chevron_back: 'chevron.left',
+  CupertinoIcons.back: 'chevron.left',
+  Icons.arrow_back: 'chevron.left',
+  CupertinoIcons.create: 'square.and.pencil',
+  Icons.add_comment: 'square.and.pencil',
+  CupertinoIcons.add: 'plus',
+  Icons.add: 'plus',
+  CupertinoIcons.eye: 'eye',
+  Icons.visibility_outlined: 'eye',
+  CupertinoIcons.eye_slash: 'eye.slash',
+  Icons.visibility_off: 'eye.slash',
+  CupertinoIcons.arrow_down_doc: 'arrow.down.doc',
+  Icons.save_alt: 'arrow.down.doc',
+  Icons.people_outline: 'person.2',
+  Icons.circle: 'circle',
+};
+
+String? conduitToolbarSfSymbolForIcon(IconData icon, {String? iosSymbol}) =>
+    iosSymbol ?? _kConduitToolbarSfSymbolByIcon[icon];
 
 /// Adaptive floating app-bar icon button for route-level toolbar actions.
 class ConduitAdaptiveAppBarIconButton extends StatelessWidget {
@@ -509,6 +505,7 @@ class ConduitAdaptiveAppBarIconButton extends StatelessWidget {
     this.iosSymbol,
     this.onPressed,
     this.iconColor,
+    this.iosSymbolSize = kConduitNativeToolbarSymbolExtent,
   });
 
   /// Icon shown inside the control.
@@ -522,6 +519,9 @@ class ConduitAdaptiveAppBarIconButton extends StatelessWidget {
 
   /// Optional icon tint.
   final Color? iconColor;
+
+  /// Native SF Symbol point size on iOS 26+.
+  final double iosSymbolSize;
 
   @override
   Widget build(BuildContext context) {
@@ -555,7 +555,7 @@ class ConduitAdaptiveAppBarIconButton extends StatelessWidget {
               onPressed: onPressed,
               sfSymbol: SFSymbol(
                 nativeSymbol,
-                size: kConduitNativeUtilitySymbolExtent,
+                size: iosSymbolSize,
                 color: effectiveIconColor,
               ),
               style: AdaptiveButtonStyle.glass,

--- a/lib/shared/widgets/adaptive_toolbar_components.dart
+++ b/lib/shared/widgets/adaptive_toolbar_components.dart
@@ -20,11 +20,12 @@ const double kConduitMaximumSystemControlScale = 1.5;
 const double kConduitNativeToolbarSymbolExtent = 17;
 const double kConduitNativeUtilitySymbolExtent = 17;
 const double kConduitNativePrimarySymbolExtent = 17;
+const double kConduitNativeModelChevronExtent = 13;
 
 const double _kConduitNativeButtonHorizontalInsets = 32;
 const double _kConduitNativeModelChevronPadding = 6;
 const double _kConduitNativeModelChevronReservedWidth =
-    kConduitNativeToolbarSymbolExtent + _kConduitNativeModelChevronPadding;
+    kConduitNativeModelChevronExtent + _kConduitNativeModelChevronPadding;
 // Flutter and UIKit do not produce perfectly identical SF Pro advances. Keep
 // a small optical guard instead of letting UIButton wrap at the measured edge.
 const double _kConduitNativeModelTitleWrapGuard = 8;
@@ -758,7 +759,7 @@ class _ConduitNativeModelSelectorButtonState
       creationParams: <String, Object?>{
         'label': widget.label,
         'symbolName': widget.symbolName,
-        'symbolSize': kConduitNativeToolbarSymbolExtent,
+        'symbolSize': kConduitNativeModelChevronExtent,
         'symbolPadding': _kConduitNativeModelChevronPadding,
         'foregroundColor': widget.foregroundColor.toARGB32(),
         'enabled': widget.enabled,

--- a/lib/shared/widgets/adaptive_toolbar_components.dart
+++ b/lib/shared/widgets/adaptive_toolbar_components.dart
@@ -31,6 +31,8 @@ const double _kConduitNativeModelChevronReservedWidth =
 // Flutter and UIKit do not produce perfectly identical SF Pro advances. Keep
 // a small optical guard instead of letting UIButton wrap at the measured edge.
 const double _kConduitNativeModelTitleWrapGuard = 8;
+const int kConduitNativeModelLabelMaxCodeUnits = 256;
+const int _kConduitNativeModelLabelPrefixCodeUnits = 160;
 const TextStyle _kConduitNativeModelTitleStyle = TextStyle(
   fontSize: 17,
   fontWeight: FontWeight.w600,
@@ -755,12 +757,52 @@ class _ConduitNativeToolbarActionGroupState
   }
 }
 
+double resolveConduitNativeModelTitleFontSize(TextScaler textScaler) {
+  final scaledSize = textScaler.scale(_kConduitNativeModelTitleStyle.fontSize!);
+  if (!scaledSize.isFinite || scaledSize <= 0) {
+    return _kConduitNativeModelTitleStyle.fontSize!;
+  }
+  return scaledSize;
+}
+
+bool _isLeadingSurrogate(int codeUnit) =>
+    codeUnit >= 0xd800 && codeUnit <= 0xdbff;
+
+bool _isTrailingSurrogate(int codeUnit) =>
+    codeUnit >= 0xdc00 && codeUnit <= 0xdfff;
+
+/// Bounds backend-controlled model names before regex, layout, grapheme, or
+/// platform-channel work while preserving enough of both ends to distinguish
+/// namespaced model identifiers.
+String boundConduitNativeModelLabel(String value) {
+  if (value.length <= kConduitNativeModelLabelMaxCodeUnits) return value;
+
+  var prefixEnd = _kConduitNativeModelLabelPrefixCodeUnits;
+  if (_isLeadingSurrogate(value.codeUnitAt(prefixEnd - 1)) &&
+      _isTrailingSurrogate(value.codeUnitAt(prefixEnd))) {
+    prefixEnd -= 1;
+  }
+
+  final suffixBudget = kConduitNativeModelLabelMaxCodeUnits - prefixEnd - 1;
+  var suffixStart = value.length - suffixBudget;
+  if (_isTrailingSurrogate(value.codeUnitAt(suffixStart)) &&
+      _isLeadingSurrogate(value.codeUnitAt(suffixStart - 1))) {
+    suffixStart += 1;
+  }
+
+  return '${value.substring(0, prefixEnd)}…${value.substring(suffixStart)}';
+}
+
 double _measureConduitNativeModelTitle(
   String value,
   TextDirection textDirection,
+  double titleFontSize,
 ) {
   final painter = TextPainter(
-    text: TextSpan(text: value, style: _kConduitNativeModelTitleStyle),
+    text: TextSpan(
+      text: value,
+      style: _kConduitNativeModelTitleStyle.copyWith(fontSize: titleFontSize),
+    ),
     maxLines: 1,
     textScaler: TextScaler.noScaling,
     textDirection: textDirection,
@@ -774,14 +816,17 @@ String _middleEllipsizeConduitNativeModelTitle({
   required String value,
   required double maxWidth,
   required TextDirection textDirection,
+  required double titleFontSize,
 }) {
   if (value.isEmpty || maxWidth <= 0) return '';
-  if (_measureConduitNativeModelTitle(value, textDirection) <= maxWidth) {
+  if (_measureConduitNativeModelTitle(value, textDirection, titleFontSize) <=
+      maxWidth) {
     return value;
   }
 
   const ellipsis = '…';
-  if (_measureConduitNativeModelTitle(ellipsis, textDirection) > maxWidth) {
+  if (_measureConduitNativeModelTitle(ellipsis, textDirection, titleFontSize) >
+      maxWidth) {
     return '';
   }
 
@@ -798,7 +843,12 @@ String _middleEllipsizeConduitNativeModelTitle({
         ? ''
         : graphemes.takeLast(trailingCount).toString();
     final candidate = '$leading$ellipsis$trailing';
-    if (_measureConduitNativeModelTitle(candidate, textDirection) <= maxWidth) {
+    if (_measureConduitNativeModelTitle(
+          candidate,
+          textDirection,
+          titleFontSize,
+        ) <=
+        maxWidth) {
       best = candidate;
       low = visibleCount + 1;
     } else {
@@ -809,10 +859,16 @@ String _middleEllipsizeConduitNativeModelTitle({
 }
 
 String _normalizedConduitNativeModelLabel(String label) =>
-    label.replaceAll(RegExp(r'\s+'), ' ').trim();
+    boundConduitNativeModelLabel(label).replaceAll(RegExp(r'\s+'), ' ').trim();
 
 String? conduitNativeModelSelectorSymbol({required bool showChevron}) =>
     showChevron ? 'chevron.down' : null;
+
+VoidCallback? conduitNativeModelSelectorActivation({
+  required bool isLoading,
+  required bool showChevron,
+  required VoidCallback onPressed,
+}) => !isLoading && showChevron ? onPressed : null;
 
 /// Width required by the package's native large label button, capped to the
 /// toolbar space Conduit can safely allocate.
@@ -823,6 +879,7 @@ double resolveConduitNativeModelSelectorWidth({
   required double maxWidth,
   required TextDirection textDirection,
   double minWidth = 112,
+  double titleFontSize = 17,
 }) {
   final safeMaxWidth = maxWidth.clamp(0.0, double.infinity).toDouble();
   if (safeMaxWidth == 0) return 0;
@@ -831,7 +888,11 @@ double resolveConduitNativeModelSelectorWidth({
   final safeMinWidth = minWidth.clamp(0.0, safeMaxWidth).toDouble();
   final normalizedLabel = _normalizedConduitNativeModelLabel(label);
   final desiredWidth =
-      _measureConduitNativeModelTitle(normalizedLabel, textDirection) +
+      _measureConduitNativeModelTitle(
+        normalizedLabel,
+        textDirection,
+        titleFontSize,
+      ) +
       (showChevron ? _kConduitNativeModelChevronReservedWidth : 0) +
       _kConduitNativeButtonHorizontalInsets +
       _kConduitNativeModelTitleWrapGuard;
@@ -846,6 +907,7 @@ String resolveConduitNativeModelSelectorLabel({
   required bool showChevron,
   required double availableWidth,
   required TextDirection textDirection,
+  double titleFontSize = 17,
 }) {
   if (isLoading) return '…';
 
@@ -854,22 +916,33 @@ String resolveConduitNativeModelSelectorLabel({
       availableWidth -
       _kConduitNativeButtonHorizontalInsets -
       (showChevron ? _kConduitNativeModelChevronReservedWidth : 0);
-  if (_measureConduitNativeModelTitle(normalizedLabel, textDirection) <=
-      contentWidth) {
+  final guardedContentWidth =
+      (contentWidth - _kConduitNativeModelTitleWrapGuard)
+          .clamp(0.0, double.infinity)
+          .toDouble();
+  if (_measureConduitNativeModelTitle(
+        normalizedLabel,
+        textDirection,
+        titleFontSize,
+      ) <=
+      guardedContentWidth) {
     return normalizedLabel;
   }
   return _middleEllipsizeConduitNativeModelTitle(
     value: normalizedLabel,
-    maxWidth: contentWidth - _kConduitNativeModelTitleWrapGuard,
+    maxWidth: guardedContentWidth,
     textDirection: textDirection,
+    titleFontSize: titleFontSize,
   );
 }
 
 /// Forces the package-owned platform view to be recreated when its foreground
 /// changes. adaptive_platform_ui 0.1.110 does not synchronize `textColor` from
 /// `didUpdateWidget`, so preserving the state would retain the previous theme.
-ValueKey<int> conduitNativeModelSelectorViewKey(Color foregroundColor) =>
-    ValueKey<int>(foregroundColor.toARGB32());
+ValueKey<Object> conduitNativeModelSelectorViewKey(
+  Color foregroundColor, {
+  double titleFontSize = 17,
+}) => ValueKey<Object>((foregroundColor.toARGB32(), titleFontSize));
 
 class _ConduitNativeModelSelectorButton extends StatefulWidget {
   const _ConduitNativeModelSelectorButton({
@@ -877,6 +950,7 @@ class _ConduitNativeModelSelectorButton extends StatefulWidget {
     required this.label,
     required this.symbolName,
     required this.foregroundColor,
+    required this.titleFontSize,
     required this.enabled,
     required this.onPressed,
   });
@@ -884,6 +958,7 @@ class _ConduitNativeModelSelectorButton extends StatefulWidget {
   final String label;
   final String? symbolName;
   final Color foregroundColor;
+  final double titleFontSize;
   final bool enabled;
   final VoidCallback onPressed;
 
@@ -922,6 +997,7 @@ class _ConduitNativeModelSelectorButtonState
         widget.label,
         widget.symbolName,
         widget.foregroundColor.toARGB32(),
+        widget.titleFontSize,
         widget.enabled,
       )),
       viewType: 'app.cogwheel.conduit/native_model_selector_button',
@@ -931,6 +1007,7 @@ class _ConduitNativeModelSelectorButtonState
         'symbolSize': kConduitNativeModelChevronExtent,
         'symbolPadding': _kConduitNativeModelChevronPadding,
         'foregroundColor': widget.foregroundColor.toARGB32(),
+        'titleFontSize': widget.titleFontSize,
         'enabled': widget.enabled,
       },
       creationParamsCodec: const StandardMessageCodec(),
@@ -993,20 +1070,25 @@ class ConduitAdaptiveAppBarModelSelector extends StatelessWidget {
     );
     final usesNativeGlass = conduitSupportsNativeGlass();
     final textDirection = Directionality.of(context);
+    final nativeTitleFontSize = resolveConduitNativeModelTitleFontSize(
+      MediaQuery.textScalerOf(context),
+    );
+    final boundedLabel = boundConduitNativeModelLabel(label);
     const leadingPadding = 10.0;
     final targetWidth = isLoading
         ? safeMaxWidth.clamp(0.0, 104.0).toDouble()
         : usesNativeGlass
         ? resolveConduitNativeModelSelectorWidth(
-            label: label,
+            label: boundedLabel,
             isLoading: false,
             showChevron: showChevron,
             maxWidth: safeMaxWidth,
             textDirection: textDirection,
+            titleFontSize: nativeTitleFontSize,
           )
         : resolveConduitAdaptiveTextPillWidth(
             context: context,
-            label: label,
+            label: boundedLabel,
             textStyle: effectiveTextStyle,
             maxWidth: safeMaxWidth,
             minWidth: 96,
@@ -1033,10 +1115,10 @@ class ConduitAdaptiveAppBarModelSelector extends StatelessWidget {
                     children: [
                       Flexible(
                         child: MiddleEllipsisText(
-                          label,
+                          boundedLabel,
                           style: effectiveTextStyle,
                           textAlign: TextAlign.center,
-                          semanticsLabel: label,
+                          semanticsLabel: boundedLabel,
                           textHeightBehavior: const TextHeightBehavior(
                             applyHeightToFirstAscent: false,
                             applyHeightToLastDescent: false,
@@ -1062,8 +1144,12 @@ class ConduitAdaptiveAppBarModelSelector extends StatelessWidget {
 
     if (conduitUsesOpaqueGlassFallback()) {
       return FloatingAppBarButton(
-        onTap: (isLoading || !showChevron) ? null : onPressed,
-        semanticLabel: label,
+        onTap: conduitNativeModelSelectorActivation(
+          isLoading: isLoading,
+          showChevron: showChevron,
+          onPressed: onPressed,
+        ),
+        semanticLabel: boundedLabel,
         child: buildFallbackChild(),
       );
     }
@@ -1072,9 +1158,14 @@ class ConduitAdaptiveAppBarModelSelector extends StatelessWidget {
       size: Size(targetWidth, controlExtent),
       child: usesNativeGlass
           ? Semantics(
-              label: label,
+              label: boundedLabel,
               button: true,
               enabled: !isLoading && showChevron,
+              onTap: conduitNativeModelSelectorActivation(
+                isLoading: isLoading,
+                showChevron: showChevron,
+                onPressed: onPressed,
+              ),
               excludeSemantics: true,
               child: SizedBox(
                 width: targetWidth,
@@ -1082,25 +1173,32 @@ class ConduitAdaptiveAppBarModelSelector extends StatelessWidget {
                 child: _ConduitNativeModelSelectorButton(
                   key: conduitNativeModelSelectorViewKey(
                     context.conduitTheme.textPrimary,
+                    titleFontSize: nativeTitleFontSize,
                   ),
                   label: resolveConduitNativeModelSelectorLabel(
-                    label: label,
+                    label: boundedLabel,
                     isLoading: isLoading,
                     showChevron: showChevron,
                     availableWidth: targetWidth,
                     textDirection: textDirection,
+                    titleFontSize: nativeTitleFontSize,
                   ),
                   symbolName: conduitNativeModelSelectorSymbol(
                     showChevron: showChevron,
                   ),
                   foregroundColor: context.conduitTheme.textPrimary,
+                  titleFontSize: nativeTitleFontSize,
                   enabled: !isLoading && showChevron,
                   onPressed: onPressed,
                 ),
               ),
             )
           : AdaptiveButton.child(
-              onPressed: (isLoading || !showChevron) ? null : onPressed,
+              onPressed: conduitNativeModelSelectorActivation(
+                isLoading: isLoading,
+                showChevron: showChevron,
+                onPressed: onPressed,
+              ),
               style: AdaptiveButtonStyle.glass,
               size: AdaptiveButtonSize.large,
               padding: EdgeInsets.zero,

--- a/lib/shared/widgets/adaptive_toolbar_components.dart
+++ b/lib/shared/widgets/adaptive_toolbar_components.dart
@@ -15,6 +15,18 @@ import 'themed_sheets.dart';
 const double kConduitAdaptiveToolbarLeadingGap = Spacing.sm;
 const double kConduitAdaptiveToolbarMaxPillWidth = 220;
 const double kConduitMaximumSystemControlScale = 1.5;
+const double kConduitNativeUtilitySymbolExtent = 20;
+const double kConduitNativePrimarySymbolExtent = 22;
+
+const double _kConduitNativeButtonHorizontalInsets = 32;
+// Flutter and UIKit do not produce perfectly identical SF Pro advances. Keep
+// a small optical guard instead of letting UIButton wrap at the measured edge.
+const double _kConduitNativeModelTitleWrapGuard = 8;
+const String _kConduitNativeModelChevronSuffix = '  ▾';
+const TextStyle _kConduitNativeModelTitleStyle = TextStyle(
+  fontSize: 17,
+  fontWeight: FontWeight.w600,
+);
 
 /// Converts Dynamic Type into bounded control geometry.
 ///
@@ -267,6 +279,7 @@ Widget _buildMaterialToolbarAction(
 
   return ConduitAdaptiveAppBarIconButton(
     icon: action.icon ?? Icons.circle,
+    iosSymbol: action.iosSymbol,
     onPressed: action.onPressed,
     iconColor: tintColor,
   );
@@ -455,18 +468,54 @@ Object conduitAdaptivePopupMenuIcon({
   return Platform.isIOS ? iosSymbol : materialIcon;
 }
 
+/// Resolves the native SF Symbol used by Conduit's common toolbar actions.
+///
+/// Callers may still provide [iosSymbol] explicitly for icons that do not have
+/// a stable cross-platform mapping.
+String? conduitToolbarSfSymbolForIcon(IconData icon, {String? iosSymbol}) {
+  if (iosSymbol != null) return iosSymbol;
+  if (icon == CupertinoIcons.line_horizontal_3 || icon == Icons.menu) {
+    return 'line.3.horizontal';
+  }
+  if (icon == CupertinoIcons.chevron_back ||
+      icon == CupertinoIcons.back ||
+      icon == Icons.arrow_back) {
+    return 'chevron.left';
+  }
+  if (icon == CupertinoIcons.create || icon == Icons.add_comment) {
+    return 'square.and.pencil';
+  }
+  if (icon == CupertinoIcons.add || icon == Icons.add) return 'plus';
+  if (icon == CupertinoIcons.eye || icon == Icons.visibility_outlined) {
+    return 'eye';
+  }
+  if (icon == CupertinoIcons.eye_slash || icon == Icons.visibility_off) {
+    return 'eye.slash';
+  }
+  if (icon == CupertinoIcons.arrow_down_doc || icon == Icons.save_alt) {
+    return 'arrow.down.doc';
+  }
+  if (icon == Icons.people_outline) return 'person.2';
+  if (icon == Icons.circle) return 'circle';
+  return null;
+}
+
 /// Adaptive floating app-bar icon button for route-level toolbar actions.
 class ConduitAdaptiveAppBarIconButton extends StatelessWidget {
   /// Creates an adaptive toolbar icon button.
   const ConduitAdaptiveAppBarIconButton({
     super.key,
     required this.icon,
+    this.iosSymbol,
     this.onPressed,
     this.iconColor,
   });
 
   /// Icon shown inside the control.
   final IconData icon;
+
+  /// Native SF Symbol rendered on iOS 26+.
+  final String? iosSymbol;
 
   /// Invoked when the control is tapped.
   final VoidCallback? onPressed;
@@ -479,6 +528,10 @@ class ConduitAdaptiveAppBarIconButton extends StatelessWidget {
     final effectiveIconColor = iconColor ?? context.conduitTheme.textPrimary;
     final controlExtent = conduitScaledControlExtent(context);
     final iconExtent = conduitScaledIconExtent(context, IconSize.appBar);
+    final nativeSymbol = conduitToolbarSfSymbolForIcon(
+      icon,
+      iosSymbol: iosSymbol,
+    );
 
     if (conduitUsesOpaqueGlassFallback()) {
       return SizedBox.square(
@@ -497,22 +550,153 @@ class ConduitAdaptiveAppBarIconButton extends StatelessWidget {
 
     return _hideNativeToolbarChromeWhileSheetCovered(
       size: Size.square(controlExtent),
-      child: AdaptiveButton.child(
-        onPressed: onPressed,
-        style: AdaptiveButtonStyle.glass,
-        size: AdaptiveButtonSize.large,
-        padding: EdgeInsets.zero,
-        minSize: Size.square(controlExtent),
-        useSmoothRectangleBorder: false,
-        child: ConduitSystemAdaptiveIcon(
-          icon,
-          size: iconExtent,
-          color: effectiveIconColor,
-        ),
-      ),
+      child: conduitSupportsNativeGlass() && nativeSymbol != null
+          ? AdaptiveButton.sfSymbol(
+              onPressed: onPressed,
+              sfSymbol: SFSymbol(
+                nativeSymbol,
+                size: kConduitNativeUtilitySymbolExtent,
+                color: effectiveIconColor,
+              ),
+              style: AdaptiveButtonStyle.glass,
+              size: AdaptiveButtonSize.large,
+              padding: EdgeInsets.zero,
+              minSize: Size.square(controlExtent),
+              useSmoothRectangleBorder: false,
+            )
+          : AdaptiveButton.child(
+              onPressed: onPressed,
+              style: AdaptiveButtonStyle.glass,
+              size: AdaptiveButtonSize.large,
+              padding: EdgeInsets.zero,
+              minSize: Size.square(controlExtent),
+              useSmoothRectangleBorder: false,
+              child: ConduitSystemAdaptiveIcon(
+                icon,
+                size: iconExtent,
+                color: effectiveIconColor,
+              ),
+            ),
     );
   }
 }
+
+double _measureConduitNativeModelTitle(
+  String value,
+  TextDirection textDirection,
+) {
+  final painter = TextPainter(
+    text: TextSpan(text: value, style: _kConduitNativeModelTitleStyle),
+    maxLines: 1,
+    textScaler: TextScaler.noScaling,
+    textDirection: textDirection,
+  )..layout(minWidth: 0, maxWidth: double.infinity);
+  final width = painter.width;
+  painter.dispose();
+  return width;
+}
+
+String _middleEllipsizeConduitNativeModelTitle({
+  required String value,
+  required double maxWidth,
+  required TextDirection textDirection,
+}) {
+  if (value.isEmpty || maxWidth <= 0) return '';
+  if (_measureConduitNativeModelTitle(value, textDirection) <= maxWidth) {
+    return value;
+  }
+
+  const ellipsis = '…';
+  if (_measureConduitNativeModelTitle(ellipsis, textDirection) > maxWidth) {
+    return '';
+  }
+
+  final graphemes = value.characters;
+  var low = 0;
+  var high = graphemes.length;
+  var best = ellipsis;
+  while (low <= high) {
+    final visibleCount = (low + high) >> 1;
+    final leadingCount = (visibleCount + 1) >> 1;
+    final trailingCount = visibleCount - leadingCount;
+    final leading = graphemes.take(leadingCount).toString();
+    final trailing = trailingCount == 0
+        ? ''
+        : graphemes.takeLast(trailingCount).toString();
+    final candidate = '$leading$ellipsis$trailing';
+    if (_measureConduitNativeModelTitle(candidate, textDirection) <= maxWidth) {
+      best = candidate;
+      low = visibleCount + 1;
+    } else {
+      high = visibleCount - 1;
+    }
+  }
+  return best;
+}
+
+String _normalizedConduitNativeModelLabel(String label) =>
+    label.replaceAll(RegExp(r'\s+'), ' ').trim();
+
+/// Width required by the package's native large label button, capped to the
+/// toolbar space Conduit can safely allocate.
+double resolveConduitNativeModelSelectorWidth({
+  required String label,
+  required bool isLoading,
+  required bool showChevron,
+  required double maxWidth,
+  required TextDirection textDirection,
+  double minWidth = 112,
+}) {
+  final safeMaxWidth = maxWidth.clamp(0.0, double.infinity).toDouble();
+  if (safeMaxWidth == 0) return 0;
+  if (isLoading) return safeMaxWidth.clamp(0.0, 104.0).toDouble();
+
+  final safeMinWidth = minWidth.clamp(0.0, safeMaxWidth).toDouble();
+  final suffix = showChevron ? _kConduitNativeModelChevronSuffix : '';
+  final normalizedLabel = _normalizedConduitNativeModelLabel(label);
+  final desiredWidth =
+      _measureConduitNativeModelTitle(normalizedLabel, textDirection) +
+      _measureConduitNativeModelTitle(suffix, textDirection) +
+      _kConduitNativeButtonHorizontalInsets +
+      _kConduitNativeModelTitleWrapGuard;
+  return desiredWidth.clamp(safeMinWidth, safeMaxWidth).toDouble();
+}
+
+/// Produces a single-line native button title while retaining both ends of a
+/// long model name and reserving the trailing disclosure chevron.
+String resolveConduitNativeModelSelectorLabel({
+  required String label,
+  required bool isLoading,
+  required bool showChevron,
+  required double availableWidth,
+  required TextDirection textDirection,
+}) {
+  if (isLoading) return '…';
+
+  final suffix = showChevron ? _kConduitNativeModelChevronSuffix : '';
+  final normalizedLabel = _normalizedConduitNativeModelLabel(label);
+  final suffixWidth = _measureConduitNativeModelTitle(suffix, textDirection);
+  final contentWidth = availableWidth - _kConduitNativeButtonHorizontalInsets;
+  if (_measureConduitNativeModelTitle(normalizedLabel, textDirection) +
+          suffixWidth <=
+      contentWidth) {
+    return '$normalizedLabel$suffix';
+  }
+  final labelWidth =
+      contentWidth - suffixWidth - _kConduitNativeModelTitleWrapGuard;
+  final fittedLabel = _middleEllipsizeConduitNativeModelTitle(
+    value: normalizedLabel,
+    maxWidth: labelWidth,
+    textDirection: textDirection,
+  );
+  return '$fittedLabel$suffix';
+}
+
+/// Forces the package-owned platform view to be recreated when its foreground
+/// changes. adaptive_platform_ui 0.1.110 does not synchronize `textColor` from
+/// `didUpdateWidget`, so preserving the state would retain the previous theme.
+ValueKey<int> conduitNativeModelSelectorViewKey(Color foregroundColor) =>
+    ValueKey<int>(foregroundColor.toARGB32());
 
 /// Adaptive model-selector control used by floating route toolbars.
 class ConduitAdaptiveAppBarModelSelector extends StatelessWidget {
@@ -563,9 +747,19 @@ class ConduitAdaptiveAppBarModelSelector extends StatelessWidget {
       context,
       Platform.isIOS ? IconSize.small : IconSize.medium,
     );
+    final usesNativeGlass = conduitSupportsNativeGlass();
+    final textDirection = Directionality.of(context);
     const leadingPadding = 10.0;
     final targetWidth = isLoading
         ? safeMaxWidth.clamp(0.0, 104.0).toDouble()
+        : usesNativeGlass
+        ? resolveConduitNativeModelSelectorWidth(
+            label: label,
+            isLoading: false,
+            showChevron: showChevron,
+            maxWidth: safeMaxWidth,
+            textDirection: textDirection,
+          )
         : resolveConduitAdaptiveTextPillWidth(
             context: context,
             label: label,
@@ -632,15 +826,41 @@ class ConduitAdaptiveAppBarModelSelector extends StatelessWidget {
 
     return _hideNativeToolbarChromeWhileSheetCovered(
       size: Size(targetWidth, controlExtent),
-      child: AdaptiveButton.child(
-        onPressed: (isLoading || !showChevron) ? null : onPressed,
-        style: AdaptiveButtonStyle.glass,
-        size: AdaptiveButtonSize.large,
-        padding: EdgeInsets.zero,
-        minSize: Size(targetWidth, controlExtent),
-        useSmoothRectangleBorder: false,
-        child: child,
-      ),
+      child: usesNativeGlass
+          ? Semantics(
+              label: label,
+              button: true,
+              enabled: !isLoading && showChevron,
+              excludeSemantics: true,
+              child: AdaptiveButton(
+                key: conduitNativeModelSelectorViewKey(
+                  context.conduitTheme.textPrimary,
+                ),
+                onPressed: (isLoading || !showChevron) ? null : onPressed,
+                label: resolveConduitNativeModelSelectorLabel(
+                  label: label,
+                  isLoading: isLoading,
+                  showChevron: showChevron,
+                  availableWidth: targetWidth,
+                  textDirection: textDirection,
+                ),
+                textColor: context.conduitTheme.textPrimary,
+                style: AdaptiveButtonStyle.glass,
+                size: AdaptiveButtonSize.large,
+                padding: EdgeInsets.zero,
+                minSize: Size(targetWidth, controlExtent),
+                useSmoothRectangleBorder: false,
+              ),
+            )
+          : AdaptiveButton.child(
+              onPressed: (isLoading || !showChevron) ? null : onPressed,
+              style: AdaptiveButtonStyle.glass,
+              size: AdaptiveButtonSize.large,
+              padding: EdgeInsets.zero,
+              minSize: Size(targetWidth, controlExtent),
+              useSmoothRectangleBorder: false,
+              child: child,
+            ),
     );
   }
 }

--- a/lib/shared/widgets/adaptive_toolbar_components.dart
+++ b/lib/shared/widgets/adaptive_toolbar_components.dart
@@ -677,10 +677,10 @@ Map<String, Object?> encodeConduitNativeToolbarActionGroupParams(
   'symbolSize': kConduitNativeGroupedToolbarSymbolExtent,
 };
 
-/// A native toolbar surface for one action or two adjacent shared actions.
+/// A native toolbar surface for one to three adjacent shared actions.
 class ConduitNativeToolbarActionGroup extends StatefulWidget {
   const ConduitNativeToolbarActionGroup({super.key, required this.actions})
-    : assert(actions.length == 1 || actions.length == 2);
+    : assert(actions.length >= 1 && actions.length <= 3);
 
   final List<ConduitNativeToolbarAction> actions;
 
@@ -1252,51 +1252,24 @@ class ConduitAdaptiveToolbarOverflowButton<T> extends StatelessWidget {
     }
   }
 
-  List<ConduitNativeToolbarMenuItem>? _nativeMenuItems() {
-    final nativeItems = <ConduitNativeToolbarMenuItem>[];
-    for (final entry in items) {
-      if (entry is! AdaptivePopupMenuItem<T> ||
-          entry.value == null ||
-          entry.subtitle?.isNotEmpty == true ||
-          entry.imageBytes != null ||
-          (entry.icon != null && entry.icon is! String)) {
-        return null;
-      }
-      final value = entry.value as T;
-      nativeItems.add(
-        ConduitNativeToolbarMenuItem(
-          label: entry.label,
-          iosSymbol: entry.icon as String?,
-          isDestructive: entry.isDestructive,
-          enabled: entry.enabled,
-          onSelected: () => onSelected(value),
-        ),
-      );
-    }
-    return nativeItems.isEmpty ? null : nativeItems;
-  }
-
   @override
   Widget build(BuildContext context) {
     final controlExtent = conduitScaledControlExtent(context);
     final iconExtent = conduitScaledIconExtent(context, IconSize.appBar);
-    final nativeMenuItems = conduitSupportsNativeGlass()
-        ? _nativeMenuItems()
-        : null;
-    if (nativeMenuItems != null) {
-      return ConduitNativeToolbarActionGroup(
-        actions: [
-          ConduitNativeToolbarAction(
+    final nativeMenuAction = conduitSupportsNativeGlass()
+        ? buildConduitNativeToolbarMenuAction<T>(
             iosSymbol: iosIcon,
             accessibilityLabel: MaterialLocalizations.of(
               context,
             ).moreButtonTooltip,
-            menuItems: nativeMenuItems,
             tintColor: tintColor,
             symbolSize: conduitNativeToolbarSymbolExtentFor(iosIcon),
-          ),
-        ],
-      );
+            items: items,
+            onSelected: onSelected,
+          )
+        : null;
+    if (nativeMenuAction != null) {
+      return ConduitNativeToolbarActionGroup(actions: [nativeMenuAction]);
     }
     if (conduitUsesOpaqueGlassFallback()) {
       return AdaptivePopupMenuButton.widget<T>(
@@ -1328,4 +1301,48 @@ class ConduitAdaptiveToolbarOverflowButton<T> extends StatelessWidget {
       ),
     );
   }
+}
+
+/// Converts simple adaptive popup entries into one native toolbar menu action.
+///
+/// Entries with subtitles, images, dividers, non-SF-Symbol icons, or null
+/// values keep the package popup fallback because UIKit cannot reproduce those
+/// trigger/menu contracts through this compact adapter.
+ConduitNativeToolbarAction? buildConduitNativeToolbarMenuAction<T>({
+  required String iosSymbol,
+  required String accessibilityLabel,
+  required Color tintColor,
+  required double symbolSize,
+  required List<AdaptivePopupMenuEntry> items,
+  required ValueChanged<T> onSelected,
+}) {
+  final nativeItems = <ConduitNativeToolbarMenuItem>[];
+  for (final entry in items) {
+    if (entry is! AdaptivePopupMenuItem<T> ||
+        entry.value == null ||
+        entry.subtitle?.isNotEmpty == true ||
+        entry.imageBytes != null ||
+        (entry.icon != null && entry.icon is! String)) {
+      return null;
+    }
+    final value = entry.value as T;
+    nativeItems.add(
+      ConduitNativeToolbarMenuItem(
+        label: entry.label,
+        iosSymbol: entry.icon as String?,
+        isDestructive: entry.isDestructive,
+        enabled: entry.enabled,
+        onSelected: () => onSelected(value),
+      ),
+    );
+  }
+  if (nativeItems.isEmpty) return null;
+
+  return ConduitNativeToolbarAction(
+    iosSymbol: iosSymbol,
+    accessibilityLabel: accessibilityLabel,
+    menuItems: nativeItems,
+    tintColor: tintColor,
+    symbolSize: symbolSize,
+  );
 }

--- a/test/features/chat/widgets/modern_chat_input_direct_test.dart
+++ b/test/features/chat/widgets/modern_chat_input_direct_test.dart
@@ -21,6 +21,15 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
+  test('native composer glass uses non-animated cursor opacity', () {
+    check(
+      composerCursorOpacityAnimates(usesNativePlatformView: true),
+    ).equals(false);
+    check(
+      composerCursorOpacityAnimates(usesNativePlatformView: false),
+    ).equals(true);
+  });
+
   test('composer measurement style matches recording typography', () {
     final recordingStyle = ModernChatInput.debugComposerInputTextStyle(
       isRecording: true,

--- a/test/features/chat/widgets/modern_chat_input_direct_test.dart
+++ b/test/features/chat/widgets/modern_chat_input_direct_test.dart
@@ -13,6 +13,7 @@ import 'package:conduit/features/chat/widgets/modern_chat_input.dart';
 import 'package:conduit/features/direct_connections/direct_connections.dart';
 import 'package:conduit/l10n/app_localizations.dart';
 import 'package:conduit/shared/theme/theme_extensions.dart';
+import 'package:conduit/shared/widgets/adaptive_toolbar_components.dart';
 import 'package:conduit/shared/widgets/themed_sheets.dart';
 import 'package:adaptive_platform_ui/adaptive_platform_ui.dart';
 import 'package:checks/checks.dart';
@@ -30,48 +31,64 @@ void main() {
     ).equals(true);
   });
 
-  test('native composer hides the blinking caret under its selection menu', () {
+  test('iOS composer uses the native system edit menu when supported', () {
     check(
-      composerShowsCursor(
-        usesNativePlatformView: true,
-        selectionMenuVisible: true,
+      composerUsesNativeSystemSelectionMenu(
+        isIOS: true,
+        systemMenuSupported: true,
+      ),
+    ).isTrue();
+    check(
+      composerUsesNativeSystemSelectionMenu(
+        isIOS: true,
+        systemMenuSupported: false,
       ),
     ).isFalse();
     check(
-      composerShowsCursor(
-        usesNativePlatformView: true,
-        selectionMenuVisible: false,
+      composerUsesNativeSystemSelectionMenu(
+        isIOS: false,
+        systemMenuSupported: true,
       ),
-    ).isTrue();
-    check(
-      composerShowsCursor(
-        usesNativePlatformView: false,
-        selectionMenuVisible: true,
-      ),
-    ).isTrue();
+    ).isFalse();
   });
 
-  testWidgets('composer selection menu reports mount and removal', (
-    tester,
-  ) async {
-    final visibility = <bool>[];
-
-    await tester.pumpWidget(
-      MaterialApp(
-        home: buildComposerSelectionMenuLifecycle(
-          onVisibilityChanged: visibility.add,
-          child: const SizedBox.shrink(),
-        ),
+  test('native toolbar action groups preserve action and menu order', () {
+    final actions = [
+      ConduitNativeToolbarAction(
+        iosSymbol: 'square.and.pencil',
+        accessibilityLabel: 'New Chat',
+        onPressed: () {},
       ),
-    );
-    await tester.pump();
+      ConduitNativeToolbarAction(
+        iosSymbol: 'ellipsis',
+        accessibilityLabel: 'More',
+        menuItems: [
+          ConduitNativeToolbarMenuItem(
+            label: 'Rename',
+            iosSymbol: 'pencil',
+            onSelected: () {},
+          ),
+          ConduitNativeToolbarMenuItem(
+            label: 'Delete',
+            iosSymbol: 'trash',
+            isDestructive: true,
+            onSelected: () {},
+          ),
+        ],
+      ),
+    ];
+    final creationParams = encodeConduitNativeToolbarActionGroupParams(actions);
+    final params = creationParams['actions']! as List<Map<String, Object?>>;
 
-    check(visibility).deepEquals(<bool>[true]);
-
-    await tester.pumpWidget(const MaterialApp(home: SizedBox.shrink()));
-    await tester.pump();
-
-    check(visibility).deepEquals(<bool>[true, false]);
+    check(creationParams['symbolSize']).equals(20.0);
+    check(params.length).equals(2);
+    check(params[0]['iosSymbol']).equals('square.and.pencil');
+    check(params[1]['iosSymbol']).equals('ellipsis');
+    final menuItems = params[1]['menuItems']! as List<Map<String, Object?>>;
+    check(
+      menuItems.map((item) => item['label']),
+    ).deepEquals(['Rename', 'Delete']);
+    check(menuItems[1]['isDestructive']).equals(true);
   });
 
   test('composer measurement style matches recording typography', () {

--- a/test/features/chat/widgets/modern_chat_input_direct_test.dart
+++ b/test/features/chat/widgets/modern_chat_input_direct_test.dart
@@ -30,6 +30,50 @@ void main() {
     ).equals(true);
   });
 
+  test('native composer hides the blinking caret under its selection menu', () {
+    check(
+      composerShowsCursor(
+        usesNativePlatformView: true,
+        selectionMenuVisible: true,
+      ),
+    ).isFalse();
+    check(
+      composerShowsCursor(
+        usesNativePlatformView: true,
+        selectionMenuVisible: false,
+      ),
+    ).isTrue();
+    check(
+      composerShowsCursor(
+        usesNativePlatformView: false,
+        selectionMenuVisible: true,
+      ),
+    ).isTrue();
+  });
+
+  testWidgets('composer selection menu reports mount and removal', (
+    tester,
+  ) async {
+    final visibility = <bool>[];
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: buildComposerSelectionMenuLifecycle(
+          onVisibilityChanged: visibility.add,
+          child: const SizedBox.shrink(),
+        ),
+      ),
+    );
+    await tester.pump();
+
+    check(visibility).deepEquals(<bool>[true]);
+
+    await tester.pumpWidget(const MaterialApp(home: SizedBox.shrink()));
+    await tester.pump();
+
+    check(visibility).deepEquals(<bool>[true, false]);
+  });
+
   test('composer measurement style matches recording typography', () {
     final recordingStyle = ModernChatInput.debugComposerInputTextStyle(
       isRecording: true,

--- a/test/features/chat/widgets/modern_chat_input_direct_test.dart
+++ b/test/features/chat/widgets/modern_chat_input_direct_test.dart
@@ -118,6 +118,28 @@ void main() {
     check(menuItems[1]['isDestructive']).equals(true);
   });
 
+  test('native toolbar action groups support one optical-sized menu', () {
+    final params = encodeConduitNativeToolbarActionGroupParams([
+      ConduitNativeToolbarAction(
+        iosSymbol: 'ellipsis',
+        accessibilityLabel: 'More',
+        symbolSize: kConduitNativeToolbarSymbolExtent,
+        menuItems: [
+          ConduitNativeToolbarMenuItem(
+            label: 'Delete',
+            isDestructive: true,
+            onSelected: () {},
+          ),
+        ],
+      ),
+    ]);
+    final actions = params['actions']! as List<Map<String, Object?>>;
+
+    check(actions).length.equals(1);
+    check(actions.single['iosSymbol']).equals('ellipsis');
+    check(actions.single['symbolSize']).equals(22.0);
+  });
+
   test('composer measurement style matches recording typography', () {
     final recordingStyle = ModernChatInput.debugComposerInputTextStyle(
       isRecording: true,

--- a/test/features/chat/widgets/modern_chat_input_direct_test.dart
+++ b/test/features/chat/widgets/modern_chat_input_direct_test.dart
@@ -82,6 +82,7 @@ void main() {
       ConduitNativeToolbarAction(
         iosSymbol: 'square.and.pencil',
         accessibilityLabel: 'New Chat',
+        symbolSize: kConduitNativeVisibilitySymbolExtent,
         onPressed: () {},
       ),
       ConduitNativeToolbarAction(
@@ -105,9 +106,10 @@ void main() {
     final creationParams = encodeConduitNativeToolbarActionGroupParams(actions);
     final params = creationParams['actions']! as List<Map<String, Object?>>;
 
-    check(creationParams['symbolSize']).equals(20.0);
+    check(creationParams['symbolSize']).equals(22.0);
     check(params.length).equals(2);
     check(params[0]['iosSymbol']).equals('square.and.pencil');
+    check(params[0]['symbolSize']).equals(18.0);
     check(params[1]['iosSymbol']).equals('ellipsis');
     final menuItems = params[1]['menuItems']! as List<Map<String, Object?>>;
     check(

--- a/test/features/chat/widgets/modern_chat_input_direct_test.dart
+++ b/test/features/chat/widgets/modern_chat_input_direct_test.dart
@@ -140,6 +140,55 @@ void main() {
     check(actions.single['symbolSize']).equals(22.0);
   });
 
+  test('native toolbar menu adapters preserve values, order, and state', () {
+    String? selected;
+    final action = buildConduitNativeToolbarMenuAction<String>(
+      iosSymbol: 'ellipsis',
+      accessibilityLabel: 'More',
+      tintColor: Colors.black,
+      symbolSize: kConduitNativeToolbarSymbolExtent,
+      items: const [
+        AdaptivePopupMenuItem<String>(
+          value: 'edit',
+          label: 'Edit',
+          icon: 'pencil',
+        ),
+        AdaptivePopupMenuItem<String>(
+          value: 'delete',
+          label: 'Delete',
+          icon: 'trash',
+          enabled: false,
+          isDestructive: true,
+        ),
+      ],
+      onSelected: (value) => selected = value,
+    );
+
+    check(action).isNotNull();
+    check(
+      action!.menuItems.map((item) => item.label),
+    ).deepEquals(['Edit', 'Delete']);
+    check(action.menuItems[1].enabled).isFalse();
+    check(action.menuItems[1].isDestructive).isTrue();
+    action.menuItems[0].onSelected();
+    check(selected).equals('edit');
+  });
+
+  test('native toolbar groups accept three shared actions', () {
+    final actions = List.generate(
+      3,
+      (index) => ConduitNativeToolbarAction(
+        iosSymbol: 'circle',
+        accessibilityLabel: 'Action $index',
+        onPressed: () {},
+      ),
+    );
+
+    check(
+      ConduitNativeToolbarActionGroup(actions: actions).actions,
+    ).length.equals(3);
+  });
+
   test('composer measurement style matches recording typography', () {
     final recordingStyle = ModernChatInput.debugComposerInputTextStyle(
       isRecording: true,

--- a/test/features/chat/widgets/modern_chat_input_direct_test.dart
+++ b/test/features/chat/widgets/modern_chat_input_direct_test.dart
@@ -52,6 +52,31 @@ void main() {
     ).isFalse();
   });
 
+  test(
+    'native composer edit items remain stable across selection rebuilds',
+    () {
+      const defaults = <IOSSystemContextMenuItem>[
+        IOSSystemContextMenuItemCopy(),
+        IOSSystemContextMenuItemSelectAll(),
+      ];
+
+      final first = buildComposerSystemContextMenuItems(
+        defaultItems: defaults,
+        ensurePaste: true,
+      );
+      final second = buildComposerSystemContextMenuItems(
+        defaultItems: defaults,
+        ensurePaste: true,
+      );
+
+      expect(first, orderedEquals(second));
+      expect(first.whereType<IOSSystemContextMenuItemCustom>(), isEmpty);
+      expect(first[0], isA<IOSSystemContextMenuItemCopy>());
+      expect(first[1], isA<IOSSystemContextMenuItemPaste>());
+      expect(first[2], isA<IOSSystemContextMenuItemSelectAll>());
+    },
+  );
+
   test('native toolbar action groups preserve action and menu order', () {
     final actions = [
       ConduitNativeToolbarAction(

--- a/test/features/navigation/widgets/sidebar_page_test.dart
+++ b/test/features/navigation/widgets/sidebar_page_test.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 import 'dart:ui' show Tristate;
 
+import 'package:adaptive_platform_ui/adaptive_platform_ui.dart';
 import 'package:checks/checks.dart';
 import 'package:conduit/core/database/chat_database_repository.dart';
 import 'package:conduit/core/database/database_provider.dart';
@@ -59,6 +60,47 @@ Finder _sidebarBottomNavTabLabel(String label) =>
     find.descendant(of: find.byType(NavigationBar), matching: find.text(label));
 
 void main() {
+  testWidgets('native glass profile avatar stays compact and Flutter-owned', (
+    tester,
+  ) async {
+    var presses = 0;
+    const profileButtonKey = ValueKey<String>('sidebar-profile-button');
+
+    await tester.pumpWidget(
+      CupertinoApp(
+        home: Center(
+          child: buildSidebarProfileButton(
+            supportsNativeGlass: true,
+            onPressed: () => presses++,
+            fallbackStyle: AdaptiveButtonStyle.glass,
+            child: const SizedBox.square(dimension: 36),
+          ),
+        ),
+      ),
+    );
+
+    expect(find.byType(CupertinoButton), findsOneWidget);
+    expect(find.byType(AdaptiveButton), findsNothing);
+    expect(tester.getSize(find.byKey(profileButtonKey)), const Size(44, 44));
+    await tester.tap(find.byKey(profileButtonKey));
+    expect(presses, 1);
+
+    await tester.pumpWidget(
+      CupertinoApp(
+        home: Center(
+          child: buildSidebarProfileButton(
+            supportsNativeGlass: false,
+            onPressed: () {},
+            fallbackStyle: AdaptiveButtonStyle.plain,
+            child: const SizedBox.square(dimension: 36),
+          ),
+        ),
+      ),
+    );
+
+    expect(find.byType(AdaptiveButton), findsOneWidget);
+  });
+
   test('Hermes profile host fallback comes from localizations', () {
     check(
       AppLocalizationsEn().hermesSelfHostedAgentLabel,

--- a/test/shared/widgets/themed_sheets_test.dart
+++ b/test/shared/widgets/themed_sheets_test.dart
@@ -16,12 +16,43 @@ void main() {
   test(
     'native SF Symbols keep compact optical sizes inside scaled controls',
     () {
-      check(kConduitNativeUtilitySymbolExtent).equals(20);
-      check(kConduitNativePrimarySymbolExtent).equals(22);
+      check(kConduitNativeToolbarSymbolExtent).equals(17);
+      check(kConduitNativeUtilitySymbolExtent).equals(17);
+      check(kConduitNativePrimarySymbolExtent).equals(17);
+      check(
+        kConduitNativeToolbarSymbolExtent,
+      ).equals(kConduitNativeUtilitySymbolExtent);
       check(kConduitNativeUtilitySymbolExtent).isLessThan(IconSize.large);
-      check(kConduitNativePrimarySymbolExtent).isLessThan(IconSize.large);
+      check(
+        kConduitNativePrimarySymbolExtent,
+      ).equals(kConduitNativeUtilitySymbolExtent);
     },
   );
+
+  test('toolbar icons preserve their SF Symbol lookup values', () {
+    check(
+      conduitToolbarSfSymbolForIcon(CupertinoIcons.line_horizontal_3),
+    ).equals('line.3.horizontal');
+    check(
+      conduitToolbarSfSymbolForIcon(Icons.menu),
+    ).equals('line.3.horizontal');
+    check(
+      conduitToolbarSfSymbolForIcon(CupertinoIcons.chevron_back),
+    ).equals('chevron.left');
+    check(
+      conduitToolbarSfSymbolForIcon(CupertinoIcons.create),
+    ).equals('square.and.pencil');
+    check(
+      conduitToolbarSfSymbolForIcon(CupertinoIcons.eye_slash),
+    ).equals('eye.slash');
+    check(
+      conduitToolbarSfSymbolForIcon(Icons.people_outline),
+    ).equals('person.2');
+    check(
+      conduitToolbarSfSymbolForIcon(Icons.circle, iosSymbol: 'ellipsis'),
+    ).equals('ellipsis');
+    check(conduitToolbarSfSymbolForIcon(Icons.delete)).isNull();
+  });
 
   test('native model-selector labels remain on one line within their cap', () {
     const maxWidth = 198.0;
@@ -49,12 +80,12 @@ void main() {
       textDirection: TextDirection.ltr,
     );
 
-    check(shortLabel).equals('Inkling  ▾');
+    check(shortLabel).equals('Inkling  ⌄');
     expect(shortWidth, lessThan(400));
     check(longLabel).contains('…');
-    check(longLabel.endsWith('  ▾')).isTrue();
+    check(longLabel.endsWith('  ⌄')).isTrue();
     check(longLabel.contains('\n')).isFalse();
-    check(longLabel.length).isLessThan('google/gemma-4-31b-it  ▾'.length);
+    check(longLabel.length).isLessThan('google/gemma-4-31b-it  ⌄'.length);
   });
 
   test('native model-selector identity follows its foreground color', () {

--- a/test/shared/widgets/themed_sheets_test.dart
+++ b/test/shared/widgets/themed_sheets_test.dart
@@ -80,12 +80,15 @@ void main() {
       textDirection: TextDirection.ltr,
     );
 
-    check(shortLabel).equals('Inkling  ⌄');
+    check(shortLabel).equals('Inkling');
     expect(shortWidth, lessThan(400));
     check(longLabel).contains('…');
-    check(longLabel.endsWith('  ⌄')).isTrue();
     check(longLabel.contains('\n')).isFalse();
-    check(longLabel.length).isLessThan('google/gemma-4-31b-it  ⌄'.length);
+    check(longLabel.length).isLessThan('google/gemma-4-31b-it'.length);
+    check(
+      conduitNativeModelSelectorSymbol(showChevron: true),
+    ).equals('chevron.down');
+    check(conduitNativeModelSelectorSymbol(showChevron: false)).isNull();
   });
 
   test('native model-selector identity follows its foreground color', () {

--- a/test/shared/widgets/themed_sheets_test.dart
+++ b/test/shared/widgets/themed_sheets_test.dart
@@ -16,7 +16,10 @@ void main() {
   test(
     'native SF Symbols keep compact optical sizes inside scaled controls',
     () {
-      check(kConduitNativeToolbarSymbolExtent).equals(20);
+      check(kConduitNativeSidebarSymbolExtent).equals(20);
+      check(kConduitNativeToolbarSymbolExtent).equals(22);
+      check(kConduitNativeGroupedToolbarSymbolExtent).equals(22);
+      check(kConduitNativeVisibilitySymbolExtent).equals(18);
       check(kConduitNativeUtilitySymbolExtent).equals(17);
       check(kConduitNativePrimarySymbolExtent).equals(17);
       check(kConduitNativeModelChevronExtent).equals(13);

--- a/test/shared/widgets/themed_sheets_test.dart
+++ b/test/shared/widgets/themed_sheets_test.dart
@@ -95,9 +95,89 @@ void main() {
   test('native model-selector identity follows its foreground color', () {
     final lightKey = conduitNativeModelSelectorViewKey(Colors.black);
     final darkKey = conduitNativeModelSelectorViewKey(Colors.white);
+    final largeTextKey = conduitNativeModelSelectorViewKey(
+      Colors.black,
+      titleFontSize: 34,
+    );
 
     check(lightKey == darkKey).isFalse();
+    check(lightKey == largeTextKey).isFalse();
     check(lightKey).equals(conduitNativeModelSelectorViewKey(Colors.black));
+  });
+
+  test('native model-selector title follows Dynamic Type', () {
+    check(
+      resolveConduitNativeModelTitleFontSize(TextScaler.noScaling),
+    ).equals(17);
+    check(
+      resolveConduitNativeModelTitleFontSize(const TextScaler.linear(2)),
+    ).equals(34);
+  });
+
+  test('native model-selector semantics expose only valid activation', () {
+    var activations = 0;
+    void activate() => activations += 1;
+
+    final enabled = conduitNativeModelSelectorActivation(
+      isLoading: false,
+      showChevron: true,
+      onPressed: activate,
+    );
+    enabled!();
+
+    check(activations).equals(1);
+    check(
+      conduitNativeModelSelectorActivation(
+        isLoading: true,
+        showChevron: true,
+        onPressed: activate,
+      ),
+    ).isNull();
+    check(
+      conduitNativeModelSelectorActivation(
+        isLoading: false,
+        showChevron: false,
+        onPressed: activate,
+      ),
+    ).isNull();
+  });
+
+  test('native model-selector bounds untrusted labels before layout', () {
+    final oversized = '${List.filled(5000, 'a').join()}-model-tail';
+    final bounded = boundConduitNativeModelLabel(oversized);
+
+    check(bounded.length).isLessOrEqual(kConduitNativeModelLabelMaxCodeUnits);
+    check(bounded).startsWith('aaa');
+    check(bounded).contains('…');
+    check(bounded).endsWith('-model-tail');
+  });
+
+  test('native model-selector omits chevron width when hidden', () {
+    final withChevron = resolveConduitNativeModelSelectorWidth(
+      label: 'Inkling',
+      isLoading: false,
+      showChevron: true,
+      maxWidth: 400,
+      textDirection: TextDirection.ltr,
+    );
+    final withoutChevron = resolveConduitNativeModelSelectorWidth(
+      label: 'Inkling',
+      isLoading: false,
+      showChevron: false,
+      maxWidth: 400,
+      textDirection: TextDirection.ltr,
+    );
+
+    check(withoutChevron).isLessThan(withChevron);
+    check(
+      resolveConduitNativeModelSelectorLabel(
+        label: 'Inkling',
+        isLoading: false,
+        showChevron: false,
+        availableWidth: withoutChevron,
+        textDirection: TextDirection.ltr,
+      ),
+    ).equals('Inkling');
   });
 
   testWidgets('adaptive sheets use the iOS 26 glass route on iOS', (

--- a/test/shared/widgets/themed_sheets_test.dart
+++ b/test/shared/widgets/themed_sheets_test.dart
@@ -16,13 +16,13 @@ void main() {
   test(
     'native SF Symbols keep compact optical sizes inside scaled controls',
     () {
-      check(kConduitNativeToolbarSymbolExtent).equals(17);
+      check(kConduitNativeToolbarSymbolExtent).equals(20);
       check(kConduitNativeUtilitySymbolExtent).equals(17);
       check(kConduitNativePrimarySymbolExtent).equals(17);
       check(kConduitNativeModelChevronExtent).equals(13);
       check(
-        kConduitNativeToolbarSymbolExtent,
-      ).equals(kConduitNativeUtilitySymbolExtent);
+        kConduitNativeUtilitySymbolExtent,
+      ).isLessThan(kConduitNativeToolbarSymbolExtent);
       check(kConduitNativeUtilitySymbolExtent).isLessThan(IconSize.large);
       check(
         kConduitNativePrimarySymbolExtent,

--- a/test/shared/widgets/themed_sheets_test.dart
+++ b/test/shared/widgets/themed_sheets_test.dart
@@ -19,6 +19,7 @@ void main() {
       check(kConduitNativeToolbarSymbolExtent).equals(17);
       check(kConduitNativeUtilitySymbolExtent).equals(17);
       check(kConduitNativePrimarySymbolExtent).equals(17);
+      check(kConduitNativeModelChevronExtent).equals(13);
       check(
         kConduitNativeToolbarSymbolExtent,
       ).equals(kConduitNativeUtilitySymbolExtent);

--- a/test/shared/widgets/themed_sheets_test.dart
+++ b/test/shared/widgets/themed_sheets_test.dart
@@ -58,6 +58,16 @@ void main() {
     check(conduitToolbarSfSymbolForIcon(Icons.delete)).isNull();
   });
 
+  test('toolbar symbols use optical sizes across shared app bars', () {
+    check(conduitNativeToolbarSymbolExtentFor('line.3.horizontal')).equals(20);
+    check(conduitNativeToolbarSymbolExtentFor('chevron.left')).equals(20);
+    check(conduitNativeToolbarSymbolExtentFor('eye')).equals(18);
+    check(conduitNativeToolbarSymbolExtentFor('eye.slash')).equals(18);
+    check(conduitNativeToolbarSymbolExtentFor('square.and.pencil')).equals(22);
+    check(conduitNativeToolbarSymbolExtentFor('person.2')).equals(22);
+    check(conduitNativeToolbarSymbolExtentFor(null)).equals(22);
+  });
+
   test('native model-selector labels remain on one line within their cap', () {
     const maxWidth = 198.0;
     final shortWidth = resolveConduitNativeModelSelectorWidth(

--- a/test/shared/widgets/themed_sheets_test.dart
+++ b/test/shared/widgets/themed_sheets_test.dart
@@ -13,6 +13,58 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:stupid_simple_sheet/stupid_simple_sheet.dart';
 
 void main() {
+  test(
+    'native SF Symbols keep compact optical sizes inside scaled controls',
+    () {
+      check(kConduitNativeUtilitySymbolExtent).equals(20);
+      check(kConduitNativePrimarySymbolExtent).equals(22);
+      check(kConduitNativeUtilitySymbolExtent).isLessThan(IconSize.large);
+      check(kConduitNativePrimarySymbolExtent).isLessThan(IconSize.large);
+    },
+  );
+
+  test('native model-selector labels remain on one line within their cap', () {
+    const maxWidth = 198.0;
+    final shortWidth = resolveConduitNativeModelSelectorWidth(
+      label: 'Inkling',
+      isLoading: false,
+      showChevron: true,
+      // Widget tests use the wide Ahem test font rather than UIKit's SF Pro.
+      // Leave enough room here to exercise the untruncated branch itself.
+      maxWidth: 400,
+      textDirection: TextDirection.ltr,
+    );
+    final shortLabel = resolveConduitNativeModelSelectorLabel(
+      label: 'Inkling',
+      isLoading: false,
+      showChevron: true,
+      availableWidth: shortWidth,
+      textDirection: TextDirection.ltr,
+    );
+    final longLabel = resolveConduitNativeModelSelectorLabel(
+      label: 'google/gemma-4-31b-it',
+      isLoading: false,
+      showChevron: true,
+      availableWidth: maxWidth,
+      textDirection: TextDirection.ltr,
+    );
+
+    check(shortLabel).equals('Inkling  ▾');
+    expect(shortWidth, lessThan(400));
+    check(longLabel).contains('…');
+    check(longLabel.endsWith('  ▾')).isTrue();
+    check(longLabel.contains('\n')).isFalse();
+    check(longLabel.length).isLessThan('google/gemma-4-31b-it  ▾'.length);
+  });
+
+  test('native model-selector identity follows its foreground color', () {
+    final lightKey = conduitNativeModelSelectorViewKey(Colors.black);
+    final darkKey = conduitNativeModelSelectorViewKey(Colors.white);
+
+    check(lightKey == darkKey).isFalse();
+    check(lightKey).equals(conduitNativeModelSelectorViewKey(Colors.black));
+  });
+
   testWidgets('adaptive sheets use the iOS 26 glass route on iOS', (
     tester,
   ) async {

--- a/test/shared/widgets/themed_sheets_test.dart
+++ b/test/shared/widgets/themed_sheets_test.dart
@@ -165,6 +165,30 @@ void main() {
     check(bounded).endsWith('-model-tail');
   });
 
+  testWidgets('model-selector semantics preserve the full label', (
+    tester,
+  ) async {
+    final label = '${List.filled(5000, 'a').join()}-model-tail';
+    final bounded = boundConduitNativeModelLabel(label);
+    final semantics = tester.ensureSemantics();
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: ConduitAdaptiveAppBarModelSelector(
+            label: label,
+            maxWidth: 198,
+            onPressed: () {},
+          ),
+        ),
+      ),
+    );
+
+    expect(find.bySemanticsLabel(label), findsOneWidget);
+    expect(find.bySemanticsLabel(bounded), findsNothing);
+    semantics.dispose();
+  });
+
   test('native model-selector omits chevron width when hidden', () {
     final withChevron = resolveConduitNativeModelSelectorWidth(
       label: 'Inkling',

--- a/test/shared/widgets/themed_sheets_test.dart
+++ b/test/shared/widgets/themed_sheets_test.dart
@@ -118,6 +118,21 @@ void main() {
     check(lightKey).equals(conduitNativeModelSelectorViewKey(Colors.black));
   });
 
+  test('native model-selector parameters preserve the full label', () {
+    final label = '${List.filled(5000, 'a').join()}-model-tail';
+    final bounded = boundConduitNativeModelLabel(label);
+    final params = encodeConduitNativeModelSelectorParams(
+      label: label,
+      symbolName: 'chevron.down',
+      foregroundColor: Colors.black,
+      titleFontSize: 17,
+      enabled: true,
+    );
+
+    check(params['label']).equals(label);
+    check(params['label'] == bounded).isFalse();
+  });
+
   test('native model-selector title follows Dynamic Type', () {
     check(
       resolveConduitNativeModelTitleFontSize(TextScaler.noScaling),


### PR DESCRIPTION
## Summary

- replace iOS 26 child-mode toolbar and composer controls with native SF Symbols while keeping the existing platform fallbacks
- keep the sidebar avatar compact, retain one persistent composer glass surface, and avoid animated cursor-opacity recomposition around platform views
- constrain native symbol sizing and preserve one-line, theme-correct, fully accessible model labels

## Verification

- `flutter analyze`
- clean detached worktree: `flutter pub get`, `dart run build_runner build`, analyzer, and 89 focused tests
- `flutter build ios --simulator --debug`
- iOS 26.5 simulator: Light/Dark, Large/Extra Large text, long model names, populated/empty chats, composer controls, and the full VoiceOver model label

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added native iOS glass controls with SF Symbols across chat, navigation, composers, toolbars, and model selection.
  * Added grouped toolbar actions with overflow menus, accessibility labels, enabled states, and destructive actions.
  * Improved model-selector sizing, labels, truncation, colors, loading states, and Dynamic Type support.
  * Improved cursor and system selection-menu behavior in native text input.
  * Preserved adaptive Flutter fallbacks on unsupported platforms and during loading.

* **Tests**
  * Added coverage for native and fallback controls, toolbar menus, cursor behavior, sizing, labels, and model-selector rendering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Polish iOS 26 native glass controls across toolbar, composer, and model selector
> - Renders chat and folder page toolbar actions as native `UIToolbar`-backed `ConduitNativeToolbarActionGroup` platform views on iOS with glass support, replacing Flutter widgets for the trailing app bar area.
> - Adds `ConduitNativeModelSelectorButtonView` and `ConduitNativeToolbarActionGroupView` Swift platform views in [AppDelegate.swift](https://github.com/cogwheel0/conduit/pull/610/files#diff-2d8ca8a3da302654c934d7f3be4c2f6c8edc7788f2b8ed0178730d6d703ebe72), communicating taps back to Dart via `FlutterMethodChannel`.
> - Composer icon buttons in [modern_chat_input.dart](https://github.com/cogwheel0/conduit/pull/610/files#diff-c6dc1bffeaea79facaf47a17818417883c068df43c545c18e8c48e8ce7a1ce63) now render as `AdaptiveButton.sfSymbol` native views on iOS glass, with cursor opacity animation disabled and native `SystemContextMenu` used for text selection.
> - Sidebar profile button switches to a plain `CupertinoButton` (Flutter widget, no platform view) when native glass is active to avoid unnecessary embedding overhead.
> - SF Symbol name/size mappings and middle-ellipsis label truncation logic are centralized in [adaptive_toolbar_components.dart](https://github.com/cogwheel0/conduit/pull/610/files#diff-95f8e408b2bcdf8bd1617a2eb80b5224c7b7183113d7d9bac736d2378b7c7e8d) and covered by new unit tests.
> - Behavioral Change: the
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c041115.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This change introduces native iOS controls for toolbar actions, model selection, composer buttons, and glass surfaces while retaining Flutter fallbacks on unsupported devices.

The executed bridge checks confirmed that native model-selector labels preserve their complete accessibility payload, visual labels remain bounded, and selector, toolbar, and menu callbacks retain their intended indices. No product defect was found.

## T-Rex validation blocked

Native iOS 26 rendering could not run because the required tools are unavailable: the Flutter SDK (`flutter`) and Xcode/iOS Simulator (`xcodebuild`). The focused Flutter test could not start. Chromium successfully recorded the executed source-contract checks, but it cannot render UIKit platform views.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR is safe to merge; no blocking failure remains.

No defects were found. Executed checks confirmed the native selector payload and grouped-toolbar callback routing behavior. Native UIKit rendering requires Flutter and Xcode, which are not installed in this environment.
</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran the ios26-native-toolbar-contract-probe.js main and HEAD to compare the native toolbar bridge contracts, and the HEAD run passed all six inspected contracts: bounded visual model title behavior, full selector label payload, enabled selector callback delivery, primary toolbar callback routing, menu callback routing, and disabled-state handling.
- Environment limitations prevented Flutter-based iOS validation and UIKit rendering because Flutter and Xcode are unavailable in this environment.
- No concrete bug was proven by the contract validation; consequently, no file/line/severity finding was reported.
- Disproved the source-level hypothesis that enabled selector presses and grouped primary/menu interactions are misrouted; Swift captures actionIndex and itemIndex, and Dart bounds are dispatched using the same indices.
- Uploaded references and artifacts to support review, including the native toolbar contract probes, captures, logs, posters, and related videos.

<a href="https://app.greptile.com/trex/runs/17211061/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (14): Last reviewed commit: ["test: cover native model selector semant..."](https://github.com/cogwheel0/conduit/commit/c04111507347d06402016be827418c2630a69062) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49696829)</sub>

<!-- /greptile_comment -->