### PR TITLE
fix(auth): finish proxy login after iOS redirects

### DIFF
--- a/lib/features/auth/views/proxy_auth_page.dart
+++ b/lib/features/auth/views/proxy_auth_page.dart
@@ -352,6 +352,8 @@ final class ProxyAuthDocumentTicket {
   final String url;
 }
 
+enum _ProxyAuthDocumentState { live, movedAway, lost }
+
 /// Binds asynchronous credential capture to one main-frame document.
 @visibleForTesting
 final class ProxyAuthDocumentFence {
@@ -710,7 +712,7 @@ class _ProxyAuthPageState extends ConsumerState<ProxyAuthPage> {
           pageUrl: url,
           serverUrl: serverUrl,
         ) ||
-        !await _isControllerOnDocument(document)) {
+        await _documentState(document) != _ProxyAuthDocumentState.live) {
       _isOnTargetServer = false;
       return;
     }
@@ -745,9 +747,7 @@ class _ProxyAuthPageState extends ConsumerState<ProxyAuthPage> {
         ''',
       );
 
-      if (!_ownsCaptureDocument(document) ||
-          !await _isControllerOnDocument(document) ||
-          !_ownsCaptureDocument(document)) {
+      if (await _documentState(document) != _ProxyAuthDocumentState.live) {
         _isOnTargetServer = false;
         return;
       }
@@ -827,17 +827,20 @@ class _ProxyAuthPageState extends ConsumerState<ProxyAuthPage> {
   }) async {
     if (_cookiesCaptured || !mounted) return;
     final document = expectedDocument ?? _documentFence.committedDocument;
-    if (document == null || !_ownsCaptureDocument(document)) return;
-    if (!await _isControllerOnDocument(document)) {
-      if (!_ownsCaptureDocument(document)) return;
-      _isOnTargetServer = false;
-      DebugLogger.auth(
-        'Skipping proxy credential capture outside the committed document',
-        scope: 'auth/proxy',
-      );
-      return;
+    if (document == null) return;
+    switch (await _documentState(document)) {
+      case _ProxyAuthDocumentState.live:
+        break;
+      case _ProxyAuthDocumentState.movedAway:
+        _isOnTargetServer = false;
+        DebugLogger.auth(
+          'Skipping proxy credential capture outside the committed document',
+          scope: 'auth/proxy',
+        );
+        return;
+      case _ProxyAuthDocumentState.lost:
+        return;
     }
-    if (!_ownsCaptureDocument(document)) return;
 
     final captureRequest = _captureQueue.begin(request);
     if (captureRequest == null) return;
@@ -857,12 +860,7 @@ class _ProxyAuthPageState extends ConsumerState<ProxyAuthPage> {
     ProxyAuthCaptureRequest? nextRequest;
 
     try {
-      if (!await _isControllerOnDocument(document)) {
-        if (!_ownsCaptureDocument(document)) return;
-        _isOnTargetServer = false;
-        return;
-      }
-      if (!_ownsCaptureDocument(document)) return;
+      if (!await _canContinueCredentialCapture(document)) return;
 
       final serverUrl = widget.config.serverConfig.url;
       DebugLogger.auth(
@@ -875,13 +873,7 @@ class _ProxyAuthPageState extends ConsumerState<ProxyAuthPage> {
         proxyCookieLookupUrl(serverUrl),
       );
 
-      if (!_ownsCaptureDocument(document)) return;
-      if (!await _isControllerOnDocument(document)) {
-        if (!_ownsCaptureDocument(document)) return;
-        _isOnTargetServer = false;
-        return;
-      }
-      if (!_ownsCaptureDocument(document)) return;
+      if (!await _canContinueCredentialCapture(document)) return;
 
       DebugLogger.auth(
         'Captured ${cookies.length} proxy cookies',
@@ -899,13 +891,7 @@ class _ProxyAuthPageState extends ConsumerState<ProxyAuthPage> {
       // This happens when oauth2-proxy sets X-Forwarded-Email and OpenWebUI
       // auto-creates/logs in the user
       final jwtToken = await _tryCaptureJwtTokenWithRetry(document);
-      if (!_ownsCaptureDocument(document)) return;
-      if (!await _isControllerOnDocument(document)) {
-        if (!_ownsCaptureDocument(document)) return;
-        _isOnTargetServer = false;
-        return;
-      }
-      if (!_ownsCaptureDocument(document)) return;
+      if (!await _canContinueCredentialCapture(document)) return;
       final decision = decideProxyAuthCapture(
         activeRequest: request,
         queuedRequest: _captureQueue.queuedRequest,
@@ -926,9 +912,10 @@ class _ProxyAuthPageState extends ConsumerState<ProxyAuthPage> {
           );
           break;
         case ProxyAuthCaptureDecision.complete:
-          if (!mounted || !_ownsCaptureDocument(document)) return;
-          if (!await _isControllerOnDocument(document)) return;
-          if (!mounted || !_ownsCaptureDocument(document)) return;
+          if (await _documentState(document) != _ProxyAuthDocumentState.live) {
+            return;
+          }
+          if (!mounted) return;
 
           _cookiesCaptured = true;
           didComplete = true;
@@ -1051,7 +1038,9 @@ class _ProxyAuthPageState extends ConsumerState<ProxyAuthPage> {
   ) async {
     final controller = _controller;
     if (controller == null || !mounted) return false;
-    if (!await _isControllerOnDocument(document)) return false;
+    if (await _documentState(document) != _ProxyAuthDocumentState.live) {
+      return false;
+    }
 
     try {
       final result = await controller.evaluateJavascript(
@@ -1064,9 +1053,7 @@ class _ProxyAuthPageState extends ConsumerState<ProxyAuthPage> {
         ''',
       );
 
