### PR TITLE
Fix reasoning effort persistence for unsupported models

### DIFF
--- a/android/app/src/main/kotlin/app/cogwheel/conduit/ConduitPlatformApis.g.kt
+++ b/android/app/src/main/kotlin/app/cogwheel/conduit/ConduitPlatformApis.g.kt
@@ -3068,7 +3068,7 @@ class BackgroundStreamingFlutterApi(private val binaryMessenger: BinaryMessenger
         }
       } else {
         callback(Result.failure(ConduitPlatformApisPigeonUtils.createConnectionError(channelName)))
-      } 
+      }
     }
   }
   fun backgroundTaskExpiring(callback: (Result<Unit>) -> Unit)
@@ -3085,7 +3085,7 @@ class BackgroundStreamingFlutterApi(private val binaryMessenger: BinaryMessenger
         }
       } else {
         callback(Result.failure(ConduitPlatformApisPigeonUtils.createConnectionError(channelName)))
-      } 
+      }
     }
   }
   fun backgroundTaskExtended(eventArg: PlatformBackgroundTaskExtendedEvent, callback: (Result<Unit>) -> Unit)
@@ -3102,7 +3102,7 @@ class BackgroundStreamingFlutterApi(private val binaryMessenger: BinaryMessenger
         }
       } else {
         callback(Result.failure(ConduitPlatformApisPigeonUtils.createConnectionError(channelName)))
-      } 
+      }
     }
   }
   fun backgroundKeepAlive(callback: (Result<Unit>) -> Unit)
@@ -3119,7 +3119,7 @@ class BackgroundStreamingFlutterApi(private val binaryMessenger: BinaryMessenger
         }
       } else {
         callback(Result.failure(ConduitPlatformApisPigeonUtils.createConnectionError(channelName)))
-      } 
+      }
     }
   }
   fun serviceFailed(eventArg: PlatformServiceFailureEvent, callback: (Result<Unit>) -> Unit)
@@ -3136,7 +3136,7 @@ class BackgroundStreamingFlutterApi(private val binaryMessenger: BinaryMessenger
         }
       } else {
         callback(Result.failure(ConduitPlatformApisPigeonUtils.createConnectionError(channelName)))
-      } 
+      }
     }
   }
   fun timeLimitApproaching(eventArg: PlatformTimeLimitWarningEvent, callback: (Result<Unit>) -> Unit)
@@ -3153,7 +3153,7 @@ class BackgroundStreamingFlutterApi(private val binaryMessenger: BinaryMessenger
         }
       } else {
         callback(Result.failure(ConduitPlatformApisPigeonUtils.createConnectionError(channelName)))
-      } 
+      }
     }
   }
   fun microphonePermissionFallback(callback: (Result<Unit>) -> Unit)
@@ -3170,7 +3170,7 @@ class BackgroundStreamingFlutterApi(private val binaryMessenger: BinaryMessenger
         }
       } else {
         callback(Result.failure(ConduitPlatformApisPigeonUtils.createConnectionError(channelName)))
-      } 
+      }
     }
   }
 }
@@ -3199,7 +3199,7 @@ class AppIntentFlutterApi(private val binaryMessenger: BinaryMessenger, private 
         }
       } else {
         callback(Result.failure(ConduitPlatformApisPigeonUtils.createConnectionError(channelName)))
-      } 
+      }
     }
   }
   fun startVoiceCall(invocationIdArg: String, callback: (Result<PlatformAppIntentResponse>) -> Unit)
@@ -3219,7 +3219,7 @@ class AppIntentFlutterApi(private val binaryMessenger: BinaryMessenger, private 
         }
       } else {
         callback(Result.failure(ConduitPlatformApisPigeonUtils.createConnectionError(channelName)))
-      } 
+      }
     }
   }
   fun sendText(invocationIdArg: String, textArg: String, callback: (Result<PlatformAppIntentResponse>) -> Unit)
@@ -3239,7 +3239,7 @@ class AppIntentFlutterApi(private val binaryMessenger: BinaryMessenger, private 
         }
       } else {
         callback(Result.failure(ConduitPlatformApisPigeonUtils.createConnectionError(channelName)))
-      } 
+      }
     }
   }
   fun sendUrl(invocationIdArg: String, urlArg: String, callback: (Result<PlatformAppIntentResponse>) -> Unit)
@@ -3259,7 +3259,7 @@ class AppIntentFlutterApi(private val binaryMessenger: BinaryMessenger, private 
         }
       } else {
         callback(Result.failure(ConduitPlatformApisPigeonUtils.createConnectionError(channelName)))
-      } 
+      }
     }
   }
   fun sendImage(invocationIdArg: String, payloadArg: PlatformAppIntentImagePayload, callback: (Result<PlatformAppIntentResponse>) -> Unit)
@@ -3279,7 +3279,7 @@ class AppIntentFlutterApi(private val binaryMessenger: BinaryMessenger, private 
         }
       } else {
         callback(Result.failure(ConduitPlatformApisPigeonUtils.createConnectionError(channelName)))
-      } 
+      }
     }
   }
 }
@@ -3376,7 +3376,7 @@ class NativePasteFlutterApi(private val binaryMessenger: BinaryMessenger, privat
         }
       } else {
         callback(Result.failure(ConduitPlatformApisPigeonUtils.createConnectionError(channelName)))
-      } 
+      }
     }
   }
 }
@@ -3471,7 +3471,7 @@ class NativeKeyboardAttachmentFlutterApi(private val binaryMessenger: BinaryMess
         }
       } else {
         callback(Result.failure(ConduitPlatformApisPigeonUtils.createConnectionError(channelName)))
-      } 
+      }
     }
   }
   fun onVisibilityChanged(eventArg: PlatformKeyboardAttachmentVisibilityEvent, callback: (Result<Unit>) -> Unit)
@@ -3488,7 +3488,7 @@ class NativeKeyboardAttachmentFlutterApi(private val binaryMessenger: BinaryMess
         }
       } else {
         callback(Result.failure(ConduitPlatformApisPigeonUtils.createConnectionError(channelName)))
-      } 
+      }
     }
   }
 }
@@ -3535,6 +3535,7 @@ interface NativeSheetHostApi {
   fun requestAppStoreReview(): Boolean
   fun presentModelSelector(request: PlatformNativeSheetModelSelectorRequest, callback: (Result<String?>) -> Unit)
   fun updateModelSelectorModels(presentationId: String, models: List<PlatformNativeSheetModelOption>)
+  fun updateModelSelectorReasoningEffort(presentationId: String, value: String, options: List<String>, allowsCustom: Boolean)
   fun presentOptionsSelector(request: PlatformNativeSheetOptionsSelectorRequest, callback: (Result<String?>) -> Unit)
   fun presentDatePicker(request: PlatformNativeSheetDatePickerRequest, callback: (Result<String?>) -> Unit)
   fun presentTextEditor(request: PlatformNativeSheetTextEditorRequest, callback: (Result<PlatformNativeSheetActionResult?>) -> Unit)
@@ -3629,6 +3630,27 @@ interface NativeSheetHostApi {
             val modelsArg = args[1] as List<PlatformNativeSheetModelOption>
             val wrapped: List<Any?> = try {
               api.updateModelSelectorModels(presentationIdArg, modelsArg)
+              listOf(null)
+            } catch (exception: Throwable) {
+              ConduitPlatformApisPigeonUtils.wrapError(exception)
+            }
+            reply.reply(wrapped)
+          }
+        } else {
+          channel.setMessageHandler(null)
+        }
+      }
+      run {
+        val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.conduit.NativeSheetHostApi.updateModelSelectorReasoningEffort$separatedMessageChannelSuffix", codec)
+        if (api != null) {
+          channel.setMessageHandler { message, reply ->
+            val args = message as List<Any?>
+            val presentationIdArg = args[0] as String
+            val valueArg = args[1] as String
+            val optionsArg = args[2] as List<String>
+            val allowsCustomArg = args[3] as Boolean
+            val wrapped: List<Any?> = try {
+              api.updateModelSelectorReasoningEffort(presentationIdArg, valueArg, optionsArg, allowsCustomArg)
               listOf(null)
             } catch (exception: Throwable) {
               ConduitPlatformApisPigeonUtils.wrapError(exception)
@@ -3761,7 +3783,7 @@ class NativeSheetFlutterApi(private val binaryMessenger: BinaryMessenger, privat
         }
       } else {
         callback(Result.failure(ConduitPlatformApisPigeonUtils.createConnectionError(channelName)))
-      } 
+      }
     }
   }
   fun onLogoutRequested(callback: (Result<Unit>) -> Unit)
@@ -3778,7 +3800,7 @@ class NativeSheetFlutterApi(private val binaryMessenger: BinaryMessenger, privat
         }
       } else {
         callback(Result.failure(ConduitPlatformApisPigeonUtils.createConnectionError(channelName)))
-      } 
+      }
     }
   }
   fun onControlChanged(eventArg: PlatformNativeSheetControlChangedEvent, callback: (Result<Unit>) -> Unit)
@@ -3795,7 +3817,7 @@ class NativeSheetFlutterApi(private val binaryMessenger: BinaryMessenger, privat
         }
       } else {
         callback(Result.failure(ConduitPlatformApisPigeonUtils.createConnectionError(channelName)))
-      } 
+      }
     }
   }
   fun onDetailAppeared(eventArg: PlatformNativeSheetDetailAppearedEvent, callback: (Result<Unit>) -> Unit)
@@ -3812,7 +3834,7 @@ class NativeSheetFlutterApi(private val binaryMessenger: BinaryMessenger, privat
         }
       } else {
         callback(Result.failure(ConduitPlatformApisPigeonUtils.createConnectionError(channelName)))
-      } 
+      }
     }
   }
   fun onModelPinToggled(eventArg: PlatformNativeSheetModelPinToggledEvent, callback: (Result<Unit>) -> Unit)
@@ -3829,7 +3851,7 @@ class NativeSheetFlutterApi(private val binaryMessenger: BinaryMessenger, privat
         }
       } else {
         callback(Result.failure(ConduitPlatformApisPigeonUtils.createConnectionError(channelName)))
-      } 
+      }
     }
   }
   fun onReasoningEffortChanged(eventArg: PlatformNativeSheetReasoningEffortChangedEvent, callback: (Result<Unit>) -> Unit)
@@ -3863,7 +3885,7 @@ class NativeSheetFlutterApi(private val binaryMessenger: BinaryMessenger, privat
         }
       } else {
         callback(Result.failure(ConduitPlatformApisPigeonUtils.createConnectionError(channelName)))
-      } 
+      }
     }
   }
 }

--- a/ios/Runner/ConduitPlatformApis.g.swift
+++ b/ios/Runner/ConduitPlatformApis.g.swift
@@ -3456,6 +3456,7 @@ protocol NativeSheetHostApi {
   func requestAppStoreReview() throws -> Bool
   func presentModelSelector(request: PlatformNativeSheetModelSelectorRequest, completion: @escaping (Result<String?, Error>) -> Void)
   func updateModelSelectorModels(presentationId: String, models: [PlatformNativeSheetModelOption]) throws
+  func updateModelSelectorReasoningEffort(presentationId: String, value: String, options: [String], allowsCustom: Bool) throws
   func presentOptionsSelector(request: PlatformNativeSheetOptionsSelectorRequest, completion: @escaping (Result<String?, Error>) -> Void)
   func presentDatePicker(request: PlatformNativeSheetDatePickerRequest, completion: @escaping (Result<String?, Error>) -> Void)
   func presentTextEditor(request: PlatformNativeSheetTextEditorRequest, completion: @escaping (Result<PlatformNativeSheetActionResult?, Error>) -> Void)
@@ -3544,6 +3545,24 @@ class NativeSheetHostApiSetup {
       }
     } else {
       updateModelSelectorModelsChannel.setMessageHandler(nil)
+    }
+    let updateModelSelectorReasoningEffortChannel = FlutterBasicMessageChannel(name: "dev.flutter.pigeon.conduit.NativeSheetHostApi.updateModelSelectorReasoningEffort\(channelSuffix)", binaryMessenger: binaryMessenger, codec: codec)
+    if let api = api {
+      updateModelSelectorReasoningEffortChannel.setMessageHandler { message, reply in
+        let args = message as! [Any?]
+        let presentationIdArg = args[0] as! String
+        let valueArg = args[1] as! String
+        let optionsArg = args[2] as! [String]
+        let allowsCustomArg = args[3] as! Bool
+        do {
+          try api.updateModelSelectorReasoningEffort(presentationId: presentationIdArg, value: valueArg, options: optionsArg, allowsCustom: allowsCustomArg)
+          reply(wrapResult(nil))
+        } catch {
+          reply(wrapError(error))
+        }
+      }
+    } else {
+      updateModelSelectorReasoningEffortChannel.setMessageHandler(nil)
     }
     let presentOptionsSelectorChannel = FlutterBasicMessageChannel(name: "dev.flutter.pigeon.conduit.NativeSheetHostApi.presentOptionsSelector\(channelSuffix)", binaryMessenger: binaryMessenger, codec: codec)
     if let api = api {

--- a/ios/Runner/NativeSheetBridge.swift
+++ b/ios/Runner/NativeSheetBridge.swift
@@ -1237,6 +1237,29 @@ final class NativeSheetBridge: NativeSheetHostApi {
         )
     }
 
