### PR TITLE
Add adaptive user message text selection

### DIFF
--- a/ios/Runner/AppDelegate.swift
+++ b/ios/Runner/AppDelegate.swift
@@ -2553,6 +2553,139 @@ private final class ConduitNativeToolbarActionGroupView:
   deinit {}
 }
 
+private final class ConduitNativeContextMenuAnchorFactory:
+  NSObject, FlutterPlatformViewFactory
+{
+  private let messenger: FlutterBinaryMessenger
+
+  init(messenger: FlutterBinaryMessenger) {
+    self.messenger = messenger
+    super.init()
+  }
+
+  func create(
+    withFrame frame: CGRect,
+    viewIdentifier viewId: Int64,
+    arguments args: Any?
+  ) -> FlutterPlatformView {
+    ConduitNativeContextMenuAnchorView(
+      frame: frame,
+      viewId: viewId,
+      arguments: args,
+      messenger: messenger
+    )
+  }
+
+  func createArgsCodec() -> FlutterMessageCodec & NSObjectProtocol {
+    FlutterStandardMessageCodec.sharedInstance()
+  }
+}
+
+/// Keeps UIKit's menu button out of the touch path and performs its primary
+/// action when Flutter recognizes a long press. This preserves ordinary and
+/// double taps while still using the native iOS menu renderer.
+private final class ConduitNativeContextMenuAnchorView:
+  NSObject, FlutterPlatformView
+{
+  private let container: UIView
+  private let button: UIButton
+  private let channel: FlutterMethodChannel
+  private let labels: [String]
+  private let symbols: [String]
+  private let enabled: [Bool]
+  private let destructive: [Bool]
+
+  init(
+    frame: CGRect,
+    viewId: Int64,
+    arguments: Any?,
+    messenger: FlutterBinaryMessenger
+  ) {
+    container = UIView(frame: frame)
+    button = UIButton(type: .system)
+    channel = FlutterMethodChannel(
+      name: "app.cogwheel.conduit/native_context_menu_anchor_\(viewId)",
+      binaryMessenger: messenger
+    )
+
+    let values = arguments as? [String: Any]
+    labels = values?["labels"] as? [String] ?? []
+    symbols = values?["sfSymbols"] as? [String] ?? []
+    enabled = Self.boolValues(values?["enabled"])
+    destructive = Self.boolValues(values?["isDestructive"])
+    super.init()
+
+    container.backgroundColor = .clear
+    container.isOpaque = false
+    container.isUserInteractionEnabled = false
+    container.accessibilityElementsHidden = true
+    button.translatesAutoresizingMaskIntoConstraints = false
+    button.backgroundColor = .clear
+    button.isAccessibilityElement = false
+    button.showsMenuAsPrimaryAction = true
+    button.preferredMenuElementOrder = .fixed
+    button.menu = makeMenu()
+    container.addSubview(button)
+    NSLayoutConstraint.activate([
+      button.leadingAnchor.constraint(equalTo: container.leadingAnchor),
+      button.trailingAnchor.constraint(equalTo: container.trailingAnchor),
+      button.topAnchor.constraint(equalTo: container.topAnchor),
+      button.bottomAnchor.constraint(equalTo: container.bottomAnchor),
+    ])
+    channel.setMethodCallHandler { [weak self] call, result in
+      guard call.method == "showMenu" else {
+        result(FlutterMethodNotImplemented)
+        return
+      }
+      if #available(iOS 17.4, *) {
+        self?.button.performPrimaryAction()
+      } else {
+        self?.button.sendActions(for: .primaryActionTriggered)
+      }
+      result(nil)
+    }
+  }
+
+  func view() -> UIView { container }
+
+  private func makeMenu() -> UIMenu {
+    let actions = labels.enumerated().map { index, label in
+      var attributes: UIMenuElement.Attributes = []
+      if index < enabled.count, !enabled[index] {
+        attributes.insert(.disabled)
+      }
+      if index < destructive.count, destructive[index] {
+        attributes.insert(.destructive)
+      }
+      let image = index < symbols.count && !symbols[index].isEmpty
+        ? UIImage(systemName: symbols[index])
+        : nil
+      return UIAction(
+        title: label,
+        image: image,
+        attributes: attributes
+      ) { [weak self] _ in
+        self?.channel.invokeMethod(
+          "itemSelected",
+          arguments: ["index": index]
+        )
+      }
+    }
+    return UIMenu(title: "", children: actions)
+  }
+
+  private static func boolValues(_ value: Any?) -> [Bool] {
+    if let values = value as? [Bool] {
+      return values
+    }
+    return (value as? [NSNumber] ?? []).map(\.boolValue)
+  }
+
+  deinit {
+    channel.setMethodCallHandler(nil)
+  }
+}
+
 @main
 @objc class AppDelegate: FlutterAppDelegate, FlutterImplicitEngineDelegate {
   private var backgroundStreamingHandler: BackgroundStreamingHandler?
@@ -2752,6 +2885,16 @@ private final class ConduitNativeToolbarActionGroupView:
           messenger: registrar.messenger()
         ),
         withId: "app.cogwheel.conduit/native_toolbar_action_group"
+      )
+    }
+    if let registrar = registrarForPlugin(
+      "ConduitNativeContextMenuAnchor"
+    ) {
+      registrar.register(
+        ConduitNativeContextMenuAnchorFactory(
+          messenger: registrar.messenger()
+        ),
+        withId: "app.cogwheel.conduit/native_context_menu_anchor"
       )
     }
   }

--- a/ios/Runner/AppDelegate.swift
+++ b/ios/Runner/AppDelegate.swift
@@ -2579,6 +2579,8 @@ private final class ConduitNativeContextMenuAnchorFactory:
   func createArgsCodec() -> FlutterMessageCodec & NSObjectProtocol {
     FlutterStandardMessageCodec.sharedInstance()
   }
+
+  deinit {}
 }
 
 /// Keeps UIKit's menu button out of the touch path and performs its primary

--- a/lib/features/chat/widgets/user_message_bubble.dart
+++ b/lib/features/chat/widgets/user_message_bubble.dart
@@ -15,6 +15,7 @@ import '../../../shared/theme/conduit_input_styles.dart';
 import '../../../shared/theme/theme_extensions.dart';
 import '../../../shared/utils/conversation_context_menu.dart';
 import '../../../shared/utils/file_type_utils.dart';
+import '../../../shared/widgets/responsive_drawer_layout.dart';
 import '../../hermes/services/hermes_session_provenance.dart';
 import '../../tools/providers/tools_providers.dart';
 import '../providers/chat_providers.dart';
@@ -81,6 +82,8 @@ class _UserMessageBubbleState extends ConsumerState<UserMessageBubble> {
   bool _isEditing = false;
   late final TextEditingController _editController;
   final FocusNode _editFocusNode = FocusNode();
+  final GlobalKey<SelectionAreaState> _textSelectionAreaKey =
+      GlobalKey<SelectionAreaState>();
   List<dynamic>? _lastPartitionedFiles;
   _UserFilePartitions? _lastFilePartitions;
 
@@ -721,7 +724,10 @@ class _UserMessageBubbleState extends ConsumerState<UserMessageBubble> {
     super.dispose();
   }
 
-  List<ConduitContextMenuAction> _buildMessageActions(BuildContext context) {
+  List<ConduitContextMenuAction> _buildMessageActions(
+    BuildContext context, {
+    bool includeSelect = false,
+  }) {
     // Don't show menu while editing - return empty list
     if (_isEditing) return [];
 
@@ -730,6 +736,7 @@ class _UserMessageBubbleState extends ConsumerState<UserMessageBubble> {
     return [
       ConduitContextMenuAction(
         cupertinoIcon: CupertinoIcons.pencil,
+        sfSymbol: 'pencil',
         materialIcon: Icons.edit_outlined,
         label: l10n.edit,
         onBeforeClose: () => ConduitHaptics.selectionClick(),
@@ -737,6 +744,7 @@ class _UserMessageBubbleState extends ConsumerState<UserMessageBubble> {
       ),
       ConduitContextMenuAction(
         cupertinoIcon: CupertinoIcons.doc_on_clipboard,
+        sfSymbol: 'doc.on.clipboard',
         materialIcon: Icons.content_copy,
         label: l10n.copy,
         onBeforeClose: () => ConduitHaptics.selectionClick(),
@@ -746,8 +754,17 @@ class _UserMessageBubbleState extends ConsumerState<UserMessageBubble> {
           }
         },
       ),
+      if (includeSelect)
+        ConduitContextMenuAction(
+          cupertinoIcon: CupertinoIcons.text_cursor,
+          sfSymbol: 'text.cursor',
+          materialIcon: Icons.select_all,
+          label: l10n.selectText,
+          onSelected: () async => _selectAllUserText(),
+        ),
       ConduitContextMenuAction(
         cupertinoIcon: CupertinoIcons.delete,
+        sfSymbol: 'trash',
         materialIcon: Icons.delete_outline,
         label: l10n.delete,
         destructive: true,
@@ -757,6 +774,15 @@ class _UserMessageBubbleState extends ConsumerState<UserMessageBubble> {
         },
       ),
     ];
+  }
+
+  void _selectAllUserText() {
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted || _isEditing) return;
+      _textSelectionAreaKey.currentState?.selectableRegion.selectAll(
+        SelectionChangedCause.toolbar,
+      );
+    });
   }
 
   @override