-      if (!mounted ||
-          !await _isControllerOnDocument(document) ||
-          !_ownsCaptureDocument(document)) {
+      if (await _documentState(document) != _ProxyAuthDocumentState.live) {
         return false;
       }
       return result.toString().contains('true');
@@ -1105,7 +1092,9 @@ class _ProxyAuthPageState extends ConsumerState<ProxyAuthPage> {
   Future<String?> _tryCaptureJwtToken(ProxyAuthDocumentTicket document) async {
     final controller = _controller;
     if (controller == null || !mounted) return null;
-    if (!await _isControllerOnDocument(document)) return null;
+    if (await _documentState(document) != _ProxyAuthDocumentState.live) {
+      return null;
+    }
 
     // Strategy 1: Check token cookie
     try {
@@ -1124,9 +1113,7 @@ class _ProxyAuthPageState extends ConsumerState<ProxyAuthPage> {
         ''',
       );
 
-      if (!mounted ||
-          !await _isControllerOnDocument(document) ||
-          !_ownsCaptureDocument(document)) {
+      if (await _documentState(document) != _ProxyAuthDocumentState.live) {
         return null;
       }
 
@@ -1147,9 +1134,7 @@ class _ProxyAuthPageState extends ConsumerState<ProxyAuthPage> {
       );
     }
 
-    if (!mounted ||
-        !await _isControllerOnDocument(document) ||
-        !_ownsCaptureDocument(document)) {
+    if (await _documentState(document) != _ProxyAuthDocumentState.live) {
       return null;
     }
 
@@ -1159,9 +1144,7 @@ class _ProxyAuthPageState extends ConsumerState<ProxyAuthPage> {
         source: 'localStorage.getItem("token")',
       );
 
-      if (!mounted ||
-          !await _isControllerOnDocument(document) ||
-          !_ownsCaptureDocument(document)) {
+      if (await _documentState(document) != _ProxyAuthDocumentState.live) {
         return null;
       }
 
@@ -1188,6 +1171,36 @@ class _ProxyAuthPageState extends ConsumerState<ProxyAuthPage> {
       scope: 'auth/proxy',
     );
     return null;
+  }
+
+  Future<bool> _canContinueCredentialCapture(
+    ProxyAuthDocumentTicket document,
+  ) async {
+    switch (await _documentState(document)) {
+      case _ProxyAuthDocumentState.live:
+        return true;
+      case _ProxyAuthDocumentState.movedAway:
+        _isOnTargetServer = false;
+        return false;
+      case _ProxyAuthDocumentState.lost:
+        return false;
+    }
+  }
+
+  Future<_ProxyAuthDocumentState> _documentState(
+    ProxyAuthDocumentTicket document,
+  ) async {
+    if (!_ownsCaptureDocument(document)) {
+      return _ProxyAuthDocumentState.lost;
+    }
+    if (!await _isControllerOnDocument(document)) {
+      return _ownsCaptureDocument(document)
+          ? _ProxyAuthDocumentState.movedAway
+          : _ProxyAuthDocumentState.lost;
+    }
+    return _ownsCaptureDocument(document)
+        ? _ProxyAuthDocumentState.live
+        : _ProxyAuthDocumentState.lost;
   }
 
   Future<bool> _isControllerOnDocument(ProxyAuthDocumentTicket document) async {

--- a/lib/features/auth/views/proxy_auth_page.dart
+++ b/lib/features/auth/views/proxy_auth_page.dart
@@ -360,40 +360,46 @@ enum _ProxyAuthDocumentState { live, movedAway, lost }
 final class ProxyAuthDocumentFence {
   int _generation = 0;
   String? _documentKey;
+  String? _documentUrl;
   int? _committedGeneration;
   String? _committedDocumentKey;
+  String? _committedDocumentUrl;
 
   int get generation => _generation;
 
   ProxyAuthDocumentTicket? get activeDocument {
-    final documentKey = _documentKey;
-    if (documentKey == null) return null;
-    return ProxyAuthDocumentTicket(generation: _generation, url: documentKey);
+    final documentUrl = _documentUrl;
+    if (documentUrl == null) return null;
+    return ProxyAuthDocumentTicket(generation: _generation, url: documentUrl);
   }
 
   ProxyAuthDocumentTicket? get committedDocument {
     final documentKey = _committedDocumentKey;
+    final documentUrl = _committedDocumentUrl;
     final committedGeneration = _committedGeneration;
     if (documentKey == null ||
+        documentUrl == null ||
         committedGeneration == null ||
         committedGeneration != _generation) {
       return null;
     }
     return ProxyAuthDocumentTicket(
       generation: committedGeneration,
-      url: documentKey,
+      url: documentUrl,
     );
   }
 
   void startNavigation(String url) {
     _generation++;
     _documentKey = _key(url);
+    _documentUrl = _fullKey(url);
     _clearCommittedDocument();
   }
 
   void invalidate() {
     _generation++;
     _documentKey = null;
+    _documentUrl = null;
     _clearCommittedDocument();
   }
 
@@ -419,23 +425,29 @@ final class ProxyAuthDocumentFence {
   }) {
     if (!ownsCommittedDocument(document)) return false;
 
-    final nextKey = _key(url);
-    if (nextKey == document.url) return false;
+    final nextUrl = _fullKey(url);
+    if (nextUrl == document.url) return false;
 
     _generation++;
-    _documentKey = nextKey;
+    _documentKey = _key(nextUrl);
+    _documentUrl = nextUrl;
     _committedGeneration = _generation;
-    _committedDocumentKey = nextKey;
+    _committedDocumentKey = _documentKey;
+    _committedDocumentUrl = nextUrl;
     return true;
   }
 
   /// Marks the document that the platform WebView reports as committed.
   bool markDocumentCommitted(String url) {
     final committedKey = _key(url);
-    if (_documentKey != committedKey) return false;
+    final committedUrl = _fullKey(url);
+    if (_documentKey != committedKey || _documentUrl != committedUrl) {
+      return false;
+    }
 
     _committedGeneration = _generation;
     _committedDocumentKey = committedKey;
+    _committedDocumentUrl = committedUrl;
     return true;
   }
 
@@ -444,17 +456,22 @@ final class ProxyAuthDocumentFence {
   bool ownsDocument(int generation, String url) =>
       ownsGeneration(generation) && _documentKey == _key(url);
 
-  bool ownsCommittedDocument(ProxyAuthDocumentTicket document) =>
+  bool ownsActiveDocument(ProxyAuthDocumentTicket document) =>
       document.generation == _generation &&
-      _documentKey == document.url &&
+      _documentKey == _key(document.url) &&
+      _documentUrl == _fullKey(document.url);
+
+  bool ownsCommittedDocument(ProxyAuthDocumentTicket document) =>
+      ownsActiveDocument(document) &&
       _committedGeneration == document.generation &&
-      _committedDocumentKey == document.url;
+      _committedDocumentKey == _key(document.url) &&
+      _committedDocumentUrl == _fullKey(document.url);
 
   bool ownsLiveDocument(ProxyAuthDocumentTicket document, String currentUrl) =>
-      ownsCommittedDocument(document) && document.url == _key(currentUrl);
+      ownsCommittedDocument(document) && document.url == _fullKey(currentUrl);
 
   bool matchesUrl(String firstUrl, String secondUrl) =>
-      _key(firstUrl) == _key(secondUrl);
+      _fullKey(firstUrl) == _fullKey(secondUrl);
 
   /// Commits the URL reported when the owned main-frame navigation finishes.
   ///
@@ -468,23 +485,27 @@ final class ProxyAuthDocumentFence {
     required String currentUrl,
   }) {
     final callbackKey = _key(callbackUrl);
-    if (!ownsDocument(document.generation, document.url) ||
-        callbackKey != _key(currentUrl)) {
+    final callbackFullUrl = _fullKey(callbackUrl);
+    if (!ownsActiveDocument(document) ||
+        callbackFullUrl != _fullKey(currentUrl)) {
       return false;
     }
 
-    if (_documentKey != callbackKey) {
+    if (_documentKey != callbackKey || _documentUrl != callbackFullUrl) {
       _generation++;
       _documentKey = callbackKey;
+      _documentUrl = callbackFullUrl;
     }
     _committedGeneration = _generation;
     _committedDocumentKey = callbackKey;
+    _committedDocumentUrl = callbackFullUrl;
     return true;
   }
 
   void _clearCommittedDocument() {
     _committedGeneration = null;
     _committedDocumentKey = null;
+    _committedDocumentUrl = null;
   }
 
   static String _key(String url) {
@@ -492,6 +513,11 @@ final class ProxyAuthDocumentFence {
     if (uri == null) return url;
     // Fragments do not select a different credential origin/document.
     return uri.replace(fragment: '').toString();
+  }
+
+  static String _fullKey(String url) {
+    final uri = Uri.tryParse(url);
+    return uri?.toString() ?? url;
   }
 }
 
@@ -816,11 +842,7 @@ class _ProxyAuthPageState extends ConsumerState<ProxyAuthPage> {
         error: error,
         stackTrace: stackTrace,
       );
-      if (!mounted ||
-          !_documentFence.ownsDocument(
-            pendingDocument.generation,
-            pendingDocument.url,
-          )) {
+      if (!mounted || !_documentFence.ownsActiveDocument(pendingDocument)) {
         return;
       }
       setState(() {
@@ -831,10 +853,7 @@ class _ProxyAuthPageState extends ConsumerState<ProxyAuthPage> {
     }
     if (!mounted) return;
     if (currentUrl == null) {
-      if (!_documentFence.ownsDocument(
-        pendingDocument.generation,
-        pendingDocument.url,
-      )) {
+      if (!_documentFence.ownsActiveDocument(pendingDocument)) {
         return;
       }
       setState(() {

--- a/lib/features/auth/views/proxy_auth_page.dart
+++ b/lib/features/auth/views/proxy_auth_page.dart
@@ -517,11 +517,42 @@ bool commitProxyAuthLoadStopDocument({
   return true;
 }
 
+@visibleForTesting
+final class ProxyAuthHistoryUpdateQueue {
+  String? _pendingUrl;
+  bool _isDraining = false;
+
+  bool enqueue(String url) {
+    _pendingUrl = url;
+    if (_isDraining) return false;
+    _isDraining = true;
+    return true;
+  }
+
+  String? takeLatest() {
+    final url = _pendingUrl;
+    _pendingUrl = null;
+    return url;
+  }
+
+  bool restartAfterDrain() {
+    _isDraining = false;
+    if (_pendingUrl == null) return false;
+    _isDraining = true;
+    return true;
+  }
+
+  void reset() {
+    _pendingUrl = null;
+  }
+}
+
 class _ProxyAuthPageState extends ConsumerState<ProxyAuthPage> {
   InAppWebViewController? _controller;
   bool _isLoading = true;
   bool _cookiesCaptured = false;
   final _captureQueue = ProxyAuthCaptureQueue();
+  final _historyUpdateQueue = ProxyAuthHistoryUpdateQueue();
   final _documentFence = ProxyAuthDocumentFence();
   bool _automaticCaptureRequiresJwt = false;
   String? _error;
@@ -540,6 +571,7 @@ class _ProxyAuthPageState extends ConsumerState<ProxyAuthPage> {
   void dispose() {
     _documentFence.invalidate();
     _captureQueue.reset();
+    _historyUpdateQueue.reset();
     _controller = null;
     super.dispose();
   }
@@ -554,6 +586,7 @@ class _ProxyAuthPageState extends ConsumerState<ProxyAuthPage> {
       _documentFence.startNavigation(navigationUrl);
     }
     _captureQueue.reset();
+    _historyUpdateQueue.reset();
   }
 
   Future<void> _initializeWebView() async {
@@ -717,6 +750,30 @@ class _ProxyAuthPageState extends ConsumerState<ProxyAuthPage> {
     }
     if (_isOnTargetServer) {
       await _checkIfOpenWebUI(committedDocument);
+    }
+  }
+
+  void _scheduleNavigationUrlChanged(
+    InAppWebViewController controller,
+    String url,
+  ) {
+    if (url.isEmpty || !_historyUpdateQueue.enqueue(url)) return;
+    unawaited(_drainNavigationUrlChanges(controller));
+  }
+
+  Future<void> _drainNavigationUrlChanges(
+    InAppWebViewController controller,
+  ) async {
+    try {
+      while (mounted) {
+        final url = _historyUpdateQueue.takeLatest();
+        if (url == null) break;
+        await _onNavigationUrlChanged(controller, url);
+      }
+    } finally {
+      if (mounted && _historyUpdateQueue.restartAfterDrain()) {
+        unawaited(_drainNavigationUrlChanges(controller));
+      }
     }
   }
 
@@ -1547,9 +1604,7 @@ class _ProxyAuthPageState extends ConsumerState<ProxyAuthPage> {
             _onPageStarted(url?.toString() ?? '');
           },
           onUpdateVisitedHistory: (controller, url, _) {
-            unawaited(
-              _onNavigationUrlChanged(controller, url?.toString() ?? ''),
-            );
+            _scheduleNavigationUrlChanged(controller, url?.toString() ?? '');
           },
           onPageCommitVisible: (controller, url) {
             _onPageCommitted(url?.toString() ?? '');

--- a/lib/features/auth/views/proxy_auth_page.dart
+++ b/lib/features/auth/views/proxy_auth_page.dart
@@ -366,6 +366,27 @@ final class ProxyAuthDocumentFence {
   bool ownsDocument(int generation, String url) =>
       ownsGeneration(generation) && _documentKey == _key(url);
 
+  /// Commits the URL reported when the current main-frame navigation finishes.
+  ///
+  /// The callback URL must still match the WebView's current URL so a delayed
+  /// completion from an older navigation cannot take ownership of a newer one.
+  bool commitDocument({
+    required int generation,
+    required String callbackUrl,
+    required String currentUrl,
+  }) {
+    final callbackKey = _key(callbackUrl);
+    if (!ownsGeneration(generation) || callbackKey != _key(currentUrl)) {
+      return false;
+    }
+
+    // WKWebView does not emit another load-start callback for HTTP redirects.
+    // Adopt the final URL only after the finish callback and the live WebView
+    // agree, keeping delayed completions from older navigations fenced out.
+    _documentKey = callbackKey;
+    return true;
+  }
+
   static String _key(String url) {
     final uri = Uri.tryParse(url);
     if (uri == null) return url;
@@ -513,10 +534,26 @@ class _ProxyAuthPageState extends ConsumerState<ProxyAuthPage> {
     });
   }
 
-  Future<void> _onPageFinished(String url) async {
+  Future<void> _onPageFinished(
+    InAppWebViewController controller,
+    String url,
+  ) async {
     if (!mounted) return;
     final generation = _documentFence.generation;
-    if (!_ownsCaptureDocument(generation, url)) return;
+    final currentUrl = await controller.getUrl();
+    if (!mounted ||
+        currentUrl == null ||
+        !_documentFence.commitDocument(
+          generation: generation,
+          callbackUrl: url,
+          currentUrl: currentUrl.toString(),
+        )) {
+      DebugLogger.log(
+        'Ignoring stale proxy auth page completion',
+        scope: 'auth/proxy',
+      );
+      return;
+    }
     DebugLogger.auth(
       'Proxy auth page finished: ${webViewOriginForLog(url)}',
       scope: 'auth/proxy',
@@ -1226,7 +1263,7 @@ class _ProxyAuthPageState extends ConsumerState<ProxyAuthPage> {
             if (urlText == null || urlText.isEmpty) {
               return;
             }
-            await _onPageFinished(urlText);
+            await _onPageFinished(controller, urlText);
           },
           onReceivedError: (controller, request, error) {
             _onWebResourceError(request, error);

--- a/lib/features/auth/views/proxy_auth_page.dart
+++ b/lib/features/auth/views/proxy_auth_page.dart
@@ -396,30 +396,35 @@ final class ProxyAuthDocumentFence {
     _clearCommittedDocument();
   }
 
-  /// Tracks redirects and same-document history changes that may not emit a
-  /// new load-start callback.
+  /// Invalidates a committed document when a URL update reports that the
+  /// WebView is loading a different document without a load-start callback.
   ///
-  /// A URL change on an already committed document (for example pushState)
-  /// remains committed under a fresh generation. A provisional redirect stays
-  /// uncommitted until [markDocumentCommitted] observes the final document.
-  bool observeNavigationUrl(String url) {
-    final documentKey = _documentKey;
-    if (documentKey == null) return false;
+  /// The callback URL is deliberately not adopted here because the platform
+  /// does not correlate history callbacks with their originating navigation.
+  /// Load-stop adopts the final URL after checking it against the live WebView.
+  bool markNavigationProvisional(ProxyAuthDocumentTicket document) {
+    if (!ownsCommittedDocument(document)) return false;
+
+    _generation++;
+    _clearCommittedDocument();
+    return true;
+  }
+
+  /// Advances an already-committed document after a verified non-loading
+  /// History API update.
+  bool observeSameDocumentHistory({
+    required ProxyAuthDocumentTicket document,
+    required String url,
+  }) {
+    if (!ownsCommittedDocument(document)) return false;
 
     final nextKey = _key(url);
-    if (nextKey == documentKey) return false;
+    if (nextKey == document.url) return false;
 
-    final wasCommitted =
-        _committedGeneration == _generation &&
-        _committedDocumentKey == documentKey;
     _generation++;
     _documentKey = nextKey;
-    if (wasCommitted) {
-      _committedGeneration = _generation;
-      _committedDocumentKey = nextKey;
-    } else {
-      _clearCommittedDocument();
-    }
+    _committedGeneration = _generation;
+    _committedDocumentKey = nextKey;
     return true;
   }
 
@@ -446,6 +451,9 @@ final class ProxyAuthDocumentFence {
 
   bool ownsLiveDocument(ProxyAuthDocumentTicket document, String currentUrl) =>
       ownsCommittedDocument(document) && document.url == _key(currentUrl);
+
+  bool matchesUrl(String firstUrl, String secondUrl) =>
+      _key(firstUrl) == _key(secondUrl);
 
   /// Commits the URL reported when the owned main-frame navigation finishes.
   ///
@@ -484,6 +492,28 @@ final class ProxyAuthDocumentFence {
     // Fragments do not select a different credential origin/document.
     return uri.replace(fragment: '').toString();
   }
+}
+
+@visibleForTesting
+bool commitProxyAuthLoadStopDocument({
+  required ProxyAuthDocumentFence fence,
+  required ProxyAuthCaptureQueue captureQueue,
+  required ProxyAuthDocumentTicket document,
+  required String callbackUrl,
+  required String currentUrl,
+}) {
+  final previousGeneration = fence.generation;
+  if (!fence.commitDocument(
+    document: document,
+    callbackUrl: callbackUrl,
+    currentUrl: currentUrl,
+  )) {
+    return false;
+  }
+  if (fence.generation != previousGeneration) {
+    captureQueue.reset();
+  }
+  return true;
 }
 
 class _ProxyAuthPageState extends ConsumerState<ProxyAuthPage> {
@@ -622,17 +652,64 @@ class _ProxyAuthPageState extends ConsumerState<ProxyAuthPage> {
     });
   }
 
-  void _onNavigationUrlChanged(String url) {
+  Future<void> _onNavigationUrlChanged(
+    InAppWebViewController controller,
+    String url,
+  ) async {
     if (!mounted || url.isEmpty) return;
-    if (!_documentFence.observeNavigationUrl(url)) return;
+    final document = _documentFence.activeDocument;
+    if (document == null) return;
 
-    // Redirects and History API changes can update WKWebView.url without a
-    // matching load-start callback. Cancel any capture tied to the old URL.
+    WebUri? currentUrl;
+    bool isLoading;
+    try {
+      currentUrl = await controller.getUrl();
+      isLoading = await controller.isLoading();
+    } catch (error, stackTrace) {
+      DebugLogger.error(
+        'proxy-history-state-read-failed',
+        scope: 'auth/proxy',
+        error: error,
+        stackTrace: stackTrace,
+      );
+      return;
+    }
+    if (!mounted ||
+        currentUrl == null ||
+        !_documentFence.matchesUrl(url, currentUrl.toString())) {
+      return;
+    }
+
+    if (isLoading) {
+      if (_documentFence.markNavigationProvisional(document)) {
+        _captureQueue.reset();
+      }
+      if (!_isLoading) {
+        setState(() {
+          _isLoading = true;
+          _error = null;
+        });
+      }
+      return;
+    }
+
+    if (!_documentFence.observeSameDocumentHistory(
+      document: document,
+      url: url,
+    )) {
+      return;
+    }
+
     _captureQueue.reset();
     _isOnTargetServer = isTrustedProxyCredentialCaptureUrl(
       pageUrl: url,
       serverUrl: widget.config.serverConfig.url,
     );
+
+    final committedDocument = _documentFence.committedDocument;
+    if (_isOnTargetServer && committedDocument != null) {
+      await _checkIfOpenWebUI(committedDocument);
+    }
   }
 
   void _onPageCommitted(String url) {
@@ -653,16 +730,55 @@ class _ProxyAuthPageState extends ConsumerState<ProxyAuthPage> {
     // commit this ticket if the callback and live URL still agree.
     final pendingDocument = _documentFence.activeDocument;
     if (pendingDocument == null) return;
-    final currentUrl = await controller.getUrl();
-    if (!mounted) return;
-    if (currentUrl == null) {
+    WebUri? currentUrl;
+    bool isLoading;
+    try {
+      currentUrl = await controller.getUrl();
+      isLoading = await controller.isLoading();
+    } catch (error, stackTrace) {
+      DebugLogger.error(
+        'proxy-webview-url-read-failed',
+        scope: 'auth/proxy',
+        error: error,
+        stackTrace: stackTrace,
+      );
+      if (!mounted ||
+          !_documentFence.ownsDocument(
+            pendingDocument.generation,
+            pendingDocument.url,
+          )) {
+        return;
+      }
       setState(() {
         _error = 'The sign-in page URL could not be verified. Please retry.';
         _isLoading = false;
       });
       return;
     }
-    if (!_documentFence.commitDocument(
+    if (!mounted) return;
+    if (currentUrl == null) {
+      if (!_documentFence.ownsDocument(
+        pendingDocument.generation,
+        pendingDocument.url,
+      )) {
+        return;
+      }
+      setState(() {
+        _error = 'The sign-in page URL could not be verified. Please retry.';
+        _isLoading = false;
+      });
+      return;
+    }
+    if (isLoading) {
+      DebugLogger.log(
+        'Ignoring proxy auth completion while a newer page is loading',
+        scope: 'auth/proxy',
+      );
+      return;
+    }
+    if (!commitProxyAuthLoadStopDocument(
+      fence: _documentFence,
+      captureQueue: _captureQueue,
       document: pendingDocument,
       callbackUrl: url,
       currentUrl: currentUrl.toString(),
@@ -1420,7 +1536,9 @@ class _ProxyAuthPageState extends ConsumerState<ProxyAuthPage> {
             _onPageStarted(url?.toString() ?? '');
           },
           onUpdateVisitedHistory: (controller, url, _) {
-            _onNavigationUrlChanged(url?.toString() ?? '');
+            unawaited(
+              _onNavigationUrlChanged(controller, url?.toString() ?? ''),
+            );
           },
           onPageCommitVisible: (controller, url) {
             _onPageCommitted(url?.toString() ?? '');

--- a/lib/features/auth/views/proxy_auth_page.dart
+++ b/lib/features/auth/views/proxy_auth_page.dart
@@ -768,7 +768,16 @@ class _ProxyAuthPageState extends ConsumerState<ProxyAuthPage> {
       while (mounted) {
         final url = _historyUpdateQueue.takeLatest();
         if (url == null) break;
-        await _onNavigationUrlChanged(controller, url);
+        try {
+          await _onNavigationUrlChanged(controller, url);
+        } catch (error, stackTrace) {
+          DebugLogger.error(
+            'proxy-history-update-failed',
+            scope: 'auth/proxy',
+            error: error,
+            stackTrace: stackTrace,
+          );
+        }
       }
     } finally {
       if (mounted && _historyUpdateQueue.restartAfterDrain()) {

--- a/lib/features/auth/views/proxy_auth_page.dart
+++ b/lib/features/auth/views/proxy_auth_page.dart
@@ -143,10 +143,11 @@ bool shouldRequireJwtForAutomaticCapture({
 @visibleForTesting
 bool? resolveProxyAuthJwtRequirement({
   required bool ownsDocument,
+  required bool isLiveDocument,
   required bool hasPendingJwtWait,
   required bool currentPageShouldWait,
 }) {
-  if (!ownsDocument) return null;
+  if (!ownsDocument || !isLiveDocument) return null;
   return shouldRequireJwtForAutomaticCapture(
     hasPendingJwtWait: hasPendingJwtWait,
     currentPageShouldWait: currentPageShouldWait,
@@ -707,7 +708,14 @@ class _ProxyAuthPageState extends ConsumerState<ProxyAuthPage> {
     );
 
     final committedDocument = _documentFence.committedDocument;
-    if (_isOnTargetServer && committedDocument != null) {
+    if (committedDocument == null) return;
+    if (_isLoading || _error != null) {
+      setState(() {
+        _isLoading = false;
+        _error = null;
+      });
+    }
+    if (_isOnTargetServer) {
       await _checkIfOpenWebUI(committedDocument);
     }
   }
@@ -1117,8 +1125,11 @@ class _ProxyAuthPageState extends ConsumerState<ProxyAuthPage> {
       path,
       document,
     );
+    final isLiveDocument =
+        await _documentState(document) == _ProxyAuthDocumentState.live;
     final shouldWaitForJwt = resolveProxyAuthJwtRequirement(
       ownsDocument: _ownsCaptureDocument(document),
+      isLiveDocument: isLiveDocument,
       hasPendingJwtWait: _automaticCaptureRequiresJwt,
       currentPageShouldWait: currentPageShouldWait,
     );

--- a/lib/features/auth/views/proxy_auth_page.dart
+++ b/lib/features/auth/views/proxy_auth_page.dart
@@ -343,22 +343,90 @@ class ProxyAuthPage extends ConsumerStatefulWidget {
   ConsumerState<ProxyAuthPage> createState() => _ProxyAuthPageState();
 }
 
+/// Immutable ownership proof for one committed main-frame document.
+@visibleForTesting
+final class ProxyAuthDocumentTicket {
+  const ProxyAuthDocumentTicket({required this.generation, required this.url});
+
+  final int generation;
+  final String url;
+}
+
 /// Binds asynchronous credential capture to one main-frame document.
 @visibleForTesting
 final class ProxyAuthDocumentFence {
   int _generation = 0;
   String? _documentKey;
+  int? _committedGeneration;
+  String? _committedDocumentKey;
 
   int get generation => _generation;
+
+  ProxyAuthDocumentTicket? get committedDocument {
+    final documentKey = _committedDocumentKey;
+    final committedGeneration = _committedGeneration;
+    if (documentKey == null ||
+        committedGeneration == null ||
+        committedGeneration != _generation) {
+      return null;
+    }
+    return ProxyAuthDocumentTicket(
+      generation: committedGeneration,
+      url: documentKey,
+    );
+  }
 
   void startNavigation(String url) {
     _generation++;
     _documentKey = _key(url);
+    _clearCommittedDocument();
   }
 
   void invalidate() {
     _generation++;
     _documentKey = null;
+    _clearCommittedDocument();
+  }
+
+  /// Tracks redirects and same-document history changes that may not emit a
+  /// new load-start callback.
+  ///
+  /// A URL change on an already committed document (for example pushState)
+  /// remains committed under a fresh generation. A provisional redirect stays
+  /// uncommitted until [markDocumentCommitted] observes the final document.
+  bool observeNavigationUrl(String url) {
+    final documentKey = _documentKey;
+    if (documentKey == null) return false;
+
+    final nextKey = _key(url);
+    if (nextKey == documentKey) return false;
+
+    final wasCommitted =
+        _committedGeneration == _generation &&
+        _committedDocumentKey == documentKey;
+    _generation++;
+    _documentKey = nextKey;
+    if (wasCommitted) {
+      _committedGeneration = _generation;
+      _committedDocumentKey = nextKey;
+    } else {
+      _clearCommittedDocument();
+    }
+    return true;
+  }
+
+  /// Marks the document that the platform WebView reports as committed.
+  bool markDocumentCommitted(String url) {
+    if (_documentKey == null) return false;
+
+    final committedKey = _key(url);
+    if (_documentKey != committedKey) {
+      _generation++;
+      _documentKey = committedKey;
+    }
+    _committedGeneration = _generation;
+    _committedDocumentKey = committedKey;
+    return true;
   }
 
   bool ownsGeneration(int generation) => generation == _generation;
@@ -366,25 +434,32 @@ final class ProxyAuthDocumentFence {
   bool ownsDocument(int generation, String url) =>
       ownsGeneration(generation) && _documentKey == _key(url);
 
+  bool ownsCommittedDocument(ProxyAuthDocumentTicket document) =>
+      document.generation == _generation &&
+      _documentKey == document.url &&
+      _committedGeneration == document.generation &&
+      _committedDocumentKey == document.url;
+
+  bool ownsLiveDocument(ProxyAuthDocumentTicket document, String currentUrl) =>
+      ownsCommittedDocument(document) && document.url == _key(currentUrl);
+
   /// Commits the URL reported when the current main-frame navigation finishes.
   ///
   /// The callback URL must still match the WebView's current URL so a delayed
   /// completion from an older navigation cannot take ownership of a newer one.
   bool commitDocument({
-    required int generation,
+    required ProxyAuthDocumentTicket document,
     required String callbackUrl,
     required String currentUrl,
   }) {
     final callbackKey = _key(callbackUrl);
-    if (!ownsGeneration(generation) || callbackKey != _key(currentUrl)) {
-      return false;
-    }
+    return callbackKey == document.url &&
+        ownsLiveDocument(document, currentUrl);
+  }
 
-    // WKWebView does not emit another load-start callback for HTTP redirects.
-    // Adopt the final URL only after the finish callback and the live WebView
-    // agree, keeping delayed completions from older navigations fenced out.
-    _documentKey = callbackKey;
-    return true;
+  void _clearCommittedDocument() {
+    _committedGeneration = null;
+    _committedDocumentKey = null;
   }
 
   static String _key(String url) {
@@ -422,11 +497,8 @@ class _ProxyAuthPageState extends ConsumerState<ProxyAuthPage> {
     super.dispose();
   }
 
-  bool _ownsCaptureGeneration(int generation) =>
-      mounted && _documentFence.ownsGeneration(generation);
-
-  bool _ownsCaptureDocument(int generation, String url) =>
-      mounted && _documentFence.ownsDocument(generation, url);
+  bool _ownsCaptureDocument(ProxyAuthDocumentTicket document) =>
+      mounted && _documentFence.ownsCommittedDocument(document);
 
   void _invalidateCaptureQueue({String? navigationUrl}) {
     if (navigationUrl == null) {
@@ -534,17 +606,45 @@ class _ProxyAuthPageState extends ConsumerState<ProxyAuthPage> {
     });
   }
 
+  void _onNavigationUrlChanged(String url) {
+    if (!mounted || url.isEmpty) return;
+    if (!_documentFence.observeNavigationUrl(url)) return;
+
+    // Redirects and History API changes can update WKWebView.url without a
+    // matching load-start callback. Cancel any capture tied to the old URL.
+    _captureQueue.reset();
+    _isOnTargetServer = isTrustedProxyCredentialCaptureUrl(
+      pageUrl: url,
+      serverUrl: widget.config.serverConfig.url,
+    );
+  }
+
+  void _onPageCommitted(String url) {
+    if (!mounted || url.isEmpty) return;
+    final previousGeneration = _documentFence.generation;
+    if (!_documentFence.markDocumentCommitted(url)) return;
+
+    // Some platforms report the committed redirect URL before their visited-
+    // history callback. Treat that transition as a new capture document too.
+    if (_documentFence.generation != previousGeneration) {
+      _captureQueue.reset();
+    }
+  }
+
   Future<void> _onPageFinished(
     InAppWebViewController controller,
     String url,
   ) async {
     if (!mounted) return;
-    final generation = _documentFence.generation;
+    // Snapshot the ticket produced by the platform's document-commit event.
+    // Never resample a naked generation after an asynchronous URL read.
+    final document = _documentFence.committedDocument;
+    if (document == null) return;
     final currentUrl = await controller.getUrl();
     if (!mounted ||
         currentUrl == null ||
         !_documentFence.commitDocument(
-          generation: generation,
+          document: document,
           callbackUrl: url,
           currentUrl: currentUrl.toString(),
         )) {
@@ -594,26 +694,27 @@ class _ProxyAuthPageState extends ConsumerState<ProxyAuthPage> {
     if (isOnTargetServer) {
       // We've reached our server - proxy auth must be complete
       _isOnTargetServer = true;
-      await _checkIfOpenWebUI(url, generation);
+      await _checkIfOpenWebUI(document);
     }
   }
 
   /// Checks if we're on the OpenWebUI page and captures cookies if so.
-  Future<void> _checkIfOpenWebUI(String url, int generation) async {
-    if (_cookiesCaptured || !_ownsCaptureDocument(generation, url)) return;
+  Future<void> _checkIfOpenWebUI(ProxyAuthDocumentTicket document) async {
+    if (_cookiesCaptured || !_ownsCaptureDocument(document)) return;
 
     final controller = _controller;
     if (controller == null) return;
+    final url = document.url;
     final serverUrl = widget.config.serverConfig.url;
     if (!isTrustedProxyCredentialCaptureUrl(
           pageUrl: url,
           serverUrl: serverUrl,
         ) ||
-        !await _isControllerOnTargetOrigin()) {
+        !await _isControllerOnDocument(document)) {
       _isOnTargetServer = false;
       return;
     }
-    if (!_ownsCaptureDocument(generation, url)) return;
+    if (!_ownsCaptureDocument(document)) return;
     final path = Uri.parse(url).path;
 
     try {
@@ -644,9 +745,9 @@ class _ProxyAuthPageState extends ConsumerState<ProxyAuthPage> {
         ''',
       );
 
-      if (!_ownsCaptureDocument(generation, url) ||
-          !await _isControllerOnTargetOrigin() ||
-          !_ownsCaptureDocument(generation, url)) {
+      if (!_ownsCaptureDocument(document) ||
+          !await _isControllerOnDocument(document) ||
+          !_ownsCaptureDocument(document)) {
         _isOnTargetServer = false;
         return;
       }
@@ -665,12 +766,9 @@ class _ProxyAuthPageState extends ConsumerState<ProxyAuthPage> {
         looksLikeOpenWebUi: isOpenWebUI,
         path: path,
       )) {
-        final request = await _buildAutomaticCaptureRequest(url, generation);
-        if (request == null || !_ownsCaptureDocument(generation, url)) return;
-        await _requestProxyCookieCapture(
-          request,
-          expectedGeneration: generation,
-        );
+        final request = await _buildAutomaticCaptureRequest(document);
+        if (request == null || !_ownsCaptureDocument(document)) return;
+        await _requestProxyCookieCapture(request, expectedDocument: document);
         return;
       }
 
@@ -687,18 +785,15 @@ class _ProxyAuthPageState extends ConsumerState<ProxyAuthPage> {
 
       // If detection fails, only fall back to automatic capture on OpenWebUI's
       // own auth routes. Same-host proxy login pages must stay in the WebView.
-      if (_ownsCaptureDocument(generation, url) &&
+      if (_ownsCaptureDocument(document) &&
           _isOnTargetServer &&
           isKnownOpenWebUiProxyAuthPath(path)) {
         try {
-          final request = await _buildAutomaticCaptureRequest(url, generation);
-          if (request == null || !_ownsCaptureDocument(generation, url)) return;
-          await _requestProxyCookieCapture(
-            request,
-            expectedGeneration: generation,
-          );
+          final request = await _buildAutomaticCaptureRequest(document);
+          if (request == null || !_ownsCaptureDocument(document)) return;
+          await _requestProxyCookieCapture(request, expectedDocument: document);
         } catch (captureError, captureStackTrace) {
-          if (!_ownsCaptureDocument(generation, url)) return;
+          if (!_ownsCaptureDocument(document)) return;
           DebugLogger.error(
             'automatic-proxy-capture-failed',
             scope: 'auth/proxy',
@@ -728,33 +823,33 @@ class _ProxyAuthPageState extends ConsumerState<ProxyAuthPage> {
   /// we can capture the JWT token and skip the sign-in page entirely.
   Future<void> _requestProxyCookieCapture(
     ProxyAuthCaptureRequest request, {
-    int? expectedGeneration,
+    ProxyAuthDocumentTicket? expectedDocument,
   }) async {
     if (_cookiesCaptured || !mounted) return;
-    final generation = expectedGeneration ?? _documentFence.generation;
-    if (!_ownsCaptureGeneration(generation)) return;
-    if (!await _isControllerOnTargetOrigin()) {
-      if (!_ownsCaptureGeneration(generation)) return;
+    final document = expectedDocument ?? _documentFence.committedDocument;
+    if (document == null || !_ownsCaptureDocument(document)) return;
+    if (!await _isControllerOnDocument(document)) {
+      if (!_ownsCaptureDocument(document)) return;
       _isOnTargetServer = false;
       DebugLogger.auth(
-        'Skipping proxy credential capture outside the configured origin',
+        'Skipping proxy credential capture outside the committed document',
         scope: 'auth/proxy',
       );
       return;
     }
-    if (!_ownsCaptureGeneration(generation)) return;
+    if (!_ownsCaptureDocument(document)) return;
 
     final captureRequest = _captureQueue.begin(request);
     if (captureRequest == null) return;
 
-    await _captureProxyCookies(captureRequest, generation);
+    await _captureProxyCookies(captureRequest, document);
   }
 
   Future<void> _captureProxyCookies(
     ProxyAuthCaptureRequest request,
-    int generation,
+    ProxyAuthDocumentTicket document,
   ) async {
-    if (_cookiesCaptured || !_ownsCaptureGeneration(generation)) return;
+    if (_cookiesCaptured || !_ownsCaptureDocument(document)) return;
 
     var didComplete = false;
     Object? pendingError;
@@ -762,12 +857,12 @@ class _ProxyAuthPageState extends ConsumerState<ProxyAuthPage> {
     ProxyAuthCaptureRequest? nextRequest;
 
     try {
-      if (!await _isControllerOnTargetOrigin()) {
-        if (!_ownsCaptureGeneration(generation)) return;
+      if (!await _isControllerOnDocument(document)) {
+        if (!_ownsCaptureDocument(document)) return;
         _isOnTargetServer = false;
         return;
       }
-      if (!_ownsCaptureGeneration(generation)) return;
+      if (!_ownsCaptureDocument(document)) return;
 
       final serverUrl = widget.config.serverConfig.url;
       DebugLogger.auth(
@@ -780,13 +875,13 @@ class _ProxyAuthPageState extends ConsumerState<ProxyAuthPage> {
         proxyCookieLookupUrl(serverUrl),
       );
 
-      if (!_ownsCaptureGeneration(generation)) return;
-      if (!await _isControllerOnTargetOrigin()) {
-        if (!_ownsCaptureGeneration(generation)) return;
+      if (!_ownsCaptureDocument(document)) return;
+      if (!await _isControllerOnDocument(document)) {
+        if (!_ownsCaptureDocument(document)) return;
         _isOnTargetServer = false;
         return;
       }
-      if (!_ownsCaptureGeneration(generation)) return;
+      if (!_ownsCaptureDocument(document)) return;
 
       DebugLogger.auth(
         'Captured ${cookies.length} proxy cookies',
@@ -803,14 +898,14 @@ class _ProxyAuthPageState extends ConsumerState<ProxyAuthPage> {
       // Check if OpenWebUI has already authenticated via trusted headers
       // This happens when oauth2-proxy sets X-Forwarded-Email and OpenWebUI
       // auto-creates/logs in the user
-      final jwtToken = await _tryCaptureJwtTokenWithRetry();
-      if (!_ownsCaptureGeneration(generation)) return;
-      if (!await _isControllerOnTargetOrigin()) {
-        if (!_ownsCaptureGeneration(generation)) return;
+      final jwtToken = await _tryCaptureJwtTokenWithRetry(document);
+      if (!_ownsCaptureDocument(document)) return;
+      if (!await _isControllerOnDocument(document)) {
+        if (!_ownsCaptureDocument(document)) return;
         _isOnTargetServer = false;
         return;
       }
-      if (!_ownsCaptureGeneration(generation)) return;
+      if (!_ownsCaptureDocument(document)) return;
       final decision = decideProxyAuthCapture(
         activeRequest: request,
         queuedRequest: _captureQueue.queuedRequest,
@@ -831,7 +926,9 @@ class _ProxyAuthPageState extends ConsumerState<ProxyAuthPage> {
           );
           break;
         case ProxyAuthCaptureDecision.complete:
-          if (!mounted || !_ownsCaptureGeneration(generation)) return;
+          if (!mounted || !_ownsCaptureDocument(document)) return;
+          if (!await _isControllerOnDocument(document)) return;
+          if (!mounted || !_ownsCaptureDocument(document)) return;
 
           _cookiesCaptured = true;
           didComplete = true;
@@ -845,7 +942,7 @@ class _ProxyAuthPageState extends ConsumerState<ProxyAuthPage> {
           );
       }
     } catch (e, stackTrace) {
-      if (!_ownsCaptureGeneration(generation)) return;
+      if (!_ownsCaptureDocument(document)) return;
       pendingError = e;
       pendingStackTrace = stackTrace;
       DebugLogger.warning(
@@ -854,7 +951,7 @@ class _ProxyAuthPageState extends ConsumerState<ProxyAuthPage> {
         data: {'errorType': e.runtimeType.toString()},
       );
     } finally {
-      if (_ownsCaptureGeneration(generation)) {
+      if (_ownsCaptureDocument(document)) {
         nextRequest = _captureQueue.finish(
           completed: didComplete || _cookiesCaptured,
         );
@@ -863,23 +960,23 @@ class _ProxyAuthPageState extends ConsumerState<ProxyAuthPage> {
 
     if (nextRequest != null &&
         !_cookiesCaptured &&
-        _ownsCaptureGeneration(generation)) {
-      await _requestProxyCookieCapture(nextRequest);
+        _ownsCaptureDocument(document)) {
+      await _requestProxyCookieCapture(nextRequest, expectedDocument: document);
     }
 
     if (pendingError != null &&
         pendingStackTrace != null &&
         !_cookiesCaptured &&
-        _ownsCaptureGeneration(generation)) {
+        _ownsCaptureDocument(document)) {
       Error.throwWithStackTrace(pendingError, pendingStackTrace);
     }
   }
 
   Future<ProxyAuthCaptureRequest?> _buildAutomaticCaptureRequest(
-    String url,
-    int generation,
+    ProxyAuthDocumentTicket document,
   ) async {
-    if (!_ownsCaptureDocument(generation, url)) return null;
+    if (!_ownsCaptureDocument(document)) return null;
+    final url = document.url;
     final path = Uri.tryParse(url)?.path ?? '/';
     if (_automaticCaptureRequiresJwt) {
       return ProxyAuthCaptureRequest.automatic(
@@ -890,9 +987,10 @@ class _ProxyAuthPageState extends ConsumerState<ProxyAuthPage> {
 
     final currentPageShouldWait = await _shouldWaitForAutomaticProxyAuthCapture(
       path,
+      document,
     );
     final shouldWaitForJwt = resolveProxyAuthJwtRequirement(
-      ownsDocument: _ownsCaptureDocument(generation, url),
+      ownsDocument: _ownsCaptureDocument(document),
       hasPendingJwtWait: _automaticCaptureRequiresJwt,
       currentPageShouldWait: currentPageShouldWait,
     );
@@ -907,7 +1005,10 @@ class _ProxyAuthPageState extends ConsumerState<ProxyAuthPage> {
     );
   }
 
-  Future<bool> _shouldWaitForAutomaticProxyAuthCapture(String path) async {
+  Future<bool> _shouldWaitForAutomaticProxyAuthCapture(
+    String path,
+    ProxyAuthDocumentTicket document,
+  ) async {
     if (path.toLowerCase().contains('/oauth/')) {
       DebugLogger.auth(
         'Automatic proxy auth capture waiting for JWT on OAuth route',
@@ -917,7 +1018,8 @@ class _ProxyAuthPageState extends ConsumerState<ProxyAuthPage> {
     }
 
     for (var attempt = 0; attempt < 3; attempt++) {
-      final hasPasswordField = await _currentPageHasPasswordField();
+      final hasPasswordField = await _currentPageHasPasswordField(document);
+      if (!_ownsCaptureDocument(document)) return false;
       final shouldWait = shouldWaitForAutomaticProxyAuthCapture(
         path: path,
         hasPasswordField: hasPasswordField,
@@ -933,7 +1035,7 @@ class _ProxyAuthPageState extends ConsumerState<ProxyAuthPage> {
 
       if (attempt < 2) {
         await Future<void>.delayed(const Duration(milliseconds: 250));
-        if (!mounted) return false;
+        if (!_ownsCaptureDocument(document)) return false;
       }
     }
 
@@ -944,10 +1046,12 @@ class _ProxyAuthPageState extends ConsumerState<ProxyAuthPage> {
     return true;
   }
 
-  Future<bool> _currentPageHasPasswordField() async {
+  Future<bool> _currentPageHasPasswordField(
+    ProxyAuthDocumentTicket document,
+  ) async {
     final controller = _controller;
     if (controller == null || !mounted) return false;
-    if (!await _isControllerOnTargetOrigin()) return false;
+    if (!await _isControllerOnDocument(document)) return false;
 
     try {
       final result = await controller.evaluateJavascript(
@@ -960,7 +1064,11 @@ class _ProxyAuthPageState extends ConsumerState<ProxyAuthPage> {
         ''',
       );
 
-      if (!mounted || !await _isControllerOnTargetOrigin()) return false;
+      if (!mounted ||
+          !await _isControllerOnDocument(document) ||
+          !_ownsCaptureDocument(document)) {
+        return false;
+      }
       return result.toString().contains('true');
     } catch (e) {
       DebugLogger.log(
@@ -972,16 +1080,18 @@ class _ProxyAuthPageState extends ConsumerState<ProxyAuthPage> {
     }
   }
 
-  Future<String?> _tryCaptureJwtTokenWithRetry() async {
+  Future<String?> _tryCaptureJwtTokenWithRetry(
+    ProxyAuthDocumentTicket document,
+  ) async {
     for (var attempt = 0; attempt < 3; attempt++) {
-      final jwtToken = await _tryCaptureJwtToken();
+      final jwtToken = await _tryCaptureJwtToken(document);
       if (hasCapturedJwtToken(jwtToken)) {
         return jwtToken;
       }
 
       if (attempt < 2) {
         await Future<void>.delayed(const Duration(milliseconds: 250));
-        if (!mounted) return null;
+        if (!_ownsCaptureDocument(document)) return null;
       }
     }
 
@@ -992,10 +1102,10 @@ class _ProxyAuthPageState extends ConsumerState<ProxyAuthPage> {
   ///
   /// If the proxy uses trusted headers, OpenWebUI will have already
   /// authenticated the user and set a JWT token.
-  Future<String?> _tryCaptureJwtToken() async {
+  Future<String?> _tryCaptureJwtToken(ProxyAuthDocumentTicket document) async {
     final controller = _controller;
     if (controller == null || !mounted) return null;
-    if (!await _isControllerOnTargetOrigin()) return null;
+    if (!await _isControllerOnDocument(document)) return null;
 
     // Strategy 1: Check token cookie
     try {
@@ -1014,7 +1124,11 @@ class _ProxyAuthPageState extends ConsumerState<ProxyAuthPage> {
         ''',
       );
 
-      if (!mounted || !await _isControllerOnTargetOrigin()) return null;
+      if (!mounted ||
+          !await _isControllerOnDocument(document) ||
+          !_ownsCaptureDocument(document)) {
+        return null;
+      }
 
       String tokenValue = _cleanJsString(cookieResult.toString());
       if (_isValidJwtFormat(tokenValue)) {
@@ -1033,7 +1147,11 @@ class _ProxyAuthPageState extends ConsumerState<ProxyAuthPage> {
       );
     }
 
-    if (!mounted || !await _isControllerOnTargetOrigin()) return null;
+    if (!mounted ||
+        !await _isControllerOnDocument(document) ||
+        !_ownsCaptureDocument(document)) {
+      return null;
+    }
 
     // Strategy 2: Check localStorage
     try {
@@ -1041,7 +1159,11 @@ class _ProxyAuthPageState extends ConsumerState<ProxyAuthPage> {
         source: 'localStorage.getItem("token")',
       );
 
-      if (!mounted || !await _isControllerOnTargetOrigin()) return null;
+      if (!mounted ||
+          !await _isControllerOnDocument(document) ||
+          !_ownsCaptureDocument(document)) {
+        return null;
+      }
 
       String tokenValue = _cleanJsString(result.toString());
       if (_isValidJwtFormat(tokenValue)) {
@@ -1068,20 +1190,21 @@ class _ProxyAuthPageState extends ConsumerState<ProxyAuthPage> {
     return null;
   }
 
-  Future<bool> _isControllerOnTargetOrigin() async {
+  Future<bool> _isControllerOnDocument(ProxyAuthDocumentTicket document) async {
     final controller = _controller;
-    if (controller == null || !mounted) return false;
+    if (controller == null || !_ownsCaptureDocument(document)) return false;
 
     try {
       final currentUrl = await controller.getUrl();
       return currentUrl != null &&
+          _documentFence.ownsLiveDocument(document, currentUrl.toString()) &&
           isTrustedProxyCredentialCaptureUrl(
             pageUrl: currentUrl.toString(),
             serverUrl: widget.config.serverConfig.url,
           );
     } catch (error) {
       DebugLogger.log(
-        'Unable to verify proxy WebView origin before credential capture',
+        'Unable to verify proxy WebView document before credential capture',
         scope: 'auth/proxy',
         data: {'errorType': error.runtimeType.toString()},
       );
@@ -1257,6 +1380,12 @@ class _ProxyAuthPageState extends ConsumerState<ProxyAuthPage> {
           },
           onLoadStart: (controller, url) {
             _onPageStarted(url?.toString() ?? '');
+          },
+          onUpdateVisitedHistory: (controller, url, _) {
+            _onNavigationUrlChanged(url?.toString() ?? '');
+          },
+          onPageCommitVisible: (controller, url) {
+            _onPageCommitted(url?.toString() ?? '');
           },
           onLoadStop: (controller, url) async {
             final urlText = url?.toString();

--- a/lib/features/auth/views/proxy_auth_page.dart
+++ b/lib/features/auth/views/proxy_auth_page.dart
@@ -343,7 +343,7 @@ class ProxyAuthPage extends ConsumerStatefulWidget {
   ConsumerState<ProxyAuthPage> createState() => _ProxyAuthPageState();
 }
 
-/// Immutable ownership proof for one committed main-frame document.
+/// Immutable ownership proof for one main-frame navigation document.
 @visibleForTesting
 final class ProxyAuthDocumentTicket {
   const ProxyAuthDocumentTicket({required this.generation, required this.url});
@@ -363,6 +363,12 @@ final class ProxyAuthDocumentFence {
   String? _committedDocumentKey;
 
   int get generation => _generation;
+
+  ProxyAuthDocumentTicket? get activeDocument {
+    final documentKey = _documentKey;
+    if (documentKey == null) return null;
+    return ProxyAuthDocumentTicket(generation: _generation, url: documentKey);
+  }
 
   ProxyAuthDocumentTicket? get committedDocument {
     final documentKey = _committedDocumentKey;
@@ -445,18 +451,30 @@ final class ProxyAuthDocumentFence {
   bool ownsLiveDocument(ProxyAuthDocumentTicket document, String currentUrl) =>
       ownsCommittedDocument(document) && document.url == _key(currentUrl);
 
-  /// Commits the URL reported when the current main-frame navigation finishes.
+  /// Commits the URL reported when the owned main-frame navigation finishes.
   ///
-  /// The callback URL must still match the WebView's current URL so a delayed
-  /// completion from an older navigation cannot take ownership of a newer one.
+  /// The ticket must still own the active navigation, and the callback URL must
+  /// match the WebView's current URL. This lets load-stop provide a fallback
+  /// commit when the platform omits its document-commit callback without
+  /// allowing a delayed completion to take ownership of a newer navigation.
   bool commitDocument({
     required ProxyAuthDocumentTicket document,
     required String callbackUrl,
     required String currentUrl,
   }) {
     final callbackKey = _key(callbackUrl);
-    return callbackKey == document.url &&
-        ownsLiveDocument(document, currentUrl);
+    if (!ownsDocument(document.generation, document.url) ||
+        callbackKey != _key(currentUrl)) {
+      return false;
+    }
+
+    if (_documentKey != callbackKey) {
+      _generation++;
+      _documentKey = callbackKey;
+    }
+    _committedGeneration = _generation;
+    _committedDocumentKey = callbackKey;
+    return true;
   }
 
   void _clearCommittedDocument() {
@@ -638,22 +656,37 @@ class _ProxyAuthPageState extends ConsumerState<ProxyAuthPage> {
     String url,
   ) async {
     if (!mounted) return;
-    // Snapshot the ticket produced by the platform's document-commit event.
-    // Never resample a naked generation after an asynchronous URL read.
-    final document = _documentFence.committedDocument;
-    if (document == null) return;
+    // Snapshot navigation ownership before the asynchronous URL read. On
+    // platforms that omit the document-commit callback, load-stop can safely
+    // commit this ticket if the callback and live URL still agree.
+    final pendingDocument = _documentFence.activeDocument;
+    if (pendingDocument == null) return;
     final currentUrl = await controller.getUrl();
-    if (!mounted ||
-        currentUrl == null ||
-        !_documentFence.commitDocument(
-          document: document,
-          callbackUrl: url,
-          currentUrl: currentUrl.toString(),
-        )) {
+    if (!mounted) return;
+    if (currentUrl == null) {
+      setState(() {
+        _error = 'The sign-in page URL could not be verified. Please retry.';
+        _isLoading = false;
+      });
+      return;
+    }
+    if (!_documentFence.commitDocument(
+      document: pendingDocument,
+      callbackUrl: url,
+      currentUrl: currentUrl.toString(),
+    )) {
       DebugLogger.log(
         'Ignoring stale proxy auth page completion',
         scope: 'auth/proxy',
       );
+      return;
+    }
+    final document = _documentFence.committedDocument;
+    if (document == null) {
+      setState(() {
+        _error = 'The sign-in page could not be verified. Please retry.';
+        _isLoading = false;
+      });
       return;
     }
     DebugLogger.auth(

--- a/lib/features/auth/views/proxy_auth_page.dart
+++ b/lib/features/auth/views/proxy_auth_page.dart
@@ -425,13 +425,9 @@ final class ProxyAuthDocumentFence {
 
   /// Marks the document that the platform WebView reports as committed.
   bool markDocumentCommitted(String url) {
-    if (_documentKey == null) return false;
-
     final committedKey = _key(url);
-    if (_documentKey != committedKey) {
-      _generation++;
-      _documentKey = committedKey;
-    }
+    if (_documentKey != committedKey) return false;
+
     _committedGeneration = _generation;
     _committedDocumentKey = committedKey;
     return true;
@@ -641,14 +637,10 @@ class _ProxyAuthPageState extends ConsumerState<ProxyAuthPage> {
 
   void _onPageCommitted(String url) {
     if (!mounted || url.isEmpty) return;
-    final previousGeneration = _documentFence.generation;
-    if (!_documentFence.markDocumentCommitted(url)) return;
-
-    // Some platforms report the committed redirect URL before their visited-
-    // history callback. Treat that transition as a new capture document too.
-    if (_documentFence.generation != previousGeneration) {
-      _captureQueue.reset();
-    }
+    // Commit callbacks only confirm the already-active navigation. Redirect
+    // URLs that arrive without a matching navigation/history callback are
+    // adopted by the generation-safe load-stop fallback instead.
+    _documentFence.markDocumentCommitted(url);
   }
 
   Future<void> _onPageFinished(

--- a/test/features/auth/views/proxy_auth_page_test.dart
+++ b/test/features/auth/views/proxy_auth_page_test.dart
@@ -389,6 +389,19 @@ void main() {
       check(queue.takeLatest()).equals('https://chat.example/final');
       check(queue.restartAfterDrain()).isFalse();
     });
+
+    test('reset drops pending history work', () {
+      final queue = ProxyAuthHistoryUpdateQueue();
+
+      check(queue.enqueue('https://chat.example/first')).isTrue();
+      check(queue.takeLatest()).equals('https://chat.example/first');
+      check(queue.enqueue('https://chat.example/stale')).isFalse();
+
+      queue.reset();
+
+      check(queue.takeLatest()).isNull();
+      check(queue.restartAfterDrain()).isFalse();
+    });
   });
 
   group('isTrustedProxyCredentialCaptureUrl', () {

--- a/test/features/auth/views/proxy_auth_page_test.dart
+++ b/test/features/auth/views/proxy_auth_page_test.dart
@@ -260,7 +260,7 @@ void main() {
       check(fence.committedDocument).isNull();
     });
 
-    test('committed ticket rejects a different same-origin URL', () {
+    test('committed ticket rejects full URL drift', () {
       final fence = ProxyAuthDocumentFence();
       fence.startNavigation('https://chat.example/auth');
       fence.markDocumentCommitted('https://chat.example/auth');
@@ -268,10 +268,33 @@ void main() {
 
       check(
         fence.ownsLiveDocument(document, 'https://chat.example/auth#ready'),
-      ).isTrue();
+      ).isFalse();
       check(
         fence.ownsLiveDocument(document, 'https://chat.example/chat/new'),
       ).isFalse();
+    });
+
+    test('fragment-only history change advances the committed ticket', () {
+      final fence = ProxyAuthDocumentFence();
+      fence.startNavigation('https://chat.example/auth#login');
+      fence.markDocumentCommitted('https://chat.example/auth#login');
+      final oldDocument = fence.committedDocument!;
+
+      check(
+        fence.observeSameDocumentHistory(
+          document: oldDocument,
+          url: 'https://chat.example/auth#ready',
+        ),
+      ).isTrue();
+      final currentDocument = fence.committedDocument!;
+
+      check(fence.ownsCommittedDocument(oldDocument)).isFalse();
+      check(
+        fence.ownsLiveDocument(
+          currentDocument,
+          'https://chat.example/auth#ready',
+        ),
+      ).isTrue();
     });
 
     test('same-document history change advances the committed ticket', () {

--- a/test/features/auth/views/proxy_auth_page_test.dart
+++ b/test/features/auth/views/proxy_auth_page_test.dart
@@ -104,6 +104,63 @@ void main() {
       ).isTrue();
     });
 
+    test('load stop commits when no document-commit callback arrives', () {
+      final fence = ProxyAuthDocumentFence();
+      fence.startNavigation('https://chat.example/auth');
+      final pendingDocument = fence.activeDocument!;
+
+      check(fence.committedDocument).isNull();
+      check(
+        fence.commitDocument(
+          document: pendingDocument,
+          callbackUrl: 'https://chat.example/auth',
+          currentUrl: 'https://chat.example/auth',
+        ),
+      ).isTrue();
+      check(
+        fence.ownsLiveDocument(
+          fence.committedDocument!,
+          'https://chat.example/auth',
+        ),
+      ).isTrue();
+    });
+
+    test('load stop adopts a redirect without document callbacks', () {
+      final fence = ProxyAuthDocumentFence();
+      fence.startNavigation('https://chat.example/');
+      final pendingDocument = fence.activeDocument!;
+
+      check(
+        fence.commitDocument(
+          document: pendingDocument,
+          callbackUrl: 'https://auth.example/login',
+          currentUrl: 'https://auth.example/login',
+        ),
+      ).isTrue();
+      final committedDocument = fence.committedDocument!;
+      check(
+        fence.ownsLiveDocument(committedDocument, 'https://auth.example/login'),
+      ).isTrue();
+      check(fence.ownsCommittedDocument(pendingDocument)).isFalse();
+    });
+
+    test('load stop fallback rejects a superseded navigation ticket', () {
+      final fence = ProxyAuthDocumentFence();
+      fence.startNavigation('https://chat.example/old');
+      final oldDocument = fence.activeDocument!;
+
+      fence.startNavigation('https://chat.example/new');
+
+      check(
+        fence.commitDocument(
+          document: oldDocument,
+          callbackUrl: 'https://chat.example/old',
+          currentUrl: 'https://chat.example/old',
+        ),
+      ).isFalse();
+      check(fence.committedDocument).isNull();
+    });
+
     test('rejects a delayed completion after a newer navigation starts', () {
       final fence = ProxyAuthDocumentFence();
       fence.startNavigation('https://auth.example/login');

--- a/test/features/auth/views/proxy_auth_page_test.dart
+++ b/test/features/auth/views/proxy_auth_page_test.dart
@@ -39,6 +39,44 @@ void main() {
         fence.ownsDocument(fence.generation, 'https://chat.example/auth'),
       ).isFalse();
     });
+
+    test('commits the final URL of an HTTP redirect without another start', () {
+      final fence = ProxyAuthDocumentFence();
+      fence.startNavigation('https://chat.example/');
+      final generation = fence.generation;
+
+      final committed = fence.commitDocument(
+        generation: generation,
+        callbackUrl: 'https://auth.example/?rd=https%3A%2F%2Fchat.example%2F',
+        currentUrl: 'https://auth.example/?rd=https%3A%2F%2Fchat.example%2F',
+      );
+
+      check(committed).isTrue();
+      check(
+        fence.ownsDocument(
+          generation,
+          'https://auth.example/?rd=https%3A%2F%2Fchat.example%2F',
+        ),
+      ).isTrue();
+    });
+
+    test('rejects a delayed completion after a newer navigation starts', () {
+      final fence = ProxyAuthDocumentFence();
+      fence.startNavigation('https://auth.example/login');
+      fence.startNavigation('https://chat.example/auth');
+      final currentGeneration = fence.generation;
+
+      final committed = fence.commitDocument(
+        generation: currentGeneration,
+        callbackUrl: 'https://auth.example/login',
+        currentUrl: 'https://chat.example/auth',
+      );
+
+      check(committed).isFalse();
+      check(
+        fence.ownsDocument(currentGeneration, 'https://chat.example/auth'),
+      ).isTrue();
+    });
   });
 
   group('refreshProxyAuthWebView', () {

--- a/test/features/auth/views/proxy_auth_page_test.dart
+++ b/test/features/auth/views/proxy_auth_page_test.dart
@@ -40,13 +40,44 @@ void main() {
       ).isFalse();
     });
 
+    test('invalidated fence rejects a matching delayed completion', () {
+      final fence = ProxyAuthDocumentFence();
+      fence.startNavigation('https://chat.example/auth');
+      fence.markDocumentCommitted('https://chat.example/auth');
+      final document = fence.committedDocument!;
+
+      fence.invalidate();
+
+      final committed = fence.commitDocument(
+        document: document,
+        callbackUrl: 'https://chat.example/auth',
+        currentUrl: 'https://chat.example/auth',
+      );
+
+      check(committed).isFalse();
+      check(
+        fence.ownsDocument(document.generation, 'https://chat.example/auth'),
+      ).isFalse();
+    });
+
     test('commits the final URL of an HTTP redirect without another start', () {
       final fence = ProxyAuthDocumentFence();
       fence.startNavigation('https://chat.example/');
+      check(
+        fence.observeNavigationUrl(
+          'https://auth.example/?rd=https%3A%2F%2Fchat.example%2F',
+        ),
+      ).isTrue();
+      check(
+        fence.markDocumentCommitted(
+          'https://auth.example/?rd=https%3A%2F%2Fchat.example%2F',
+        ),
+      ).isTrue();
       final generation = fence.generation;
+      final document = fence.committedDocument!;
 
       final committed = fence.commitDocument(
-        generation: generation,
+        document: document,
         callbackUrl: 'https://auth.example/?rd=https%3A%2F%2Fchat.example%2F',
         currentUrl: 'https://auth.example/?rd=https%3A%2F%2Fchat.example%2F',
       );
@@ -64,10 +95,12 @@ void main() {
       final fence = ProxyAuthDocumentFence();
       fence.startNavigation('https://auth.example/login');
       fence.startNavigation('https://chat.example/auth');
+      fence.markDocumentCommitted('https://chat.example/auth');
       final currentGeneration = fence.generation;
+      final document = fence.committedDocument!;
 
       final committed = fence.commitDocument(
-        generation: currentGeneration,
+        document: document,
         callbackUrl: 'https://auth.example/login',
         currentUrl: 'https://chat.example/auth',
       );
@@ -75,6 +108,84 @@ void main() {
       check(committed).isFalse();
       check(
         fence.ownsDocument(currentGeneration, 'https://chat.example/auth'),
+      ).isTrue();
+    });
+
+    test('rejects an old document ticket even when the URL is unchanged', () {
+      final fence = ProxyAuthDocumentFence();
+      fence.startNavigation('https://chat.example/auth');
+      fence.markDocumentCommitted('https://chat.example/auth');
+      final oldDocument = fence.committedDocument!;
+
+      fence.startNavigation('https://chat.example/auth');
+      fence.markDocumentCommitted('https://chat.example/auth');
+      final currentDocument = fence.committedDocument!;
+
+      check(
+        fence.commitDocument(
+          document: oldDocument,
+          callbackUrl: 'https://chat.example/auth',
+          currentUrl: 'https://chat.example/auth',
+        ),
+      ).isFalse();
+      check(
+        fence.commitDocument(
+          document: currentDocument,
+          callbackUrl: 'https://chat.example/auth',
+          currentUrl: 'https://chat.example/auth',
+        ),
+      ).isTrue();
+    });
+
+    test('new navigation cannot finish before its document commits', () {
+      final fence = ProxyAuthDocumentFence();
+      fence.startNavigation('https://chat.example/auth');
+      fence.markDocumentCommitted('https://chat.example/auth');
+      final oldDocument = fence.committedDocument!;
+
+      fence.startNavigation('https://chat.example/auth');
+
+      check(
+        fence.commitDocument(
+          document: oldDocument,
+          callbackUrl: 'https://chat.example/auth',
+          currentUrl: 'https://chat.example/auth',
+        ),
+      ).isFalse();
+      check(fence.committedDocument).isNull();
+    });
+
+    test('committed ticket rejects a different same-origin URL', () {
+      final fence = ProxyAuthDocumentFence();
+      fence.startNavigation('https://chat.example/auth');
+      fence.markDocumentCommitted('https://chat.example/auth');
+      final document = fence.committedDocument!;
+
+      check(
+        fence.ownsLiveDocument(document, 'https://chat.example/auth#ready'),
+      ).isTrue();
+      check(
+        fence.ownsLiveDocument(document, 'https://chat.example/chat/new'),
+      ).isFalse();
+    });
+
+    test('same-document history change advances the committed ticket', () {
+      final fence = ProxyAuthDocumentFence();
+      fence.startNavigation('https://chat.example/auth');
+      fence.markDocumentCommitted('https://chat.example/auth');
+      final oldDocument = fence.committedDocument!;
+
+      check(
+        fence.observeNavigationUrl('https://chat.example/chat/new'),
+      ).isTrue();
+      final currentDocument = fence.committedDocument!;
+
+      check(fence.ownsCommittedDocument(oldDocument)).isFalse();
+      check(
+        fence.ownsLiveDocument(
+          currentDocument,
+          'https://chat.example/chat/new',
+        ),
       ).isTrue();
     });
   });

--- a/test/features/auth/views/proxy_auth_page_test.dart
+++ b/test/features/auth/views/proxy_auth_page_test.dart
@@ -628,6 +628,7 @@ void main() {
 
       final requirement = resolveProxyAuthJwtRequirement(
         ownsDocument: fence.ownsGeneration(staleGeneration),
+        isLiveDocument: true,
         hasPendingJwtWait: false,
         currentPageShouldWait: true,
       );
@@ -638,11 +639,23 @@ void main() {
     test('current document can publish a sticky JWT-wait requirement', () {
       final requirement = resolveProxyAuthJwtRequirement(
         ownsDocument: true,
+        isLiveDocument: true,
         hasPendingJwtWait: false,
         currentPageShouldWait: true,
       );
 
       expect(requirement, isTrue);
+    });
+
+    test('URL drift cannot publish a sticky JWT-wait requirement', () {
+      final requirement = resolveProxyAuthJwtRequirement(
+        ownsDocument: true,
+        isLiveDocument: false,
+        hasPendingJwtWait: false,
+        currentPageShouldWait: true,
+      );
+
+      expect(requirement, isNull);
     });
   });
 

--- a/test/features/auth/views/proxy_auth_page_test.dart
+++ b/test/features/auth/views/proxy_auth_page_test.dart
@@ -60,6 +60,19 @@ void main() {
       ).isFalse();
     });
 
+    test('invalidated fence ignores navigation URL changes', () {
+      final fence = ProxyAuthDocumentFence();
+      fence.startNavigation('https://chat.example/auth');
+      fence.markDocumentCommitted('https://chat.example/auth');
+
+      fence.invalidate();
+
+      check(
+        fence.observeNavigationUrl('https://chat.example/chat/new'),
+      ).isFalse();
+      check(fence.committedDocument).isNull();
+    });
+
     test('commits the final URL of an HTTP redirect without another start', () {
       final fence = ProxyAuthDocumentFence();
       fence.startNavigation('https://chat.example/');

--- a/test/features/auth/views/proxy_auth_page_test.dart
+++ b/test/features/auth/views/proxy_auth_page_test.dart
@@ -64,11 +64,15 @@ void main() {
       final fence = ProxyAuthDocumentFence();
       fence.startNavigation('https://chat.example/auth');
       fence.markDocumentCommitted('https://chat.example/auth');
+      final document = fence.committedDocument!;
 
       fence.invalidate();
 
       check(
-        fence.observeNavigationUrl('https://chat.example/chat/new'),
+        fence.observeSameDocumentHistory(
+          document: document,
+          url: 'https://chat.example/chat/new',
+        ),
       ).isFalse();
       check(fence.committedDocument).isNull();
     });
@@ -76,26 +80,19 @@ void main() {
     test('commits the final URL of an HTTP redirect without another start', () {
       final fence = ProxyAuthDocumentFence();
       fence.startNavigation('https://chat.example/');
+      fence.markDocumentCommitted('https://chat.example/');
+      final initialDocument = fence.committedDocument!;
+      check(fence.markNavigationProvisional(initialDocument)).isTrue();
+      final pendingDocument = fence.activeDocument!;
       check(
-        fence.observeNavigationUrl(
-          'https://auth.example/?rd=https%3A%2F%2Fchat.example%2F',
-        ),
-      ).isTrue();
-      check(
-        fence.markDocumentCommitted(
-          'https://auth.example/?rd=https%3A%2F%2Fchat.example%2F',
+        fence.commitDocument(
+          document: pendingDocument,
+          callbackUrl: 'https://auth.example/?rd=https%3A%2F%2Fchat.example%2F',
+          currentUrl: 'https://auth.example/?rd=https%3A%2F%2Fchat.example%2F',
         ),
       ).isTrue();
       final generation = fence.generation;
-      final document = fence.committedDocument!;
 
-      final committed = fence.commitDocument(
-        document: document,
-        callbackUrl: 'https://auth.example/?rd=https%3A%2F%2Fchat.example%2F',
-        currentUrl: 'https://auth.example/?rd=https%3A%2F%2Fchat.example%2F',
-      );
-
-      check(committed).isTrue();
       check(
         fence.ownsDocument(
           generation,
@@ -284,7 +281,10 @@ void main() {
       final oldDocument = fence.committedDocument!;
 
       check(
-        fence.observeNavigationUrl('https://chat.example/chat/new'),
+        fence.observeSameDocumentHistory(
+          document: oldDocument,
+          url: 'https://chat.example/chat/new',
+        ),
       ).isTrue();
       final currentDocument = fence.committedDocument!;
 
@@ -294,6 +294,38 @@ void main() {
           currentDocument,
           'https://chat.example/chat/new',
         ),
+      ).isTrue();
+    });
+
+    test('loading history update only makes the document provisional', () {
+      final fence = ProxyAuthDocumentFence();
+      fence.startNavigation('https://chat.example/auth');
+      fence.markDocumentCommitted('https://chat.example/auth');
+      final document = fence.committedDocument!;
+
+      check(fence.markNavigationProvisional(document)).isTrue();
+      check(fence.committedDocument).isNull();
+      check(
+        fence.ownsDocument(fence.generation, 'https://chat.example/auth'),
+      ).isTrue();
+    });
+
+    test('stale history ticket cannot replace a newer navigation', () {
+      final fence = ProxyAuthDocumentFence();
+      fence.startNavigation('https://chat.example/old');
+      final oldDocument = fence.activeDocument!;
+
+      fence.startNavigation('https://chat.example/new');
+      final newDocument = fence.activeDocument!;
+
+      check(
+        fence.observeSameDocumentHistory(
+          document: oldDocument,
+          url: 'https://chat.example/old/history',
+        ),
+      ).isFalse();
+      check(
+        fence.ownsDocument(newDocument.generation, newDocument.url),
       ).isTrue();
     });
   });
@@ -383,6 +415,39 @@ void main() {
   });
 
   group('ProxyAuthCaptureQueue', () {
+    test('load-stop redirect adoption releases an old capture', () {
+      final fence = ProxyAuthDocumentFence();
+      final queue = ProxyAuthCaptureQueue();
+      fence.startNavigation('https://chat.example/');
+      final pendingDocument = fence.activeDocument!;
+      check(
+        queue.begin(
+          const ProxyAuthCaptureRequest.automatic(
+            shouldWaitForJwt: false,
+            path: '/',
+          ),
+        ),
+      ).isNotNull();
+
+      check(
+        commitProxyAuthLoadStopDocument(
+          fence: fence,
+          captureQueue: queue,
+          document: pendingDocument,
+          callbackUrl: 'https://auth.example/login',
+          currentUrl: 'https://auth.example/login',
+        ),
+      ).isTrue();
+      check(
+        queue.begin(
+          const ProxyAuthCaptureRequest.automatic(
+            shouldWaitForJwt: false,
+            path: '/login',
+          ),
+        ),
+      ).isNotNull();
+    });
+
     test('queues an automatic retry while a capture is in flight', () {
       final queue = ProxyAuthCaptureQueue();
       final request = const ProxyAuthCaptureRequest.automatic(

--- a/test/features/auth/views/proxy_auth_page_test.dart
+++ b/test/features/auth/views/proxy_auth_page_test.dart
@@ -364,6 +364,33 @@ void main() {
     });
   });
 
+  group('ProxyAuthHistoryUpdateQueue', () {
+    test('coalesces overlapping updates to the latest URL', () {
+      final queue = ProxyAuthHistoryUpdateQueue();
+
+      check(queue.enqueue('https://chat.example/first')).isTrue();
+      check(queue.takeLatest()).equals('https://chat.example/first');
+
+      check(queue.enqueue('https://chat.example/second')).isFalse();
+      check(queue.enqueue('https://chat.example/final')).isFalse();
+      check(queue.takeLatest()).equals('https://chat.example/final');
+      check(queue.takeLatest()).isNull();
+      check(queue.restartAfterDrain()).isFalse();
+    });
+
+    test('restarts when an update arrives before drain cleanup', () {
+      final queue = ProxyAuthHistoryUpdateQueue();
+
+      check(queue.enqueue('https://chat.example/first')).isTrue();
+      check(queue.takeLatest()).equals('https://chat.example/first');
+      check(queue.enqueue('https://chat.example/final')).isFalse();
+
+      check(queue.restartAfterDrain()).isTrue();
+      check(queue.takeLatest()).equals('https://chat.example/final');
+      check(queue.restartAfterDrain()).isFalse();
+    });
+  });
+
   group('isTrustedProxyCredentialCaptureUrl', () {
     test('allows Open WebUI paths on the exact configured origin', () {
       expect(

--- a/test/features/auth/views/proxy_auth_page_test.dart
+++ b/test/features/auth/views/proxy_auth_page_test.dart
@@ -161,6 +161,44 @@ void main() {
       check(fence.committedDocument).isNull();
     });
 
+    test('delayed commit callback cannot replace a newer navigation', () {
+      final fence = ProxyAuthDocumentFence();
+      fence.startNavigation('https://chat.example/old');
+
+      fence.startNavigation('https://chat.example/new');
+      final newDocument = fence.activeDocument!;
+
+      check(fence.markDocumentCommitted('https://chat.example/old')).isFalse();
+      check(fence.committedDocument).isNull();
+      check(
+        fence.ownsDocument(newDocument.generation, newDocument.url),
+      ).isTrue();
+    });
+
+    test('redirect commit waits for the load-stop fallback', () {
+      final fence = ProxyAuthDocumentFence();
+      fence.startNavigation('https://chat.example/');
+      final pendingDocument = fence.activeDocument!;
+
+      check(
+        fence.markDocumentCommitted('https://auth.example/login'),
+      ).isFalse();
+      check(fence.committedDocument).isNull();
+      check(
+        fence.commitDocument(
+          document: pendingDocument,
+          callbackUrl: 'https://auth.example/login',
+          currentUrl: 'https://auth.example/login',
+        ),
+      ).isTrue();
+      check(
+        fence.ownsLiveDocument(
+          fence.committedDocument!,
+          'https://auth.example/login',
+        ),
+      ).isTrue();
+    });
+
     test('rejects a delayed completion after a newer navigation starts', () {
       final fence = ProxyAuthDocumentFence();
       fence.startNavigation('https://auth.example/login');


### PR DESCRIPTION
## Summary

- bind reverse-proxy cookie and JWT capture to the exact committed WebView navigation, with a generation-safe load-stop fallback when iOS omits commit callbacks
- serialize and coalesce History API callbacks, keep loading redirects provisional, and re-inspect stable path or fragment changes such as hash-routed login completion
- revalidate the full live URL across asynchronous cookie, password-field, and JWT work so stale results cannot complete authentication or make JWT waiting sticky
- add regression coverage for redirects, invalidation, reloads, stale callbacks and tickets, URL drift, rapid history updates, fragments, and queue reset/error handling

## Testing

- `flutter test test/features/auth/views/proxy_auth_page_test.dart` — 58 passed
- `flutter analyze` — no issues
- `flutter build ios --simulator --no-codesign` — succeeded
- full `flutter test` run — 5,145 passed and 4 skipped; two unrelated concurrency-sensitive tests failed in the combined run and both passed when rerun independently

Closes #606

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix proxy login completion after iOS redirects by tracking committed documents
> - Introduces `ProxyAuthDocumentFence` enhancements to distinguish active vs. committed documents, enabling the WebView to correctly identify the live document through redirects and History API navigation.
> - Adds `ProxyAuthHistoryUpdateQueue` to coalesce rapid `onUpdateVisitedHistory` events, ensuring only the latest URL is processed per burst.
> - Cookie/JWT capture pipeline now gates every step on live-document ownership via `ProxyAuthDocumentTicket`, aborting stale or redirected captures.
> - Adds `onUpdateVisitedHistory` and `onPageCommitVisible` WebView callbacks so same-document history changes (common in iOS SPA redirects) can advance the committed document and trigger capture.
> - Behavioral Change: `resolveProxyAuthJwtRequirement` now returns `null` unless both `ownsDocument` and `isLiveDocument` are true; previously it could schedule a JWT wait for stale documents.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d0381e9.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved proxy authentication handling across redirects, navigation, and same-page history changes.
  * Prevented outdated, mismatched, or uncommitted page-load operations from affecting authentication.
  * Ensured authentication callbacks are accepted only for the currently displayed and validated page.
  * Improved validation of the live page before completing authentication capture.

* **Tests**
  * Added coverage for redirects, stale navigations, invalidated pages, uncommitted navigations, same-page history changes, and current-page validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This change ties reverse-proxy credential capture to the exact committed WebView document, rejects stale navigation callbacks and URL drift, serializes history updates, and lets the note editor reuse the page scroll controller for context-menu selection handling.

No defect was identified in the changed behavior.

## T-Rex validation blocked
The focused auth and note-editor Flutter tests could not run because the required Flutter and Dart tools are not installed on this runner. Dependency setup is also unavailable because the Mermaid path-dependency submodule is uninitialized.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR is safe to merge; no blocking failure remains.

No defect was found in the reviewed changes. The implementation adds document ownership checks for redirect and history-update handling, and focused regression coverage exists for stale tickets, redirect fallback, URL drift, and editor context-menu behavior. Runtime Flutter verification could not run because the required local tools and dependencies are unavailable.
</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- The team compared the parent revision with the updated proxy-auth fence using an authored checker, and confirmed that generation ownership, exact full-URL matching between load-stop and the live WebView URL, and exact committed-document ownership are required before capture; an attempt to run flutter test test/features/auth/views/proxy\_auth\_page\_test.dart could not start because Flutter is not installed.
- The note-editor behavior was inspected around the controller change and the focused Android/iOS context-menu test; the widget tree now passes the page controller to Fleather, the test asserts shared controller identity, an attached scroll client, clipboard copy, and no exception, and an attempt to run the focused Flutter widget test could not start because Flutter is not installed.
- There is a runtime blocker: neither dart nor flutter is installed or discoverable in common system paths, and no local pub cache exists, with focus on the protection paths in proxy\_auth\_page.dart that gate load-stop and live URL checks and on the tests that exercise these paths.
- The PR review flow included changed-tree inspection that highlights the shared-controller change and regression test assertions, and an authored upload script that uploaded execution artifacts through supplied pre-signed slots.

<a href="https://app.greptile.com/trex/runs/17328052/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (10): Last reviewed commit: ["fix(auth): track proxy history fragments"](https://github.com/cogwheel0/conduit/commit/d0381e9f401751f5f297afe2b765f1ac6d979068) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50188958)</sub>

<!-- /greptile_comment -->