+    func updateModelSelectorReasoningEffort(
+        presentationId: String,
+        value: String,
+        options: [String],
+        allowsCustom: Bool
+    ) throws {
+        let normalizedPresentationId = presentationId.trimmingCharacters(
+            in: .whitespacesAndNewlines
+        )
+        guard !normalizedPresentationId.isEmpty else { return }
+        applyNativeSheetModelUpdateSynchronouslyOnMain(
+            presentationId: normalizedPresentationId,
+            activePresentationId: { self.activeModelSelectorPresentationId },
+            update: {
+                self.activeModelSelectorController?.updateReasoningEffort(
+                    value: value,
+                    options: options,
+                    allowsCustom: allowsCustom
+                )
+            }
+        )
+    }
+
     func presentOptionsSelector(
         request: PlatformNativeSheetOptionsSelectorRequest,
         completion: @escaping (Result<String?, Error>) -> Void
@@ -4650,6 +4673,8 @@ private final class NativeModelSelectorTableViewController: UITableViewControlle
     private var featuredModels: [NativeModelSelectorOption] = []
     private var moreModels: [NativeModelSelectorOption] = []
     private var reasoningEffortValue: String
+    private var reasoningEffortOptions: [String]
+    private var allowsCustomReasoningEffort: Bool
     private weak var moreModelsController: NativeMoreModelsTableViewController?
 
     init(
@@ -4668,6 +4693,8 @@ private final class NativeModelSelectorTableViewController: UITableViewControlle
         pinnedModelIdSet = Set(configuration.pinnedModelIds)
         models = configuration.models
         reasoningEffortValue = configuration.reasoningEffortValue
+        reasoningEffortOptions = configuration.reasoningEffortOptions
+        allowsCustomReasoningEffort = configuration.allowsCustomReasoningEffort
         super.init(style: .insetGrouped)
         refreshModelPartitions()
     }
@@ -4824,6 +4851,20 @@ private final class NativeModelSelectorTableViewController: UITableViewControlle
         if isViewLoaded { tableView.reloadData() }
     }
 