@@ -788,12 +814,87 @@ class _UserMessageBubbleState extends ConsumerState<UserMessageBubble> {
       bottomLeft: Radius.circular(AppBorderRadius.chatBubble),
       bottomRight: Radius.circular(AppBorderRadius.md),
     );
-    final actions = _buildMessageActions(context);
+    final attachmentActions = _buildMessageActions(context);
+    final textActions = _buildMessageActions(context, includeSelect: true);
     final attachmentContent = hasFilesFromArray
         ? _buildUserFileImages(filePartitions!)
         : hasImages
         ? _buildUserAttachmentImages()
         : null;
+    final bubbleSurface = Container(
+      key: const Key('user-message-bubble-surface'),
+      padding: const EdgeInsets.all(Spacing.sm + Spacing.xs),
+      decoration: BoxDecoration(
+        color: theme.chatBubbleUser,
+        borderRadius: bubbleBorderRadius,
+        border: Border.all(color: bubbleBorderColor, width: BorderWidth.thin),
+      ),
+      child: _isEditing
+          ? Focus(
+              focusNode: _editFocusNode,
+              autofocus: true,
+              child: DecoratedBox(
+                decoration: BoxDecoration(
+                  color: inlineEditFill,
+                  borderRadius: BorderRadius.circular(AppBorderRadius.small),
+                  border: Border.all(
+                    color: theme.inputBorderFocused.withValues(alpha: 0.5),
+                    width: BorderWidth.thin,
+                  ),
+                ),
+                child: Padding(
+                  padding: const EdgeInsets.symmetric(
+                    horizontal: Spacing.xs,
+                    vertical: Spacing.xxs,
+                  ),
+                  child: AdaptiveTextField(
+                    controller: _editController,
+                    maxLines: null,
+                    style: AppTypography.chatMessageStyle.copyWith(
+                      color: inlineEditTextColor,
+                    ),
+                    onSubmitted: (_) => _saveInlineEdit(),
+                    padding: EdgeInsets.zero,
+                    cupertinoDecoration: const BoxDecoration(),
+                    decoration: context.conduitInputStyles
+                        .borderless()
+                        .copyWith(
+                          isCollapsed: true,
+                          contentPadding: EdgeInsets.zero,
+                        ),
+                  ),
+                ),
+              ),
+            )
+          : Text(
+              widget.message.content,
+              style: AppTypography.chatMessageStyle.copyWith(
+                color: theme.chatBubbleUserText,
+              ),
+              softWrap: true,
+              textAlign: TextAlign.left,
+              textWidthBasis: TextWidthBasis.longestLine,
+              textHeightBehavior: const TextHeightBehavior(
+                applyHeightToFirstAscent: false,
+                applyHeightToLastDescent: false,
+                leadingDistribution: TextLeadingDistribution.even,
+              ),
+            ),
+    );
+    final textBubble = _isEditing
+        ? bubbleSurface
+        : DrawerOpenGestureExclusion(
+            child: SelectionArea(
+              key: _textSelectionAreaKey,
+              child: DrawerOpenGesturePriority(
+                child: ConduitContextMenu(
+                  actions: textActions,
+                  presentation: ConduitContextMenuPresentation.popup,
+                  child: bubbleSurface,
+                ),
+              ),
+            ),
+          );
 
     return Container(
       width: double.infinity,
@@ -804,7 +905,10 @@ class _UserMessageBubbleState extends ConsumerState<UserMessageBubble> {
           // Display images outside and above the text bubble (iMessage style)
           // Prioritize files array over attachmentIds to avoid duplication
           if (attachmentContent != null)
-            ConduitContextMenu(actions: actions, child: attachmentContent),
+            ConduitContextMenu(
+              actions: attachmentActions,
+              child: attachmentContent,
+            ),
 
           // Display text bubble if there's text content
           if (hasText) const SizedBox(height: Spacing.xs),
@@ -815,76 +919,7 @@ class _UserMessageBubbleState extends ConsumerState<UserMessageBubble> {
                 Flexible(
                   child: ConstrainedBox(
                     constraints: BoxConstraints(maxWidth: bubbleMaxWidth),
-                    child: ConduitContextMenu(
-                      actions: actions,
-                      child: Container(
-                        key: const Key('user-message-bubble-surface'),
-                        padding: const EdgeInsets.all(Spacing.sm + Spacing.xs),
-                        decoration: BoxDecoration(
-                          color: theme.chatBubbleUser,
-                          borderRadius: bubbleBorderRadius,
-                          border: Border.all(
-                            color: bubbleBorderColor,
-                            width: BorderWidth.thin,
-                          ),
-                        ),
-                        child: _isEditing
-                            ? Focus(
-                                focusNode: _editFocusNode,
-                                autofocus: true,
-                                child: DecoratedBox(
-                                  decoration: BoxDecoration(
-                                    color: inlineEditFill,
-                                    borderRadius: BorderRadius.circular(
-                                      AppBorderRadius.small,
-                                    ),
-                                    border: Border.all(
-                                      color: theme.inputBorderFocused
-                                          .withValues(alpha: 0.5),
-                                      width: BorderWidth.thin,
-                                    ),
-                                  ),
-                                  child: Padding(
-                                    padding: const EdgeInsets.symmetric(
-                                      horizontal: Spacing.xs,
-                                      vertical: Spacing.xxs,
-                                    ),
-                                    child: AdaptiveTextField(
-                                      controller: _editController,
-                                      maxLines: null,
-                                      style: AppTypography.chatMessageStyle
-                                          .copyWith(color: inlineEditTextColor),
-                                      onSubmitted: (_) => _saveInlineEdit(),
-                                      padding: EdgeInsets.zero,
-                                      cupertinoDecoration:
-                                          const BoxDecoration(),
-                                      decoration: context.conduitInputStyles
-                                          .borderless()
-                                          .copyWith(
-                                            isCollapsed: true,
-                                            contentPadding: EdgeInsets.zero,
-                                          ),
-                                    ),
-                                  ),
-                                ),
-                              )
-                            : Text(
-                                widget.message.content,
-                                style: AppTypography.chatMessageStyle.copyWith(
-                                  color: theme.chatBubbleUserText,
-                                ),
-                                softWrap: true,
-                                textAlign: TextAlign.left,
-                                textWidthBasis: TextWidthBasis.longestLine,
-                                textHeightBehavior: const TextHeightBehavior(
-                                  applyHeightToFirstAscent: false,
-                                  applyHeightToLastDescent: false,
-                                  leadingDistribution:
-                                      TextLeadingDistribution.even,
-                                ),
-                              ),
-                      ),
-                    ),
+                    child: textBubble,
                   ),
                 ),
               ],
@@ -986,6 +1021,11 @@ class _UserMessageBubbleState extends ConsumerState<UserMessageBubble> {
 
   void _startInlineEdit() {
     if (_isEditing) return;
+    final selectionArea = _textSelectionAreaKey.currentState;
+    if (selectionArea != null) {
+      selectionArea.selectableRegion.hideToolbar();
+      selectionArea.selectableRegion.clearSelection();
+    }
     setState(() {
       _isEditing = true;
       _editController.text = widget.message.content ?? '';

--- a/lib/l10n/app_cs.arb
+++ b/lib/l10n/app_cs.arb
@@ -992,6 +992,7 @@
   "@copy": {
     "description": "Action to copy text to clipboard."
   },
+  "selectText": "Vybrat",
   "ttsListen": "Poslechnout",
   "@ttsListen": {
     "description": "Action to play the assistant message using text to speech"

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -232,6 +232,7 @@
   "imageGeneration": "Bildgenerierung",
   "imageGenerationDescription": "Bilder aus deinen Prompts erstellen.",
   "copy": "Kopieren",
+  "selectText": "Auswählen",
   "ttsListen": "Anhören",
   "ttsStop": "Stoppen",
   "edit": "Bearbeiten",

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -1181,6 +1181,10 @@
   "@copy": {
     "description": "Action to copy text to clipboard."
   },
+  "selectText": "Select",
+  "@selectText": {
+    "description": "Action that selects the full text of a chat message."
+  },
   "ttsListen": "Listen",
   "@ttsListen": {
     "description": "Action to play the assistant message using text to speech"

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -230,6 +230,7 @@
   "imageGeneration": "Generación de imágenes",
   "imageGenerationDescription": "Crea imágenes a partir de tus prompts.",
   "copy": "Copiar",
+  "selectText": "Seleccionar",
   "ttsListen": "Escuchar",
   "ttsStop": "Detener",
   "edit": "Editar",

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -230,6 +230,7 @@
   "imageGeneration": "Génération d'images",
   "imageGenerationDescription": "Créez des images à partir de vos prompts.",
   "copy": "Copier",
+  "selectText": "Sélectionner",
   "ttsListen": "Écouter",
   "ttsStop": "Arrêter",
   "edit": "Modifier",

--- a/lib/l10n/app_it.arb
+++ b/lib/l10n/app_it.arb
@@ -230,6 +230,7 @@
   "imageGeneration": "Generazione immagini",
   "imageGenerationDescription": "Crea immagini dai tuoi prompt.",
   "copy": "Copia",
+  "selectText": "Seleziona",
   "ttsListen": "Ascolta",
   "ttsStop": "Interrompi",
   "edit": "Modifica",

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -992,6 +992,7 @@
   "@copy": {
     "description": "Action to copy text to clipboard."
   },
+  "selectText": "選択",
   "ttsListen": "聞く",
   "@ttsListen": {
     "description": "Action to play the assistant message using text to speech"

--- a/lib/l10n/app_ko.arb
+++ b/lib/l10n/app_ko.arb
@@ -331,6 +331,7 @@
   "imageGeneration": "이미지 생성",
   "imageGenerationDescription": "프롬프트에서 이미지를 생성합니다.",
   "copy": "복사",
+  "selectText": "선택",
   "ttsListen": "듣기",
   "ttsStop": "중지",
   "edit": "편집",

--- a/lib/l10n/app_nl.arb
+++ b/lib/l10n/app_nl.arb
@@ -230,6 +230,7 @@
   "imageGeneration": "Afbeeldingsgeneratie",
   "imageGenerationDescription": "Maak afbeeldingen van je prompts.",
   "copy": "Kopiëren",
+  "selectText": "Selecteren",
   "ttsListen": "Luisteren",
   "ttsStop": "Stoppen",
   "edit": "Bewerken",

--- a/lib/l10n/app_ru.arb
+++ b/lib/l10n/app_ru.arb
@@ -230,6 +230,7 @@
   "imageGeneration": "Генерация изображений",
   "imageGenerationDescription": "Создавайте изображения из ваших запросов.",
   "copy": "Копировать",
+  "selectText": "Выбрать",
   "ttsListen": "Прослушать",
   "ttsStop": "Остановить",
   "edit": "Редактировать",

--- a/lib/l10n/app_sk.arb
+++ b/lib/l10n/app_sk.arb
@@ -992,6 +992,7 @@
   "@copy": {
     "description": "Action to copy text to clipboard."
   },
+  "selectText": "Vybrať",
   "ttsListen": "Vypočuť",
   "@ttsListen": {
     "description": "Action to play the assistant message using text to speech"

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -230,6 +230,7 @@
   "imageGeneration": "图像生成",
   "imageGenerationDescription": "从您的提示创建图像。",
   "copy": "复制",
+  "selectText": "选择",
   "ttsListen": "收听",
   "ttsStop": "停止",
   "edit": "编辑",

--- a/lib/l10n/app_zh_Hant.arb
+++ b/lib/l10n/app_zh_Hant.arb
@@ -230,6 +230,7 @@
   "imageGeneration": "圖像生成",
   "imageGenerationDescription": "從您的提示創建圖像。",
   "copy": "複製",
+  "selectText": "選取",
   "ttsListen": "收聽",
   "ttsStop": "停止",
   "edit": "編輯",

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -4,6 +4,7 @@ import 'package:adaptive_platform_ui/adaptive_platform_ui.dart';
 import 'package:flutter/foundation.dart'
     show LicenseEntryWithLineBreaks, LicenseRegistry;
 import 'package:flutter_driver/driver_extension.dart';
+import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter/services.dart' show rootBundle;
@@ -113,6 +114,7 @@ void main() {
   runZonedGuarded(
     () async {
       WidgetsFlutterBinding.ensureInitialized();
+      GestureBinding.instance.resamplingEnabled = true;
       RasterMediaPolicy.configureGlobalImageCache();
       // Measure the complete Dart-side startup path, including the first plugin
       // calls. Package metadata is not required to paint the auth/theme shell;

--- a/lib/shared/utils/conversation_context_menu.dart
+++ b/lib/shared/utils/conversation_context_menu.dart
@@ -52,8 +52,10 @@ enum ConduitContextMenuPresentation {
 /// A long-press context menu widget with platform-specific presentation.
 ///
 /// The app keeps its own action model so call sites can share haptics and
-/// icons while the menu presentation follows the current platform. On iOS we
-/// keep the child size stable during preview because stock
+/// icons while the menu presentation follows the current platform. Popup
+/// menus stay in Flutter's gesture arena so gestures owned by the child, such
+/// as text selection on double tap, remain available. On iOS we keep the child
+/// size stable during preview because stock
 /// [CupertinoContextMenu] can assert when the child is laid out by flex-based
 /// parents.
 class ConduitContextMenu extends StatefulWidget {
@@ -69,7 +71,7 @@ class ConduitContextMenu extends StatefulWidget {
     required this.child,
     this.topWidgetBuilder,
     this.stabilizePreviewSize = true,
-    this.presentation = ConduitContextMenuPresentation.preview,
+    this.presentation = ConduitContextMenuPresentation.popup,
   });
 
   @override
@@ -77,7 +79,30 @@ class ConduitContextMenu extends StatefulWidget {
 }
 
 class _ConduitContextMenuState extends State<ConduitContextMenu> {
+  ContextMenuController? _activePopupController;
+  bool? _usesIOSPopupRoute;
   Size? _childSize;
+
+  @override
+  void didUpdateWidget(covariant ConduitContextMenu oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (!identical(oldWidget.actions, widget.actions) ||
+        oldWidget.presentation != widget.presentation) {
+      _dismissPopup();
+    }
+  }
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    final usesIOSPopupRoute =
+        Theme.of(context).platform == TargetPlatform.iOS &&
+        widget.presentation == ConduitContextMenuPresentation.popup;
+    if (_usesIOSPopupRoute != null && _usesIOSPopupRoute != usesIOSPopupRoute) {
+      _dismissPopup();
+    }
+    _usesIOSPopupRoute = usesIOSPopupRoute;
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -85,12 +110,12 @@ class _ConduitContextMenuState extends State<ConduitContextMenu> {
       return widget.child;
     }
 
-    if (PlatformInfo.isIOS &&
-        widget.presentation == ConduitContextMenuPresentation.popup) {
-      return _buildAdaptivePopupMenu();
+    final isIOS = Theme.of(context).platform == TargetPlatform.iOS;
+    if (isIOS && widget.presentation == ConduitContextMenuPresentation.popup) {
+      return _buildAdaptivePopupMenu(context);
     }
 
-    if (PlatformInfo.isIOS) {
+    if (isIOS) {
       return _buildCupertinoContextMenu(context);
     }
 
@@ -108,30 +133,58 @@ class _ConduitContextMenuState extends State<ConduitContextMenu> {
     );
   }
 
-  Widget _buildAdaptivePopupMenu() {
-    final usesNativeSFSymbols = PlatformInfo.isIOS26OrHigher();
-    return AdaptivePopupMenuButton.widget<int>(
-      items: [
-        for (var index = 0; index < widget.actions.length; index++)
-          AdaptivePopupMenuItem<int>(
-            value: index,
-            label: widget.actions[index].label,
-            icon: usesNativeSFSymbols
-                ? widget.actions[index].sfSymbol ??
-                      widget.actions[index].cupertinoIcon
-                : widget.actions[index].cupertinoIcon,
-            isDestructive: widget.actions[index].destructive,
-          ),
-      ],
-      onSelected: (_, entry) {
-        final index = entry.value;
-        if (index == null || index < 0 || index >= widget.actions.length) {
-          return;
-        }
-        Future.microtask(() => _invokeAction(widget.actions[index]));
-      },
-      triggerOnLongPress: true,
+  Widget _buildAdaptivePopupMenu(BuildContext context) {
+    return GestureDetector(
+      key: const ValueKey('conduit-context-menu-popup-gesture'),
+      behavior: HitTestBehavior.opaque,
+      onLongPressStart: (details) =>
+          _showPopupMenu(context, details.globalPosition),
+      onSecondaryTapUp: (details) =>
+          _showPopupMenu(context, details.globalPosition),
       child: widget.child,
+    );
+  }
+
+  void _showPopupMenu(BuildContext context, Offset anchor) {
+    final actions = List<ConduitContextMenuAction>.of(widget.actions);
+    _dismissPopup();
+    late final ContextMenuController controller;
+    controller = ContextMenuController(
+      onRemove: () {
+        if (identical(_activePopupController, controller)) {
+          _activePopupController = null;
+        }
+      },
+    );
+    _activePopupController = controller;
+    controller.show(
+      context: context,
+      debugRequiredFor: widget,
+      contextMenuBuilder: (overlayContext) {
+        return Stack(
+          children: [
+            Positioned.fill(
+              child: GestureDetector(
+                behavior: HitTestBehavior.opaque,
+                onTap: controller.remove,
+              ),
+            ),
+            AdaptiveTextSelectionToolbar(
+              anchors: TextSelectionToolbarAnchors(primaryAnchor: anchor),
+              children: [
+                for (final action in actions)
+                  CupertinoTextSelectionToolbarButton(
+                    onPressed: () {
+                      controller.remove();
+                      Future.microtask(() => _invokeAction(action));
+                    },
+                    child: _PopupMenuActionContent(action: action),
+                  ),
+              ],
+            ),
+          ],
+        );
+      },
     );
   }
 
@@ -204,6 +257,48 @@ class _ConduitContextMenuState extends State<ConduitContextMenu> {
       return;
     }
     _childSize = size;
+  }
+
+  void _dismissPopup() {
+    _activePopupController?.remove();
+  }
+
+  @override
+  void dispose() {
+    _dismissPopup();
+    _activePopupController = null;
+    super.dispose();
+  }
+}
+
+class _PopupMenuActionContent extends StatelessWidget {
+  const _PopupMenuActionContent({required this.action});
+
+  final ConduitContextMenuAction action;
+
+  @override
+  Widget build(BuildContext context) {
+    final color = action.destructive
+        ? CupertinoColors.systemRed.resolveFrom(context)
+        : CupertinoColors.label.resolveFrom(context);
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        Icon(action.cupertinoIcon, size: 16, color: color),
+        const SizedBox(width: 6),
+        Text(
+          action.label,
+          overflow: TextOverflow.ellipsis,
+          style: TextStyle(
+            inherit: false,
+            color: color,
+            fontSize: 15,
+            letterSpacing: -0.15,
+            fontWeight: FontWeight.w400,
+          ),
+        ),
+      ],
+    );
   }
 }
 

--- a/lib/shared/utils/conversation_context_menu.dart
+++ b/lib/shared/utils/conversation_context_menu.dart
@@ -39,6 +39,16 @@ class ConduitContextMenuAction {
   });
 }
 
+/// Controls how a [ConduitContextMenu] is presented on platforms that support
+/// more than one native menu treatment.
+enum ConduitContextMenuPresentation {
+  /// A lifted preview with its actions alongside it.
+  preview,
+
+  /// A compact popup anchored to the pressed child.
+  popup,
+}
+
 /// A long-press context menu widget with platform-specific presentation.
 ///
 /// The app keeps its own action model so call sites can share haptics and
@@ -51,6 +61,7 @@ class ConduitContextMenu extends StatefulWidget {
   final Widget child;
   final WidgetBuilder? topWidgetBuilder;
   final bool stabilizePreviewSize;
+  final ConduitContextMenuPresentation presentation;
 
   const ConduitContextMenu({
     super.key,
@@ -58,6 +69,7 @@ class ConduitContextMenu extends StatefulWidget {
     required this.child,
     this.topWidgetBuilder,
     this.stabilizePreviewSize = true,
+    this.presentation = ConduitContextMenuPresentation.preview,
   });
 
   @override
@@ -73,6 +85,11 @@ class _ConduitContextMenuState extends State<ConduitContextMenu> {
       return widget.child;
     }
 
+    if (PlatformInfo.isIOS &&
+        widget.presentation == ConduitContextMenuPresentation.popup) {
+      return _buildAdaptivePopupMenu();
+    }
+
     if (PlatformInfo.isIOS) {
       return _buildCupertinoContextMenu(context);
     }
@@ -84,15 +101,42 @@ class _ConduitContextMenuState extends State<ConduitContextMenu> {
             title: action.label,
             icon: action.materialIcon,
             isDestructive: action.destructive,
-            onPressed: () {
-              ConduitHaptics.selectionClick();
-              action.onBeforeClose?.call();
-              action.onSelected();
-            },
+            onPressed: () => _invokeAction(action),
           ),
       ],
       child: widget.child,
     );
+  }
+
+  Widget _buildAdaptivePopupMenu() {
+    return AdaptivePopupMenuButton.widget<int>(
+      items: [
+        for (var index = 0; index < widget.actions.length; index++)
+          AdaptivePopupMenuItem<int>(
+            value: index,
+            label: widget.actions[index].label,
+            icon:
+                widget.actions[index].sfSymbol ??
+                widget.actions[index].cupertinoIcon,
+            isDestructive: widget.actions[index].destructive,
+          ),
+      ],
+      onSelected: (_, entry) {
+        final index = entry.value;
+        if (index == null || index < 0 || index >= widget.actions.length) {
+          return;
+        }
+        Future.microtask(() => _invokeAction(widget.actions[index]));
+      },
+      triggerOnLongPress: true,
+      child: widget.child,
+    );
+  }
+
+  void _invokeAction(ConduitContextMenuAction action) {
+    ConduitHaptics.selectionClick();
+    action.onBeforeClose?.call();
+    action.onSelected();
   }
 
   Widget _buildCupertinoContextMenu(BuildContext context) {
@@ -105,9 +149,7 @@ class _ConduitContextMenuState extends State<ConduitContextMenu> {
             onPressed: () {
               Navigator.of(context, rootNavigator: true).pop();
               Future.microtask(() {
-                ConduitHaptics.selectionClick();
-                action.onBeforeClose?.call();
-                action.onSelected();
+                _invokeAction(action);
               });
             },
             child: Text(action.label),

--- a/lib/shared/utils/conversation_context_menu.dart
+++ b/lib/shared/utils/conversation_context_menu.dart
@@ -109,15 +109,17 @@ class _ConduitContextMenuState extends State<ConduitContextMenu> {
   }
 
   Widget _buildAdaptivePopupMenu() {
+    final usesNativeSFSymbols = PlatformInfo.isIOS26OrHigher();
     return AdaptivePopupMenuButton.widget<int>(
       items: [
         for (var index = 0; index < widget.actions.length; index++)
           AdaptivePopupMenuItem<int>(
             value: index,
             label: widget.actions[index].label,
-            icon:
-                widget.actions[index].sfSymbol ??
-                widget.actions[index].cupertinoIcon,
+            icon: usesNativeSFSymbols
+                ? widget.actions[index].sfSymbol ??
+                      widget.actions[index].cupertinoIcon
+                : widget.actions[index].cupertinoIcon,
             isDestructive: widget.actions[index].destructive,
           ),
       ],

--- a/lib/shared/utils/conversation_context_menu.dart
+++ b/lib/shared/utils/conversation_context_menu.dart
@@ -1,3 +1,5 @@
+import 'dart:convert';
+
 import 'package:adaptive_platform_ui/adaptive_platform_ui.dart';
 import 'package:conduit/core/database/chat_database_repository.dart';
 import 'package:conduit/core/models/conversation.dart';
@@ -340,14 +342,11 @@ class _IOS26ConduitContextMenuState extends State<_IOS26ConduitContextMenu> {
   Widget build(BuildContext context) {
     final actions = widget.actions;
     final isDark = MediaQuery.platformBrightnessOf(context) == Brightness.dark;
-    final viewKey = ValueKey<Object>(
-      Object.hashAll(<Object?>[
+    final viewKey = ValueKey<String>(
+      jsonEncode(<Object?>[
         isDark,
-        for (final action in actions) ...<Object?>[
-          action.label,
-          action.sfSymbol,
-          action.destructive,
-        ],
+        for (final action in actions)
+          <Object?>[action.label, action.sfSymbol, action.destructive],
       ]),
     );
 

--- a/lib/shared/utils/conversation_context_menu.dart
+++ b/lib/shared/utils/conversation_context_menu.dart
@@ -11,6 +11,8 @@ import 'package:conduit/shared/widgets/themed_dialogs.dart';
 import 'package:conduit/shared/widgets/themed_sheets.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart';
+import 'package:flutter/services.dart';
 import 'package:conduit/core/services/haptic_service.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
@@ -86,7 +88,7 @@ class _ConduitContextMenuState extends State<ConduitContextMenu> {
   @override
   void didUpdateWidget(covariant ConduitContextMenu oldWidget) {
     super.didUpdateWidget(oldWidget);
-    if (!identical(oldWidget.actions, widget.actions) ||
+    if (!_hasEquivalentActionPresentation(oldWidget.actions, widget.actions) ||
         oldWidget.presentation != widget.presentation) {
       _dismissPopup();
     }
@@ -134,6 +136,14 @@ class _ConduitContextMenuState extends State<ConduitContextMenu> {
   }
 
   Widget _buildAdaptivePopupMenu(BuildContext context) {
+    if (PlatformInfo.isIOS26OrHigher()) {
+      return _IOS26ConduitContextMenu(
+        actions: widget.actions,
+        onSelected: _invokeAction,
+        child: widget.child,
+      );
+    }
+
     return GestureDetector(
       key: const ValueKey('conduit-context-menu-popup-gesture'),
       behavior: HitTestBehavior.opaque,
@@ -172,11 +182,20 @@ class _ConduitContextMenuState extends State<ConduitContextMenu> {
             AdaptiveTextSelectionToolbar(
               anchors: TextSelectionToolbarAnchors(primaryAnchor: anchor),
               children: [
-                for (final action in actions)
+                for (final (index, action) in actions.indexed)
                   CupertinoTextSelectionToolbarButton(
                     onPressed: () {
+                      final currentActions = widget.actions;
+                      if (!_hasEquivalentActionPresentation(
+                        actions,
+                        currentActions,
+                      )) {
+                        controller.remove();
+                        return;
+                      }
+                      final currentAction = currentActions[index];
                       controller.remove();
-                      Future.microtask(() => _invokeAction(action));
+                      Future.microtask(() => _invokeAction(currentAction));
                     },
                     child: _PopupMenuActionContent(action: action),
                   ),
@@ -269,6 +288,149 @@ class _ConduitContextMenuState extends State<ConduitContextMenu> {
     _activePopupController = null;
     super.dispose();
   }
+}
+
+bool _hasEquivalentActionPresentation(
+  List<ConduitContextMenuAction> previous,
+  List<ConduitContextMenuAction> current,
+) {
+  if (previous.length != current.length) {
+    return false;
+  }
+  for (var index = 0; index < previous.length; index++) {
+    final oldAction = previous[index];
+    final newAction = current[index];
+    if (oldAction.label != newAction.label ||
+        oldAction.cupertinoIcon != newAction.cupertinoIcon ||
+        oldAction.sfSymbol != newAction.sfSymbol ||
+        oldAction.materialIcon != newAction.materialIcon ||
+        oldAction.destructive != newAction.destructive) {
+      return false;
+    }
+  }
+  return true;
+}
+
+/// Hosts a native iOS 26 [UIMenu] without hiding Flutter's selectable content
+/// from hit testing.
+///
+/// Flutter recognizes the long press and asks a transparent native anchor to
+/// present its [UIMenu], so regular and double taps remain available to the
+/// selectable child.
+class _IOS26ConduitContextMenu extends StatefulWidget {
+  const _IOS26ConduitContextMenu({
+    required this.actions,
+    required this.onSelected,
+    required this.child,
+  });
+
+  final List<ConduitContextMenuAction> actions;
+  final ValueChanged<ConduitContextMenuAction> onSelected;
+  final Widget child;
+
+  @override
+  State<_IOS26ConduitContextMenu> createState() =>
+      _IOS26ConduitContextMenuState();
+}
+
+class _IOS26ConduitContextMenuState extends State<_IOS26ConduitContextMenu> {
+  MethodChannel? _channel;
+
+  @override
+  Widget build(BuildContext context) {
+    final actions = widget.actions;
+    final isDark = MediaQuery.platformBrightnessOf(context) == Brightness.dark;
+    final viewKey = ValueKey<Object>(
+      Object.hashAll(<Object?>[
+        isDark,
+        for (final action in actions) ...<Object?>[
+          action.label,
+          action.sfSymbol,
+          action.destructive,
+        ],
+      ]),
+    );
+
+    return Stack(
+      fit: StackFit.passthrough,
+      children: [
+        GestureDetector(
+          key: const ValueKey('conduit-context-menu-popup-gesture'),
+          behavior: HitTestBehavior.opaque,
+          onLongPress: () {
+            _channel?.invokeMethod<void>('showMenu');
+          },
+          child: widget.child,
+        ),
+        Positioned.fill(
+          child: buildConduitIOS26PopupPlatformView(
+            key: viewKey,
+            creationParams: <String, Object?>{
+              'labels': [for (final action in actions) action.label],
+              'sfSymbols': [
+                for (final action in actions) action.sfSymbol ?? '',
+              ],
+              'enabled': [for (final _ in actions) true],
+              'isDestructive': [
+                for (final action in actions) action.destructive,
+              ],
+            },
+            onPlatformViewCreated: _handlePlatformViewCreated,
+          ),
+        ),
+      ],
+    );
+  }
+
+  void _handlePlatformViewCreated(int id) {
+    _channel?.setMethodCallHandler(null);
+    final channel = MethodChannel(
+      'app.cogwheel.conduit/native_context_menu_anchor_$id',
+    );
+    _channel = channel;
+    channel.setMethodCallHandler(_handleMethodCall);
+  }
+
+  Future<void> _handleMethodCall(MethodCall call) async {
+    if (call.method != 'itemSelected') {
+      return;
+    }
+    final arguments = call.arguments;
+    final index = arguments is Map
+        ? (arguments['index'] as num?)?.toInt()
+        : null;
+    if (index == null || index < 0 || index >= widget.actions.length) {
+      return;
+    }
+    widget.onSelected(widget.actions[index]);
+  }
+
+  @override
+  void dispose() {
+    _channel?.setMethodCallHandler(null);
+    _channel = null;
+    super.dispose();
+  }
+}
+
+/// Creates the native iOS 26 menu surface used by [ConduitContextMenu].
+///
+/// Exposed for the gesture regression test: accepting pointer events here
+/// removes the selectable child from Flutter's hit-test path.
+@visibleForTesting
+UiKitView buildConduitIOS26PopupPlatformView({
+  required Key key,
+  required Map<String, Object?> creationParams,
+  required PlatformViewCreatedCallback onPlatformViewCreated,
+}) {
+  return UiKitView(
+    key: key,
+    viewType: 'app.cogwheel.conduit/native_context_menu_anchor',
+    creationParams: creationParams,
+    creationParamsCodec: const StandardMessageCodec(),
+    onPlatformViewCreated: onPlatformViewCreated,
+    hitTestBehavior: PlatformViewHitTestBehavior.transparent,
+  );
 }
 
 class _PopupMenuActionContent extends StatelessWidget {

--- a/test/features/chat/widgets/user_message_bubble_test.dart
+++ b/test/features/chat/widgets/user_message_bubble_test.dart
@@ -18,6 +18,7 @@ import 'package:conduit/shared/theme/theme_extensions.dart';
 import 'package:conduit/shared/theme/tweakcn_themes.dart';
 import 'package:conduit/shared/utils/conversation_context_menu.dart';
 import 'package:conduit/shared/widgets/skeleton_loader.dart';
+import 'package:checks/checks.dart';
 import 'package:dio/dio.dart' show CancelToken;
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
@@ -51,18 +52,21 @@ void main() {
         return null;
       },
     );
-    final selectionArea = tester.state<SelectionAreaState>(
-      find.byType(SelectionArea),
-    );
-    final copyAction = selectionArea.selectableRegion.contextMenuButtonItems
-        .singleWhere((item) => item.type == ContextMenuButtonType.copy);
-    copyAction.onPressed!.call();
-    await tester.pump();
-    tester.binding.defaultBinaryMessenger.setMockMethodCallHandler(
-      SystemChannels.platform,
-      null,
-    );
-    return copiedText;
+    try {
+      final selectionArea = tester.state<SelectionAreaState>(
+        find.byType(SelectionArea),
+      );
+      final copyAction = selectionArea.selectableRegion.contextMenuButtonItems
+          .singleWhere((item) => item.type == ContextMenuButtonType.copy);
+      copyAction.onPressed!.call();
+      await tester.pump();
+      return copiedText;
+    } finally {
+      tester.binding.defaultBinaryMessenger.setMockMethodCallHandler(
+        SystemChannels.platform,
+        null,
+      );
+    }
   }
 
   Widget buildHarness(
@@ -111,16 +115,17 @@ void main() {
 
     expect(find.text('Sprint Plan'), findsOneWidget);
     expect(find.byIcon(Icons.sticky_note_2_outlined), findsOneWidget);
-    expect(find.byType(SelectionArea), findsNothing);
+    check(find.byType(SelectionArea).evaluate()).isEmpty();
 
     final attachmentMenu = tester.widget<ConduitContextMenu>(
       find.byType(ConduitContextMenu),
     );
-    expect(attachmentMenu.presentation, ConduitContextMenuPresentation.preview);
-    expect(
-      attachmentMenu.actions.map((action) => action.label),
-      orderedEquals(<String>['Edit', 'Copy', 'Delete']),
-    );
+    check(
+      attachmentMenu.presentation,
+    ).equals(ConduitContextMenuPresentation.preview);
+    check(
+      attachmentMenu.actions.map((action) => action.label).toList(),
+    ).deepEquals(<String>['Edit', 'Copy', 'Delete']);
   });
 
   testWidgets(
@@ -251,42 +256,38 @@ void main() {
           final contextMenu = tester.widget<ConduitContextMenu>(
             find.byType(ConduitContextMenu),
           );
-          expect(
+          check(
             contextMenu.presentation,
-            ConduitContextMenuPresentation.popup,
-          );
-          expect(
-            contextMenu.actions.map((action) => action.label),
-            orderedEquals(<String>['Edit', 'Copy', 'Select', 'Delete']),
-          );
+          ).equals(ConduitContextMenuPresentation.popup);
+          check(
+            contextMenu.actions.map((action) => action.label).toList(),
+          ).deepEquals(<String>['Edit', 'Copy', 'Select', 'Delete']);
 
           final selectionArea = tester.state<SelectionAreaState>(
             find.byType(SelectionArea),
           );
-          expect(
+          check(
             selectionArea.selectableRegion.contextMenuButtonItems.where(
               (item) => item.type == ContextMenuButtonType.copy,
             ),
-            isEmpty,
-          );
+          ).isEmpty();
 
           await tester.longPress(find.text(content));
           await tester.pump();
           await tester.pump(const Duration(milliseconds: 500));
 
-          expect(find.text('Select'), findsOneWidget);
-          expect(
+          check(find.text('Select').evaluate()).length.equals(1);
+          check(
             selectionArea.selectableRegion.contextMenuButtonItems.where(
               (item) => item.type == ContextMenuButtonType.copy,
             ),
-            isEmpty,
-          );
+          ).isEmpty();
 
           await tester.tap(find.text('Select'));
           await tester.pump();
           await tester.pump(const Duration(milliseconds: 500));
 
-          expect(await copySelectedText(tester), content);
+          check(await copySelectedText(tester)).equals(content);
         });
       },
     );
@@ -314,7 +315,7 @@ void main() {
         await tester.pump();
         await tester.pump(const Duration(milliseconds: 500));
 
-        expect(await copySelectedText(tester), 'alpha');
+        check(await copySelectedText(tester)).equals('alpha');
       });
     });
   }
@@ -375,7 +376,7 @@ void main() {
     );
     await contextMenu.actions.first.onSelected();
     await tester.pump();
-    expect(find.byType(SelectionArea), findsNothing);
+    check(find.byType(SelectionArea).evaluate()).isEmpty();
     await tester.enterText(find.byType(AdaptiveTextField), 'Edited prompt');
     await tester.tap(find.text('Save'));
     await tester.pumpAndSettle();

--- a/test/features/chat/widgets/user_message_bubble_test.dart
+++ b/test/features/chat/widgets/user_message_bubble_test.dart
@@ -122,7 +122,7 @@ void main() {
     );
     check(
       attachmentMenu.presentation,
-    ).equals(ConduitContextMenuPresentation.preview);
+    ).equals(ConduitContextMenuPresentation.popup);
     check(
       attachmentMenu.actions.map((action) => action.label).toList(),
     ).deepEquals(<String>['Edit', 'Copy', 'Delete']);

--- a/test/features/chat/widgets/user_message_bubble_test.dart
+++ b/test/features/chat/widgets/user_message_bubble_test.dart
@@ -19,12 +19,52 @@ import 'package:conduit/shared/theme/tweakcn_themes.dart';
 import 'package:conduit/shared/utils/conversation_context_menu.dart';
 import 'package:conduit/shared/widgets/skeleton_loader.dart';
 import 'package:dio/dio.dart' show CancelToken;
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_riverpod/misc.dart';
 
 void main() {
+  Future<void> withTargetPlatform(
+    TargetPlatform platform,
+    Future<void> Function() body,
+  ) async {
+    debugDefaultTargetPlatformOverride = platform;
+    try {
+      await body();
+    } finally {
+      debugDefaultTargetPlatformOverride = null;
+    }
+  }
+
+  Future<String?> copySelectedText(WidgetTester tester) async {
+    String? copiedText;
+    tester.binding.defaultBinaryMessenger.setMockMethodCallHandler(
+      SystemChannels.platform,
+      (call) async {
+        if (call.method == 'Clipboard.setData') {
+          copiedText =
+              (call.arguments as Map<dynamic, dynamic>)['text'] as String?;
+        }
+        return null;
+      },
+    );
+    final selectionArea = tester.state<SelectionAreaState>(
+      find.byType(SelectionArea),
+    );
+    final copyAction = selectionArea.selectableRegion.contextMenuButtonItems
+        .singleWhere((item) => item.type == ContextMenuButtonType.copy);
+    copyAction.onPressed!.call();
+    await tester.pump();
+    tester.binding.defaultBinaryMessenger.setMockMethodCallHandler(
+      SystemChannels.platform,
+      null,
+    );
+    return copiedText;
+  }
+
   Widget buildHarness(
     ChatMessage message, {
     List<Override> overrides = const [],
@@ -71,6 +111,16 @@ void main() {
 
     expect(find.text('Sprint Plan'), findsOneWidget);
     expect(find.byIcon(Icons.sticky_note_2_outlined), findsOneWidget);
+    expect(find.byType(SelectionArea), findsNothing);
+
+    final attachmentMenu = tester.widget<ConduitContextMenu>(
+      find.byType(ConduitContextMenu),
+    );
+    expect(attachmentMenu.presentation, ConduitContextMenuPresentation.preview);
+    expect(
+      attachmentMenu.actions.map((action) => action.label),
+      orderedEquals(<String>['Edit', 'Copy', 'Delete']),
+    );
   });
 
   testWidgets(
@@ -179,6 +229,96 @@ void main() {
     expect(textWidget.textWidthBasis, TextWidthBasis.longestLine);
   });
 
+  for (final platform in <TargetPlatform>[
+    TargetPlatform.iOS,
+    TargetPlatform.android,
+  ]) {
+    testWidgets(
+      'long press offers Select and selects the whole message on ${platform.name}',
+      (WidgetTester tester) async {
+        await withTargetPlatform(platform, () async {
+          const content = 'Select this entire user message';
+          final message = ChatMessage(
+            id: 'select-all-${platform.name}',
+            role: 'user',
+            content: content,
+            timestamp: DateTime.utc(2026, 8, 6, 10),
+          );
+
+          await tester.pumpWidget(buildHarness(message));
+          await tester.pump();
+
+          final contextMenu = tester.widget<ConduitContextMenu>(
+            find.byType(ConduitContextMenu),
+          );
+          expect(
+            contextMenu.presentation,
+            ConduitContextMenuPresentation.popup,
+          );
+          expect(
+            contextMenu.actions.map((action) => action.label),
+            orderedEquals(<String>['Edit', 'Copy', 'Select', 'Delete']),
+          );
+
+          final selectionArea = tester.state<SelectionAreaState>(
+            find.byType(SelectionArea),
+          );
+          expect(
+            selectionArea.selectableRegion.contextMenuButtonItems.where(
+              (item) => item.type == ContextMenuButtonType.copy,
+            ),
+            isEmpty,
+          );
+
+          await tester.longPress(find.text(content));
+          await tester.pump();
+          await tester.pump(const Duration(milliseconds: 500));
+
+          expect(find.text('Select'), findsOneWidget);
+          expect(
+            selectionArea.selectableRegion.contextMenuButtonItems.where(
+              (item) => item.type == ContextMenuButtonType.copy,
+            ),
+            isEmpty,
+          );
+
+          await tester.tap(find.text('Select'));
+          await tester.pump();
+          await tester.pump(const Duration(milliseconds: 500));
+
+          expect(await copySelectedText(tester), content);
+        });
+      },
+    );
+
+    testWidgets('double tap selects one word on ${platform.name}', (
+      WidgetTester tester,
+    ) async {
+      await withTargetPlatform(platform, () async {
+        const content = 'alpha beta gamma';
+        final message = ChatMessage(
+          id: 'double-tap-${platform.name}',
+          role: 'user',
+          content: content,
+          timestamp: DateTime.utc(2026, 8, 6, 10),
+        );
+
+        await tester.pumpWidget(buildHarness(message));
+        await tester.pump();
+
+        final textRect = tester.getRect(find.text(content));
+        final alphaPosition = Offset(textRect.left + 10, textRect.center.dy);
+        await tester.tapAt(alphaPosition);
+        await tester.pump(const Duration(milliseconds: 50));
+        await tester.tapAt(alphaPosition);
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 500));
+
+        expect(await copySelectedText(tester), 'alpha');
+      });
+    });
+  }
+
   testWidgets('failed Hermes inline edit reports the error to the user', (
     WidgetTester tester,
   ) async {
@@ -235,6 +375,7 @@ void main() {
     );
     await contextMenu.actions.first.onSelected();
     await tester.pump();
+    expect(find.byType(SelectionArea), findsNothing);
     await tester.enterText(find.byType(AdaptiveTextField), 'Edited prompt');
     await tester.tap(find.text('Save'));
     await tester.pumpAndSettle();

--- a/test/shared/utils/conversation_context_menu_test.dart
+++ b/test/shared/utils/conversation_context_menu_test.dart
@@ -3,6 +3,7 @@ import 'package:conduit/shared/theme/tweakcn_themes.dart';
 import 'package:conduit/shared/utils/conversation_context_menu.dart';
 import 'package:checks/checks.dart';
 import 'package:flutter/cupertino.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
@@ -51,7 +52,122 @@ void main() {
     expect(find.byType(GestureDetector), findsOneWidget);
   });
 
-  testWidgets('defaults to preview presentation and accepts popup opt-in', (
+  testWidgets('iOS popup keeps descendant double taps in Flutter', (
+    tester,
+  ) async {
+    debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
+    try {
+      var doubleTapCount = 0;
+
+      await tester.pumpWidget(
+        _buildHarness(
+          ConduitContextMenu(
+            actions: [
+              ConduitContextMenuAction(
+                cupertinoIcon: CupertinoIcons.doc_on_clipboard,
+                materialIcon: Icons.copy,
+                label: 'Copy',
+                onSelected: () async {},
+              ),
+            ],
+            child: GestureDetector(
+              behavior: HitTestBehavior.opaque,
+              onDoubleTap: () => doubleTapCount++,
+              child: const SizedBox(
+                width: 160,
+                height: 60,
+                child: Text('Child'),
+              ),
+            ),
+          ),
+        ),
+      );
+
+      expect(
+        find.byKey(const ValueKey('conduit-context-menu-popup-gesture')),
+        findsOneWidget,
+      );
+
+      await tester.tap(find.text('Child'));
+      await tester.pump(const Duration(milliseconds: 50));
+      await tester.tap(find.text('Child'));
+      await tester.pump();
+
+      expect(doubleTapCount, 1);
+      await tester.pump(const Duration(milliseconds: 400));
+    } finally {
+      debugDefaultTargetPlatformOverride = null;
+    }
+  });
+
+  testWidgets('iOS popup can show again after dismissal', (tester) async {
+    debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
+    try {
+      await tester.pumpWidget(
+        _buildHarness(
+          ConduitContextMenu(
+            actions: [
+              ConduitContextMenuAction(
+                cupertinoIcon: CupertinoIcons.doc_on_clipboard,
+                materialIcon: Icons.copy,
+                label: 'Copy action',
+                onSelected: () async {},
+              ),
+            ],
+            child: const SizedBox(width: 160, height: 60, child: Text('Child')),
+          ),
+        ),
+      );
+
+      await tester.longPress(find.text('Child'));
+      await tester.pump();
+      expect(find.text('Copy action'), findsOneWidget);
+
+      await tester.tapAt(const Offset(4, 4));
+      await tester.pump();
+      expect(find.text('Copy action'), findsNothing);
+
+      await tester.longPress(find.text('Child'));
+      await tester.pump();
+      expect(find.text('Copy action'), findsOneWidget);
+    } finally {
+      debugDefaultTargetPlatformOverride = null;
+    }
+  });
+
+  testWidgets('iOS popup closes when its actions change', (tester) async {
+    debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
+    try {
+      ConduitContextMenu buildMenu(String label) {
+        return ConduitContextMenu(
+          actions: [
+            ConduitContextMenuAction(
+              cupertinoIcon: CupertinoIcons.doc_on_clipboard,
+              materialIcon: Icons.copy,
+              label: label,
+              onSelected: () async {},
+            ),
+          ],
+          child: const SizedBox(width: 160, height: 60, child: Text('Child')),
+        );
+      }
+
+      await tester.pumpWidget(_buildHarness(buildMenu('Old action')));
+      await tester.longPress(find.text('Child'));
+      await tester.pump();
+      expect(find.text('Old action'), findsOneWidget);
+
+      await tester.pumpWidget(_buildHarness(buildMenu('New action')));
+      await tester.pump();
+
+      expect(find.text('Old action'), findsNothing);
+      expect(find.text('New action'), findsNothing);
+    } finally {
+      debugDefaultTargetPlatformOverride = null;
+    }
+  });
+
+  testWidgets('defaults to popup presentation and accepts preview opt-in', (
     tester,
   ) async {
     final actions = [
@@ -65,23 +181,7 @@ void main() {
 
     await tester.pumpWidget(
       _buildHarness(
-        ConduitContextMenu(actions: actions, child: const Text('Preview')),
-      ),
-    );
-
-    check(
-      tester
-          .widget<ConduitContextMenu>(find.byType(ConduitContextMenu))
-          .presentation,
-    ).equals(ConduitContextMenuPresentation.preview);
-
-    await tester.pumpWidget(
-      _buildHarness(
-        ConduitContextMenu(
-          actions: actions,
-          presentation: ConduitContextMenuPresentation.popup,
-          child: const Text('Popup'),
-        ),
+        ConduitContextMenu(actions: actions, child: const Text('Popup')),
       ),
     );
 
@@ -90,6 +190,22 @@ void main() {
           .widget<ConduitContextMenu>(find.byType(ConduitContextMenu))
           .presentation,
     ).equals(ConduitContextMenuPresentation.popup);
+
+    await tester.pumpWidget(
+      _buildHarness(
+        ConduitContextMenu(
+          actions: actions,
+          presentation: ConduitContextMenuPresentation.preview,
+          child: const Text('Preview'),
+        ),
+      ),
+    );
+
+    check(
+      tester
+          .widget<ConduitContextMenu>(find.byType(ConduitContextMenu))
+          .presentation,
+    ).equals(ConduitContextMenuPresentation.preview);
   });
 
   testWidgets('does not build lazy top widget before the menu opens', (
@@ -112,6 +228,7 @@ void main() {
             buildCount++;
             return const Text('Top widget');
           },
+          presentation: ConduitContextMenuPresentation.preview,
           child: const Text('Child'),
         ),
       ),

--- a/test/shared/utils/conversation_context_menu_test.dart
+++ b/test/shared/utils/conversation_context_menu_test.dart
@@ -5,6 +5,7 @@ import 'package:checks/checks.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 Widget _buildHarness(Widget child) {
@@ -15,6 +16,22 @@ Widget _buildHarness(Widget child) {
 }
 
 void main() {
+  test('iOS 26 native popup leaves hit testing to selectable text', () {
+    final platformView = buildConduitIOS26PopupPlatformView(
+      key: const ValueKey('native-popup'),
+      creationParams: const <String, Object?>{},
+      onPlatformViewCreated: (_) {},
+    );
+
+    check(
+      platformView.viewType,
+    ).equals('app.cogwheel.conduit/native_context_menu_anchor');
+    check(
+      platformView.hitTestBehavior,
+    ).equals(PlatformViewHitTestBehavior.transparent);
+    check(platformView.gestureRecognizers).isNull();
+  });
+
   testWidgets('bypasses the platform wrapper when there are no actions', (
     tester,
   ) async {
@@ -162,6 +179,50 @@ void main() {
 
       expect(find.text('Old action'), findsNothing);
       expect(find.text('New action'), findsNothing);
+    } finally {
+      debugDefaultTargetPlatformOverride = null;
+    }
+  });
+
+  testWidgets('iOS popup survives an equivalent action-list rebuild', (
+    tester,
+  ) async {
+    debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
+    try {
+      var oldCallbackCount = 0;
+      var currentCallbackCount = 0;
+
+      ConduitContextMenu buildMenu(VoidCallback onSelected) {
+        return ConduitContextMenu(
+          actions: [
+            ConduitContextMenuAction(
+              cupertinoIcon: CupertinoIcons.doc_on_clipboard,
+              materialIcon: Icons.copy,
+              label: 'Copy action',
+              onSelected: () async => onSelected(),
+            ),
+          ],
+          child: const SizedBox(width: 160, height: 60, child: Text('Child')),
+        );
+      }
+
+      await tester.pumpWidget(
+        _buildHarness(buildMenu(() => oldCallbackCount++)),
+      );
+      await tester.longPress(find.text('Child'));
+      await tester.pump();
+      expect(find.text('Copy action'), findsOneWidget);
+
+      await tester.pumpWidget(
+        _buildHarness(buildMenu(() => currentCallbackCount++)),
+      );
+      await tester.pump();
+
+      expect(find.text('Copy action'), findsOneWidget);
+      await tester.tap(find.text('Copy action'));
+      await tester.pump();
+      expect(oldCallbackCount, 0);
+      expect(currentCallbackCount, 1);
     } finally {
       debugDefaultTargetPlatformOverride = null;
     }

--- a/test/shared/utils/conversation_context_menu_test.dart
+++ b/test/shared/utils/conversation_context_menu_test.dart
@@ -50,6 +50,49 @@ void main() {
     expect(find.byType(GestureDetector), findsOneWidget);
   });
 
+  testWidgets('defaults to preview presentation and accepts popup opt-in', (
+    tester,
+  ) async {
+    final actions = [
+      ConduitContextMenuAction(
+        cupertinoIcon: CupertinoIcons.doc_on_clipboard,
+        materialIcon: Icons.copy,
+        label: 'Copy',
+        onSelected: () async {},
+      ),
+    ];
+
+    await tester.pumpWidget(
+      _buildHarness(
+        ConduitContextMenu(actions: actions, child: const Text('Preview')),
+      ),
+    );
+
+    expect(
+      tester
+          .widget<ConduitContextMenu>(find.byType(ConduitContextMenu))
+          .presentation,
+      ConduitContextMenuPresentation.preview,
+    );
+
+    await tester.pumpWidget(
+      _buildHarness(
+        ConduitContextMenu(
+          actions: actions,
+          presentation: ConduitContextMenuPresentation.popup,
+          child: const Text('Popup'),
+        ),
+      ),
+    );
+
+    expect(
+      tester
+          .widget<ConduitContextMenu>(find.byType(ConduitContextMenu))
+          .presentation,
+      ConduitContextMenuPresentation.popup,
+    );
+  });
+
   testWidgets('does not build lazy top widget before the menu opens', (
     tester,
   ) async {

--- a/test/shared/utils/conversation_context_menu_test.dart
+++ b/test/shared/utils/conversation_context_menu_test.dart
@@ -1,6 +1,7 @@
 import 'package:conduit/shared/theme/app_theme.dart';
 import 'package:conduit/shared/theme/tweakcn_themes.dart';
 import 'package:conduit/shared/utils/conversation_context_menu.dart';
+import 'package:checks/checks.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -68,12 +69,11 @@ void main() {
       ),
     );
 
-    expect(
+    check(
       tester
           .widget<ConduitContextMenu>(find.byType(ConduitContextMenu))
           .presentation,
-      ConduitContextMenuPresentation.preview,
-    );
+    ).equals(ConduitContextMenuPresentation.preview);
 
     await tester.pumpWidget(
       _buildHarness(
@@ -85,12 +85,11 @@ void main() {
       ),
     );
 
-    expect(
+    check(
       tester
           .widget<ConduitContextMenu>(find.byType(ConduitContextMenu))
           .presentation,
-      ConduitContextMenuPresentation.popup,
-    );
+    ).equals(ConduitContextMenuPresentation.popup);
   });
 
   testWidgets('does not build lazy top widget before the menu opens', (


### PR DESCRIPTION
## Summary

- restore the native UIKit popup menu on iOS 26 for shared long-press context menus
- keep Flutter in control of gesture recognition through a transparent native anchor, preserving double-tap word selection
- retain the adaptive Flutter popup fallback on older iOS versions and existing Material behavior on Android
- provide Edit, Copy, Select, and destructive Delete for user-message text while keeping attachment-only actions unchanged
- keep equivalent rebuilt action lists from dismissing an open popup and dispatch the latest callbacks
- enable Flutter touch resampling during binding initialization
- preserve inline editing, drawer gestures, localization, and full-message Select behavior

## Verification

- flutter analyze: passed
- focused context-menu and user-message widget tests: passed, including iOS and Android double-tap word selection
- iOS simulator debug build: passed
- iOS 26.5 simulator: native Edit/Copy/Select/Delete popup verified; long press did not preselect text; Select highlighted the complete message with handles and adaptive Copy/Select All controls
- regression test proves the native platform view is transparent to Flutter hit testing
- equivalent action-list rebuild regression test: passed

## Full-suite note

The complete flutter test run finished with 5,163 passing tests and 4 skipped tests. Three unrelated timing/concurrency tests failed: the FTS append performance budget, native avatar batch timeout behavior, and the 1,000-chat read-path emission budget.

## Compatibility

- iOS 26+: native UIButton/UIMenu popup rendered by UIKit
- iOS 16-18: adaptive Flutter/Cupertino popup fallback
- Android: existing Material long-press popup

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Select all or individual text in chat messages using long-press and double-tap gestures.
  * Added a “Select text” action to message menus.
  * Added adaptive popup menus for supported iOS interactions.
  * Kept attachment menus separate from text-message actions.
  * Added text-selection translations across supported languages.

* **Improvements**
  * Text selection clears automatically when editing a message.
  * Existing edit, copy, and delete actions remain available.
  * Popup menus dismiss appropriately when tapping outside or when actions change.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add text selection and native popup context menu to user message bubbles
> - Long-pressing a user message text bubble now shows a popup context menu (Edit, Copy, Select, Delete); "Select" selects all text via a `SelectionArea`, and double-tap selects a word.
> - On iOS, the context menu uses a native `UIMenu` via a new `ConduitNativeContextMenuAnchorView` platform view registered under `app.cogwheel.conduit/native_context_menu_anchor`; older iOS and Android fall back to `AdaptiveTextSelectionToolbar`.
> - `ConduitContextMenu` gains a `presentation` property (defaulting to `popup`) that keeps the menu within Flutter's gesture arena so descendants still receive taps and double-taps.
> - Attachment bubbles show the popup menu without the Select option.
> - Gesture resampling is enabled globally at startup via `GestureBinding.instance.resamplingEnabled = true`.
> - Behavioral Change: context menus now default to popup presentation instead of the previous Cupertino preview path; starting inline edit clears any active text selection and hides the toolbar.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7033014.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds selectable user-message text with platform-adaptive context menus, including native iOS menu presentation on newer iOS versions. Attachment actions remain separate from text-selection actions.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

No blocking failure remains.

No accepted blocking findings remain.
</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- I attempted the focused equivalent action-list rebuild widget test, but it could not run because flutter: not found, and the test checks that an equivalent rebuilt action list leaves the popup open and dispatches only the replacement callback.
- I attempted the focused UserMessageBubble tests covering iOS and Android double-tap word selection and long-press Select behavior, but the command could not run because flutter: not found, and the test source defines the intended gesture and clipboard assertions.
- I observed a blocker where flutter test failed immediately due to flutter not found on PATH, and the source and command output were uploaded as artifacts.

<a href="https://app.greptile.com/trex/runs/17602403/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (6): Last reviewed commit: ["fix(ios): harden native menu view update..."](https://github.com/cogwheel0/conduit/commit/703301476feada47030519121b5055bd1afb373d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50734165)</sub>

<!-- /greptile_comment -->