### PR TITLE
Fix note editor context-menu crashes

### DIFF
--- a/lib/features/notes/views/note_editor_page.dart
+++ b/lib/features/notes/views/note_editor_page.dart
@@ -2661,7 +2661,10 @@ class _NoteEditorPageState extends ConsumerState<NoteEditorPage> {
         controller: controller,
         focusNode: _contentFocusNode,
         // Lives inside the page's SingleChildScrollView; the editor must not
-        // scroll independently so the whole note grows with the content.
+        // scroll independently so the whole note grows with the content. Give
+        // Fleather the parent controller so context-menu actions can reveal the
+        // selection without reading an unattached internal ScrollController.
+        scrollController: _scrollController,
         scrollable: false,
         expands: false,
         padding: EdgeInsets.zero,

--- a/test/features/notes/providers/notes_providers_test.dart
+++ b/test/features/notes/providers/notes_providers_test.dart
@@ -22,8 +22,11 @@ import 'package:conduit/shared/theme/app_theme.dart';
 import 'package:conduit/shared/theme/tweakcn_themes.dart';
 import 'package:dio/dio.dart';
 import 'package:drift/native.dart';
+import 'package:fleather/fleather.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 const _testUser = User(
@@ -108,6 +111,7 @@ Widget _noteEditorHarness({
   required AppDatabase db,
   required SyncEngine syncEngine,
   bool withBackRoute = false,
+  TargetPlatform platform = TargetPlatform.android,
 }) {
   return ProviderScope(
     overrides: [
@@ -126,7 +130,7 @@ Widget _noteEditorHarness({
     child: MaterialApp(
       theme: AppTheme.light(
         TweakcnThemes.conduit,
-      ).copyWith(platform: TargetPlatform.android),
+      ).copyWith(platform: platform),
       localizationsDelegates: AppLocalizations.localizationsDelegates,
       supportedLocales: AppLocalizations.supportedLocales,
       initialRoute: withBackRoute ? '/editor' : null,
@@ -152,6 +156,79 @@ void main() {
     tearDown(() async {
       await db.close();
     });
+
+    testWidgets(
+      'note context-menu copy keeps a scroll client on Android and iOS',
+      (tester) async {
+        final originalErrorWidgetBuilder = ErrorWidget.builder;
+        final messenger =
+            TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger;
+        final platformCalls = <MethodCall>[];
+        messenger.setMockMethodCallHandler(
+          SystemChannels.platform,
+          (call) async {
+            platformCalls.add(call);
+            return null;
+          },
+        );
+
+        try {
+          await tester.binding.setSurfaceSize(const Size(1200, 900));
+          await tester.pumpWidget(
+            _noteEditorHarness(
+              db: db,
+              syncEngine: _NoDrainSyncEngine(),
+              platform: defaultTargetPlatform,
+            ),
+          );
+          await tester.pumpAndSettle();
+
+          final editorState = tester.state<EditorState>(find.byType(RawEditor));
+          editorState.userUpdateTextEditingValue(
+            editorState.textEditingValue.copyWith(
+              selection: const TextSelection(baseOffset: 0, extentOffset: 7),
+            ),
+            SelectionChangedCause.longPress,
+          );
+          await tester.pump();
+
+          final copyButton = editorState.contextMenuButtonItems.singleWhere(
+            (button) => button.type == ContextMenuButtonType.copy,
+          );
+          expect(copyButton.onPressed, isNotNull);
+          copyButton.onPressed!();
+          await tester.pumpAndSettle();
+
+          final editor = tester.widget<FleatherEditor>(
+            find.byType(FleatherEditor),
+          );
+          final pageScrollView = tester.widget<SingleChildScrollView>(
+            find
+                .ancestor(
+                  of: find.byType(FleatherEditor),
+                  matching: find.byType(SingleChildScrollView),
+                )
+                .first,
+          );
+          expect(editor.scrollController, same(pageScrollView.controller));
+          expect(editor.scrollController?.hasClients, isTrue);
+          final clipboardCall = platformCalls.singleWhere(
+            (call) => call.method == 'Clipboard.setData',
+          );
+          expect(clipboardCall.arguments, <String, dynamic>{'text': 'Deleted'});
+          expect(tester.takeException(), isNull);
+        } finally {
+          messenger.setMockMethodCallHandler(SystemChannels.platform, null);
+          await tester.pumpWidget(const SizedBox.shrink());
+          await tester.binding.setSurfaceSize(null);
+          ErrorWidget.builder = originalErrorWidgetBuilder;
+        }
+      },
+      variant: const TargetPlatformVariant({
+        TargetPlatform.android,
+        TargetPlatform.iOS,
+      }),
+    );
 
     test('renders cached Drift notes when the API is unavailable', () async {
       await db


### PR DESCRIPTION
## Summary

- give the non-scrollable Fleather editor its parent page scroll controller so selection actions can safely reveal the selection
- add Android and iOS regression coverage that invokes the Copy context-menu action and verifies clipboard output
- verify the reported Select All flow on an iOS simulator without a crash or error log

## Testing

- `flutter test test/features/notes/providers/notes_providers_test.dart` — 26 passed
- `flutter analyze` — no issues
- repository-wide `flutter test --reporter failures-only` — 5,137 passed, 4 skipped, 2 resource-sensitive timing failures under parallel load; both affected files pass serially (10 tests)

Fixes #612

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix note editor context-menu crashes by sharing the page-level ScrollController with FleatherEditor
> - Passes the page-level `_scrollController` to `FleatherEditor` in [note_editor_page.dart](https://github.com/cogwheel0/conduit/pull/614/files#diff-78854ea1159ecb3432e03346b97a0fe608a7e37275f5685601fc69ec944c11f4), so it shares the same controller as the surrounding `SingleChildScrollView` instead of using an unattached internal one.
> - Without this, context-menu actions (e.g. Copy) on Android and iOS could crash because the editor's scroll controller had no attached client.
> - Adds a widget test covering the copy context-menu on both Android and iOS via `TargetPlatformVariant`, asserting the shared controller has an attached scroll client and that clipboard data is set correctly.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4db819c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved note editor scrolling when using selection-related context-menu actions.
  * Copying selected text now preserves the surrounding scroll position and reliably writes content to the clipboard across Android and iOS.
  * Prevented Flutter exceptions during copy actions in the note editor.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This change lets the embedded note editor use the page’s existing scroll controller, so selection context-menu actions can reveal text through the attached page scroll view without enabling an independent editor scroll area. It also adds Android and iOS widget coverage for long-press Copy, clipboard output, controller attachment, and uncaught exceptions.

No defects were found.

## T-Rex validation blocked

The focused Flutter widget test could not start because the Flutter SDK tool (`flutter`) is not installed or available on `PATH`. The captured command exited with code 127 before the test suite could load.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- The team attempted the focused Flutter widget test for Android and iOS long-press Copy behavior from /home/user/repo, but the command exited with code 127 because flutter was not found on PATH.

<a href="https://app.greptile.com/trex/runs/17285252/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(notes): keep context-menu scrolling ..."](https://github.com/cogwheel0/conduit/commit/4db819cfb1be6930a74da2d4ffdb90d0b90f8bb7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50145432)</sub>

<!-- /greptile_comment -->