+    func updateReasoningEffort(
+        value: String,
+        options: [String],
+        allowsCustom: Bool
+    ) {
+        guard let normalized = normalizedEffort(value) else { return }
+        reasoningEffortValue = normalized
+        reasoningEffortOptions = options
+        allowsCustomReasoningEffort = allowsCustom
+        if isViewLoaded {
+            tableView.reloadSections(IndexSet(integer: 1), with: .none)
+        }
+    }
+
     private func refreshModelPartitions() {
         let ids = nativeModelSelectorFeaturedIds(
             pinnedModelIds: pinnedModelIds,
@@ -4844,8 +4885,7 @@ private final class NativeModelSelectorTableViewController: UITableViewControlle
     }
 
     private var effortSelectionEnabled: Bool {
-        !configuration.reasoningEffortOptions.isEmpty ||
-            configuration.allowsCustomReasoningEffort
+        !reasoningEffortOptions.isEmpty || allowsCustomReasoningEffort
     }
 
     private func presentEffortSelector(sourceView: UIView?) {
@@ -4854,7 +4894,7 @@ private final class NativeModelSelectorTableViewController: UITableViewControlle
             message: nil,
             preferredStyle: .actionSheet
         )
-        for option in configuration.reasoningEffortOptions {
+        for option in reasoningEffortOptions {
             let label = option == reasoningEffortValue
                 ? "✓ \(effortLabel(option))"
                 : effortLabel(option)
@@ -4863,7 +4903,7 @@ private final class NativeModelSelectorTableViewController: UITableViewControlle
             }
             alert.addAction(action)
         }
-        if configuration.allowsCustomReasoningEffort {
+        if allowsCustomReasoningEffort {
             alert.addAction(UIAlertAction(
                 title: configuration.customReasoningEffortTitle,
                 style: .default
@@ -4886,7 +4926,7 @@ private final class NativeModelSelectorTableViewController: UITableViewControlle
         alert.addTextField { [weak self] field in
             guard let self else { return }
             field.placeholder = configuration.customReasoningEffortHint
-            if !configuration.reasoningEffortOptions.contains(reasoningEffortValue) {
+            if !reasoningEffortOptions.contains(reasoningEffortValue) {
                 field.text = reasoningEffortValue
             }
             field.autocapitalizationType = .none

--- a/lib/core/models/model.dart
+++ b/lib/core/models/model.dart
@@ -148,8 +148,17 @@ sealed class Model with _$Model {
 
     // Handle different response formats from OpenWebUI
 
+    // Preserve provider-specific capability metadata while normalizing the
+    // fields Conduit consumes directly.
+    final rawCapabilities = json['capabilities'];
+    final incomingCapabilities = rawCapabilities is Map
+        ? Map<String, dynamic>.from(rawCapabilities)
+        : const <String, dynamic>{};
+
     // Extract architecture info for capabilities
-    final architecture = json['architecture'] as Map<String, dynamic>?;
+    final architecture =
+        (json['architecture'] as Map<String, dynamic>?) ??
+        (incomingCapabilities['architecture'] as Map<String, dynamic>?);
     final modality = architecture?['modality'] as String?;
     final inputModalities = architecture?['input_modalities'] as List?;
 
@@ -162,7 +171,9 @@ sealed class Model with _$Model {
     // Extract supported parameters robustly (top-level or nested under provider keys)
     List? supportedParams =
         (json['supported_parameters'] as List?) ??
-        (json['supportedParameters'] as List?);
+        (json['supportedParameters'] as List?) ??
+        (incomingCapabilities['supported_parameters'] as List?) ??
+        (incomingCapabilities['supportedParameters'] as List?);
 
     if (supportedParams == null) {
       const providerKeys = [
@@ -330,11 +341,13 @@ sealed class Model with _$Model {
       supportsRAG: _safeBool(json['supportsRAG']) ?? false,
       supportedParameters: supportedParamsList,
       capabilities: {
+        ...incomingCapabilities,
         'architecture': architecture,
-        'pricing': json['pricing'],
-        'context_length': json['context_length'],
+        'pricing': json['pricing'] ?? incomingCapabilities['pricing'],
+        'context_length':
+            json['context_length'] ?? incomingCapabilities['context_length'],
         'supported_parameters': supportedParamsList ?? supportedParams,
-        'usage': supportsUsage,
+        'usage': supportsUsage || incomingCapabilities['usage'] == true,
       },
       metadata: mergedMetadata,
       toolIds: toolIds,

--- a/lib/core/models/model.dart
+++ b/lib/core/models/model.dart
@@ -45,6 +45,73 @@ List<String> _coerceModelTags(dynamic value) {
   return tags;
 }
 
+bool _containsReasoningEffortParameter(Object? value) {
+  if (value is! Iterable) return false;
+  return value.any(
+    (parameter) =>
+        parameter.toString().trim().toLowerCase() == 'reasoning_effort',
+  );
+}
+
+bool _paramsConfigureReasoningEffort(Object? value) =>
+    value is Map && value.containsKey('reasoning_effort');
+
+bool _isOpenAiReasoningEffortModel(String value) {
+  final id = value.trim().toLowerCase();
+  if (id.isEmpty) return false;
+
+  // Keep this aligned with OpenWebUI's is_openai_new_model routing rule.
+  if (RegExp(r'(?:^|[/.:])o\d+').hasMatch(id)) return true;
+  final match = RegExp(r'(?:^|[/.:])gpt-(\d+)').firstMatch(id);
+  return match != null && int.parse(match.group(1)!) >= 5;
+}
+
+/// Whether a model explicitly supports the OpenAI `reasoning_effort` request
+/// parameter. Unknown models fail closed because forwarding an unsupported
+/// optional parameter causes the entire completion request to fail.
+bool modelSupportsReasoningEffort({
+  required String modelId,
+  Object? supportedParameters,
+  Map<String, dynamic>? capabilities,
+  Map<String, dynamic>? metadata,
+}) {
+  if (_containsReasoningEffortParameter(supportedParameters) ||
+      _containsReasoningEffortParameter(
+        capabilities?['supported_parameters'],
+      )) {
+    return true;
+  }
+
+  final explicitCapability = capabilities?['reasoning_effort'];
+  if (explicitCapability is bool) return explicitCapability;
+  if (explicitCapability is Map) return true;
+
+  final reasoningCapability = capabilities?['reasoning'];
+  if (reasoningCapability is Map &&
+      reasoningCapability.containsKey('supported_efforts')) {
+    final supportedEfforts = reasoningCapability['supported_efforts'];
+    if (supportedEfforts == null) return true;
+    return supportedEfforts is Iterable && supportedEfforts.isNotEmpty;
+  }
+
+  final info = metadata?['info'];
+  if (_paramsConfigureReasoningEffort(metadata?['params']) ||
+      _paramsConfigureReasoningEffort(info is Map ? info['params'] : null)) {
+    return true;
+  }
+
+  final candidateIds = <Object?>[
+    modelId,
+    metadata?['base_model_id'],
+    if (info is Map) info['base_model_id'],
+  ];
+  return candidateIds.any(
+    (candidate) =>
+        candidate != null &&
+        _isOpenAiReasoningEffortModel(candidate.toString()),
+  );
+}
+
 @freezed
 sealed class Model with _$Model {
   const Model._();
@@ -302,6 +369,12 @@ sealed class Model with _$Model {
 
   String? get workspaceOwnerId => metadata?['user_id']?.toString();
   String? get baseModelId => metadata?['base_model_id']?.toString();
+  bool get supportsReasoningEffort => modelSupportsReasoningEffort(
+    modelId: id,
+    supportedParameters: supportedParameters,
+    capabilities: capabilities,
+    metadata: metadata,
+  );
   bool get isWorkspaceActive => _safeBool(metadata?['is_active']) ?? true;
   bool get hasWorkspaceWriteAccess =>
       _safeBool(metadata?['write_access']) ?? false;

--- a/lib/core/platform/conduit_platform_apis.g.dart
+++ b/lib/core/platform/conduit_platform_apis.g.dart
@@ -3934,6 +3934,24 @@ class NativeSheetHostApi {
     ;
   }
 
+  Future<void> updateModelSelectorReasoningEffort(String presentationId, String value, List<String> options, bool allowsCustom) async {
+    final pigeonVar_channelName = 'dev.flutter.pigeon.conduit.NativeSheetHostApi.updateModelSelectorReasoningEffort$pigeonVar_messageChannelSuffix';
+    final pigeonVar_channel = BasicMessageChannel<Object?>(
+      pigeonVar_channelName,
+      pigeonChannelCodec,
+      binaryMessenger: pigeonVar_binaryMessenger,
+    );
+    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[presentationId, value, options, allowsCustom]);
+    final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
+
+    _extractReplyValueOrThrow(
+        pigeonVar_replyList,
+        pigeonVar_channelName,
+        isNullValid: true,
+    )
+    ;
+  }
+
   Future<String?> presentOptionsSelector(PlatformNativeSheetOptionsSelectorRequest request) async {
     final pigeonVar_channelName = 'dev.flutter.pigeon.conduit.NativeSheetHostApi.presentOptionsSelector$pigeonVar_messageChannelSuffix';
     final pigeonVar_channel = BasicMessageChannel<Object?>(

--- a/lib/core/services/api_service.dart
+++ b/lib/core/services/api_service.dart
@@ -3621,11 +3621,9 @@ class ApiService {
         params['reasoning_effort'] = trimmed;
       }
 
-      if (params.isEmpty) {
-        settings.remove('params');
-      } else {
-        settings['params'] = params;
-      }
+      // OpenWebUI shallow-merges the top-level settings object. Posting no
+      // `params` key would therefore preserve the previous nested map.
+      settings['params'] = params;
       _traceApi('Updating user reasoning effort');
       final response = await _postUserSettings(
         settings,
@@ -7666,6 +7664,27 @@ class ApiService {
       }
     } catch (_) {
       // Non-critical: proceed without user params
+    }
+
+    final modelInfo = modelItem?['info'];
+    final openAiModel = modelItem?['openai'];
+    final effort = params['reasoning_effort'];
+    final isAutomaticEffort =
+        effort is String && effort.trim().toLowerCase() == 'automatic';
+    final supportsReasoningEffort = modelSupportsReasoningEffort(
+      modelId: model,
+      supportedParameters: modelItem?['supported_parameters'],
+      capabilities: _coerceJsonMap(modelItem?['capabilities']),
+      metadata: <String, dynamic>{
+        'params': modelItem?['params'],
+        'info': modelInfo,
+        'base_model_id':
+            modelItem?['base_model_id'] ??
+            (openAiModel is Map ? openAiModel['id'] : null),
+      },
+    );
+    if (isAutomaticEffort || !supportsReasoningEffort) {
+      params.remove('reasoning_effort');
     }
     data['params'] = params;
 

--- a/lib/core/services/native_sheet_bridge.dart
+++ b/lib/core/services/native_sheet_bridge.dart
@@ -253,6 +253,37 @@ class NativeSheetBridge implements NativeSheetFlutterApi {
     }
   }
 
+  Future<void> updateModelSelectorReasoningEffort({
+    required String presentationId,
+    required String value,
+    required List<String> options,
+    required bool allowsCustom,
+    Future<void> Function(String value)? onReasoningEffortChanged,
+  }) async {
+    final normalizedPresentationId = presentationId.trim();
+    if (!_isIOS || normalizedPresentationId.isEmpty) return;
+    final previousHandler = _reasoningEffortChangedHandler;
+    _reasoningEffortChangedHandler = onReasoningEffortChanged;
+    try {
+      await _api.updateModelSelectorReasoningEffort(
+        normalizedPresentationId,
+        value,
+        options,
+        allowsCustom,
+      );
+    } catch (error, stackTrace) {
+      if (identical(_reasoningEffortChangedHandler, onReasoningEffortChanged)) {
+        _reasoningEffortChangedHandler = previousHandler;
+      }
+      _logNativeSheetBridgeError(
+        'updateModelSelectorReasoningEffort',
+        error,
+        stackTrace,
+        data: {'optionCount': options.length},
+      );
+    }
+  }
+
   void _restorePreviousModelPinToggleHandler({
     required Object owner,
     required Future<void> Function(String modelId)? previousHandler,

--- a/lib/core/services/native_sheet_bridge.dart
+++ b/lib/core/services/native_sheet_bridge.dart
@@ -59,6 +59,7 @@ class NativeSheetBridge implements NativeSheetFlutterApi {
   Object? _modelPinToggleHandlerOwner;
   Future<void> Function(String value)? _reasoningEffortChangedHandler;
   Object? _reasoningEffortChangedHandlerOwner;
+  Object? _reasoningEffortUpdateOwner;
 
   @visibleForTesting
   bool? debugIsIOSOverride;
@@ -140,12 +141,14 @@ class NativeSheetBridge implements NativeSheetFlutterApi {
     final previousPinToggleHandlerOwner = _modelPinToggleHandlerOwner;
     final previousEffortHandler = _reasoningEffortChangedHandler;
     final previousEffortHandlerOwner = _reasoningEffortChangedHandlerOwner;
+    final previousEffortUpdateOwner = _reasoningEffortUpdateOwner;
     final pinToggleHandlerOwner = Object();
     var shouldClearPinToggleHandler = false;
     _modelPinToggleHandler = onTogglePinned;
     _modelPinToggleHandlerOwner = pinToggleHandlerOwner;
     _reasoningEffortChangedHandler = onReasoningEffortChanged;
     _reasoningEffortChangedHandlerOwner = pinToggleHandlerOwner;
+    _reasoningEffortUpdateOwner = null;
     try {
       final result = await _api.presentModelSelector(
         PlatformNativeSheetModelSelectorRequest(
@@ -185,6 +188,7 @@ class NativeSheetBridge implements NativeSheetFlutterApi {
           owner: pinToggleHandlerOwner,
           previousHandler: previousEffortHandler,
           previousOwner: previousEffortHandlerOwner,
+          previousUpdateOwner: previousEffortUpdateOwner,
         );
       }
       _logNativeSheetBridgeError(
@@ -206,6 +210,7 @@ class NativeSheetBridge implements NativeSheetFlutterApi {
           owner: pinToggleHandlerOwner,
           previousHandler: previousEffortHandler,
           previousOwner: previousEffortHandlerOwner,
+          previousUpdateOwner: previousEffortUpdateOwner,
         );
       }
       _logNativeSheetBridgeError(
@@ -227,6 +232,7 @@ class NativeSheetBridge implements NativeSheetFlutterApi {
         )) {
           _reasoningEffortChangedHandler = null;
           _reasoningEffortChangedHandlerOwner = null;
+          _reasoningEffortUpdateOwner = null;
         }
       }
     }
@@ -263,7 +269,10 @@ class NativeSheetBridge implements NativeSheetFlutterApi {
     final normalizedPresentationId = presentationId.trim();
     if (!_isIOS || normalizedPresentationId.isEmpty) return;
     final previousHandler = _reasoningEffortChangedHandler;
+    final previousUpdateOwner = _reasoningEffortUpdateOwner;
+    final updateOwner = Object();
     _reasoningEffortChangedHandler = onReasoningEffortChanged;
+    _reasoningEffortUpdateOwner = updateOwner;
     try {
       await _api.updateModelSelectorReasoningEffort(
         normalizedPresentationId,
@@ -272,8 +281,9 @@ class NativeSheetBridge implements NativeSheetFlutterApi {
         allowsCustom,
       );
     } catch (error, stackTrace) {
-      if (identical(_reasoningEffortChangedHandler, onReasoningEffortChanged)) {
+      if (identical(_reasoningEffortUpdateOwner, updateOwner)) {
         _reasoningEffortChangedHandler = previousHandler;
+        _reasoningEffortUpdateOwner = previousUpdateOwner;
       }
       _logNativeSheetBridgeError(
         'updateModelSelectorReasoningEffort',
@@ -300,10 +310,12 @@ class NativeSheetBridge implements NativeSheetFlutterApi {
     required Object owner,
     required Future<void> Function(String value)? previousHandler,
     required Object? previousOwner,
+    required Object? previousUpdateOwner,
   }) {
     if (!identical(_reasoningEffortChangedHandlerOwner, owner)) return;
     _reasoningEffortChangedHandler = previousHandler;
     _reasoningEffortChangedHandlerOwner = previousOwner;
+    _reasoningEffortUpdateOwner = previousUpdateOwner;
   }
 
   Future<String?> presentOptionsSelector({

--- a/lib/core/services/native_sheet_bridge.dart
+++ b/lib/core/services/native_sheet_bridge.dart
@@ -60,6 +60,7 @@ class NativeSheetBridge implements NativeSheetFlutterApi {
   Future<void> Function(String value)? _reasoningEffortChangedHandler;
   Object? _reasoningEffortChangedHandlerOwner;
   Object? _reasoningEffortUpdateOwner;
+  Future<void> _reasoningEffortUpdateQueue = Future<void>.value();
 
   @visibleForTesting
   bool? debugIsIOSOverride;
@@ -268,29 +269,37 @@ class NativeSheetBridge implements NativeSheetFlutterApi {
   }) async {
     final normalizedPresentationId = presentationId.trim();
     if (!_isIOS || normalizedPresentationId.isEmpty) return;
-    final previousHandler = _reasoningEffortChangedHandler;
-    final previousUpdateOwner = _reasoningEffortUpdateOwner;
-    final updateOwner = Object();
-    _reasoningEffortChangedHandler = onReasoningEffortChanged;
-    _reasoningEffortUpdateOwner = updateOwner;
+    final previousUpdate = _reasoningEffortUpdateQueue;
+    final updateComplete = Completer<void>();
+    _reasoningEffortUpdateQueue = updateComplete.future;
+    await previousUpdate;
     try {
-      await _api.updateModelSelectorReasoningEffort(
-        normalizedPresentationId,
-        value,
-        options,
-        allowsCustom,
-      );
-    } catch (error, stackTrace) {
-      if (identical(_reasoningEffortUpdateOwner, updateOwner)) {
-        _reasoningEffortChangedHandler = previousHandler;
-        _reasoningEffortUpdateOwner = previousUpdateOwner;
+      final previousHandler = _reasoningEffortChangedHandler;
+      final previousUpdateOwner = _reasoningEffortUpdateOwner;
+      final updateOwner = Object();
+      _reasoningEffortChangedHandler = onReasoningEffortChanged;
+      _reasoningEffortUpdateOwner = updateOwner;
+      try {
+        await _api.updateModelSelectorReasoningEffort(
+          normalizedPresentationId,
+          value,
+          options,
+          allowsCustom,
+        );
+      } catch (error, stackTrace) {
+        if (identical(_reasoningEffortUpdateOwner, updateOwner)) {
+          _reasoningEffortChangedHandler = previousHandler;
+          _reasoningEffortUpdateOwner = previousUpdateOwner;
+        }
+        _logNativeSheetBridgeError(
+          'updateModelSelectorReasoningEffort',
+          error,
+          stackTrace,
+          data: {'optionCount': options.length},
+        );
       }
-      _logNativeSheetBridgeError(
-        'updateModelSelectorReasoningEffort',
-        error,
-        stackTrace,
-        data: {'optionCount': options.length},
-      );
+    } finally {
+      updateComplete.complete();
     }
   }
 

--- a/lib/core/services/native_sheet_hydration_service.dart
+++ b/lib/core/services/native_sheet_hydration_service.dart
@@ -74,6 +74,12 @@ Future<bool> waitForNativeReasoningEffortHydration(
   }
 }
 
+@visibleForTesting
+ReasoningEffortPolicy nativeModelSelectorReasoningEffortPolicy(
+  bool hydrated,
+  ReasoningEffortPolicy hydratedPolicy,
+) => hydrated ? hydratedPolicy : ReasoningEffortPolicy.unsupported;
+
 class NativeSheetHydrationService {
   NativeSheetHydrationService(this._ref);
 
@@ -141,11 +147,12 @@ class NativeSheetHydrationService {
       final effortModel = orderedModels
           .where((model) => model.id == selectedModelId)
           .firstOrNull;
+      var effortHydrated = effortModel == null;
       if (effortModel != null) {
-        final hydrated = await waitForNativeReasoningEffortHydration(
+        effortHydrated = await waitForNativeReasoningEffortHydration(
           _ref.read(serverModelReasoningEffortProvider(effortModel).future),
         );
-        if (!hydrated) {
+        if (!effortHydrated) {
           DebugLogger.warning(
             'reasoning-effort-hydration-timeout',
             scope: 'native-sheet/models',
@@ -154,9 +161,9 @@ class NativeSheetHydrationService {
         }
         if (!context.mounted) return null;
       }
-      final effortPolicy = reasoningEffortPolicyForModel(
-        _ref.read,
-        effortModel,
+      final effortPolicy = nativeModelSelectorReasoningEffortPolicy(
+        effortHydrated,
+        reasoningEffortPolicyForModel(_ref.read, effortModel),
       );
       final allowsCustomEffort = effortPolicy.allowsCustom;
       final effortOptions = effortPolicy.options;
@@ -204,7 +211,7 @@ class NativeSheetHydrationService {
         moreModelsTitle: l10n?.moreModels ?? 'More models',
         searchModelsTitle: l10n?.searchModels ?? 'Search models',
         reasoningEffortTitle: l10n?.reasoningEffort ?? 'Effort',
-        reasoningEffortValue: effortModel == null
+        reasoningEffortValue: effortModel == null || !effortHydrated
             ? kAutomaticReasoningEffort
             : reasoningEffortForModel(_ref.read, effortModel),
         reasoningEffortOptions: effortOptions,

--- a/lib/core/services/native_sheet_hydration_service.dart
+++ b/lib/core/services/native_sheet_hydration_service.dart
@@ -128,6 +128,10 @@ class NativeSheetHydrationService {
       final effortModel = orderedModels
           .where((model) => model.id == selectedModelId)
           .firstOrNull;
+      if (effortModel != null) {
+        await _ref.read(serverModelReasoningEffortProvider(effortModel).future);
+        if (!context.mounted) return null;
+      }
       final effortPolicy = reasoningEffortPolicyForModel(
         _ref.read,
         effortModel,

--- a/lib/core/services/native_sheet_hydration_service.dart
+++ b/lib/core/services/native_sheet_hydration_service.dart
@@ -61,6 +61,19 @@ class NativeSheetPresentationAdmission {
   void finish() => _active = false;
 }
 
+@visibleForTesting
+Future<bool> waitForNativeReasoningEffortHydration(
+  Future<Object?> hydration, {
+  Duration timeout = const Duration(seconds: 1),
+}) async {
+  try {
+    await hydration.timeout(timeout);
+    return true;
+  } on TimeoutException {
+    return false;
+  }
+}
+
 class NativeSheetHydrationService {
   NativeSheetHydrationService(this._ref);
 
@@ -129,7 +142,16 @@ class NativeSheetHydrationService {
           .where((model) => model.id == selectedModelId)
           .firstOrNull;
       if (effortModel != null) {
-        await _ref.read(serverModelReasoningEffortProvider(effortModel).future);
+        final hydrated = await waitForNativeReasoningEffortHydration(
+          _ref.read(serverModelReasoningEffortProvider(effortModel).future),
+        );
+        if (!hydrated) {
+          DebugLogger.warning(
+            'reasoning-effort-hydration-timeout',
+            scope: 'native-sheet/models',
+            data: {'modelId': effortModel.id},
+          );
+        }
         if (!context.mounted) return null;
       }
       final effortPolicy = reasoningEffortPolicyForModel(

--- a/lib/core/services/native_sheet_hydration_service.dart
+++ b/lib/core/services/native_sheet_hydration_service.dart
@@ -80,6 +80,27 @@ ReasoningEffortPolicy nativeModelSelectorReasoningEffortPolicy(
   ReasoningEffortPolicy hydratedPolicy,
 ) => hydrated ? hydratedPolicy : ReasoningEffortPolicy.unsupported;
 
+@visibleForTesting
+({ReasoningEffortPolicy policy, String value})
+nativeHydratedServerReasoningEffort({
+  required Model model,
+  required ServerModelReasoningEffort detail,
+  String? personalizationEffort,
+}) {
+  final modelEffort = detail.value ?? modelConfiguredReasoningEffort(model);
+  final policy = model.supportsReasoningEffort || modelEffort != null
+      ? ReasoningEffortPolicy.generic
+      : ReasoningEffortPolicy.unsupported;
+  return (
+    policy: policy,
+    value:
+        policy.effectiveConfiguredEffort(
+          modelEffort ?? personalizationEffort,
+        ) ??
+        kAutomaticReasoningEffort,
+  );
+}
+
 class NativeSheetHydrationService {
   NativeSheetHydrationService(this._ref);
 
@@ -147,10 +168,15 @@ class NativeSheetHydrationService {
       final effortModel = orderedModels
           .where((model) => model.id == selectedModelId)
           .firstOrNull;
+      Future<ServerModelReasoningEffort>? effortHydration;
       var effortHydrated = effortModel == null;
       if (effortModel != null) {
+        final pendingEffortHydration = _ref.read(
+          serverModelReasoningEffortProvider(effortModel).future,
+        );
+        effortHydration = pendingEffortHydration;
         effortHydrated = await waitForNativeReasoningEffortHydration(
-          _ref.read(serverModelReasoningEffortProvider(effortModel).future),
+          pendingEffortHydration,
         );
         if (!effortHydrated) {
           DebugLogger.warning(
@@ -243,6 +269,53 @@ class NativeSheetHydrationService {
         models: nativePresentationOptions,
         rethrowErrors: rethrowErrors,
       );
+      final lateEffortModel = effortHydrated ? null : effortModel;
+      final lateEffortHydration = effortHydrated ? null : effortHydration;
+      if (lateEffortModel != null && lateEffortHydration != null) {
+        unawaited(
+          lateEffortHydration
+              .then((detail) async {
+                if (!detail.canUsePersonalizationFallback ||
+                    !context.mounted ||
+                    !_modelSelectorHydration.isActive(
+                      activeHydrationGeneration,
+                    ) ||
+                    !identical(_ref.read(apiServiceProvider), api)) {
+                  return;
+                }
+                final hydrated = nativeHydratedServerReasoningEffort(
+                  model: lateEffortModel,
+                  detail: detail,
+                  personalizationEffort: _ref
+                      .read(personalizationSettingsProvider)
+                      .asData
+                      ?.value
+                      .reasoningEffort,
+                );
+                await bridge.updateModelSelectorReasoningEffort(
+                  presentationId: presentationId,
+                  value: hydrated.value,
+                  options: hydrated.policy.options,
+                  allowsCustom: hydrated.policy.allowsCustom,
+                  onReasoningEffortChanged: hydrated.policy.visible
+                      ? (value) => setReasoningEffortForModel(
+                          _ref.read,
+                          lateEffortModel,
+                          value,
+                        )
+                      : null,
+                );
+              })
+              .catchError((Object error, StackTrace stackTrace) {
+                DebugLogger.error(
+                  'native-model-effort-progressive-hydration-failed',
+                  scope: 'native-sheet/model-effort-hydration',
+                  error: error,
+                  stackTrace: stackTrace,
+                );
+              }),
+        );
+      }
       unawaited(
         avatarHydrator
             .hydrateModelOptions(

--- a/lib/features/chat/providers/chat_providers.dart
+++ b/lib/features/chat/providers/chat_providers.dart
@@ -18297,6 +18297,8 @@ Map<String, dynamic> _buildLocalModelItem(
         ],
     'capabilities': selectedModel.capabilities,
     'info': meta?['info'],
+    if (meta?['params'] != null) 'params': meta!['params'],
+    if (meta?['base_model_id'] != null) 'base_model_id': meta!['base_model_id'],
     // Routing-critical fields for pipe models
     if (meta?['pipe'] != null) 'pipe': meta!['pipe'],
     if (meta?['actions'] != null) 'actions': meta!['actions'],
@@ -18313,3 +18315,7 @@ Map<String, dynamic> _buildLocalModelItem(
           .toList(),
   };
 }
+
+@visibleForTesting
+Map<String, dynamic> buildLocalModelItemForTest(Model selectedModel) =>
+    _buildLocalModelItem(selectedModel);

--- a/lib/features/chat/providers/reasoning_effort_provider.dart
+++ b/lib/features/chat/providers/reasoning_effort_provider.dart
@@ -84,10 +84,13 @@ String? modelConfiguredReasoningEffort(Model? model) {
   if (metadata == null) return null;
 
   final info = metadata['info'];
-  final candidates = <Object?>[
+  return _reasoningEffortFromParams(<Object?>[
     if (info is Map) info['params'],
     metadata['params'],
-  ];
+  ]);
+}
+
+String? _reasoningEffortFromParams(Iterable<Object?> candidates) {
   for (final candidate in candidates) {
     if (candidate is! Map) continue;
     final rawEffort = candidate['reasoning_effort'];
@@ -100,6 +103,25 @@ String? modelConfiguredReasoningEffort(Model? model) {
   }
   return null;
 }
+
+bool _isOpenWebUiWorkspaceModel(Model model) {
+  final info = model.metadata?['info'];
+  if (info is! Map) return false;
+  return info['id']?.toString() == model.id &&
+      (info.containsKey('user_id') || info.containsKey('base_model_id'));
+}
+
+/// Loads private workspace-model parameters that OpenWebUI intentionally omits
+/// from `/api/models`. The detail route returns them only to callers with write
+/// access; read-only callers receive an empty params map.
+final serverModelReasoningEffortProvider =
+    FutureProvider.family<String?, Model>((ref, model) async {
+      if (!_isOpenWebUiWorkspaceModel(model)) return null;
+      final api = ref.watch(apiServiceProvider);
+      if (api == null) return null;
+      final details = await api.getModelDetails(model.id);
+      return _reasoningEffortFromParams(<Object?>[details?['params']]);
+    });
 
 @Riverpod(keepAlive: true)
 class LocalReasoningEfforts extends _$LocalReasoningEfforts {
@@ -180,7 +202,12 @@ final configuredReasoningEffortProvider = Provider<String?>((ref) {
         );
   }
 
-  final modelEffort = modelConfiguredReasoningEffort(model);
+  final detailedModelEffort = ref
+      .watch(serverModelReasoningEffortProvider(model))
+      .asData
+      ?.value;
+  final modelEffort =
+      detailedModelEffort ?? modelConfiguredReasoningEffort(model);
   if (modelEffort != null) {
     return reasoningEffortPolicyForModel(
       ref.watch,
@@ -240,7 +267,11 @@ String reasoningEffortForModel(ReasoningEffortReader read, Model? model) {
     return read(localReasoningEffortsProvider)['hermes:${model.id}'] ??
         kAutomaticReasoningEffort;
   }
-  final modelEffort = modelConfiguredReasoningEffort(model);
+  final detailedModelEffort = read(
+    serverModelReasoningEffortProvider(model),
+  ).asData?.value;
+  final modelEffort =
+      detailedModelEffort ?? modelConfiguredReasoningEffort(model);
   final policy = reasoningEffortPolicyForModel(read, model);
   if (modelEffort != null) {
     return policy.effectiveConfiguredEffort(modelEffort) ??
@@ -275,7 +306,10 @@ ReasoningEffortPolicy reasoningEffortPolicyForModel(
   if (isHermesModel(model)) return ReasoningEffortPolicy.generic;
   final binding = read(directModelRegistryProvider).resolve(model);
   if (binding == null) {
-    return model.supportsReasoningEffort
+    final detailedModelEffort = read(
+      serverModelReasoningEffortProvider(model),
+    ).asData?.value;
+    return model.supportsReasoningEffort || detailedModelEffort != null
         ? ReasoningEffortPolicy.generic
         : ReasoningEffortPolicy.unsupported;
   }

--- a/lib/features/chat/providers/reasoning_effort_provider.dart
+++ b/lib/features/chat/providers/reasoning_effort_provider.dart
@@ -40,6 +40,13 @@ final class ReasoningEffortPolicy {
     allowsCustom: true,
   );
 
+  static const unsupported = ReasoningEffortPolicy(
+    visible: false,
+    options: <String>[],
+    allowsCustom: false,
+    restrictsValues: true,
+  );
+
   final bool visible;
   final List<String> options;
   final bool allowsCustom;
@@ -174,14 +181,23 @@ final configuredReasoningEffortProvider = Provider<String?>((ref) {
   }
 
   final modelEffort = modelConfiguredReasoningEffort(model);
-  if (modelEffort != null) return modelEffort;
+  if (modelEffort != null) {
+    return reasoningEffortPolicyForModel(
+      ref.watch,
+      model,
+    ).effectiveConfiguredEffort(modelEffort);
+  }
 
   if (ref.watch(apiServiceProvider) != null) {
-    return ref
+    final configured = ref
         .watch(personalizationSettingsProvider)
         .asData
         ?.value
         .reasoningEffort;
+    return reasoningEffortPolicyForModel(
+      ref.watch,
+      model,
+    ).effectiveConfiguredEffort(configured);
   }
   return null;
 });
@@ -225,11 +241,16 @@ String reasoningEffortForModel(ReasoningEffortReader read, Model? model) {
         kAutomaticReasoningEffort;
   }
   final modelEffort = modelConfiguredReasoningEffort(model);
-  if (modelEffort != null) return modelEffort;
+  final policy = reasoningEffortPolicyForModel(read, model);
+  if (modelEffort != null) {
+    return policy.effectiveConfiguredEffort(modelEffort) ??
+        kAutomaticReasoningEffort;
+  }
   if (read(apiServiceProvider) != null) {
-    return read(
-          personalizationSettingsProvider,
-        ).asData?.value.reasoningEffort ??
+    final configured = read(
+      personalizationSettingsProvider,
+    ).asData?.value.reasoningEffort;
+    return policy.effectiveConfiguredEffort(configured) ??
         kAutomaticReasoningEffort;
   }
   return kAutomaticReasoningEffort;
@@ -251,8 +272,13 @@ ReasoningEffortPolicy reasoningEffortPolicyForModel(
       allowsCustom: false,
     );
   }
+  if (isHermesModel(model)) return ReasoningEffortPolicy.generic;
   final binding = read(directModelRegistryProvider).resolve(model);
-  if (binding == null) return ReasoningEffortPolicy.generic;
+  if (binding == null) {
+    return model.supportsReasoningEffort
+        ? ReasoningEffortPolicy.generic
+        : ReasoningEffortPolicy.unsupported;
+  }
   if (binding.adapterKey == kOllamaAdapterKey) {
     return const ReasoningEffortPolicy(
       visible: true,

--- a/lib/features/chat/providers/reasoning_effort_provider.dart
+++ b/lib/features/chat/providers/reasoning_effort_provider.dart
@@ -114,7 +114,7 @@ bool _isOpenWebUiWorkspaceModel(Model model) {
 /// Loads private workspace-model parameters that OpenWebUI intentionally omits
 /// from `/api/models`. The detail route returns them only to callers with write
 /// access; read-only callers receive an empty params map.
-@Riverpod(keepAlive: true)
+@riverpod
 Future<String?> serverModelReasoningEffort(Ref ref, Model model) async {
   if (!_isOpenWebUiWorkspaceModel(model)) return null;
   final api = ref.watch(apiServiceProvider);

--- a/lib/features/chat/providers/reasoning_effort_provider.dart
+++ b/lib/features/chat/providers/reasoning_effort_provider.dart
@@ -202,10 +202,14 @@ final configuredReasoningEffortProvider = Provider<String?>((ref) {
         );
   }
 
-  final detailedModelEffort = ref
-      .watch(serverModelReasoningEffortProvider(model))
-      .asData
-      ?.value;
+  String? detailedModelEffort;
+  if (_isOpenWebUiWorkspaceModel(model)) {
+    final detailedEffort = ref.watch(serverModelReasoningEffortProvider(model));
+    // Until OpenWebUI returns the private workspace params, do not let a
+    // user-level fallback override the model's server-side configuration.
+    if (detailedEffort.isLoading) return null;
+    detailedModelEffort = detailedEffort.asData?.value;
+  }
   final modelEffort =
       detailedModelEffort ?? modelConfiguredReasoningEffort(model);
   if (modelEffort != null) {
@@ -267,9 +271,12 @@ String reasoningEffortForModel(ReasoningEffortReader read, Model? model) {
     return read(localReasoningEffortsProvider)['hermes:${model.id}'] ??
         kAutomaticReasoningEffort;
   }
-  final detailedModelEffort = read(
-    serverModelReasoningEffortProvider(model),
-  ).asData?.value;
+  String? detailedModelEffort;
+  if (_isOpenWebUiWorkspaceModel(model)) {
+    final detailedEffort = read(serverModelReasoningEffortProvider(model));
+    if (detailedEffort.isLoading) return kAutomaticReasoningEffort;
+    detailedModelEffort = detailedEffort.asData?.value;
+  }
   final modelEffort =
       detailedModelEffort ?? modelConfiguredReasoningEffort(model);
   final policy = reasoningEffortPolicyForModel(read, model);
@@ -306,9 +313,9 @@ ReasoningEffortPolicy reasoningEffortPolicyForModel(
   if (isHermesModel(model)) return ReasoningEffortPolicy.generic;
   final binding = read(directModelRegistryProvider).resolve(model);
   if (binding == null) {
-    final detailedModelEffort = read(
-      serverModelReasoningEffortProvider(model),
-    ).asData?.value;
+    final detailedModelEffort = _isOpenWebUiWorkspaceModel(model)
+        ? read(serverModelReasoningEffortProvider(model)).asData?.value
+        : null;
     return model.supportsReasoningEffort || detailedModelEffort != null
         ? ReasoningEffortPolicy.generic
         : ReasoningEffortPolicy.unsupported;

--- a/lib/features/chat/providers/reasoning_effort_provider.dart
+++ b/lib/features/chat/providers/reasoning_effort_provider.dart
@@ -111,16 +111,41 @@ bool _isOpenWebUiWorkspaceModel(Model model) {
       (info.containsKey('user_id') || info.containsKey('base_model_id'));
 }
 
+final class ServerModelReasoningEffort {
+  const ServerModelReasoningEffort.known(this.value)
+    : canUsePersonalizationFallback = true;
+
+  const ServerModelReasoningEffort.unavailable()
+    : value = null,
+      canUsePersonalizationFallback = false;
+
+  final String? value;
+  final bool canUsePersonalizationFallback;
+}
+
 /// Loads private workspace-model parameters that OpenWebUI intentionally omits
 /// from `/api/models`. The detail route returns them only to callers with write
 /// access; read-only callers receive an empty params map.
 @riverpod
-Future<String?> serverModelReasoningEffort(Ref ref, Model model) async {
-  if (!_isOpenWebUiWorkspaceModel(model)) return null;
+Future<ServerModelReasoningEffort> serverModelReasoningEffort(
+  Ref ref,
+  Model model,
+) async {
+  if (!_isOpenWebUiWorkspaceModel(model)) {
+    return const ServerModelReasoningEffort.known(null);
+  }
   final api = ref.watch(apiServiceProvider);
-  if (api == null) return null;
+  if (api == null) return const ServerModelReasoningEffort.unavailable();
   final details = await api.getModelDetails(model.id);
-  return _reasoningEffortFromParams(<Object?>[details?['params']]);
+  if (details == null) return const ServerModelReasoningEffort.unavailable();
+  final effort = _reasoningEffortFromParams(<Object?>[details['params']]);
+  if (effort != null || details['write_access'] == true) {
+    return ServerModelReasoningEffort.known(effort);
+  }
+  // OpenWebUI deliberately returns an empty params map to read-only callers.
+  // Do not mistake that hidden value for confirmed absence and override it
+  // with the user's personalization setting.
+  return const ServerModelReasoningEffort.unavailable();
 }
 
 @Riverpod(keepAlive: true)
@@ -207,8 +232,10 @@ final configuredReasoningEffortProvider = Provider<String?>((ref) {
     final detailedEffort = ref.watch(serverModelReasoningEffortProvider(model));
     // Until OpenWebUI returns the private workspace params, do not let a
     // user-level fallback override the model's server-side configuration.
-    if (detailedEffort.isLoading) return null;
-    detailedModelEffort = detailedEffort.asData?.value;
+    if (detailedEffort.isLoading || detailedEffort.hasError) return null;
+    final detail = detailedEffort.asData?.value;
+    if (detail == null || !detail.canUsePersonalizationFallback) return null;
+    detailedModelEffort = detail.value;
   }
   final modelEffort =
       detailedModelEffort ?? modelConfiguredReasoningEffort(model);
@@ -274,8 +301,14 @@ String reasoningEffortForModel(ReasoningEffortReader read, Model? model) {
   String? detailedModelEffort;
   if (_isOpenWebUiWorkspaceModel(model)) {
     final detailedEffort = read(serverModelReasoningEffortProvider(model));
-    if (detailedEffort.isLoading) return kAutomaticReasoningEffort;
-    detailedModelEffort = detailedEffort.asData?.value;
+    if (detailedEffort.isLoading || detailedEffort.hasError) {
+      return kAutomaticReasoningEffort;
+    }
+    final detail = detailedEffort.asData?.value;
+    if (detail == null || !detail.canUsePersonalizationFallback) {
+      return kAutomaticReasoningEffort;
+    }
+    detailedModelEffort = detail.value;
   }
   final modelEffort =
       detailedModelEffort ?? modelConfiguredReasoningEffort(model);
@@ -314,7 +347,7 @@ ReasoningEffortPolicy reasoningEffortPolicyForModel(
   final binding = read(directModelRegistryProvider).resolve(model);
   if (binding == null) {
     final detailedModelEffort = _isOpenWebUiWorkspaceModel(model)
-        ? read(serverModelReasoningEffortProvider(model)).asData?.value
+        ? read(serverModelReasoningEffortProvider(model)).asData?.value.value
         : null;
     return model.supportsReasoningEffort || detailedModelEffort != null
         ? ReasoningEffortPolicy.generic

--- a/lib/features/chat/providers/reasoning_effort_provider.dart
+++ b/lib/features/chat/providers/reasoning_effort_provider.dart
@@ -114,14 +114,14 @@ bool _isOpenWebUiWorkspaceModel(Model model) {
 /// Loads private workspace-model parameters that OpenWebUI intentionally omits
 /// from `/api/models`. The detail route returns them only to callers with write
 /// access; read-only callers receive an empty params map.
-final serverModelReasoningEffortProvider =
-    FutureProvider.family<String?, Model>((ref, model) async {
-      if (!_isOpenWebUiWorkspaceModel(model)) return null;
-      final api = ref.watch(apiServiceProvider);
-      if (api == null) return null;
-      final details = await api.getModelDetails(model.id);
-      return _reasoningEffortFromParams(<Object?>[details?['params']]);
-    });
+@Riverpod(keepAlive: true)
+Future<String?> serverModelReasoningEffort(Ref ref, Model model) async {
+  if (!_isOpenWebUiWorkspaceModel(model)) return null;
+  final api = ref.watch(apiServiceProvider);
+  if (api == null) return null;
+  final details = await api.getModelDetails(model.id);
+  return _reasoningEffortFromParams(<Object?>[details?['params']]);
+}
 
 @Riverpod(keepAlive: true)
 class LocalReasoningEfforts extends _$LocalReasoningEfforts {

--- a/lib/features/chat/widgets/model_selector_sheet.dart
+++ b/lib/features/chat/widgets/model_selector_sheet.dart
@@ -271,6 +271,10 @@ String _effortLabel(AppLocalizations l10n, String effort) => switch (effort) {
 };
 
 @visibleForTesting
+String reasoningEffortLabelForTest(AppLocalizations l10n, String effort) =>
+    _effortLabel(l10n, effort);
+
+@visibleForTesting
 bool modelSelectorQueryMatches(Model model, String query) {
   final normalizedQuery = query.trim().toLowerCase();
   if (normalizedQuery.isEmpty) return true;

--- a/pigeons/conduit_platform_apis.dart
+++ b/pigeons/conduit_platform_apis.dart
@@ -776,6 +776,13 @@ abstract class NativeSheetHostApi {
     List<PlatformNativeSheetModelOption> models,
   );
 
+  void updateModelSelectorReasoningEffort(
+    String presentationId,
+    String value,
+    List<String> options,
+    bool allowsCustom,
+  );
+
   @async
   String? presentOptionsSelector(
     PlatformNativeSheetOptionsSelectorRequest request,

--- a/test/core/models/model_serialization_test.dart
+++ b/test/core/models/model_serialization_test.dart
@@ -113,6 +113,27 @@ void main() {
       check(model.isMultimodal).isTrue();
     });
 
+    test('preserves provider reasoning capabilities', () {
+      final model = Model.fromJson({
+        'id': 'provider-reasoning-model',
+        'name': 'Provider reasoning model',
+        'capabilities': {
+          'reasoning_effort': true,
+          'reasoning': {
+            'supported_efforts': ['low', 'vendor_ultra'],
+          },
+        },
+      });
+
+      check(model.capabilities?['reasoning_effort']).equals(true);
+      check(
+        model.capabilities?['reasoning'],
+      ).isA<Map<String, dynamic>>().deepEquals(<String, dynamic>{
+        'supported_efforts': ['low', 'vendor_ultra'],
+      });
+      check(model.supportsReasoningEffort).isTrue();
+    });
+
     test('name defaults to id when blank', () {
       final model = Model.fromJson({'id': 'my-model', 'name': ''});
       check(model.name).equals('my-model');

--- a/test/core/services/api_service_user_settings_test.dart
+++ b/test/core/services/api_service_user_settings_test.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 import 'dart:convert';
 import 'dart:typed_data';
 
+import 'package:checks/checks.dart';
 import 'package:conduit/core/models/server_config.dart';
 import 'package:conduit/core/services/api_service.dart';
 import 'package:conduit/core/services/worker_manager.dart';
@@ -99,21 +100,25 @@ void main() {
 
     test('automatic reasoning effort clears the server-side value', () async {
       final adapter = _UserSettingsAdapter(<String, dynamic>{
-        'params': <String, dynamic>{'reasoning_effort': 'medium'},
+        'params': <String, dynamic>{
+          'reasoning_effort': 'medium',
+          'temperature': 0.3,
+        },
       });
       final api = _buildApi(adapter, authToken: 'account-a');
 
-      expect(
+      check(
         (adapter.settings['params']
             as Map<String, dynamic>)['reasoning_effort'],
-        'medium',
-      );
+      ).equals('medium');
       adapter.releaseFirstGet.complete();
 
       final result = await api.updateUserReasoningEffort(null);
 
-      expect(result.reasoningEffort, isNull);
-      expect(adapter.settings['params'], isEmpty);
+      check(result.reasoningEffort).isNull();
+      check(adapter.settings['params']).isA<Map<String, dynamic>>().deepEquals(
+        <String, dynamic>{'temperature': 0.3},
+      );
     });
   });
 }

--- a/test/core/services/api_service_user_settings_test.dart
+++ b/test/core/services/api_service_user_settings_test.dart
@@ -96,6 +96,25 @@ void main() {
       );
       expect(result, 42);
     });
+
+    test('automatic reasoning effort clears the server-side value', () async {
+      final adapter = _UserSettingsAdapter(<String, dynamic>{
+        'params': <String, dynamic>{'reasoning_effort': 'medium'},
+      });
+      final api = _buildApi(adapter, authToken: 'account-a');
+
+      expect(
+        (adapter.settings['params']
+            as Map<String, dynamic>)['reasoning_effort'],
+        'medium',
+      );
+      adapter.releaseFirstGet.complete();
+
+      final result = await api.updateUserReasoningEffort(null);
+
+      expect(result.reasoningEffort, isNull);
+      expect(adapter.settings['params'], isEmpty);
+    });
   });
 }
 
@@ -145,7 +164,8 @@ final class _UserSettingsAdapter implements HttpClientAdapter {
       }
 
       if (options.method == 'POST') {
-        settings = _clone(options.data as Map<String, dynamic>);
+        final submitted = _clone(options.data as Map<String, dynamic>);
+        settings = <String, dynamic>{...settings, ...submitted};
       }
       return _jsonResponse(settings);
     } finally {

--- a/test/core/services/native_sheet_bridge_test.dart
+++ b/test/core/services/native_sheet_bridge_test.dart
@@ -485,7 +485,8 @@ void main() {
       final presentation = Completer<dynamic>();
       final firstUpdate = Completer<dynamic>();
       final initialChanges = <String>[];
-      final currentChanges = <String>[];
+      final olderChanges = <String>[];
+      final newerChanges = <String>[];
       var updateCalls = 0;
       messenger.setMockDecodedMessageHandler<Object?>(
         _presentModelSelectorChannel,
@@ -506,17 +507,13 @@ void main() {
         onReasoningEffortChanged: (value) async => initialChanges.add(value),
       );
       await Future<void>.delayed(Duration.zero);
-      Future<void> currentHandler(String value) async {
-        currentChanges.add(value);
-      }
-
       final older = NativeSheetBridge.instance
           .updateModelSelectorReasoningEffort(
             presentationId: 'presentation-current',
             value: 'vendor_ultra',
             options: const ['automatic', 'vendor_ultra'],
             allowsCustom: true,
-            onReasoningEffortChanged: currentHandler,
+            onReasoningEffortChanged: (value) async => olderChanges.add(value),
           );
       await Future<void>.delayed(Duration.zero);
       final newer = NativeSheetBridge.instance
@@ -525,7 +522,7 @@ void main() {
             value: 'vendor_ultra',
             options: const ['automatic', 'vendor_ultra'],
             allowsCustom: true,
-            onReasoningEffortChanged: currentHandler,
+            onReasoningEffortChanged: (value) async => newerChanges.add(value),
           );
       await Future<void>.delayed(Duration.zero);
       check(updateCalls).equals(1);
@@ -541,7 +538,8 @@ void main() {
       await Future<void>.delayed(Duration.zero);
 
       check(initialChanges).isEmpty();
-      check(currentChanges).deepEquals(['vendor_ultra']);
+      check(olderChanges).isEmpty();
+      check(newerChanges).deepEquals(['vendor_ultra']);
       presentation.complete(wrapResponse(result: null));
       await presented;
     });

--- a/test/core/services/native_sheet_bridge_test.dart
+++ b/test/core/services/native_sheet_bridge_test.dart
@@ -21,6 +21,11 @@ final _updateModelSelectorChannel = BasicMessageChannel<Object?>(
   NativeSheetHostApi.pigeonChannelCodec,
 );
 
+final _updateModelSelectorReasoningChannel = BasicMessageChannel<Object?>(
+  'dev.flutter.pigeon.conduit.NativeSheetHostApi.updateModelSelectorReasoningEffort',
+  NativeSheetHostApi.pigeonChannelCodec,
+);
+
 final _requestAppStoreReviewChannel = BasicMessageChannel<Object?>(
   'dev.flutter.pigeon.conduit.NativeSheetHostApi.requestAppStoreReview',
   NativeSheetHostApi.pigeonChannelCodec,
@@ -43,6 +48,10 @@ void main() {
     );
     messenger.setMockDecodedMessageHandler<Object?>(
       _updateModelSelectorChannel,
+      null,
+    );
+    messenger.setMockDecodedMessageHandler<Object?>(
+      _updateModelSelectorReasoningChannel,
       null,
     );
     messenger.setMockDecodedMessageHandler<Object?>(
@@ -420,6 +429,53 @@ void main() {
           avatarBytes: Uint8List.fromList([4, 5, 6]),
         ),
       ], presentationId: 'presentation-current');
+    });
+
+    test('effort hydration updates controls and installs callback', () async {
+      NativeSheetBridge.instance.debugIsIOSOverride = true;
+      final messenger =
+          TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger;
+      final presentation = Completer<dynamic>();
+      final changed = <String>[];
+      messenger.setMockDecodedMessageHandler<Object?>(
+        _presentModelSelectorChannel,
+        (_) => presentation.future,
+      );
+      messenger.setMockDecodedMessageHandler<Object?>(
+        _updateModelSelectorReasoningChannel,
+        (message) async {
+          final args = message! as List<Object?>;
+          check(args[0]).equals('presentation-current');
+          check(args[1]).equals('vendor_ultra');
+          check(
+            args[2]! as List<Object?>,
+          ).deepEquals(['automatic', 'vendor_ultra']);
+          check(args[3]).equals(true);
+          return wrapResponse(empty: true);
+        },
+      );
+      final presented = NativeSheetBridge.instance.presentModelSelector(
+        presentationId: 'presentation-current',
+        title: 'Models',
+        models: const [NativeSheetModelOption(id: 'model-a', name: 'A')],
+      );
+      await Future<void>.delayed(Duration.zero);
+
+      await NativeSheetBridge.instance.updateModelSelectorReasoningEffort(
+        presentationId: 'presentation-current',
+        value: 'vendor_ultra',
+        options: const ['automatic', 'vendor_ultra'],
+        allowsCustom: true,
+        onReasoningEffortChanged: (value) async => changed.add(value),
+      );
+      NativeSheetBridge.instance.onReasoningEffortChanged(
+        PlatformNativeSheetReasoningEffortChangedEvent(value: 'vendor_ultra'),
+      );
+      await Future<void>.delayed(Duration.zero);
+
+      check(changed).deepEquals(['vendor_ultra']);
+      presentation.complete(wrapResponse(result: null));
+      await presented;
     });
   });
 }

--- a/test/core/services/native_sheet_bridge_test.dart
+++ b/test/core/services/native_sheet_bridge_test.dart
@@ -478,70 +478,123 @@ void main() {
       await presented;
     });
 
-    test(
-      'older failed effort update cannot restore a stale callback',
-      () async {
-        NativeSheetBridge.instance.debugIsIOSOverride = true;
-        final messenger =
-            TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger;
-        final presentation = Completer<dynamic>();
-        final firstUpdate = Completer<dynamic>();
-        final initialChanges = <String>[];
-        final currentChanges = <String>[];
-        var updateCalls = 0;
-        messenger.setMockDecodedMessageHandler<Object?>(
-          _presentModelSelectorChannel,
-          (_) => presentation.future,
-        );
-        messenger.setMockDecodedMessageHandler<Object?>(
-          _updateModelSelectorReasoningChannel,
-          (_) async {
-            updateCalls += 1;
-            if (updateCalls == 1) return firstUpdate.future;
-            return wrapResponse(empty: true);
-          },
-        );
-        final presented = NativeSheetBridge.instance.presentModelSelector(
-          presentationId: 'presentation-current',
-          title: 'Models',
-          models: const [NativeSheetModelOption(id: 'model-a', name: 'A')],
-          onReasoningEffortChanged: (value) async => initialChanges.add(value),
-        );
-        await Future<void>.delayed(Duration.zero);
-        Future<void> currentHandler(String value) async {
-          currentChanges.add(value);
-        }
+    test('effort updates serialize before rollback', () async {
+      NativeSheetBridge.instance.debugIsIOSOverride = true;
+      final messenger =
+          TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger;
+      final presentation = Completer<dynamic>();
+      final firstUpdate = Completer<dynamic>();
+      final initialChanges = <String>[];
+      final currentChanges = <String>[];
+      var updateCalls = 0;
+      messenger.setMockDecodedMessageHandler<Object?>(
+        _presentModelSelectorChannel,
+        (_) => presentation.future,
+      );
+      messenger.setMockDecodedMessageHandler<Object?>(
+        _updateModelSelectorReasoningChannel,
+        (_) async {
+          updateCalls += 1;
+          if (updateCalls == 1) return firstUpdate.future;
+          return wrapResponse(empty: true);
+        },
+      );
+      final presented = NativeSheetBridge.instance.presentModelSelector(
+        presentationId: 'presentation-current',
+        title: 'Models',
+        models: const [NativeSheetModelOption(id: 'model-a', name: 'A')],
+        onReasoningEffortChanged: (value) async => initialChanges.add(value),
+      );
+      await Future<void>.delayed(Duration.zero);
+      Future<void> currentHandler(String value) async {
+        currentChanges.add(value);
+      }
 
-        final older = NativeSheetBridge.instance
-            .updateModelSelectorReasoningEffort(
-              presentationId: 'presentation-current',
-              value: 'vendor_ultra',
-              options: const ['automatic', 'vendor_ultra'],
-              allowsCustom: true,
-              onReasoningEffortChanged: currentHandler,
-            );
-        await Future<void>.delayed(Duration.zero);
-        await NativeSheetBridge.instance.updateModelSelectorReasoningEffort(
+      final older = NativeSheetBridge.instance
+          .updateModelSelectorReasoningEffort(
+            presentationId: 'presentation-current',
+            value: 'vendor_ultra',
+            options: const ['automatic', 'vendor_ultra'],
+            allowsCustom: true,
+            onReasoningEffortChanged: currentHandler,
+          );
+      await Future<void>.delayed(Duration.zero);
+      final newer = NativeSheetBridge.instance
+          .updateModelSelectorReasoningEffort(
+            presentationId: 'presentation-current',
+            value: 'vendor_ultra',
+            options: const ['automatic', 'vendor_ultra'],
+            allowsCustom: true,
+            onReasoningEffortChanged: currentHandler,
+          );
+      await Future<void>.delayed(Duration.zero);
+      check(updateCalls).equals(1);
+      firstUpdate.complete(
+        wrapResponse(error: PlatformException(code: 'STALE_UPDATE')),
+      );
+      await older;
+      await newer;
+      check(updateCalls).equals(2);
+      NativeSheetBridge.instance.onReasoningEffortChanged(
+        PlatformNativeSheetReasoningEffortChangedEvent(value: 'vendor_ultra'),
+      );
+      await Future<void>.delayed(Duration.zero);
+
+      check(initialChanges).isEmpty();
+      check(currentChanges).deepEquals(['vendor_ultra']);
+      presentation.complete(wrapResponse(result: null));
+      await presented;
+    });
+
+    test('two failed effort updates restore committed callback', () async {
+      NativeSheetBridge.instance.debugIsIOSOverride = true;
+      final messenger =
+          TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger;
+      final presentation = Completer<dynamic>();
+      final initialChanges = <String>[];
+      final failedChanges = <String>[];
+      messenger.setMockDecodedMessageHandler<Object?>(
+        _presentModelSelectorChannel,
+        (_) => presentation.future,
+      );
+      messenger.setMockDecodedMessageHandler<Object?>(
+        _updateModelSelectorReasoningChannel,
+        (_) async =>
+            wrapResponse(error: PlatformException(code: 'UPDATE_FAILED')),
+      );
+      final presented = NativeSheetBridge.instance.presentModelSelector(
+        presentationId: 'presentation-current',
+        title: 'Models',
+        models: const [NativeSheetModelOption(id: 'model-a', name: 'A')],
+        onReasoningEffortChanged: (value) async => initialChanges.add(value),
+      );
+      await Future<void>.delayed(Duration.zero);
+
+      await Future.wait([
+        NativeSheetBridge.instance.updateModelSelectorReasoningEffort(
           presentationId: 'presentation-current',
-          value: 'vendor_ultra',
-          options: const ['automatic', 'vendor_ultra'],
+          value: 'medium',
+          options: const ['automatic', 'medium'],
           allowsCustom: true,
-          onReasoningEffortChanged: currentHandler,
-        );
-        firstUpdate.complete(
-          wrapResponse(error: PlatformException(code: 'STALE_UPDATE')),
-        );
-        await older;
-        NativeSheetBridge.instance.onReasoningEffortChanged(
-          PlatformNativeSheetReasoningEffortChangedEvent(value: 'vendor_ultra'),
-        );
-        await Future<void>.delayed(Duration.zero);
+          onReasoningEffortChanged: (value) async => failedChanges.add(value),
+        ),
+        NativeSheetBridge.instance.updateModelSelectorReasoningEffort(
+          presentationId: 'presentation-current',
+          value: 'high',
+          options: const ['automatic', 'high'],
+          allowsCustom: true,
+          onReasoningEffortChanged: (value) async => failedChanges.add(value),
+        ),
+      ]);
+      NativeSheetBridge.instance.onReasoningEffortChanged(
+        PlatformNativeSheetReasoningEffortChangedEvent(value: 'low'),
+      );
+      await Future<void>.delayed(Duration.zero);
 
-        check(initialChanges).isEmpty();
-        check(currentChanges).deepEquals(['vendor_ultra']);
-        presentation.complete(wrapResponse(result: null));
-        await presented;
-      },
-    );
+      check(initialChanges).deepEquals(['low']);
+      check(failedChanges).isEmpty();
+      presentation.complete(wrapResponse(result: null));
+      await presented;
+    });
   });
 }

--- a/test/core/services/native_sheet_bridge_test.dart
+++ b/test/core/services/native_sheet_bridge_test.dart
@@ -477,5 +477,71 @@ void main() {
       presentation.complete(wrapResponse(result: null));
       await presented;
     });
+
+    test(
+      'older failed effort update cannot restore a stale callback',
+      () async {
+        NativeSheetBridge.instance.debugIsIOSOverride = true;
+        final messenger =
+            TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger;
+        final presentation = Completer<dynamic>();
+        final firstUpdate = Completer<dynamic>();
+        final initialChanges = <String>[];
+        final currentChanges = <String>[];
+        var updateCalls = 0;
+        messenger.setMockDecodedMessageHandler<Object?>(
+          _presentModelSelectorChannel,
+          (_) => presentation.future,
+        );
+        messenger.setMockDecodedMessageHandler<Object?>(
+          _updateModelSelectorReasoningChannel,
+          (_) async {
+            updateCalls += 1;
+            if (updateCalls == 1) return firstUpdate.future;
+            return wrapResponse(empty: true);
+          },
+        );
+        final presented = NativeSheetBridge.instance.presentModelSelector(
+          presentationId: 'presentation-current',
+          title: 'Models',
+          models: const [NativeSheetModelOption(id: 'model-a', name: 'A')],
+          onReasoningEffortChanged: (value) async => initialChanges.add(value),
+        );
+        await Future<void>.delayed(Duration.zero);
+        Future<void> currentHandler(String value) async {
+          currentChanges.add(value);
+        }
+
+        final older = NativeSheetBridge.instance
+            .updateModelSelectorReasoningEffort(
+              presentationId: 'presentation-current',
+              value: 'vendor_ultra',
+              options: const ['automatic', 'vendor_ultra'],
+              allowsCustom: true,
+              onReasoningEffortChanged: currentHandler,
+            );
+        await Future<void>.delayed(Duration.zero);
+        await NativeSheetBridge.instance.updateModelSelectorReasoningEffort(
+          presentationId: 'presentation-current',
+          value: 'vendor_ultra',
+          options: const ['automatic', 'vendor_ultra'],
+          allowsCustom: true,
+          onReasoningEffortChanged: currentHandler,
+        );
+        firstUpdate.complete(
+          wrapResponse(error: PlatformException(code: 'STALE_UPDATE')),
+        );
+        await older;
+        NativeSheetBridge.instance.onReasoningEffortChanged(
+          PlatformNativeSheetReasoningEffortChangedEvent(value: 'vendor_ultra'),
+        );
+        await Future<void>.delayed(Duration.zero);
+
+        check(initialChanges).isEmpty();
+        check(currentChanges).deepEquals(['vendor_ultra']);
+        presentation.complete(wrapResponse(result: null));
+        await presented;
+      },
+    );
   });
 }

--- a/test/core/services/native_sheet_hydration_generation_test.dart
+++ b/test/core/services/native_sheet_hydration_generation_test.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 
 import 'package:checks/checks.dart';
 import 'package:conduit/core/services/native_sheet_hydration_service.dart';
+import 'package:conduit/features/chat/providers/reasoning_effort_provider.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
@@ -18,6 +19,17 @@ void main() {
       ).isFalse();
     },
   );
+
+  test('timed-out effort hydration hides stale picker controls', () {
+    final policy = nativeModelSelectorReasoningEffortPolicy(
+      false,
+      ReasoningEffortPolicy.generic,
+    );
+
+    check(policy.visible).isFalse();
+    check(policy.options).isEmpty();
+    check(policy.allowsCustom).isFalse();
+  });
 
   test('late selector hydration cannot update a newer presentation', () {
     final generations = NativeSheetHydrationGeneration();

--- a/test/core/services/native_sheet_hydration_generation_test.dart
+++ b/test/core/services/native_sheet_hydration_generation_test.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 
 import 'package:checks/checks.dart';
+import 'package:conduit/core/models/model.dart';
 import 'package:conduit/core/services/native_sheet_hydration_service.dart';
 import 'package:conduit/features/chat/providers/reasoning_effort_provider.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -29,6 +30,21 @@ void main() {
     check(policy.visible).isFalse();
     check(policy.options).isEmpty();
     check(policy.allowsCustom).isFalse();
+  });
+
+  test('late effort hydration restores the server custom value', () {
+    final hydrated = nativeHydratedServerReasoningEffort(
+      model: const Model(
+        id: 'workspace-reasoning-model',
+        name: 'Workspace reasoning model',
+      ),
+      detail: const ServerModelReasoningEffort.known('vendor_ultra'),
+      personalizationEffort: 'low',
+    );
+
+    check(hydrated.policy.visible).isTrue();
+    check(hydrated.policy.allowsCustom).isTrue();
+    check(hydrated.value).equals('vendor_ultra');
   });
 
   test('late selector hydration cannot update a newer presentation', () {

--- a/test/core/services/native_sheet_hydration_generation_test.dart
+++ b/test/core/services/native_sheet_hydration_generation_test.dart
@@ -1,8 +1,24 @@
+import 'dart:async';
+
 import 'package:checks/checks.dart';
 import 'package:conduit/core/services/native_sheet_hydration_service.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
+  test(
+    'reasoning effort hydration timeout does not block the picker',
+    () async {
+      final pending = Completer<void>();
+
+      check(
+        await waitForNativeReasoningEffortHydration(
+          pending.future,
+          timeout: Duration.zero,
+        ),
+      ).isFalse();
+    },
+  );
+
   test('late selector hydration cannot update a newer presentation', () {
     final generations = NativeSheetHydrationGeneration();
     final first = generations.begin();

--- a/test/features/chat/providers/reasoning_effort_provider_test.dart
+++ b/test/features/chat/providers/reasoning_effort_provider_test.dart
@@ -1,9 +1,11 @@
 import 'dart:async';
 import 'dart:convert';
+import 'dart:typed_data';
 
 import 'package:checks/checks.dart';
 import 'package:conduit/core/models/model.dart';
 import 'package:conduit/core/models/server_config.dart';
+import 'package:conduit/core/models/server_user_settings.dart';
 import 'package:conduit/core/persistence/persistence_keys.dart';
 import 'package:conduit/core/persistence/preferences_store.dart';
 import 'package:conduit/core/providers/app_providers.dart';
@@ -18,6 +20,7 @@ import 'package:conduit/features/direct_connections/models/openrouter_reasoning.
 import 'package:conduit/features/direct_connections/providers/direct_connection_providers.dart';
 import 'package:conduit/features/direct_connections/services/direct_model_registry.dart';
 import 'package:conduit/features/hermes/models/hermes_model.dart';
+import 'package:dio/dio.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:shared_preferences/shared_preferences.dart';
@@ -43,6 +46,68 @@ final class _PendingProfiles extends DirectConnectionProfilesController {
       setting: setting?.storageValue,
     ));
   }
+}
+
+final class _FixedPersonalizationSettings extends PersonalizationSettings {
+  _FixedPersonalizationSettings(this.settings);
+
+  final ServerUserSettings settings;
+
+  @override
+  Future<ServerUserSettings> build() async => settings;
+}
+
+final class _FixedSelectedModel extends SelectedModel {
+  _FixedSelectedModel(this.model);
+
+  final Model model;
+
+  @override
+  Model build() => model;
+}
+
+final class _ModelDetailsAdapter implements HttpClientAdapter {
+  int requestCount = 0;
+  final Completer<void> requested = Completer<void>();
+
+  @override
+  Future<ResponseBody> fetch(
+    RequestOptions options,
+    Stream<Uint8List>? requestStream,
+    Future<void>? cancelFuture,
+  ) async {
+    requestCount++;
+    if (!requested.isCompleted) requested.complete();
+    check(options.method).equals('GET');
+    check(options.path).equals('/api/v1/models/model');
+    check(
+      options.queryParameters,
+    ).deepEquals(<String, dynamic>{'id': 'workspace-reasoning-model'});
+    return ResponseBody(
+      Stream<Uint8List>.value(
+        Uint8List.fromList(
+          utf8.encode(
+            jsonEncode(<String, dynamic>{
+              'id': 'workspace-reasoning-model',
+              'name': 'Workspace reasoning model',
+              'base_model_id': 'gpt-5',
+              'params': <String, dynamic>{'reasoning_effort': 'Vendor_Ultra'},
+              'meta': <String, dynamic>{},
+              'is_active': true,
+              'write_access': true,
+            }),
+          ),
+        ),
+      ),
+      200,
+      headers: <String, List<String>>{
+        Headers.contentTypeHeader: <String>[Headers.jsonContentType],
+      },
+    );
+  }
+
+  @override
+  void close({bool force = false}) {}
 }
 
 void main() {
@@ -117,6 +182,62 @@ void main() {
     check(modelConfiguredReasoningEffort(model)).equals('vendor_ultra');
     check(container.read(reasoningEffortProvider)).equals('vendor_ultra');
   });
+
+  test(
+    'workspace model detail restores effort stripped from the model catalog',
+    () async {
+      const model = Model(
+        id: 'workspace-reasoning-model',
+        name: 'Workspace reasoning model',
+        metadata: <String, dynamic>{
+          'info': <String, dynamic>{
+            'id': 'workspace-reasoning-model',
+            'user_id': 'owner',
+            'base_model_id': 'gpt-5',
+            'meta': <String, dynamic>{},
+          },
+        },
+      );
+      final adapter = _ModelDetailsAdapter();
+      final api = ApiService(
+        serverConfig: const ServerConfig(
+          id: 'reasoning-test',
+          name: 'Reasoning test',
+          url: 'https://example.test',
+        ),
+        workerManager: WorkerManager(),
+      );
+      api.dio.httpClientAdapter = adapter;
+      api.dio.interceptors.clear();
+      final container = ProviderContainer(
+        overrides: [
+          apiServiceProvider.overrideWithValue(api),
+          personalizationSettingsProvider.overrideWith(
+            () => _FixedPersonalizationSettings(
+              const ServerUserSettings(reasoningEffort: 'low'),
+            ),
+          ),
+          selectedModelProvider.overrideWith(() => _FixedSelectedModel(model)),
+        ],
+      );
+      addTearDown(container.dispose);
+      await container.read(personalizationSettingsProvider.future);
+      final subscription = container.listen<String?>(
+        configuredReasoningEffortProvider,
+        (_, _) {},
+        fireImmediately: true,
+      );
+      addTearDown(subscription.close);
+
+      await adapter.requested.future.timeout(const Duration(seconds: 1));
+      await container.read(serverModelReasoningEffortProvider(model).future);
+
+      check(adapter.requestCount).equals(1);
+      check(
+        container.read(configuredReasoningEffortProvider),
+      ).equals('vendor_ultra');
+    },
+  );
 
   test('server policy only exposes effort for supported models', () {
     const unsupported = Model(id: 'gpt-4o', name: 'GPT-4o');

--- a/test/features/chat/providers/reasoning_effort_provider_test.dart
+++ b/test/features/chat/providers/reasoning_effort_provider_test.dart
@@ -9,6 +9,7 @@ import 'package:conduit/core/persistence/preferences_store.dart';
 import 'package:conduit/core/providers/app_providers.dart';
 import 'package:conduit/core/services/api_service.dart';
 import 'package:conduit/core/services/worker_manager.dart';
+import 'package:conduit/features/chat/providers/chat_providers.dart';
 import 'package:conduit/features/chat/providers/reasoning_effort_provider.dart';
 import 'package:conduit/features/direct_connections/models/direct_connection_profile.dart';
 import 'package:conduit/features/direct_connections/models/direct_remote_model.dart';
@@ -109,7 +110,12 @@ void main() {
       },
     );
 
+    final container = ProviderContainer();
+    addTearDown(container.dispose);
+    container.read(selectedModelProvider.notifier).set(model);
+
     check(modelConfiguredReasoningEffort(model)).equals('vendor_ultra');
+    check(container.read(reasoningEffortProvider)).equals('vendor_ultra');
   });
 
   test('server policy only exposes effort for supported models', () {
@@ -177,6 +183,59 @@ void main() {
     check(unsupportedParams.containsKey('reasoning_effort')).isFalse();
     check(unsupportedParams['temperature']).equals(0.3);
     check(supportedParams['reasoning_effort']).equals('medium');
+  });
+
+  test('custom OpenWebUI model metadata retains supported effort', () {
+    final api = ApiService(
+      serverConfig: const ServerConfig(
+        id: 'reasoning-test',
+        name: 'Reasoning test',
+        url: 'https://example.test',
+      ),
+      workerManager: WorkerManager(),
+    );
+
+    Map<String, dynamic> build(Model model, String effort) {
+      final modelItem = buildLocalModelItemForTest(model);
+      return api.buildChatCompletionPayloadForTest(
+        messages: const <Map<String, dynamic>>[
+          <String, dynamic>{'role': 'user', 'content': 'Hello'},
+        ],
+        model: model.id,
+        messageId: 'message-id',
+        sessionId: 'session-id',
+        modelItem: modelItem,
+        userSettings: <String, dynamic>{
+          'params': <String, dynamic>{'reasoning_effort': effort},
+        },
+      );
+    }
+
+    final configuredModel = Model.fromJson(<String, dynamic>{
+      'id': 'custom-configured-model',
+      'name': 'Custom configured model',
+      'params': <String, dynamic>{'reasoning_effort': 'vendor_ultra'},
+    });
+    final aliasModel = Model.fromJson(<String, dynamic>{
+      'id': 'custom-gpt-alias',
+      'name': 'Custom GPT alias',
+      'base_model_id': 'gpt-5',
+    });
+
+    final configuredModelItem = buildLocalModelItemForTest(configuredModel);
+    final aliasModelItem = buildLocalModelItemForTest(aliasModel);
+    check(configuredModelItem['params']).isA<Map<String, dynamic>>().deepEquals(
+      <String, dynamic>{'reasoning_effort': 'vendor_ultra'},
+    );
+    check(aliasModelItem['base_model_id']).equals('gpt-5');
+    check(
+      (build(configuredModel, 'vendor_ultra')['params']
+          as Map<String, dynamic>)['reasoning_effort'],
+    ).equals('vendor_ultra');
+    check(
+      (build(aliasModel, 'high')['params']
+          as Map<String, dynamic>)['reasoning_effort'],
+    ).equals('high');
   });
 
   test(

--- a/test/features/chat/providers/reasoning_effort_provider_test.dart
+++ b/test/features/chat/providers/reasoning_effort_provider_test.dart
@@ -3,9 +3,12 @@ import 'dart:convert';
 
 import 'package:checks/checks.dart';
 import 'package:conduit/core/models/model.dart';
+import 'package:conduit/core/models/server_config.dart';
 import 'package:conduit/core/persistence/persistence_keys.dart';
 import 'package:conduit/core/persistence/preferences_store.dart';
 import 'package:conduit/core/providers/app_providers.dart';
+import 'package:conduit/core/services/api_service.dart';
+import 'package:conduit/core/services/worker_manager.dart';
 import 'package:conduit/features/chat/providers/reasoning_effort_provider.dart';
 import 'package:conduit/features/direct_connections/models/direct_connection_profile.dart';
 import 'package:conduit/features/direct_connections/models/direct_remote_model.dart';
@@ -13,6 +16,7 @@ import 'package:conduit/features/direct_connections/models/ollama_thinking.dart'
 import 'package:conduit/features/direct_connections/models/openrouter_reasoning.dart';
 import 'package:conduit/features/direct_connections/providers/direct_connection_providers.dart';
 import 'package:conduit/features/direct_connections/services/direct_model_registry.dart';
+import 'package:conduit/features/hermes/models/hermes_model.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:shared_preferences/shared_preferences.dart';
@@ -106,6 +110,73 @@ void main() {
     );
 
     check(modelConfiguredReasoningEffort(model)).equals('vendor_ultra');
+  });
+
+  test('server policy only exposes effort for supported models', () {
+    const unsupported = Model(id: 'gpt-4o', name: 'GPT-4o');
+    const explicitlyUnsupported = Model(
+      id: 'catalog-model',
+      name: 'Catalog model',
+      capabilities: <String, dynamic>{
+        'reasoning': <String, dynamic>{'supported_efforts': <String>[]},
+      },
+    );
+    const supported = Model(id: 'gpt-5', name: 'GPT-5');
+    final hermes = hermesSyntheticModel();
+    final container = ProviderContainer();
+    addTearDown(container.dispose);
+
+    check(
+      reasoningEffortPolicyForModel(container.read, unsupported).visible,
+    ).isFalse();
+    check(
+      reasoningEffortPolicyForModel(
+        container.read,
+        explicitlyUnsupported,
+      ).visible,
+    ).isFalse();
+    check(
+      reasoningEffortPolicyForModel(container.read, supported).visible,
+    ).isTrue();
+    check(
+      reasoningEffortPolicyForModel(container.read, hermes).visible,
+    ).isTrue();
+  });
+
+  test('chat payload omits effort for unsupported server models', () {
+    final api = ApiService(
+      serverConfig: const ServerConfig(
+        id: 'reasoning-test',
+        name: 'Reasoning test',
+        url: 'https://example.test',
+      ),
+      workerManager: WorkerManager(),
+    );
+    final userSettings = <String, dynamic>{
+      'params': <String, dynamic>{
+        'reasoning_effort': 'medium',
+        'temperature': 0.3,
+      },
+    };
+
+    Map<String, dynamic> build(String model) =>
+        api.buildChatCompletionPayloadForTest(
+          messages: const <Map<String, dynamic>>[
+            <String, dynamic>{'role': 'user', 'content': 'Hello'},
+          ],
+          model: model,
+          messageId: 'message-id',
+          sessionId: 'session-id',
+          modelItem: <String, dynamic>{'id': model, 'name': model},
+          userSettings: userSettings,
+        );
+
+    final unsupportedParams = build('gpt-4o')['params'] as Map<String, dynamic>;
+    final supportedParams = build('gpt-5')['params'] as Map<String, dynamic>;
+
+    check(unsupportedParams.containsKey('reasoning_effort')).isFalse();
+    check(unsupportedParams['temperature']).equals(0.3);
+    check(supportedParams['reasoning_effort']).equals('medium');
   });
 
   test(

--- a/test/features/chat/providers/reasoning_effort_provider_test.dart
+++ b/test/features/chat/providers/reasoning_effort_provider_test.dart
@@ -70,10 +70,14 @@ final class _ModelDetailsAdapter implements HttpClientAdapter {
   _ModelDetailsAdapter({
     this.failuresBeforeSuccess = 0,
     this.holdSuccessfulResponse = true,
+    this.writeAccess = true,
+    this.includeEffort = true,
   });
 
   final int failuresBeforeSuccess;
   final bool holdSuccessfulResponse;
+  final bool writeAccess;
+  final bool includeEffort;
   int requestCount = 0;
   final Completer<void> requested = Completer<void>();
   final Completer<void> release = Completer<void>();
@@ -109,10 +113,12 @@ final class _ModelDetailsAdapter implements HttpClientAdapter {
               'id': 'workspace-reasoning-model',
               'name': 'Workspace reasoning model',
               'base_model_id': 'gpt-5',
-              'params': <String, dynamic>{'reasoning_effort': 'Vendor_Ultra'},
+              'params': <String, dynamic>{
+                if (includeEffort) 'reasoning_effort': 'Vendor_Ultra',
+              },
               'meta': <String, dynamic>{},
               'is_active': true,
-              'write_access': true,
+              'write_access': writeAccess,
             }),
           ),
         ),
@@ -291,13 +297,67 @@ void main() {
     addTearDown(container.dispose);
 
     check(
-      await container.read(serverModelReasoningEffortProvider(model).future),
+      (await container.read(
+        serverModelReasoningEffortProvider(model).future,
+      )).value,
     ).isNull();
     await container.pump();
     check(
-      await container.read(serverModelReasoningEffortProvider(model).future),
+      (await container.read(
+        serverModelReasoningEffortProvider(model).future,
+      )).value,
     ).equals('vendor_ultra');
     check(adapter.requestCount).equals(2);
+  });
+
+  test('read-only workspace params do not restore the user fallback', () async {
+    const model = Model(
+      id: 'workspace-reasoning-model',
+      name: 'Workspace reasoning model',
+      metadata: <String, dynamic>{
+        'info': <String, dynamic>{
+          'id': 'workspace-reasoning-model',
+          'user_id': 'owner',
+          'base_model_id': 'gpt-5',
+        },
+      },
+    );
+    final adapter = _ModelDetailsAdapter(
+      holdSuccessfulResponse: false,
+      writeAccess: false,
+      includeEffort: false,
+    );
+    final api = ApiService(
+      serverConfig: const ServerConfig(
+        id: 'reasoning-read-only-test',
+        name: 'Reasoning read-only test',
+        url: 'https://example.test',
+      ),
+      workerManager: WorkerManager(),
+    );
+    api.dio.httpClientAdapter = adapter;
+    api.dio.interceptors.clear();
+    final container = ProviderContainer(
+      overrides: [
+        apiServiceProvider.overrideWithValue(api),
+        personalizationSettingsProvider.overrideWith(
+          () => _FixedPersonalizationSettings(
+            const ServerUserSettings(reasoningEffort: 'low'),
+          ),
+        ),
+        selectedModelProvider.overrideWith(() => _FixedSelectedModel(model)),
+      ],
+    );
+    addTearDown(container.dispose);
+    await container.read(personalizationSettingsProvider.future);
+
+    final detail = await container.read(
+      serverModelReasoningEffortProvider(model).future,
+    );
+
+    check(detail.canUsePersonalizationFallback).isFalse();
+    check(container.read(configuredReasoningEffortProvider)).isNull();
+    check(container.read(reasoningEffortProvider)).equals('automatic');
   });
 
   test('server policy only exposes effort for supported models', () {

--- a/test/features/chat/providers/reasoning_effort_provider_test.dart
+++ b/test/features/chat/providers/reasoning_effort_provider_test.dart
@@ -69,6 +69,7 @@ final class _FixedSelectedModel extends SelectedModel {
 final class _ModelDetailsAdapter implements HttpClientAdapter {
   int requestCount = 0;
   final Completer<void> requested = Completer<void>();
+  final Completer<void> release = Completer<void>();
 
   @override
   Future<ResponseBody> fetch(
@@ -83,6 +84,7 @@ final class _ModelDetailsAdapter implements HttpClientAdapter {
     check(
       options.queryParameters,
     ).deepEquals(<String, dynamic>{'id': 'workspace-reasoning-model'});
+    await release.future;
     return ResponseBody(
       Stream<Uint8List>.value(
         Uint8List.fromList(
@@ -230,6 +232,8 @@ void main() {
       addTearDown(subscription.close);
 
       await adapter.requested.future.timeout(const Duration(seconds: 1));
+      check(container.read(configuredReasoningEffortProvider)).isNull();
+      adapter.release.complete();
       await container.read(serverModelReasoningEffortProvider(model).future);
 
       check(adapter.requestCount).equals(1);

--- a/test/features/chat/providers/reasoning_effort_provider_test.dart
+++ b/test/features/chat/providers/reasoning_effort_provider_test.dart
@@ -67,6 +67,13 @@ final class _FixedSelectedModel extends SelectedModel {
 }
 
 final class _ModelDetailsAdapter implements HttpClientAdapter {
+  _ModelDetailsAdapter({
+    this.failuresBeforeSuccess = 0,
+    this.holdSuccessfulResponse = true,
+  });
+
+  final int failuresBeforeSuccess;
+  final bool holdSuccessfulResponse;
   int requestCount = 0;
   final Completer<void> requested = Completer<void>();
   final Completer<void> release = Completer<void>();
@@ -84,7 +91,16 @@ final class _ModelDetailsAdapter implements HttpClientAdapter {
     check(
       options.queryParameters,
     ).deepEquals(<String, dynamic>{'id': 'workspace-reasoning-model'});
-    await release.future;
+    if (requestCount <= failuresBeforeSuccess) {
+      return ResponseBody.fromString(
+        '{"detail":"temporary failure"}',
+        503,
+        headers: <String, List<String>>{
+          Headers.contentTypeHeader: <String>[Headers.jsonContentType],
+        },
+      );
+    }
+    if (holdSuccessfulResponse) await release.future;
     return ResponseBody(
       Stream<Uint8List>.value(
         Uint8List.fromList(
@@ -242,6 +258,47 @@ void main() {
       ).equals('vendor_ultra');
     },
   );
+
+  test('workspace model detail retries after a transient failure', () async {
+    const model = Model(
+      id: 'workspace-reasoning-model',
+      name: 'Workspace reasoning model',
+      metadata: <String, dynamic>{
+        'info': <String, dynamic>{
+          'id': 'workspace-reasoning-model',
+          'user_id': 'owner',
+          'base_model_id': 'gpt-5',
+        },
+      },
+    );
+    final adapter = _ModelDetailsAdapter(
+      failuresBeforeSuccess: 1,
+      holdSuccessfulResponse: false,
+    );
+    final api = ApiService(
+      serverConfig: const ServerConfig(
+        id: 'reasoning-retry-test',
+        name: 'Reasoning retry test',
+        url: 'https://example.test',
+      ),
+      workerManager: WorkerManager(),
+    );
+    api.dio.httpClientAdapter = adapter;
+    api.dio.interceptors.clear();
+    final container = ProviderContainer(
+      overrides: [apiServiceProvider.overrideWithValue(api)],
+    );
+    addTearDown(container.dispose);
+
+    check(
+      await container.read(serverModelReasoningEffortProvider(model).future),
+    ).isNull();
+    await container.pump();
+    check(
+      await container.read(serverModelReasoningEffortProvider(model).future),
+    ).equals('vendor_ultra');
+    check(adapter.requestCount).equals(2);
+  });
 
   test('server policy only exposes effort for supported models', () {
     const unsupported = Model(id: 'gpt-4o', name: 'GPT-4o');

--- a/test/features/chat/widgets/model_selector_sheet_test.dart
+++ b/test/features/chat/widgets/model_selector_sheet_test.dart
@@ -7,6 +7,7 @@ import 'package:conduit/features/chat/widgets/model_selector_sheet.dart';
 import 'package:conduit/features/direct_connections/models/direct_connection_profile.dart';
 import 'package:conduit/features/direct_connections/models/direct_remote_model.dart';
 import 'package:conduit/features/direct_connections/services/direct_model_registry.dart';
+import 'package:conduit/l10n/app_localizations_en.dart';
 
 void main() {
   group('sortModelsWithPinnedOrder', () {
@@ -58,5 +59,11 @@ void main() {
     ]).single;
 
     check(modelSelectorQueryMatches(model, 'home ollama')).isTrue();
+  });
+
+  test('custom server reasoning effort uses its configured level name', () {
+    check(
+      reasoningEffortLabelForTest(AppLocalizationsEn(), 'vendor_ultra'),
+    ).equals('vendor_ultra');
   });
 }


### PR DESCRIPTION
## Summary

- clear server-backed `reasoning_effort` by explicitly replacing the nested params map when Automatic is selected
- omit the parameter at the chat request boundary for models that do not advertise support
- hide the effort control for unsupported server models while preserving GPT-5, o-series, Hermes, and explicit/custom capability metadata
- retain custom server-provided effort names and unrelated user parameters

## Verification

- `flutter test test/core/services/api_service_user_settings_test.dart test/features/chat/providers/reasoning_effort_provider_test.dart test/core/services/api_service_chat_completion_test.dart test/features/direct_connections/direct_adapters_test.dart test/features/hermes/hermes_real_payloads_test.dart test/features/hermes/hermes_model_test.dart`
- `flutter analyze`

Closes #611

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added model-aware reasoning-effort support across supported model types.
  * Model selector controls, available options, custom values, and labels now adapt to model and server configuration.
  * Selected model settings can load and update while the selector is open.
  * Custom model metadata is preserved.

* **Bug Fixes**
  * Chat requests include reasoning effort only when supported.
  * Unsupported models no longer receive reasoning-effort parameters.
  * Clearing reasoning-effort settings preserves other preferences.
  * Delayed or failed model details no longer leave stale selector options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix reasoning effort persistence and model support detection for chat completions
> - Adds `modelSupportsReasoningEffort` detection to strip `reasoning_effort` from chat payloads when the value is `'automatic'` or the selected model does not support it.
> - Fixes a server-side merge bug where the `params` key was omitted from user-settings updates when empty, causing the server to retain previously stored nested values.
> - For OpenWebUI workspace models, reasoning effort is now fetched asynchronously from a model details endpoint; the iOS model selector sheet updates in-place once hydration completes, initially showing 'Automatic' if data is not ready.
> - Extends `Model.fromJson` to preserve provider capability metadata and adds a `supportsReasoningEffort` getter, used by both payload assembly and policy evaluation.
> - Risk: `configuredReasoningEffortProvider` may now return `null` while awaiting server details for workspace models, and models without explicit reasoning effort support are classified as `unsupported`, hiding the control entirely.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized cf729e5.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This change adds model-aware reasoning-effort detection, removes unsupported reasoning parameters from completion requests, preserves model capability metadata, and progressively updates native model-selector controls when workspace-model details arrive.

No product defects were established.

## T-Rex validation blocked
- **Missing tool — Flutter SDK:** The focused completion-payload harness, reasoning-effort provider test, delayed native hydration test, and consecutive native callback-update test could not execute because `flutter` is not installed on PATH. `dart` is also unavailable.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR is safe to merge; no blocking failure remains in the final defect set.

The changed request-filtering and native hydration paths were inspected and focused runtime checks were prepared, but application execution was unavailable because the required Flutter tooling is not installed. This environment limitation did not establish a product defect.
</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- A focused exact-path harness test was invoked to exercise the payload builder and the reasoning-effort provider, but no Dart behavior ran because the Flutter SDK was missing.
- Focused delayed-hydration and consecutive native tests were attempted via an executable harness, but both exited with code 127 due to Flutter being unavailable, so no Flutter or iOS behavior was observed.
- The hypothesis verdict remains blocked; the saved harness would verify payload forwarding for supported shapes and removal for unsupported model IDs, and relevant references were uploaded for review.
- Blocker confirmation: /bin/sh: flutter: not found, and no Flutter/iOS/Chromium toolchain is installed; the native effort bridge harness script documents these attempts.

<a href="https://app.greptile.com/trex/runs/17242700/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (9): Last reviewed commit: ["test: distinguish native effort update c..."](https://github.com/cogwheel0/conduit/commit/cf729e5b6df7ef8bdc127d1d28e2eaea9ea9607d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50027015)</sub>

<!-- /greptile_comment -->