### PR TITLE
perf: chat scrolling and markdown rendering

### DIFF
--- a/lib/core/auth/auth_state_manager.dart
+++ b/lib/core/auth/auth_state_manager.dart
@@ -4,6 +4,7 @@ import 'dart:io';
 import 'package:dio/dio.dart';
 import 'package:flutter/foundation.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
+
 // Types are used through app_providers.dart
 import '../providers/app_providers.dart';
 import '../models/user.dart';
@@ -22,11 +23,10 @@ import 'openwebui_account_owner_marker.dart';
 
 part 'auth_state_manager.g.dart';
 
-typedef SavedCredentialAuthApiFactory =
-    ApiService Function({
-      required ServerConfig serverConfig,
-      required WorkerManager workerManager,
-    });
+typedef SavedCredentialAuthApiFactory = ApiService Function({
+  required ServerConfig serverConfig,
+  required WorkerManager workerManager,
+});
 
 const _newerAuthAttemptSettleGrace = Duration(milliseconds: 500);
 
@@ -2214,8 +2214,7 @@ class AuthStateManager extends _$AuthStateManager {
       _update(
         (current) => current.copyWith(
           status: AuthStatus.error,
-          error:
-              'Saved server configuration is no longer available. Please reconnect.',
+          error: 'Saved server configuration is no longer available. Please reconnect.',
           isLoading: false,
         ),
       );
@@ -2481,9 +2480,7 @@ class AuthStateManager extends _$AuthStateManager {
           );
         }
         DebugLogger.auth(
-          cleared
-              ? 'Cleared invalid credentials after auth failure'
-              : 'Skipped clearing credentials that changed during the auth attempt',
+          cleared ? 'Cleared invalid credentials after auth failure' : 'Skipped clearing credentials that changed during the auth attempt',
         );
       } catch (deleteError) {
         _logAuthenticationFailure(

--- a/lib/core/auth/token_validator.dart
+++ b/lib/core/auth/token_validator.dart
@@ -1,5 +1,7 @@
 import 'dart:convert';
+
 import 'package:crypto/crypto.dart';
+
 import '../utils/debug_logger.dart';
 
 /// JWT token validation utilities

--- a/lib/core/database/daos/app_cache_dao.dart
+++ b/lib/core/database/daos/app_cache_dao.dart
@@ -8,7 +8,8 @@ part 'app_cache_dao.g.dart';
 /// Accessor for the per-server [AppCache] key-value table (offline-fallback
 /// caches: local user, avatar, backend config, tools, default model, models).
 @DriftAccessor(tables: [AppCache])
-class AppCacheDao extends DatabaseAccessor<AppDatabase> with _$AppCacheDaoMixin {
+class AppCacheDao extends DatabaseAccessor<AppDatabase>
+    with _$AppCacheDaoMixin {
   AppCacheDao(super.db);
 
   Future<String?> getValue(String key) async {
@@ -20,7 +21,11 @@ class AppCacheDao extends DatabaseAccessor<AppDatabase> with _$AppCacheDaoMixin 
 
   Future<void> setValue(String key, String value, {int updatedAt = 0}) {
     return into(appCache).insertOnConflictUpdate(
-      AppCacheCompanion.insert(key: key, value: value, updatedAt: Value(updatedAt)),
+      AppCacheCompanion.insert(
+        key: key,
+        value: value,
+        updatedAt: Value(updatedAt),
+      ),
     );
   }
 

--- a/lib/core/database/daos/chats_dao.dart
+++ b/lib/core/database/daos/chats_dao.dart
@@ -182,9 +182,8 @@ class ChatsDao extends DatabaseAccessor<AppDatabase> with _$ChatsDaoMixin {
 
   @visibleForTesting
   Future<List<String>> debugExplainArchivedChatCount() async {
-    final rows = await customSelect(
-      'EXPLAIN QUERY PLAN $_archivedChatCountSql',
-    ).get();
+    final rows = await customSelect('EXPLAIN QUERY PLAN $_archivedChatCountSql')
+        .get();
     return rows
         .map((row) => row.read<String>('detail'))
         .toList(growable: false);

--- a/lib/core/database/daos/folders_dao.dart
+++ b/lib/core/database/daos/folders_dao.dart
@@ -250,5 +250,4 @@ class FoldersDao extends DatabaseAccessor<AppDatabase> with _$FoldersDaoMixin {
       rawExtra: Value(jsonEncode(rawExtra)),
     );
   }
-
 }

--- a/lib/core/database/daos/notes_dao.dart
+++ b/lib/core/database/daos/notes_dao.dart
@@ -563,7 +563,6 @@ LIMIT 1
   List<Variable<String>> _ownerVariables(String userId) {
     return [Variable.withString(userId), Variable.withString(userId)];
   }
-
 }
 
 /// Decodes an outbox `noteUpdate` patch payload (used by the push handler /

--- a/lib/core/database/mappers/conversation_assembler.dart
+++ b/lib/core/database/mappers/conversation_assembler.dart
@@ -101,8 +101,9 @@ Conversation assembleConversation(ChatRow chat, List<MessageRow> messages) {
 /// Closure type for offloading a pre-built envelope to a worker isolate.
 /// The caller is responsible for routing through [parseFullConversationModelWorker]
 /// via [WorkerManager.schedule].
-typedef ConversationParseOffload =
-    Future<Conversation> Function(Object? envelope);
+typedef ConversationParseOffload = Future<Conversation> Function(
+  Object? envelope,
+);
 
 /// Contract-enforcing wrapper around [assembleConversation]: offloads via
 /// [offload] when `messages.length` exceeds [kLocalConversationWorkerThreshold],

--- a/lib/core/error/api_error_handler.dart
+++ b/lib/core/error/api_error_handler.dart
@@ -1,5 +1,6 @@
 import 'package:dio/dio.dart';
 import 'package:flutter/foundation.dart';
+
 import 'api_error.dart';
 import 'error_parser.dart';
 import '../utils/current_localizations.dart';

--- a/lib/core/error/api_error_interceptor.dart
+++ b/lib/core/error/api_error_interceptor.dart
@@ -1,5 +1,6 @@
 import 'package:dio/dio.dart';
 import 'package:flutter/foundation.dart';
+
 import 'api_error_handler.dart';
 import 'api_error.dart';
 import '../utils/debug_logger.dart';

--- a/lib/core/models/conversation.dart
+++ b/lib/core/models/conversation.dart
@@ -1,4 +1,5 @@
 import 'package:freezed_annotation/freezed_annotation.dart';
+
 import 'chat_message.dart';
 
 // Freezed applies JsonKey to constructor parameters.

--- a/lib/core/models/model.dart
+++ b/lib/core/models/model.dart
@@ -1,4 +1,5 @@
 import 'package:freezed_annotation/freezed_annotation.dart';
+
 import 'toggle_filter.dart';
 
 part 'model.freezed.dart';

--- a/lib/core/network/self_signed_image_cache_manager.dart
+++ b/lib/core/network/self_signed_image_cache_manager.dart
@@ -18,9 +18,8 @@ final selfSignedImageCacheManagerProvider = Provider<BaseCacheManager?>((ref) {
   return active.maybeWhen(
     data: (server) {
       if (server == null) return null;
-      final cacheManager =
-          self_signed_image_cache_manager_factory
-              .buildSelfSignedImageCacheManager(server);
+      final cacheManager = self_signed_image_cache_manager_factory
+          .buildSelfSignedImageCacheManager(server);
       if (cacheManager != null) {
         ref.onDispose(cacheManager.dispose);
       }

--- a/lib/core/network/self_signed_image_cache_manager_factory_io.dart
+++ b/lib/core/network/self_signed_image_cache_manager_factory_io.dart
@@ -15,7 +15,8 @@ import 'package:path_provider/path_provider.dart';
 import '../models/server_config.dart';
 import '../services/server_tls_http_client_factory.dart';
 
-typedef SelfSignedImageCacheBaseDirectoryProvider = Future<Directory> Function();
+typedef SelfSignedImageCacheBaseDirectoryProvider =
+    Future<Directory> Function();
 
 @visibleForTesting
 String? buildSelfSignedImageCacheNamespace(ServerConfig server) {

--- a/lib/core/persistence/hive_prefs_migrator.dart
+++ b/lib/core/persistence/hive_prefs_migrator.dart
@@ -87,6 +87,9 @@ class HivePrefsMigrator {
     final key =
         '${PreferenceKeys.transportOptionsPrefix}:'
         '${base64Url.encode(utf8.encode(serverId))}';
-    await PreferencesStore.put(key, jsonEncode(Map<String, dynamic>.from(data)));
+    await PreferencesStore.put(
+      key,
+      jsonEncode(Map<String, dynamic>.from(data)),
+    );
   }
 }

--- a/lib/core/services/api_service.dart
+++ b/lib/core/services/api_service.dart
@@ -40,6 +40,7 @@ import '../sync/sync_api_client.dart' show SyncTerminalException;
 import 'connectivity_service.dart';
 import '../utils/debug_logger.dart';
 import '../utils/embed_utils.dart';
+import '../utils/openwebui_message_payload.dart';
 import '../utils/json_normalization.dart';
 import '../utils/message_tree_utils.dart' as message_tree;
 import 'conversation_parsing.dart';
@@ -684,112 +685,6 @@ enum HealthCheckResult {
 
   /// Server could not be reached
   unreachable,
-}
-
-/// Converts ChatSourceReference list back to OpenWebUI's expected format.
-/// OpenWebUI expects: { source: {...}, document: [...], metadata: [...] }
-/// But ChatSourceReference stores: { id, title, url, snippet, type, metadata }
-List<Map<String, dynamic>> _convertSourcesToOpenWebUIFormat(
-  List<ChatSourceReference> sources,
-) {
-  return sources.map((ref) {
-    final result = <String, dynamic>{};
-
-    // Build the source object
-    final sourceObj = <String, dynamic>{};
-    if (ref.id != null) sourceObj['id'] = ref.id;
-    if (ref.title != null) sourceObj['name'] = ref.title;
-    if (ref.url != null) sourceObj['url'] = ref.url;
-    if (ref.type != null) sourceObj['type'] = ref.type;
-
-    // Extract nested source from metadata if present
-    final metadataSource = ref.metadata?['source'];
-    if (metadataSource is Map) {
-      for (final entry in metadataSource.entries) {
-        sourceObj[entry.key.toString()] ??= entry.value;
-      }
-    }
-
-    if (sourceObj.isNotEmpty) {
-      result['source'] = sourceObj;
-    }
-
-    // Extract documents from metadata or use snippet
-    final documents = ref.metadata?['documents'];
-    if (documents is List && documents.isNotEmpty) {
-      result['document'] = documents;
-    } else if (ref.snippet != null && ref.snippet!.isNotEmpty) {
-      result['document'] = [ref.snippet];
-    }
-
-    // Extract metadata items
-    final metadataItems = ref.metadata?['items'];
-    if (metadataItems is List && metadataItems.isNotEmpty) {
-      result['metadata'] = metadataItems;
-    } else {
-      // Create a basic metadata entry
-      final basicMeta = <String, dynamic>{};
-      if (ref.id != null) basicMeta['source'] = ref.id;
-      if (ref.title != null) basicMeta['name'] = ref.title;
-      if (result['document'] is List) {
-        result['metadata'] = List.generate(
-          (result['document'] as List).length,
-          (_) => Map<String, dynamic>.from(basicMeta),
-        );
-      }
-    }
-
-    // Extract distances if present
-    final distances = ref.metadata?['distances'];
-    if (distances is List && distances.isNotEmpty) {
-      result['distances'] = distances;
-    }
-
-    return result;
-  }).toList();
-}
-
-/// Converts ChatCodeExecution list to OpenWebUI's expected format.
-/// OpenWebUI expects `code_executions` (snake_case) with specific structure.
-/// ChatCodeExecution stores: { id, name, language, code, result, metadata }
-/// OpenWebUI expects: { id, name, code, language?, result?: { error?, output?, files? } }
-List<Map<String, dynamic>> _convertCodeExecutionsToOpenWebUIFormat(
-  List<ChatCodeExecution> executions,
-) {
-  return executions.map((exec) {
-    final result = <String, dynamic>{
-      'id': exec.id,
-      if (exec.name != null) 'name': exec.name,
-      if (exec.code != null) 'code': exec.code,
-      if (exec.language != null) 'language': exec.language,
-    };
-
-    // Convert the result if present
-    if (exec.result != null) {
-      final execResult = <String, dynamic>{};
-      if (exec.result!.output != null) {
-        execResult['output'] = exec.result!.output;
-      }
-      if (exec.result!.error != null) {
-        execResult['error'] = exec.result!.error;
-      }
-      if (exec.result!.files.isNotEmpty) {
-        execResult['files'] = exec.result!.files
-            .map(
-              (f) => <String, dynamic>{
-                if (f.name != null) 'name': f.name,
-                if (f.url != null) 'url': f.url,
-              },
-            )
-            .toList();
-      }
-      if (execResult.isNotEmpty) {
-        result['result'] = execResult;
-      }
-    }
-
-    return result;
-  }).toList();
 }
 
 class ApiService {
@@ -2610,26 +2505,6 @@ class ApiService {
   // Parse OpenWebUI message format to our ChatMessage format
   // Build ordered messages list from Open‑WebUI history using parent chain to currentId
   // ===== Helpers to synthesize tool-call details blocks for UI parsing =====
-  List<Map<String, dynamic>>? _sanitizeFilesForWebUI(
-    List<Map<String, dynamic>>? files,
-  ) {
-    if (files == null || files.isEmpty) {
-      return null;
-    }
-    final sanitized = <Map<String, dynamic>>[];
-    for (final entry in files) {
-      final safe = <String, dynamic>{};
-      for (final MapEntry(:key, :value) in entry.entries) {
-        if (value == null) continue;
-        safe[key.toString()] = value;
-      }
-      if (safe.isNotEmpty) {
-        sanitized.add(safe);
-      }
-    }
-    return sanitized.isNotEmpty ? sanitized : null;
-  }
-
   List<String>? _sanitizeEmbedsForWebUI(List<Map<String, dynamic>>? embeds) {
     return sanitizeEmbedsForWebUi(embeds);
   }
@@ -2678,8 +2553,8 @@ class ApiService {
         if (msg.role == 'user' && model != null) 'models': [model],
         if (msg.attachmentIds != null && msg.attachmentIds!.isNotEmpty)
           'attachment_ids': List<String>.from(msg.attachmentIds!),
-        if (_sanitizeFilesForWebUI(msg.files) != null)
-          'files': _sanitizeFilesForWebUI(msg.files),
+        if (sanitizeFilesForWebUi(msg.files) != null)
+          'files': sanitizeFilesForWebUi(msg.files),
         'embeds': ?sanitizedEmbeds,
         // Assistant message extended fields
         if (msg.statusHistory.isNotEmpty)
@@ -2687,11 +2562,11 @@ class ApiService {
         if (msg.followUps.isNotEmpty)
           'followUps': List<String>.from(msg.followUps),
         if (msg.codeExecutions.isNotEmpty)
-          'code_executions': _convertCodeExecutionsToOpenWebUIFormat(
+          'code_executions': convertCodeExecutionsToOpenWebUIFormat(
             msg.codeExecutions,
           ),
         if (msg.sources.isNotEmpty)
-          'sources': _convertSourcesToOpenWebUIFormat(msg.sources),
+          'sources': convertSourcesToOpenWebUIFormat(msg.sources),
         if (msg.usage != null) 'usage': msg.usage,
         // Preserve error field for OpenWebUI compatibility
         if (msg.error != null) 'error': msg.error!.toJson(),
@@ -2720,8 +2595,8 @@ class ApiService {
         if (msg.role == 'user' && model != null) 'models': [model],
         if (msg.attachmentIds != null && msg.attachmentIds!.isNotEmpty)
           'attachment_ids': List<String>.from(msg.attachmentIds!),
-        if (_sanitizeFilesForWebUI(msg.files) != null)
-          'files': _sanitizeFilesForWebUI(msg.files),
+        if (sanitizeFilesForWebUi(msg.files) != null)
+          'files': sanitizeFilesForWebUi(msg.files),
         'embeds': ?sanitizedEmbeds,
         // Assistant message extended fields
         if (msg.statusHistory.isNotEmpty)
@@ -2729,11 +2604,11 @@ class ApiService {
         if (msg.followUps.isNotEmpty)
           'followUps': List<String>.from(msg.followUps),
         if (msg.codeExecutions.isNotEmpty)
-          'code_executions': _convertCodeExecutionsToOpenWebUIFormat(
+          'code_executions': convertCodeExecutionsToOpenWebUIFormat(
             msg.codeExecutions,
           ),
         if (msg.sources.isNotEmpty)
-          'sources': _convertSourcesToOpenWebUIFormat(msg.sources),
+          'sources': convertSourcesToOpenWebUIFormat(msg.sources),
         if (msg.usage != null) 'usage': msg.usage,
         // Preserve error field for OpenWebUI compatibility
         if (msg.error != null) 'error': msg.error!.toJson(),
@@ -2814,7 +2689,7 @@ class ApiService {
 
       // Use the properly formatted files array for WebUI display
       // The msg.files array already contains all attachments in the correct format
-      final sanitizedFiles = _sanitizeFilesForWebUI(msg.files);
+      final sanitizedFiles = sanitizeFilesForWebUi(msg.files);
       final sanitizedEmbeds = _sanitizeEmbedsForWebUI(msg.embeds);
 
       // Determine parent id: allow explicit parent override via metadata
@@ -2854,12 +2729,12 @@ class ApiService {
         if (msg.followUps.isNotEmpty)
           'followUps': List<String>.from(msg.followUps),
         if (msg.codeExecutions.isNotEmpty)
-          'code_executions': _convertCodeExecutionsToOpenWebUIFormat(
+          'code_executions': convertCodeExecutionsToOpenWebUIFormat(
             msg.codeExecutions,
           ),
         // Convert sources back to OpenWebUI format (with document array)
         if (msg.sources.isNotEmpty)
-          'sources': _convertSourcesToOpenWebUIFormat(msg.sources),
+          'sources': convertSourcesToOpenWebUIFormat(msg.sources),
         // Include usage statistics for persistence (issue #274)
         if (msg.usage != null) 'usage': msg.usage,
         // Preserve error field for OpenWebUI compatibility
@@ -2872,7 +2747,7 @@ class ApiService {
       }
 
       // Use the same properly formatted files array for messages array
-      final sanitizedArrayFiles = _sanitizeFilesForWebUI(msg.files);
+      final sanitizedArrayFiles = sanitizeFilesForWebUi(msg.files);
 
       messagesArray.add({
         'id': messageId,
@@ -2897,12 +2772,12 @@ class ApiService {
         if (msg.followUps.isNotEmpty)
           'followUps': List<String>.from(msg.followUps),
         if (msg.codeExecutions.isNotEmpty)
-          'code_executions': _convertCodeExecutionsToOpenWebUIFormat(
+          'code_executions': convertCodeExecutionsToOpenWebUIFormat(
             msg.codeExecutions,
           ),
         // Convert sources back to OpenWebUI format (with document array)
         if (msg.sources.isNotEmpty)
-          'sources': _convertSourcesToOpenWebUIFormat(msg.sources),
+          'sources': convertSourcesToOpenWebUIFormat(msg.sources),
         // Include usage statistics for persistence (issue #274)
         if (msg.usage != null) 'usage': msg.usage,
         // Preserve error field for OpenWebUI compatibility
@@ -2932,7 +2807,7 @@ class ApiService {
               if (ver.model != null) 'modelName': ver.model,
               'modelIdx': 0,
               'done': true,
-              if (ver.files != null) 'files': _sanitizeFilesForWebUI(ver.files),
+              if (ver.files != null) 'files': sanitizeFilesForWebUi(ver.files),
               if (ver.output != null) 'output': ver.output,
               if (_sanitizeEmbedsForWebUI(ver.embeds) != null)
                 'embeds': _sanitizeEmbedsForWebUI(ver.embeds),
@@ -2940,12 +2815,12 @@ class ApiService {
               if (ver.followUps.isNotEmpty)
                 'followUps': List<String>.from(ver.followUps),
               if (ver.codeExecutions.isNotEmpty)
-                'code_executions': _convertCodeExecutionsToOpenWebUIFormat(
+                'code_executions': convertCodeExecutionsToOpenWebUIFormat(
                   ver.codeExecutions,
                 ),
               // Convert sources back to OpenWebUI format (with document array)
               if (ver.sources.isNotEmpty)
-                'sources': _convertSourcesToOpenWebUIFormat(ver.sources),
+                'sources': convertSourcesToOpenWebUIFormat(ver.sources),
               // Preserve error field for OpenWebUI compatibility
               if (ver.error != null) 'error': ver.error!.toJson(),
             };

--- a/lib/core/services/app_intents_service.dart
+++ b/lib/core/services/app_intents_service.dart
@@ -368,9 +368,8 @@ final class _UnavailableAppIntentHandler implements AppIntentFlutterApi {
     // reclaimed; cached completed records intentionally report no path.
     if (response.ownedFilePath != payload.filePath) {
       try {
-        await AppIntentStagedFileOwnership(
-          payload.filePath,
-        ).cleanupIfUntransferred();
+        await AppIntentStagedFileOwnership(payload.filePath)
+            .cleanupIfUntransferred();
       } catch (error) {
         // Rejection must remain available even when filesystem cleanup fails.
         // The staging sweeper can retry without exposing the sensitive path.
@@ -642,9 +641,8 @@ Future<PlatformAppIntentResponse> dispatchAppIntentInvocation({
     try {
       // A cached or joined duplicate did not adopt this delivery's fresh
       // staging path. Reclaim it on the Dart side as well as the native path.
-      await AppIntentStagedFileOwnership(
-        ownedFilePathOnSuccess,
-      ).cleanupIfUntransferred();
+      await AppIntentStagedFileOwnership(ownedFilePathOnSuccess)
+          .cleanupIfUntransferred();
     } catch (error) {
       // Preserve the durable invocation result if cleanup fails. The staging
       // sweeper can retry without exposing the sensitive path.

--- a/lib/core/services/attachment_upload_queue.dart
+++ b/lib/core/services/attachment_upload_queue.dart
@@ -7,6 +7,7 @@ import 'package:dio/dio.dart';
 import 'package:drift/drift.dart' show Value;
 import 'package:path/path.dart' as path;
 import 'package:uuid/uuid.dart';
+
 import '../database/app_database.dart';
 import '../database/daos/attachment_queue_dao.dart';
 import '../utils/debug_logger.dart';
@@ -134,19 +135,17 @@ typedef DurableAttachmentEnqueueResult = ({
   bool inserted,
 });
 
-typedef UploadCallback =
-    Future<String> Function(
-      String filePath,
-      String fileName, {
-      CancelToken? cancelToken,
-    });
+typedef UploadCallback = Future<String> Function(
+  String filePath,
+  String fileName, {
+  CancelToken? cancelToken,
+});
 typedef AttachmentsEventCallback = void Function(List<QueuedAttachment> queue);
-typedef _TerminalAttachmentCleanupWithAdmission =
-    Future<bool> Function(
-      String filePath, {
-      required Future<void> Function() beforeDeleteAdmission,
-      required bool Function() canDelete,
-    });
+typedef _TerminalAttachmentCleanupWithAdmission = Future<bool> Function(
+  String filePath, {
+  required Future<void> Function() beforeDeleteAdmission,
+  required bool Function() canDelete,
+});
 
 Future<bool> _cleanupTerminalAttachmentWithAdmission(
   String filePath, {

--- a/lib/core/services/background_streaming_handler.dart
+++ b/lib/core/services/background_streaming_handler.dart
@@ -1,6 +1,8 @@
 import 'dart:async';
 import 'dart:io';
+
 import 'package:flutter/foundation.dart';
+
 import '../platform/conduit_platform_apis.g.dart';
 import '../utils/debug_logger.dart';
 

--- a/lib/core/services/conversation_parsing.dart
+++ b/lib/core/services/conversation_parsing.dart
@@ -7,6 +7,7 @@ import '../models/conversation.dart';
 import '../utils/embed_utils.dart';
 import '../utils/message_tree_utils.dart' as message_tree;
 import '../utils/openwebui_source_parser.dart';
+import '../utils/semantic_details.dart';
 import 'direct_replay_output.dart';
 import 'semantic_message_builder.dart';
 import 'structured_output.dart';
@@ -281,9 +282,8 @@ _parseOpenWebUiFiles(Object? raw) {
       // Handle all URL formats:
       // 1. /api/v1/files/{id} and /api/v1/files/{id}/content (old format)
       // 2. Just a file ID like "abc-123-def" (new OpenWebUI format)
-      final match = RegExp(
-        r'/api/v1/files/([^/]+)(?:/content)?$',
-      ).firstMatch(url);
+      final match = RegExp(r'/api/v1/files/([^/]+)(?:/content)?$')
+          .firstMatch(url);
       if (match != null) {
         attachmentIds.add(match.group(1)!);
       } else if (!url.startsWith('data:') &&
@@ -1019,7 +1019,7 @@ String _mergeContentWithStructuredOutput(
   List<StructuredOutputBlock> outputBlocks,
 ) {
   final hasDetails = structuredOutputBlocksContainDetails(outputBlocks);
-  final baseContent = _stripRenderedSemanticDetails(content);
+  final baseContent = stripRenderedSemanticDetails(content);
   final strippedSemanticDetails = baseContent != content;
   final outputPlainText = structuredOutputBlocksPlainText(outputBlocks);
   final hasOutputPlainText = outputPlainText.trim().isNotEmpty;
@@ -1050,16 +1050,6 @@ String _mergeContentWithStructuredOutput(
   return '';
 }
 
-String _stripRenderedSemanticDetails(String content) {
-  if (!content.contains('<details')) {
-    return content;
-  }
-  final semanticDetailsPattern = RegExp(
-    r'''<details\b(?=[^>]*\btype\s*=\s*["'](?:reasoning|tool_calls|code_interpreter|openai_builtin_tool)["'])[\s\S]*?</details>\s*''',
-  );
-  return content.replaceAll(semanticDetailsPattern, '').trim();
-}
-
 String _stringOr(dynamic value, String fallback) {
   if (value is String && value.isNotEmpty) {
     return value;
@@ -1082,9 +1072,8 @@ bool? _safeBool(dynamic value) {
 }
 
 String _synthesizeToolDetailsFromToolCalls(List<Map> calls) {
-  return renderSemanticMessageBlocks(
-    _semanticToolBlocksFromToolCalls(calls),
-  ).trim();
+  return renderSemanticMessageBlocks(_semanticToolBlocksFromToolCalls(calls))
+      .trim();
 }
 
 List<SemanticMessageBlock> _semanticToolBlocksFromToolCalls(List<Map> calls) {
@@ -1299,9 +1288,9 @@ List<Conversation> parseFolderSummaryModelsWorker(
 List<Map<String, dynamic>> parseConversationSummariesWorker(
   Map<String, dynamic> payload,
 ) {
-  return parseConversationSummaryModels(
-    payload,
-  ).map((conversation) => conversation.toJson()).toList(growable: false);
+  return parseConversationSummaryModels(payload)
+      .map((conversation) => conversation.toJson())
+      .toList(growable: false);
 }
 
 Map<String, dynamic> parseFullConversationWorker(Map<String, dynamic> payload) {
@@ -1313,9 +1302,9 @@ Map<String, dynamic> parseFullConversationWorker(Map<String, dynamic> payload) {
 List<Map<String, dynamic>> parseFolderSummariesWorker(
   Map<String, dynamic> payload,
 ) {
-  return parseFolderSummaryModels(
-    payload,
-  ).map((conversation) => conversation.toJson()).toList(growable: false);
+  return parseFolderSummaryModels(payload)
+      .map((conversation) => conversation.toJson())
+      .toList(growable: false);
 }
 
 Map<String, dynamic> _coerceConversationMap(Object? raw) {

--- a/lib/core/services/local_document_extraction_service.dart
+++ b/lib/core/services/local_document_extraction_service.dart
@@ -252,12 +252,11 @@ final class LocalPdfExtraction {
   final bool isEncrypted;
 }
 
-typedef LocalPdfExtractor =
-    Future<LocalPdfExtraction> Function(
-      Uint8List bytes, {
-      required int maxPages,
-      required int maxCharacters,
-    });
+typedef LocalPdfExtractor = Future<LocalPdfExtraction> Function(
+  Uint8List bytes, {
+  required int maxPages,
+  required int maxCharacters,
+});
 
 /// A bounded local document extracted without backend-specific formatting.
 final class ExtractedLocalDocument {

--- a/lib/core/services/location_service.dart
+++ b/lib/core/services/location_service.dart
@@ -82,7 +82,8 @@ UserLocationSetting _extractUserLocationSetting(
   Map<String, dynamic>? userSettings,
 ) {
   final uiMap = _asStringDynamicMap(userSettings?['ui']);
-  final hasRootUserLocation = userSettings?.containsKey('userLocation') ?? false;
+  final hasRootUserLocation =
+      userSettings?.containsKey('userLocation') ?? false;
   final raw = hasRootUserLocation
       ? (userSettings?['userLocation'])
       : (uiMap?['userLocation']);
@@ -156,10 +157,7 @@ class LocationService {
     try {
       final servicesEnabled = await isLocationServiceEnabled();
       if (!servicesEnabled) {
-        DebugLogger.info(
-          'location-services-disabled',
-          scope: 'location',
-        );
+        DebugLogger.info('location-services-disabled', scope: 'location');
         return const UserLocationResult.failure(
           UserLocationFailureReason.servicesDisabled,
         );
@@ -181,10 +179,7 @@ class LocationService {
       }
 
       if (!_isGranted(permission)) {
-        DebugLogger.info(
-          'location-permission-denied',
-          scope: 'location',
-        );
+        DebugLogger.info('location-permission-denied', scope: 'location');
         return const UserLocationResult.failure(
           UserLocationFailureReason.permissionDenied,
         );

--- a/lib/core/services/openwebui_stream_parser.dart
+++ b/lib/core/services/openwebui_stream_parser.dart
@@ -188,9 +188,15 @@ Iterable<OpenWebUIStreamUpdate> parseOpenWebUIParsedPayload(
   // Upstream contract (Chat.svelte): a frame carrying an `output` snapshot
   // supersedes its own choices deltas — the snapshot already contains the
   // delta's text (and its reasoning as an output item), so applying both
-  // duplicates content.
+  // duplicates content. Mute only when the snapshot parses into renderable
+  // blocks (matching the socket path's predicate): an output whose items all
+  // parse away would otherwise mute the delta AND render nothing.
   final output = parsed['output'];
-  final hasOutputSnapshot = output is List && output.isNotEmpty;
+  final outputUpdate = output is List && output.isNotEmpty
+      ? OpenWebUIOutputUpdate(output)
+      : null;
+  final hasOutputSnapshot =
+      outputUpdate != null && outputUpdate.blocks.isNotEmpty;
 
   final choices = parsed['choices'];
   if (!hasOutputSnapshot && choices is List && choices.isNotEmpty) {
@@ -212,8 +218,8 @@ Iterable<OpenWebUIStreamUpdate> parseOpenWebUIParsedPayload(
     }
   }
 
-  if (hasOutputSnapshot) {
-    yield OpenWebUIOutputUpdate(output);
+  if (outputUpdate != null) {
+    yield outputUpdate;
   }
 }
 

--- a/lib/core/services/openwebui_stream_parser.dart
+++ b/lib/core/services/openwebui_stream_parser.dart
@@ -185,8 +185,15 @@ Iterable<OpenWebUIStreamUpdate> parseOpenWebUIParsedPayload(
     yield OpenWebUIUsageUpdate(parsed['usage'] as Map<String, dynamic>);
   }
 
+  // Upstream contract (Chat.svelte): a frame carrying an `output` snapshot
+  // supersedes its own choices deltas — the snapshot already contains the
+  // delta's text (and its reasoning as an output item), so applying both
+  // duplicates content.
+  final output = parsed['output'];
+  final hasOutputSnapshot = output is List && output.isNotEmpty;
+
   final choices = parsed['choices'];
-  if (choices is List && choices.isNotEmpty) {
+  if (!hasOutputSnapshot && choices is List && choices.isNotEmpty) {
     final firstChoice = choices.first;
     if (firstChoice is Map<String, dynamic>) {
       final delta = firstChoice['delta'];
@@ -205,10 +212,7 @@ Iterable<OpenWebUIStreamUpdate> parseOpenWebUIParsedPayload(
     }
   }
 
-  // Structured output snapshots are applied after deltas from the same frame so
-  // the renderer can merge details with the plain text instead of duplicating it.
-  final output = parsed['output'];
-  if (output is List && output.isNotEmpty) {
+  if (hasOutputSnapshot) {
     yield OpenWebUIOutputUpdate(output);
   }
 }

--- a/lib/core/services/semantic_message_builder.dart
+++ b/lib/core/services/semantic_message_builder.dart
@@ -10,6 +10,13 @@ import 'package:markdown/markdown.dart' as md;
 // rendered output (e.g. URLs showing `https:&#47;&#47;`). See issue #549.
 const HtmlEscape _semanticHtmlEscape = HtmlEscape(HtmlEscapeMode.attribute);
 
+// Answer TEXT must not escape quotes: `&quot;` escaped into a context the
+// markdown decoder skips (immediately after a backquote, or inside a code
+// span/fence via the streaming fragment path) surfaces literally on screen.
+// Element mode (`&`, `<`, `>`) is sufficient to neutralize tags; attribute
+// mode stays reserved for `<details>` attribute values via [_escape].
+const HtmlEscape _semanticTextEscape = HtmlEscape(HtmlEscapeMode.element);
+
 /// Semantic assistant-message blocks that can be serialized into the markdown
 /// dialect consumed by Conduit's shared markdown renderer.
 sealed class SemanticMessageBlock {
@@ -45,9 +52,9 @@ final class SemanticDetailsBlock extends SemanticMessageBlock {
     final normalized = text.trim();
     final display = normalized.isEmpty
         ? ''
-        : LineSplitter.split(
-            normalized,
-          ).map((line) => line.startsWith('>') ? line : '> $line').join('\n');
+        : LineSplitter.split(normalized)
+              .map((line) => line.startsWith('>') ? line : '> $line')
+              .join('\n');
     final resolvedDuration = duration ?? '0';
     return SemanticDetailsBlock._(
       type: 'reasoning',
@@ -123,7 +130,10 @@ String renderSemanticMessageBlocks(List<SemanticMessageBlock> blocks) {
   for (final block in blocks) {
     switch (block) {
       case SemanticTextBlock(:final text):
-        if (text.trim().isNotEmpty) {
+        // Whitespace-only blocks must survive: dropping them here loses the
+        // blank line between a reasoning/tool section and the answer, and the
+        // streaming append delta never re-emits the swallowed prefix.
+        if (text.isNotEmpty) {
           parts.add(_escapeText(text));
         }
       case SemanticDetailsBlock():
@@ -146,7 +156,7 @@ String renderSemanticMessageBlocks(List<SemanticMessageBlock> blocks) {
 /// value with [renderSemanticMessageBlocks] so [_escapeText] can parse the
 /// complete Markdown context.
 String renderSemanticPlainTextFragment(String value) =>
-    _semanticHtmlEscape.convert(value);
+    _semanticTextEscape.convert(value);
 
 String _renderDetailsBlock(SemanticDetailsBlock block) {
   final attributes = <String, String>{
@@ -194,13 +204,12 @@ String _formatBodyValue(Object value) {
 }
 
 String _markdownCodeFence(String code, String language) {
-  final longestFence = RegExp(r'`+').allMatches(code).fold<int>(0, (
-    max,
-    match,
-  ) {
-    final length = match.group(0)?.length ?? 0;
-    return length > max ? length : max;
-  });
+  final longestFence = RegExp(r'`+')
+      .allMatches(code)
+      .fold<int>(0, (max, match) {
+        final length = match.group(0)?.length ?? 0;
+        return length > max ? length : max;
+      });
   final fence = '`' * (longestFence >= 3 ? longestFence + 1 : 3);
   return '$fence$language\n$code\n$fence';
 }
@@ -414,7 +423,7 @@ List<_SourceSpan> _parserConfirmedMultilineCodeSpans(String value) {
 String _escapeInlineMarkdownSegment(String value) => value.splitMapJoin(
   _safeInlineMarkdown,
   onMatch: (match) => match[0] ?? '',
-  onNonMatch: _escape,
+  onNonMatch: _semanticTextEscape.convert,
 );
 
 ({String text, int nextSpanIndex}) _escapeInlineMarkdownLine(

--- a/lib/core/services/socket_service.dart
+++ b/lib/core/services/socket_service.dart
@@ -13,17 +13,15 @@ import '../network/conduit_user_agent.dart';
 import '../utils/debug_logger.dart';
 import 'socket_tls_override.dart';
 
-typedef SocketChatEventHandler =
-    void Function(
-      Map<String, dynamic> event,
-      void Function(dynamic response)? ack,
-    );
+typedef SocketChatEventHandler = void Function(
+  Map<String, dynamic> event,
+  void Function(dynamic response)? ack,
+);
 
-typedef SocketChannelEventHandler =
-    void Function(
-      Map<String, dynamic> event,
-      void Function(dynamic response)? ack,
-    );
+typedef SocketChannelEventHandler = void Function(
+  Map<String, dynamic> event,
+  void Function(dynamic response)? ack,
+);
 
 enum SocketReplayGapReason {
   eventLimit,
@@ -35,12 +33,11 @@ enum SocketReplayGapReason {
 
 typedef SocketReplayGapCallback = void Function(SocketReplayGapReason reason);
 
-typedef SocketFactory =
-    io.Socket Function(
-      String base,
-      io.OptionBuilder builder,
-      ServerConfig serverConfig,
-    );
+typedef SocketFactory = io.Socket Function(
+  String base,
+  io.OptionBuilder builder,
+  ServerConfig serverConfig,
+);
 
 class SocketService with WidgetsBindingObserver {
   final ServerConfig serverConfig;

--- a/lib/core/services/socket_tls_override_impl_io.dart
+++ b/lib/core/services/socket_tls_override_impl_io.dart
@@ -1,4 +1,5 @@
 import 'dart:io' show HttpClient, WebSocket;
+
 import 'package:socket_io_client/socket_io_client.dart' as io;
 import 'package:web_socket/io_web_socket.dart' show IOWebSocket;
 import 'package:web_socket/web_socket.dart' as ws;

--- a/lib/core/services/streaming_helper.dart
+++ b/lib/core/services/streaming_helper.dart
@@ -4,6 +4,7 @@ import 'dart:io';
 
 import 'package:conduit/shared/widgets/platform_ui/platform_ui.dart';
 import 'package:flutter/foundation.dart';
+import 'package:html_unescape/html_unescape.dart';
 import 'package:material_ui/material_ui.dart';
 
 import '../auth/api_auth_interceptor.dart';
@@ -793,14 +794,19 @@ ActiveChatStream attachUnifiedChunkedStreaming({
   void Function() syncImages = () {};
   void Function() updateImagesFromCurrentContent = () {};
 
+  // Rendered content is HTML-escaped; the plain accumulator must hold the
+  // UNESCAPED text, or the next full render escapes it a second time and the
+  // user sees literal entities (`&amp;quot;` decoding once to `&quot;`).
+  final plainContentUnescape = HtmlUnescape();
   String initialPlainStreamingContent(String content) {
-    if (!content.contains('<details')) {
-      return content;
+    var plain = content;
+    if (plain.contains('<details')) {
+      final semanticDetailsPattern = RegExp(
+        r'''<details\b(?=[^>]*\btype\s*=\s*["'](?:reasoning|tool_calls|code_interpreter|openai_builtin_tool)["'])[\s\S]*?</details>\s*''',
+      );
+      plain = plain.replaceAll(semanticDetailsPattern, '').trim();
     }
-    final semanticDetailsPattern = RegExp(
-      r'''<details\b(?=[^>]*\btype\s*=\s*["'](?:reasoning|tool_calls|code_interpreter|openai_builtin_tool)["'])[\s\S]*?</details>\s*''',
-    );
-    return content.replaceAll(semanticDetailsPattern, '').trim();
+    return plain.contains('&') ? plainContentUnescape.convert(plain) : plain;
   }
 
   final renderedStreamingContent = _StreamingTextAccumulator(
@@ -877,7 +883,9 @@ ActiveChatStream attachUnifiedChunkedStreaming({
             visibleContent.length >= renderedStreamingContent.length)) {
       renderedStreamingContent.replace(visibleContent);
       if (!renderedFromStructuredOutput) {
-        plainStreamingContent.replace(visibleContent);
+        plainStreamingContent.replace(
+          initialPlainStreamingContent(visibleContent),
+        );
       }
       return;
     }
@@ -889,7 +897,9 @@ ActiveChatStream attachUnifiedChunkedStreaming({
     }
     renderedStreamingContent.replace(messages.last.content);
     if (!renderedFromStructuredOutput) {
-      plainStreamingContent.replace(messages.last.content);
+      plainStreamingContent.replace(
+        initialPlainStreamingContent(messages.last.content),
+      );
     }
   }
 
@@ -4045,7 +4055,9 @@ ActiveChatStream attachUnifiedChunkedStreaming({
                 .replaceAll('[/SEARCHING]', '');
           }
 
-          if (effectiveChunk.trim().isNotEmpty) {
+          // Whitespace-only chunks are real content: dropping a " " or
+          // "\n\n" delta glues words together and loses paragraph breaks.
+          if (effectiveChunk.isNotEmpty) {
             appendVisibleAssistantChunk(effectiveChunk);
           }
         },

--- a/lib/core/services/streaming_helper.dart
+++ b/lib/core/services/streaming_helper.dart
@@ -22,6 +22,7 @@ import '../../shared/theme/theme_extensions.dart';
 import '../utils/debug_logger.dart';
 import '../utils/embed_utils.dart';
 import '../utils/openwebui_source_parser.dart';
+import '../utils/semantic_details.dart';
 import 'openwebui_stream_parser.dart';
 import 'performance_profiler.dart';
 import 'semantic_message_builder.dart';
@@ -39,6 +40,17 @@ Duration debugTaskSocketTerminalRecoveryDelay = const Duration(seconds: 2);
 
 @visibleForTesting
 int debugTaskSocketStableNonTerminalRecoveryLimit = 3;
+
+final _plainContentUnescape = HtmlUnescape();
+
+// Consumes only the wrapper's own trailing newline: the broader `\s*` used
+// by comparable-body stripping (see semantic_details.dart) would eat
+// whitespace belonging to the answer, such as the indentation of a leading
+// indented code block. That is why this deliberately does NOT share
+// stripRenderedSemanticDetails.
+final _plainWrapperDetailsPattern = RegExp(
+  r'''<details\b(?=[^>]*\btype\s*=\s*["'](?:reasoning|tool_calls|code_interpreter|openai_builtin_tool)["'])[\s\S]*?</details>\n?''',
+);
 
 /// Append-only text storage for transport streams.
 ///
@@ -797,19 +809,12 @@ ActiveChatStream attachUnifiedChunkedStreaming({
   // Rendered content is HTML-escaped; the plain accumulator must hold the
   // UNESCAPED text, or the next full render escapes it a second time and the
   // user sees literal entities (`&amp;quot;` decoding once to `&quot;`).
-  final plainContentUnescape = HtmlUnescape();
   String initialPlainStreamingContent(String content) {
     var plain = content;
     if (plain.contains('<details')) {
-      // Consume only the wrapper's own trailing newline: broader \s* (plus a
-      // trim) would eat whitespace belonging to the answer, such as the
-      // indentation of a leading indented code block.
-      final semanticDetailsPattern = RegExp(
-        r'''<details\b(?=[^>]*\btype\s*=\s*["'](?:reasoning|tool_calls|code_interpreter|openai_builtin_tool)["'])[\s\S]*?</details>\n?''',
-      );
-      plain = plain.replaceAll(semanticDetailsPattern, '');
+      plain = plain.replaceAll(_plainWrapperDetailsPattern, '');
     }
-    return plain.contains('&') ? plainContentUnescape.convert(plain) : plain;
+    return plain.contains('&') ? _plainContentUnescape.convert(plain) : plain;
   }
 
   final renderedStreamingContent = _StreamingTextAccumulator(
@@ -921,7 +926,11 @@ ActiveChatStream attachUnifiedChunkedStreaming({
     if (plainContent != null) {
       plainStreamingContent.replace(plainContent);
     } else if (!fromStructuredOutput) {
-      plainStreamingContent.replace(content);
+      // The plain accumulator holds UNESCAPED, details-stripped text; a
+      // cumulative `content` frame can carry middleware-embedded <details>
+      // wrappers that must not leak in verbatim, or a later snapshot merge
+      // re-escapes them into literal &lt;details… text.
+      plainStreamingContent.replace(initialPlainStreamingContent(content));
       seenStreamingToolCallKeys.clear();
     } else if (content.isEmpty) {
       plainStreamingContent.replace('');
@@ -930,25 +939,6 @@ ActiveChatStream attachUnifiedChunkedStreaming({
     if (updateImages) {
       updateImagesFromCurrentContent();
     }
-  }
-
-  bool containsRenderedSemanticDetails(String content) {
-    if (!content.contains('<details')) {
-      return false;
-    }
-    return RegExp(
-      r'''<details\b(?=[^>]*\btype\s*=\s*["'](?:reasoning|tool_calls|code_interpreter|openai_builtin_tool)["'])''',
-    ).hasMatch(content);
-  }
-
-  String stripRenderedSemanticDetails(String content) {
-    if (!content.contains('<details')) {
-      return content;
-    }
-    final semanticDetailsPattern = RegExp(
-      r'''<details\b(?=[^>]*\btype\s*=\s*["'](?:reasoning|tool_calls|code_interpreter|openai_builtin_tool)["'])[\s\S]*?</details>\s*''',
-    );
-    return content.replaceAll(semanticDetailsPattern, '').trim();
   }
 
   void appendVisibleAssistantStructuredOutput(
@@ -2133,15 +2123,10 @@ ActiveChatStream attachUnifiedChunkedStreaming({
           // before comparing — their attributes (reasoning duration, done
           // flags) differ between local and server renders and would defeat
           // the prefix check.
-          final localRecoveryBody = stripRenderedSemanticDetails(
+          final keepLocalContent = serverBodyTruncatesLocal(
             current.content,
-          );
-          final serverRecoveryBody = stripRenderedSemanticDetails(
             assistant.content,
           );
-          final keepLocalContent =
-              serverRecoveryBody.length < localRecoveryBody.length &&
-              localRecoveryBody.startsWith(serverRecoveryBody);
           return _AssistantServerPatch(
             content: recoverAuthoritativeState && !keepLocalContent
                 ? assistant.content
@@ -2776,8 +2761,10 @@ ActiveChatStream attachUnifiedChunkedStreaming({
             final currentBody = stripRenderedSemanticDetails(current.content);
             final newBody = stripRenderedSemanticDetails(newContent);
             if (newBody == currentBody) return current;
-            if (newBody.length < currentBody.length &&
-                currentBody.startsWith(newBody)) {
+            if (isStaleServerPrefix(
+              localBody: currentBody,
+              serverBody: newBody,
+            )) {
               return current;
             }
             // Preserve original content before filter modification
@@ -3239,13 +3226,10 @@ ActiveChatStream attachUnifiedChunkedStreaming({
             // adopting it would rebase later deltas onto a shortened buffer.
             // Rendered semantic <details> wrappers are stripped before the
             // comparison; their attributes differ between renders.
-            final currentBody = stripRenderedSemanticDetails(
+            final isStalePrefix = serverBodyTruncatesLocal(
               renderedStreamingContent.value,
+              raw,
             );
-            final rawBody = stripRenderedSemanticDetails(raw);
-            final isStalePrefix =
-                rawBody.length < currentBody.length &&
-                currentBody.startsWith(rawBody);
             if (raw.isNotEmpty && !isStalePrefix) {
               replaceVisibleAssistantContent(raw);
             }

--- a/lib/core/services/streaming_helper.dart
+++ b/lib/core/services/streaming_helper.dart
@@ -1107,19 +1107,14 @@ ActiveChatStream attachUnifiedChunkedStreaming({
   }
 
   void finalizeStructuredOutputProjection() {
+    // Every applied OR deferred output snapshot sets structuredOutputIsLatest
+    // back to true, so this bail only holds when a plain chunk was the very
+    // last content-affecting operation with no snapshot after it — where the
+    // accumulated visible text (full projection + chunk, kept complete by
+    // syncProjectionToLatest) is the right terminal value.
+    if (!structuredOutputIsLatest) return;
     final projection = structuredOutputProjector.finish();
     if (projection == null) return;
-    if (!structuredOutputIsLatest) {
-      // A plain chunk was the last content-affecting operation and no output
-      // snapshot followed it. Upstream (Chat.svelte) treats every output
-      // snapshot as a wholesale replacement of content, so the terminal
-      // render is authoritative; keep the accumulated visible text only when
-      // it is longer (hybrid backends deliver some text solely through plain
-      // deltas the snapshot never contains).
-      if (projection.plainContent.length < plainStreamingContent.length) {
-        return;
-      }
-    }
     if (projection.content == renderedStreamingContent.value) {
       plainStreamingContent.replace(projection.plainContent);
       return;

--- a/lib/core/services/streaming_helper.dart
+++ b/lib/core/services/streaming_helper.dart
@@ -2068,8 +2068,17 @@ ActiveChatStream attachUnifiedChunkedStreaming({
           final recoveredStreamingState =
               !authoritativeTerminal &&
               (preserveActiveLocalStream || assistant.isStreaming);
+          // Replay-gap recovery can race the server's own persistence of the
+          // turn: a snapshot whose body is a strict prefix of the local
+          // streamed content is mid-write, not authoritative. Keep the local
+          // body then (mirrors applyServerContent's length guard).
+          final keepLocalContent =
+              assistant.content.length < current.content.length &&
+              current.content.startsWith(assistant.content);
           return _AssistantServerPatch(
-            content: recoverAuthoritativeState ? assistant.content : null,
+            content: recoverAuthoritativeState && !keepLocalContent
+                ? assistant.content
+                : null,
             followUps: nextFollowUps,
             statusHistory: nextStatusHistory,
             sources: nextSources,
@@ -2691,6 +2700,13 @@ ActiveChatStream attachUnifiedChunkedStreaming({
             final newContent = msg['content']?.toString();
             if (newContent == null) return current;
             if (current.content == newContent) return current;
+            // A server echo of the (possibly stale) payload we sent must not
+            // truncate streamed content: a strict prefix is our own snapshot
+            // coming back, not an outlet-filter rewrite.
+            if (newContent.length < current.content.length &&
+                current.content.startsWith(newContent)) {
+              return current;
+            }
             // Preserve original content before filter modification
             final meta = <String, dynamic>{
               ...?current.metadata,
@@ -2914,6 +2930,15 @@ ActiveChatStream attachUnifiedChunkedStreaming({
       onChatTitleUpdated?.call(doneTitle);
     }
 
+    // Fold the streamed buffer into message state BEFORE building the
+    // /api/chat/completed payload. The buffer is not periodically synced into
+    // the notifier, so without this the payload carries a stale prefix of a
+    // long response — and the server's echo of that payload then truncates
+    // the full content when merged back (the HTTP/SSE transport reaches here
+    // without any earlier terminal flush).
+    finalizeStreamingReasoning();
+    flushStreamingBuffer();
+
     try {
       if (!isTemporaryChat(activeConversationId)) {
         final completed = ensureChatCompletedSynced();
@@ -2926,9 +2951,6 @@ ActiveChatStream attachUnifiedChunkedStreaming({
     } catch (_) {
       // Non-critical - continue if sync fails
     }
-
-    finalizeStreamingReasoning();
-    flushStreamingBuffer();
 
     final msgs = getMessages();
     if (msgs.isNotEmpty && msgs.last.role == 'assistant') {
@@ -3123,7 +3145,14 @@ ActiveChatStream attachUnifiedChunkedStreaming({
           }
           if (completionTargetId != null && payload.containsKey('content')) {
             final raw = payload['content']?.toString() ?? '';
-            if (raw.isNotEmpty) {
+            final currentRendered = renderedStreamingContent.value;
+            // Cumulative content snapshots must never shrink streamed
+            // content: a strict prefix is a stale/out-of-order frame, and
+            // adopting it would rebase later deltas onto a shortened buffer.
+            final isStalePrefix =
+                raw.length < currentRendered.length &&
+                currentRendered.startsWith(raw);
+            if (raw.isNotEmpty && !isStalePrefix) {
               replaceVisibleAssistantContent(raw);
             }
           }

--- a/lib/core/services/streaming_helper.dart
+++ b/lib/core/services/streaming_helper.dart
@@ -801,10 +801,13 @@ ActiveChatStream attachUnifiedChunkedStreaming({
   String initialPlainStreamingContent(String content) {
     var plain = content;
     if (plain.contains('<details')) {
+      // Consume only the wrapper's own trailing newline: broader \s* (plus a
+      // trim) would eat whitespace belonging to the answer, such as the
+      // indentation of a leading indented code block.
       final semanticDetailsPattern = RegExp(
-        r'''<details\b(?=[^>]*\btype\s*=\s*["'](?:reasoning|tool_calls|code_interpreter|openai_builtin_tool)["'])[\s\S]*?</details>\s*''',
+        r'''<details\b(?=[^>]*\btype\s*=\s*["'](?:reasoning|tool_calls|code_interpreter|openai_builtin_tool)["'])[\s\S]*?</details>\n?''',
       );
-      plain = plain.replaceAll(semanticDetailsPattern, '').trim();
+      plain = plain.replaceAll(semanticDetailsPattern, '');
     }
     return plain.contains('&') ? plainContentUnescape.convert(plain) : plain;
   }

--- a/lib/core/services/streaming_helper.dart
+++ b/lib/core/services/streaming_helper.dart
@@ -3183,11 +3183,19 @@ ActiveChatStream attachUnifiedChunkedStreaming({
                 if (delta.containsKey('tool_calls')) {
                   handleOrDeferToolCallStatuses(delta['tool_calls']);
                 }
-                handleStreamingChoiceDelta(delta);
+                // Upstream contract (Chat.svelte): a frame carrying an
+                // `output` snapshot supersedes its own delta/content — the
+                // snapshot already contains the delta's text, so applying
+                // both duplicates it.
+                if (outputBlocks.isEmpty) {
+                  handleStreamingChoiceDelta(delta);
+                }
               }
             }
           }
-          if (completionTargetId != null && payload.containsKey('content')) {
+          if (completionTargetId != null &&
+              outputBlocks.isEmpty &&
+              payload.containsKey('content')) {
             final raw = payload['content']?.toString() ?? '';
             // Cumulative content snapshots must never shrink streamed
             // content: a strict prefix is a stale/out-of-order frame, and

--- a/lib/core/services/streaming_helper.dart
+++ b/lib/core/services/streaming_helper.dart
@@ -1794,8 +1794,22 @@ ActiveChatStream attachUnifiedChunkedStreaming({
         source: 'poll recovery',
       );
 
-      // Extract content
-      final content = extractServerMessageContent(serverMsg['content']);
+      // Extract content. OWUI 0.11 does not persist a flat content string
+      // for a normal completion — the durable body is the output[] item
+      // array, so a reasoning/structured turn's raw content is ''. Recovery
+      // must render output[] the same way the snapshot parser does, or a
+      // socket that missed the final frames can never restore the tail and
+      // finishes the turn truncated.
+      var content = extractServerMessageContent(serverMsg['content']);
+      if (content.trim().isEmpty) {
+        final rawOutput = serverMsg['output'];
+        if (rawOutput is List && rawOutput.isNotEmpty) {
+          final outputBlocks = parseOpenWebUIStructuredOutput(rawOutput);
+          if (outputBlocks.isNotEmpty) {
+            content = renderStructuredOutputBlocks(outputBlocks);
+          }
+        }
+      }
 
       // Extract follow-ups (check both camelCase and snake_case keys)
       // Use _parseFollowUpsField for consistent parsing with socket handler

--- a/lib/core/services/streaming_helper.dart
+++ b/lib/core/services/streaming_helper.dart
@@ -1107,9 +1107,19 @@ ActiveChatStream attachUnifiedChunkedStreaming({
   }
 
   void finalizeStructuredOutputProjection() {
-    if (!structuredOutputIsLatest) return;
     final projection = structuredOutputProjector.finish();
     if (projection == null) return;
+    if (!structuredOutputIsLatest) {
+      // A plain chunk was the last content-affecting operation and no output
+      // snapshot followed it. Upstream (Chat.svelte) treats every output
+      // snapshot as a wholesale replacement of content, so the terminal
+      // render is authoritative; keep the accumulated visible text only when
+      // it is longer (hybrid backends deliver some text solely through plain
+      // deltas the snapshot never contains).
+      if (projection.plainContent.length < plainStreamingContent.length) {
+        return;
+      }
+    }
     if (projection.content == renderedStreamingContent.value) {
       plainStreamingContent.replace(projection.plainContent);
       return;
@@ -3021,7 +3031,12 @@ ActiveChatStream attachUnifiedChunkedStreaming({
           last.codeExecutions.isNotEmpty ||
           last.sources.isNotEmpty;
       DebugLogger.log(
-        'Done signal received: content length=${lastContent.length}',
+        // Content audit: on a healthy completion these lengths agree (modulo
+        // details wrappers). message < rendered pinpoints a lost flush;
+        // rendered < plain pinpoints an unrepaired deferred projection.
+        'Done signal received: content length=${lastContent.length} '
+        'rendered=${renderedStreamingContent.length} '
+        'plain=${plainStreamingContent.length}',
         scope: 'streaming/helper',
       );
       if (allowEmptyContentRecovery &&

--- a/lib/core/services/streaming_helper.dart
+++ b/lib/core/services/streaming_helper.dart
@@ -1926,8 +1926,19 @@ ActiveChatStream attachUnifiedChunkedStreaming({
       );
     }
 
+    // Compare answer bodies with rendered semantic <details> wrappers
+    // stripped: local and server renders carry different attributes (for
+    // example a real reasoning duration vs the locally injected duration="0"),
+    // so raw lengths can grow while the actual answer shrinks — a mid-write
+    // server body with a long reasoning block and a partial answer must not
+    // replace a complete local answer.
+    final localComparableBody = stripRenderedSemanticDetails(
+      comparisonSnapshot.comparisonContent,
+    );
+    final serverComparableBody = stripRenderedSemanticDetails(content);
     final shouldAdoptContent =
-        content.isNotEmpty && content.length >= comparisonLength;
+        content.isNotEmpty &&
+        serverComparableBody.length >= localComparableBody.length;
     if (shouldAdoptContent) {
       DebugLogger.log(
         '$source: adopting server content (${content.length} chars)',
@@ -1939,9 +1950,7 @@ ActiveChatStream attachUnifiedChunkedStreaming({
       }
     }
 
-    if (content.isNotEmpty &&
-        isVisibleTarget &&
-        content.length < comparisonLength) {
+    if (content.isNotEmpty && isVisibleTarget && !shouldAdoptContent) {
       DebugLogger.log(
         '$source: keeping fresher visible content '
         '($comparisonLength > ${content.length})',
@@ -2086,12 +2095,21 @@ ActiveChatStream attachUnifiedChunkedStreaming({
               !authoritativeTerminal &&
               (preserveActiveLocalStream || assistant.isStreaming);
           // Replay-gap recovery can race the server's own persistence of the
-          // turn: a snapshot whose body is a strict prefix of the local
+          // turn: a snapshot whose answer body is a strict prefix of the local
           // streamed content is mid-write, not authoritative. Keep the local
-          // body then (mirrors applyServerContent's length guard).
+          // body then. Rendered semantic <details> wrappers are stripped
+          // before comparing — their attributes (reasoning duration, done
+          // flags) differ between local and server renders and would defeat
+          // the prefix check.
+          final localRecoveryBody = stripRenderedSemanticDetails(
+            current.content,
+          );
+          final serverRecoveryBody = stripRenderedSemanticDetails(
+            assistant.content,
+          );
           final keepLocalContent =
-              assistant.content.length < current.content.length &&
-              current.content.startsWith(assistant.content);
+              serverRecoveryBody.length < localRecoveryBody.length &&
+              localRecoveryBody.startsWith(serverRecoveryBody);
           return _AssistantServerPatch(
             content: recoverAuthoritativeState && !keepLocalContent
                 ? assistant.content
@@ -2718,10 +2736,16 @@ ActiveChatStream attachUnifiedChunkedStreaming({
             if (newContent == null) return current;
             if (current.content == newContent) return current;
             // A server echo of the (possibly stale) payload we sent must not
-            // truncate streamed content: a strict prefix is our own snapshot
-            // coming back, not an outlet-filter rewrite.
-            if (newContent.length < current.content.length &&
-                current.content.startsWith(newContent)) {
+            // truncate streamed content: compare answer bodies with rendered
+            // semantic <details> stripped (attribute differences such as the
+            // reasoning duration would otherwise defeat the prefix check),
+            // and skip echoes that only differ by those wrappers or are a
+            // strict prefix of the streamed body.
+            final currentBody = stripRenderedSemanticDetails(current.content);
+            final newBody = stripRenderedSemanticDetails(newContent);
+            if (newBody == currentBody) return current;
+            if (newBody.length < currentBody.length &&
+                currentBody.startsWith(newBody)) {
               return current;
             }
             // Preserve original content before filter modification
@@ -3165,13 +3189,18 @@ ActiveChatStream attachUnifiedChunkedStreaming({
           }
           if (completionTargetId != null && payload.containsKey('content')) {
             final raw = payload['content']?.toString() ?? '';
-            final currentRendered = renderedStreamingContent.value;
             // Cumulative content snapshots must never shrink streamed
             // content: a strict prefix is a stale/out-of-order frame, and
             // adopting it would rebase later deltas onto a shortened buffer.
+            // Rendered semantic <details> wrappers are stripped before the
+            // comparison; their attributes differ between renders.
+            final currentBody = stripRenderedSemanticDetails(
+              renderedStreamingContent.value,
+            );
+            final rawBody = stripRenderedSemanticDetails(raw);
             final isStalePrefix =
-                raw.length < currentRendered.length &&
-                currentRendered.startsWith(raw);
+                rawBody.length < currentBody.length &&
+                currentBody.startsWith(rawBody);
             if (raw.isNotEmpty && !isStalePrefix) {
               replaceVisibleAssistantContent(raw);
             }

--- a/lib/core/services/streaming_helper.dart
+++ b/lib/core/services/streaming_helper.dart
@@ -1196,6 +1196,23 @@ ActiveChatStream attachUnifiedChunkedStreaming({
   }) {
     if (chunk.isEmpty) return;
     if (includeInPlainContent) {
+      // The projector defers full re-projections (geometric backoff), so the
+      // visible content can trail the logical structured content. Appending a
+      // plain chunk onto that stale prefix would permanently drop the
+      // deferred middle: this flip of structuredOutputIsLatest also makes the
+      // terminal finalizeStructuredOutputProjection bail. Materialize the
+      // full projection first so the chunk lands on complete content.
+      if (structuredOutputIsLatest) {
+        final syncProjection = structuredOutputProjector
+            .syncProjectionToLatest();
+        if (syncProjection != null) {
+          replaceVisibleAssistantContent(
+            syncProjection.content,
+            fromStructuredOutput: true,
+            plainContent: syncProjection.plainContent,
+          );
+        }
+      }
       renderedFromStructuredOutput = false;
       structuredProjectionIsVisible = false;
       structuredOutputIsLatest = false;
@@ -2935,8 +2952,11 @@ ActiveChatStream attachUnifiedChunkedStreaming({
     // the notifier, so without this the payload carries a stale prefix of a
     // long response — and the server's echo of that payload then truncates
     // the full content when merged back (the HTTP/SSE transport reaches here
-    // without any earlier terminal flush).
+    // without any earlier terminal flush). The projector must materialize its
+    // exact terminal render first for the same reason: a deferred projection
+    // leaves the visible content up to ~50% behind the logical content.
     finalizeStreamingReasoning();
+    finalizeStructuredOutputProjection();
     flushStreamingBuffer();
 
     try {

--- a/lib/core/services/streaming_response_controller.dart
+++ b/lib/core/services/streaming_response_controller.dart
@@ -10,8 +10,10 @@ typedef StreamingCompletionCallback = void Function();
 
 /// Signature for callbacks invoked when a streaming session encounters an
 /// error.
-typedef StreamingErrorCallback =
-    void Function(Object error, StackTrace stackTrace);
+typedef StreamingErrorCallback = void Function(
+  Object error,
+  StackTrace stackTrace,
+);
 
 /// A lightweight controller that manages the lifecycle of a streamed response.
 ///

--- a/lib/core/services/structured_output_renderer.dart
+++ b/lib/core/services/structured_output_renderer.dart
@@ -232,6 +232,28 @@ final class StructuredOutputStreamingProjector {
     return null;
   }
 
+  /// Materializes the latest observed snapshot as a full replacement when the
+  /// current projection is stale — i.e. a deferred [project] call left the
+  /// visible content behind the logical content. Returns null when the
+  /// projection is already up to date (or nothing was observed yet).
+  ///
+  /// Callers use this before switching the visible content basis away from
+  /// the projector (e.g. appending a plain delta), so the deferred middle of
+  /// the response cannot be silently dropped.
+  StructuredOutputStreamingReplace? syncProjectionToLatest() {
+    if (_finished || !_hasLatestSnapshot) return null;
+    if (identical(_projectedBlocks, _latestBlocks) &&
+        _projectedReplacementText == _latestReplacementText) {
+      return null;
+    }
+    return _replace(
+      _latestBlocks,
+      _latestReplacementText,
+      _logicalLength(_latestBlocks, _latestReplacementText),
+      reason: StructuredOutputReplacementReason.forced,
+    );
+  }
+
   void observeLatest(
     List<StructuredOutputBlock> blocks, {
     String? replacementText,

--- a/lib/core/services/structured_output_renderer.dart
+++ b/lib/core/services/structured_output_renderer.dart
@@ -323,7 +323,16 @@ final class StructuredOutputStreamingProjector {
     _projectedReplacementText = replacementText;
     _hasProjection = true;
     _appendIsPlain = !plainContent.contains('`') && !plainContent.contains('~');
-    _nextFullProjectionLength = logicalLength == 0 ? 1 : logicalLength * 2;
+    // With appends available, geometric backoff is safe — appends carry the
+    // tail between full renders. Once a backtick/tilde disables appends for
+    // the rest of the turn, doubling would leave the visible tail up to 50%
+    // behind until completion; fall back to a bounded additive step instead.
+    _nextFullProjectionLength = logicalLength == 0
+        ? 1
+        : _appendIsPlain
+        ? logicalLength * 2
+        : logicalLength +
+              ((logicalLength >> 3) > 64 ? (logicalLength >> 3) : 64);
     _fullProjectionCount += 1;
     _fullProjectionCharacterCount += content.length;
     switch (reason) {

--- a/lib/core/services/structured_output_renderer.dart
+++ b/lib/core/services/structured_output_renderer.dart
@@ -246,12 +246,20 @@ final class StructuredOutputStreamingProjector {
         _projectedReplacementText == _latestReplacementText) {
       return null;
     }
-    return _replace(
+    // This sync materializes deferred content before the caller switches the
+    // visible basis away from the projector. It must not re-arm the geometric
+    // backoff to 2x the full length: with the append path disabled after a
+    // plain chunk, subsequent snapshots would all defer until the response
+    // doubled — freezing the visible tail for the rest of the turn.
+    final preservedThreshold = _nextFullProjectionLength;
+    final projection = _replace(
       _latestBlocks,
       _latestReplacementText,
       _logicalLength(_latestBlocks, _latestReplacementText),
       reason: StructuredOutputReplacementReason.forced,
     );
+    _nextFullProjectionLength = preservedThreshold;
+    return projection;
   }
 
   void observeLatest(

--- a/lib/core/services/structured_output_renderer.dart
+++ b/lib/core/services/structured_output_renderer.dart
@@ -242,6 +242,11 @@ final class StructuredOutputStreamingProjector {
   /// the response cannot be silently dropped.
   StructuredOutputStreamingReplace? syncProjectionToLatest() {
     if (_finished || !_hasLatestSnapshot) return null;
+    // Only the projector's own projections can be stale. When snapshots were
+    // merely observed (observe-only basis: the caller kept visible content
+    // that may be a superset of the snapshot render), materializing the
+    // snapshot here would SHRINK the visible content and drop that surplus.
+    if (!_hasProjection) return null;
     if (identical(_projectedBlocks, _latestBlocks) &&
         _projectedReplacementText == _latestReplacementText) {
       return null;

--- a/lib/core/sync/pull_sync.dart
+++ b/lib/core/sync/pull_sync.dart
@@ -27,8 +27,9 @@ const int kOpenWebUiChatListPageSize = 60;
 
 /// Worker-isolate seam for decomposing a full Open WebUI chat blob into
 /// normalized rows before the database transaction begins.
-typedef ChatRowsParseOffload =
-    Future<ChatRows> Function(Map<String, dynamic> response);
+typedef ChatRowsParseOffload = Future<ChatRows> Function(
+  Map<String, dynamic> response,
+);
 
 /// Top-level callback used by [WorkerManager] through the injected
 /// [ChatRowsParseOffload]. Keeping this pure also makes it directly testable.

--- a/lib/core/sync/sync_engine.dart
+++ b/lib/core/sync/sync_engine.dart
@@ -851,14 +851,13 @@ class SyncEngine extends _$SyncEngine {
       }
 
       late final Future<void> migration;
-      migration = _runLegacyTaskQueueMigration(migrationDb: db).whenComplete(
-        () {
-          if (identical(_migrationInFlight, migration)) {
-            _migrationInFlight = null;
-            _migrationDb = null;
-          }
-        },
-      );
+      migration = _runLegacyTaskQueueMigration(migrationDb: db)
+          .whenComplete(() {
+            if (identical(_migrationInFlight, migration)) {
+              _migrationInFlight = null;
+              _migrationDb = null;
+            }
+          });
       _migrationInFlight = migration;
       _migrationDb = db;
       await migration;

--- a/lib/core/utils/message_tree_utils.dart
+++ b/lib/core/utils/message_tree_utils.dart
@@ -215,9 +215,9 @@ OpenWebUiDeletePlan? buildOpenWebUiDeletePlan<T>(
     return null;
   }
 
-  final childIds = childrenIdsOf(
-    message,
-  ).where(messagesById.containsKey).toList(growable: false);
+  final childIds = childrenIdsOf(message)
+      .where(messagesById.containsKey)
+      .toList(growable: false);
   final grandchildIds = <String>[];
   for (final childId in childIds) {
     final child = messagesById[childId];
@@ -310,9 +310,9 @@ Set<String>? deleteOpenWebUiMessageFromRawMessages(
   for (final entry in messagesById.entries) {
     final id = entry.key;
     final message = entry.value;
-    final children = rawMessageChildrenIds(
-      message,
-    ).where((id) => !plan.deletedIds.contains(id)).toList(growable: true);
+    final children = rawMessageChildrenIds(message)
+        .where((id) => !plan.deletedIds.contains(id))
+        .toList(growable: true);
     if (plan.deletedParentId != null && id == plan.deletedParentId) {
       for (final grandchildId in plan.grandchildIds) {
         if (!children.contains(grandchildId)) {

--- a/lib/core/utils/openwebui_message_payload.dart
+++ b/lib/core/utils/openwebui_message_payload.dart
@@ -1,0 +1,137 @@
+import '../models/chat_message.dart';
+
+/// Serializers for message fields OpenWebUI persists inside chat blobs.
+///
+/// Every path that writes message objects the server stores wholesale — the
+/// API chat push, the sync-outbox echo rows, and the direct/Hermes persisted
+/// payloads — must use these shapes: the server and web client read
+/// `code_executions` (snake_case) and citation-shaped `sources`, and the
+/// server's merge replaces each message object verbatim.
+
+/// Converts ChatSourceReference list back to OpenWebUI's expected format.
+/// OpenWebUI expects: { source: {...}, document: [...], metadata: [...] }
+/// But ChatSourceReference stores: { id, title, url, snippet, type, metadata }
+List<Map<String, dynamic>> convertSourcesToOpenWebUIFormat(
+  List<ChatSourceReference> sources,
+) {
+  return sources.map((ref) {
+    final result = <String, dynamic>{};
+
+    // Build the source object
+    final sourceObj = <String, dynamic>{};
+    if (ref.id != null) sourceObj['id'] = ref.id;
+    if (ref.title != null) sourceObj['name'] = ref.title;
+    if (ref.url != null) sourceObj['url'] = ref.url;
+    if (ref.type != null) sourceObj['type'] = ref.type;
+
+    // Extract nested source from metadata if present
+    final metadataSource = ref.metadata?['source'];
+    if (metadataSource is Map) {
+      for (final entry in metadataSource.entries) {
+        sourceObj[entry.key.toString()] ??= entry.value;
+      }
+    }
+
+    if (sourceObj.isNotEmpty) {
+      result['source'] = sourceObj;
+    }
+
+    // Extract documents from metadata or use snippet
+    final documents = ref.metadata?['documents'];
+    if (documents is List && documents.isNotEmpty) {
+      result['document'] = documents;
+    } else if (ref.snippet != null && ref.snippet!.isNotEmpty) {
+      result['document'] = [ref.snippet];
+    }
+
+    // Extract metadata items
+    final metadataItems = ref.metadata?['items'];
+    if (metadataItems is List && metadataItems.isNotEmpty) {
+      result['metadata'] = metadataItems;
+    } else {
+      // Create a basic metadata entry
+      final basicMeta = <String, dynamic>{};
+      if (ref.id != null) basicMeta['source'] = ref.id;
+      if (ref.title != null) basicMeta['name'] = ref.title;
+      if (result['document'] is List) {
+        result['metadata'] = List.generate(
+          (result['document'] as List).length,
+          (_) => Map<String, dynamic>.from(basicMeta),
+        );
+      }
+    }
+
+    // Extract distances if present
+    final distances = ref.metadata?['distances'];
+    if (distances is List && distances.isNotEmpty) {
+      result['distances'] = distances;
+    }
+
+    return result;
+  }).toList();
+}
+
+/// Converts ChatCodeExecution list to OpenWebUI's expected format.
+/// OpenWebUI expects `code_executions` (snake_case) with specific structure.
+/// ChatCodeExecution stores: { id, name, language, code, result, metadata }
+/// OpenWebUI expects: { id, name, code, language?, result?: { error?, output?, files? } }
+List<Map<String, dynamic>> convertCodeExecutionsToOpenWebUIFormat(
+  List<ChatCodeExecution> executions,
+) {
+  return executions.map((exec) {
+    final result = <String, dynamic>{
+      'id': exec.id,
+      if (exec.name != null) 'name': exec.name,
+      if (exec.code != null) 'code': exec.code,
+      if (exec.language != null) 'language': exec.language,
+    };
+
+    // Convert the result if present
+    if (exec.result != null) {
+      final execResult = <String, dynamic>{};
+      if (exec.result!.output != null) {
+        execResult['output'] = exec.result!.output;
+      }
+      if (exec.result!.error != null) {
+        execResult['error'] = exec.result!.error;
+      }
+      if (exec.result!.files.isNotEmpty) {
+        execResult['files'] = exec.result!.files
+            .map(
+              (f) => <String, dynamic>{
+                if (f.name != null) 'name': f.name,
+                if (f.url != null) 'url': f.url,
+              },
+            )
+            .toList();
+      }
+      if (execResult.isNotEmpty) {
+        result['result'] = execResult;
+      }
+    }
+
+    return result;
+  }).toList();
+}
+
+/// Drops null values and empty entries so the server never stores
+/// client-internal nulls inside message `files`.
+List<Map<String, dynamic>>? sanitizeFilesForWebUi(
+  List<Map<String, dynamic>>? files,
+) {
+  if (files == null || files.isEmpty) {
+    return null;
+  }
+  final sanitized = <Map<String, dynamic>>[];
+  for (final entry in files) {
+    final safe = <String, dynamic>{};
+    for (final MapEntry(:key, :value) in entry.entries) {
+      if (value == null) continue;
+      safe[key.toString()] = value;
+    }
+    if (safe.isNotEmpty) {
+      sanitized.add(safe);
+    }
+  }
+  return sanitized.isNotEmpty ? sanitized : null;
+}

--- a/lib/core/utils/openwebui_source_parser.dart
+++ b/lib/core/utils/openwebui_source_parser.dart
@@ -158,10 +158,8 @@ List<ChatSourceReference> parseOpenWebUISourceList(dynamic raw) {
       id,
     ])?.toString();
 
-    final urlCandidate = _firstNonEmpty([
-      accumulator.source['url'],
-      id,
-    ])?.toString();
+    final urlCandidate = _firstNonEmpty([accumulator.source['url'], id])
+        ?.toString();
     final url = _looksLikeUrl(urlCandidate) ? urlCandidate : null;
 
     final snippet = accumulator.documents.firstWhere(

--- a/lib/core/utils/reasoning_parser.dart
+++ b/lib/core/utils/reasoning_parser.dart
@@ -178,9 +178,8 @@ class ReasoningParser {
       (String, String)? matchedRawPair;
 
       // Check for any <details tag (we'll determine if it's reasoning later)
-      final detailsMatch = RegExp(
-        r'<details(?:\s|>)',
-      ).firstMatch(content.substring(index));
+      final detailsMatch = RegExp(r'<details(?:\s|>)')
+          .firstMatch(content.substring(index));
       if (detailsMatch != null) {
         nextDetailsIdx = index + detailsMatch.start;
       }
@@ -563,9 +562,8 @@ class ReasoningParser {
 
     // Check for <details> with reasoning-like summary
     if (content.contains('<details')) {
-      final summaryMatch = RegExp(
-        r'<summary>([^<]*)</summary>',
-      ).firstMatch(content);
+      final summaryMatch = RegExp(r'<summary>([^<]*)</summary>')
+          .firstMatch(content);
       if (summaryMatch != null) {
         final summary = summaryMatch.group(1) ?? '';
         if (_reasoningSummaryPattern.hasMatch(summary)) return true;

--- a/lib/core/utils/semantic_details.dart
+++ b/lib/core/utils/semantic_details.dart
@@ -1,0 +1,59 @@
+/// Helpers for the rendered semantic `<details>` wrappers embedded in
+/// OpenWebUI-style assistant content (reasoning, tool_calls,
+/// code_interpreter, openai_builtin_tool).
+///
+/// Local and server renders of the same turn carry different wrapper
+/// attributes (for example a locally injected reasoning `duration="0"` vs
+/// the server's real duration), so content comparisons must strip the
+/// wrappers first or length/prefix checks are defeated on otherwise
+/// identical answers. Every comparison path (streaming transport, replay
+/// recovery, snapshot merges) must share these definitions: divergent copies
+/// of the tag patterns have caused real rendering bugs.
+library;
+
+final RegExp _semanticDetailsOpenPattern = RegExp(
+  r'''<details\b(?=[^>]*\btype\s*=\s*["'](?:reasoning|tool_calls|code_interpreter|openai_builtin_tool)["'])''',
+);
+
+final RegExp _semanticDetailsBlockPattern = RegExp(
+  r'''<details\b(?=[^>]*\btype\s*=\s*["'](?:reasoning|tool_calls|code_interpreter|openai_builtin_tool)["'])[\s\S]*?</details>\s*''',
+);
+
+bool containsRenderedSemanticDetails(String content) {
+  if (!content.contains('<details')) {
+    return false;
+  }
+  return _semanticDetailsOpenPattern.hasMatch(content);
+}
+
+String stripRenderedSemanticDetails(String content) {
+  if (!content.contains('<details')) {
+    return content;
+  }
+  return content.replaceAll(_semanticDetailsBlockPattern, '').trim();
+}
+
+/// True when [serverBody] is a strict prefix of [localBody] — a stale or
+/// mid-write server frame that must not truncate content already streamed.
+/// Callers pass comparable bodies (usually already details-stripped).
+bool isStaleServerPrefix({
+  required String localBody,
+  required String serverBody,
+}) {
+  return serverBody.length < localBody.length &&
+      localBody.startsWith(serverBody);
+}
+
+/// The message body with rendered semantic `<details>` blocks removed and
+/// trimmed, for content comparisons between local and server renders of the
+/// same turn.
+String comparableAssistantBody(String content) =>
+    stripRenderedSemanticDetails(content).trim();
+
+/// [isStaleServerPrefix] on details-stripped renders of the two contents.
+bool serverBodyTruncatesLocal(String localContent, String serverContent) {
+  return isStaleServerPrefix(
+    localBody: stripRenderedSemanticDetails(localContent),
+    serverBody: stripRenderedSemanticDetails(serverContent),
+  );
+}

--- a/lib/core/utils/sensitive_value_utils.dart
+++ b/lib/core/utils/sensitive_value_utils.dart
@@ -65,9 +65,8 @@ List<String>? boundedSensitiveValueVariants(
 
   // Authorization-style values place a scheme before the credential. Retain
   // both the complete payload and its first token for custom schemes.
-  final authorization = RegExp(
-    r'^[A-Za-z][A-Za-z0-9_-]*\s+(.+)$',
-  ).firstMatch(trimmed);
+  final authorization = RegExp(r'^[A-Za-z][A-Za-z0-9_-]*\s+(.+)$')
+      .firstMatch(trimmed);
   final payload = authorization?.group(1)?.trim();
   if (payload != null && payload.isNotEmpty) {
     addWithOptionalQuotes(payload);

--- a/lib/features/auth/providers/unified_auth_providers.dart
+++ b/lib/features/auth/providers/unified_auth_providers.dart
@@ -1,4 +1,5 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+
 import '../../../core/auth/auth_state_manager.dart';
 import '../../../core/models/user.dart';
 import '../../../core/models/server_config.dart';

--- a/lib/features/chat/providers/assistant_response_builder_provider.dart
+++ b/lib/features/chat/providers/assistant_response_builder_provider.dart
@@ -3,8 +3,10 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../../core/models/chat_message.dart';
 
-typedef AssistantResponseBuilder =
-    Widget Function(BuildContext context, AssistantResponseContext response);
+typedef AssistantResponseBuilder = Widget Function(
+  BuildContext context,
+  AssistantResponseContext response,
+);
 
 class AssistantResponseContext {
   const AssistantResponseContext({

--- a/lib/features/chat/providers/chat_providers.dart
+++ b/lib/features/chat/providers/chat_providers.dart
@@ -82,6 +82,25 @@ part 'chat_composer_providers.dart';
 part 'chat_providers.g.dart';
 
 // Chat messages for current conversation
+/// The message body with rendered semantic `<details>` blocks removed, for
+/// content comparisons between local and server renders of the same turn.
+/// Their attributes (reasoning duration, done flags) differ between renders
+/// and would defeat prefix/length checks on otherwise identical answers.
+final RegExp _semanticDetailsBlockPattern = RegExp(
+  r'''<details\b(?=[^>]*\btype\s*=\s*["'](?:reasoning|tool_calls|code_interpreter|openai_builtin_tool)["'])[\s\S]*?</details>\s*''',
+);
+
+String _comparableAssistantBody(String content) {
+  if (!content.contains('<details')) {
+    return content.trim();
+  }
+  return content.replaceAll(_semanticDetailsBlockPattern, '').trim();
+}
+
+@visibleForTesting
+String debugComparableAssistantBodyForTesting(String content) =>
+    _comparableAssistantBody(content);
+
 /// Parses the Open WebUI `chat:message:follow_ups` socket envelope:
 /// `{chat_id, message_id, data: {type, data: {follow_ups: [...]}}}`.
 /// Returns null when the event is not a usable follow-ups push.
@@ -3261,12 +3280,19 @@ class ChatMessagesNotifier extends Notifier<List<ChatMessage>>
     if (!_hasLocalStreamingProvenance(localMessage)) {
       return false;
     }
-    final localContent = localMessage.content;
-    final serverContent = serverMessage.content;
-    if (localContent.trim().isEmpty) {
-      return false;
+    // Compare answer bodies with rendered semantic <details> wrappers
+    // stripped. Local and server renders of the same turn carry different
+    // details attributes (e.g. the locally injected reasoning duration="0"
+    // vs the server's real duration), which would otherwise defeat both the
+    // length and the prefix checks and let a mid-write server body replace a
+    // complete local answer on every reasoning turn.
+    final localContent = _comparableAssistantBody(localMessage.content);
+    final serverContent = _comparableAssistantBody(serverMessage.content);
+    if (localContent.isEmpty) {
+      return localMessage.content.trim().isNotEmpty &&
+          serverMessage.content.trim().isEmpty;
     }
-    if (serverContent.trim().isEmpty) {
+    if (serverContent.isEmpty) {
       return true;
     }
     if (localContent.length <= serverContent.length) {
@@ -6245,12 +6271,17 @@ class ChatMessagesNotifier extends Notifier<List<ChatMessage>>
     return null;
   }
 
-  /// Minimal history-message shape (`{id, parentId, childrenIds, role,
-  /// content, timestamp, model?}`) — explicitly a local echo.
+  /// History-message shape for the local turn echo.
   ///
   /// The `parentId` written here is only a placeholder for the payload map:
   /// `MessagesDao.upsertLocalEchoTurn` re-parents these rows via `_withParent`,
   /// rewriting both the row and `payload['parentId']` to the branch tip.
+  ///
+  /// The payload must carry every durable server-shape field the message has:
+  /// the sync outbox rebuilds the full chat blob from these rows and the
+  /// server's merge replaces each message object wholesale, so any field
+  /// omitted here (`output`, `sources`, `usage`, …) would be wiped from the
+  /// server copy on the next push.
   MessageRowData _localEchoRow(String chatId, ChatMessage message) {
     final timestamp = message.timestamp.millisecondsSinceEpoch ~/ 1000;
     final resolvedParentId = message_tree.chatMessageParentId(message);
@@ -6279,6 +6310,24 @@ class ChatMessagesNotifier extends Notifier<List<ChatMessage>>
         if (message.model != null) 'model': message.model,
         if (message.metadata != null && message.metadata!.isNotEmpty)
           'metadata': message.metadata,
+        if (message.output != null && message.output!.isNotEmpty)
+          'output': message.output,
+        if (message.files != null && message.files!.isNotEmpty)
+          'files': message.files,
+        if (message.embeds != null && message.embeds!.isNotEmpty)
+          'embeds': message.embeds,
+        if (message.usage != null) 'usage': message.usage,
+        if (message.sources.isNotEmpty)
+          'sources': message.sources
+              .map((source) => source.toJson())
+              .toList(growable: false),
+        if (message.statusHistory.isNotEmpty)
+          'statusHistory': message.statusHistory
+              .map((status) => status.toJson())
+              .toList(growable: false),
+        if (message.followUps.isNotEmpty)
+          'followUps': List<String>.from(message.followUps),
+        if (message.error != null) 'error': message.error!.toJson(),
       },
     );
   }

--- a/lib/features/chat/providers/chat_providers.dart
+++ b/lib/features/chat/providers/chat_providers.dart
@@ -53,7 +53,10 @@ import '../../../core/services/worker_manager.dart';
 import '../../../core/utils/debug_logger.dart';
 import '../../../core/utils/json_normalization.dart';
 import '../../../core/utils/message_tree_utils.dart' as message_tree;
+import '../../../core/utils/openwebui_message_payload.dart';
+import '../../../core/utils/semantic_details.dart';
 import '../../auth/providers/unified_auth_providers.dart';
+import '../utils/follow_ups_socket_event.dart';
 import '../../hermes/models/hermes_chat_input.dart';
 import '../../hermes/models/hermes_capabilities.dart';
 import '../../hermes/models/hermes_config.dart';
@@ -82,65 +85,6 @@ part 'chat_composer_providers.dart';
 part 'chat_providers.g.dart';
 
 // Chat messages for current conversation
-/// The message body with rendered semantic `<details>` blocks removed, for
-/// content comparisons between local and server renders of the same turn.
-/// Their attributes (reasoning duration, done flags) differ between renders
-/// and would defeat prefix/length checks on otherwise identical answers.
-final RegExp _semanticDetailsBlockPattern = RegExp(
-  r'''<details\b(?=[^>]*\btype\s*=\s*["'](?:reasoning|tool_calls|code_interpreter|openai_builtin_tool)["'])[\s\S]*?</details>\s*''',
-);
-
-String _comparableAssistantBody(String content) {
-  if (!content.contains('<details')) {
-    return content.trim();
-  }
-  return content.replaceAll(_semanticDetailsBlockPattern, '').trim();
-}
-
-@visibleForTesting
-String debugComparableAssistantBodyForTesting(String content) =>
-    _comparableAssistantBody(content);
-
-/// Parses the Open WebUI `chat:message:follow_ups` socket envelope:
-/// `{chat_id, message_id, data: {type, data: {follow_ups: [...]}}}`.
-/// Returns null when the event is not a usable follow-ups push.
-@visibleForTesting
-({String messageId, List<String> followUps})?
-debugParseFollowUpsSocketEventForTesting(Map<String, dynamic> event) =>
-    _parseFollowUpsSocketEvent(event);
-
-({String messageId, List<String> followUps})? _parseFollowUpsSocketEvent(
-  Map<String, dynamic> event,
-) {
-  final data = event['data'];
-  if (data is! Map || data['type'] != 'chat:message:follow_ups') {
-    return null;
-  }
-  final messageId = (event['message_id'] ?? data['message_id'])?.toString();
-  if (messageId == null || messageId.isEmpty) {
-    return null;
-  }
-  final inner = data['data'];
-  final rawFollowUps = inner is Map
-      ? (inner['follow_ups'] ?? inner['followUps'])
-      : null;
-  if (rawFollowUps is! List) {
-    return null;
-  }
-  final followUps = <String>[
-    for (final item in rawFollowUps)
-      if (item != null && item.toString().trim().isNotEmpty)
-        item.toString().trim(),
-  ];
-  if (followUps.isEmpty) {
-    return null;
-  }
-  return (
-    messageId: messageId,
-    followUps: List<String>.unmodifiable(followUps),
-  );
-}
-
 final chatMessagesProvider =
     NotifierProvider<ChatMessagesNotifier, List<ChatMessage>>(
       ChatMessagesNotifier.new,
@@ -2557,7 +2501,7 @@ class ChatMessagesNotifier extends Notifier<List<ChatMessage>>
   /// Applies a pushed `chat:message:follow_ups` payload straight to the
   /// target message. Returns true when the event was consumed.
   bool _applyPassiveFollowUpsEvent(Map<String, dynamic> event) {
-    final parsed = _parseFollowUpsSocketEvent(event);
+    final parsed = parseFollowUpsSocketEvent(event);
     if (parsed == null) {
       return false;
     }
@@ -2583,7 +2527,10 @@ class ChatMessagesNotifier extends Notifier<List<ChatMessage>>
     // The turn echo was persisted at completion, before this event fired.
     // Re-persist the message so the suggestions survive a conversation
     // switch (the local Drift copy would otherwise reload without them).
-    _persistCompletedTurnForMessage(messageIndex);
+    // Re-resolve the index: updateMessageById rebuilt the list above.
+    _persistCompletedTurnForMessage(
+      state.indexWhere((message) => message.id == parsed.messageId),
+    );
     return true;
   }
 
@@ -3293,8 +3240,8 @@ class ChatMessagesNotifier extends Notifier<List<ChatMessage>>
     // vs the server's real duration), which would otherwise defeat both the
     // length and the prefix checks and let a mid-write server body replace a
     // complete local answer on every reasoning turn.
-    final localContent = _comparableAssistantBody(localMessage.content);
-    final serverContent = _comparableAssistantBody(serverMessage.content);
+    final localContent = comparableAssistantBody(localMessage.content);
+    final serverContent = comparableAssistantBody(serverMessage.content);
     if (localContent.isEmpty) {
       return localMessage.content.trim().isNotEmpty &&
           serverMessage.content.trim().isEmpty;
@@ -6254,8 +6201,8 @@ class ChatMessagesNotifier extends Notifier<List<ChatMessage>>
           chatId: chatId,
           user: trailingUser == null
               ? null
-              : _localEchoRow(chatId, trailingUser),
-          assistant: _localEchoRow(chatId, assistant),
+              : localEchoRowForMessage(chatId, trailingUser),
+          assistant: localEchoRowForMessage(chatId, assistant),
         );
       });
     } catch (error, stackTrace) {
@@ -6277,71 +6224,75 @@ class ChatMessagesNotifier extends Notifier<List<ChatMessage>>
     }
     return null;
   }
+}
 
-  /// History-message shape for the local turn echo.
-  ///
-  /// The `parentId` written here is only a placeholder for the payload map:
-  /// `MessagesDao.upsertLocalEchoTurn` re-parents these rows via `_withParent`,
-  /// rewriting both the row and `payload['parentId']` to the branch tip.
-  ///
-  /// The payload must carry every durable server-shape field the message has:
-  /// the sync outbox rebuilds the full chat blob from these rows and the
-  /// server's merge replaces each message object wholesale, so any field
-  /// omitted here (`output`, `sources`, `usage`, …) would be wiped from the
-  /// server copy on the next push.
-  MessageRowData _localEchoRow(String chatId, ChatMessage message) {
-    final timestamp = message.timestamp.millisecondsSinceEpoch ~/ 1000;
-    final resolvedParentId = message_tree.chatMessageParentId(message);
-    final childrenIds = message_tree
-        .chatMessageChildrenIds(message)
-        .toList(growable: false);
-    return MessageRowData(
-      id: message.id,
-      chatId: chatId,
-      parentId: resolvedParentId,
-      role: message.role,
-      content: message.content,
-      model: message.model,
-      createdAt: timestamp,
-      // Recomputed by upsertLocalEcho for new rows.
-      orderIndex: 0,
-      payload: <String, dynamic>{
-        'id': message.id,
-        'parentId': resolvedParentId,
-        'childrenIds': childrenIds,
-        'role': message.role,
-        'content': message.content,
-        'timestamp': timestamp,
-        'isStreaming': message.isStreaming,
-        if (message.role == 'assistant' && !message.isStreaming) 'done': true,
-        if (message.model != null) 'model': message.model,
-        if (message.metadata != null && message.metadata!.isNotEmpty)
-          'metadata': message.metadata,
-        if (message.output != null && message.output!.isNotEmpty)
-          'output': message.output,
-        if (message.files != null && message.files!.isNotEmpty)
-          'files': message.files,
-        if (message.embeds != null && message.embeds!.isNotEmpty)
-          'embeds': message.embeds,
-        if (message.usage != null) 'usage': message.usage,
-        if (message.sources.isNotEmpty)
-          'sources': message.sources
-              .map((source) => source.toJson())
-              .toList(growable: false),
-        if (message.statusHistory.isNotEmpty)
-          'statusHistory': message.statusHistory
-              .map((status) => status.toJson())
-              .toList(growable: false),
-        if (message.codeExecutions.isNotEmpty)
-          'codeExecutions': message.codeExecutions
-              .map((execution) => execution.toJson())
-              .toList(growable: false),
-        if (message.followUps.isNotEmpty)
-          'followUps': List<String>.from(message.followUps),
-        if (message.error != null) 'error': message.error!.toJson(),
-      },
-    );
-  }
+/// History-message shape for the local turn echo.
+///
+/// Top-level (rather than a notifier method) so tests can pin payload
+/// completeness against the ChatMessage model.
+///
+/// The `parentId` written here is only a placeholder for the payload map:
+/// `MessagesDao.upsertLocalEchoTurn` re-parents these rows via `_withParent`,
+/// rewriting both the row and `payload['parentId']` to the branch tip.
+///
+/// The payload must carry every durable server-shape field the message has:
+/// the sync outbox rebuilds the full chat blob from these rows and the
+/// server's merge replaces each message object wholesale, so any field
+/// omitted here (`output`, `sources`, `usage`, …) would be wiped from the
+/// server copy on the next push.
+MessageRowData localEchoRowForMessage(String chatId, ChatMessage message) {
+  final timestamp = message.timestamp.millisecondsSinceEpoch ~/ 1000;
+  final resolvedParentId = message_tree.chatMessageParentId(message);
+  final childrenIds = message_tree
+      .chatMessageChildrenIds(message)
+      .toList(growable: false);
+  final sanitizedFiles = sanitizeFilesForWebUi(message.files);
+  return MessageRowData(
+    id: message.id,
+    chatId: chatId,
+    parentId: resolvedParentId,
+    role: message.role,
+    content: message.content,
+    model: message.model,
+    createdAt: timestamp,
+    // Recomputed by upsertLocalEcho for new rows.
+    orderIndex: 0,
+    payload: <String, dynamic>{
+      'id': message.id,
+      'parentId': resolvedParentId,
+      'childrenIds': childrenIds,
+      'role': message.role,
+      'content': message.content,
+      'timestamp': timestamp,
+      'isStreaming': message.isStreaming,
+      if (message.role == 'assistant' && !message.isStreaming) 'done': true,
+      if (message.model != null) 'model': message.model,
+      if (message.metadata != null && message.metadata!.isNotEmpty)
+        'metadata': message.metadata,
+      if (message.output != null && message.output!.isNotEmpty)
+        'output': message.output,
+      'files': ?sanitizedFiles,
+      if (message.embeds != null && message.embeds!.isNotEmpty)
+        'embeds': message.embeds,
+      if (message.usage != null) 'usage': message.usage,
+      // The OWUI web client reads `sources` in citation shape and
+      // `code_executions` in snake_case; the local parser accepts both
+      // shapes, so the server shape is the only safe one to persist.
+      if (message.sources.isNotEmpty)
+        'sources': convertSourcesToOpenWebUIFormat(message.sources),
+      if (message.statusHistory.isNotEmpty)
+        'statusHistory': message.statusHistory
+            .map((status) => status.toJson())
+            .toList(growable: false),
+      if (message.codeExecutions.isNotEmpty)
+        'code_executions': convertCodeExecutionsToOpenWebUIFormat(
+          message.codeExecutions,
+        ),
+      if (message.followUps.isNotEmpty)
+        'followUps': List<String>.from(message.followUps),
+      if (message.error != null) 'error': message.error!.toJson(),
+    },
+  );
 }
 
 bool _shouldIncludeConversationHistoryMessage(ChatMessage message) {
@@ -14705,7 +14656,8 @@ Map<String, dynamic> _directPersistedMessagePayload(
     if (metadata['modelName'] != null) 'modelName': metadata['modelName'],
     if (message.attachmentIds?.isNotEmpty == true)
       'attachment_ids': List<String>.from(message.attachmentIds!),
-    if (message.files != null) 'files': message.files,
+    if (sanitizeFilesForWebUi(message.files) != null)
+      'files': sanitizeFilesForWebUi(message.files),
     if (message.output != null) 'output': message.output,
     if (message.embeds != null) 'embeds': message.embeds,
     if (message.statusHistory.isNotEmpty)
@@ -14715,13 +14667,11 @@ Map<String, dynamic> _directPersistedMessagePayload(
     if (message.followUps.isNotEmpty)
       'followUps': List<String>.from(message.followUps),
     if (message.codeExecutions.isNotEmpty)
-      'code_executions': message.codeExecutions
-          .map((execution) => execution.toJson())
-          .toList(growable: false),
+      'code_executions': convertCodeExecutionsToOpenWebUIFormat(
+        message.codeExecutions,
+      ),
     if (message.sources.isNotEmpty)
-      'sources': message.sources
-          .map((source) => source.toJson())
-          .toList(growable: false),
+      'sources': convertSourcesToOpenWebUIFormat(message.sources),
     if (message.usage != null) 'usage': message.usage,
     if (message.versions.isNotEmpty)
       'versions': message.versions

--- a/lib/features/chat/providers/chat_providers.dart
+++ b/lib/features/chat/providers/chat_providers.dart
@@ -3731,6 +3731,14 @@ class ChatMessagesNotifier extends Notifier<List<ChatMessage>>
       unawaited(controller.cancel());
     }
     cancelSocketSubscriptions();
+    // Fold any un-flushed streamed content into state before dropping the
+    // buffer — it is not periodically synced, so clearing it here would
+    // silently discard the whole tail of an in-flight response (e.g. on
+    // conversation switch or message deletion mid-stream). Skipped during
+    // provider dispose, where touching state is forbidden and pointless.
+    if (!_disposed) {
+      _syncStreamingBufferToState();
+    }
     _clearStreamingBuffer();
     _streamingSyncTimer?.cancel();
     _streamingSyncTimer = null;

--- a/lib/features/chat/providers/chat_providers.dart
+++ b/lib/features/chat/providers/chat_providers.dart
@@ -82,6 +82,41 @@ part 'chat_composer_providers.dart';
 part 'chat_providers.g.dart';
 
 // Chat messages for current conversation
+/// Parses the Open WebUI `chat:message:follow_ups` socket envelope:
+/// `{chat_id, message_id, data: {type, data: {follow_ups: [...]}}}`.
+/// Returns null when the event is not a usable follow-ups push.
+@visibleForTesting
+({String messageId, List<String> followUps})?
+debugParseFollowUpsSocketEventForTesting(Map<String, dynamic> event) {
+  final data = event['data'];
+  if (data is! Map || data['type'] != 'chat:message:follow_ups') {
+    return null;
+  }
+  final messageId = (event['message_id'] ?? data['message_id'])?.toString();
+  if (messageId == null || messageId.isEmpty) {
+    return null;
+  }
+  final inner = data['data'];
+  final rawFollowUps = inner is Map
+      ? (inner['follow_ups'] ?? inner['followUps'])
+      : null;
+  if (rawFollowUps is! List) {
+    return null;
+  }
+  final followUps = <String>[
+    for (final item in rawFollowUps)
+      if (item != null && item.toString().trim().isNotEmpty)
+        item.toString().trim(),
+  ];
+  if (followUps.isEmpty) {
+    return null;
+  }
+  return (
+    messageId: messageId,
+    followUps: List<String>.unmodifiable(followUps),
+  );
+}
+
 final chatMessagesProvider =
     NotifierProvider<ChatMessagesNotifier, List<ChatMessage>>(
       ChatMessagesNotifier.new,
@@ -2470,6 +2505,16 @@ class ChatMessagesNotifier extends Notifier<List<ChatMessage>>
             activeOpenWebUiChatIdForMutation(ref, owner) == null) {
           return;
         }
+        // The server emits `chat:message:follow_ups` only AFTER
+        // `chat:completion {done:true}`, and the per-stream socket
+        // subscription is disposed synchronously by that done event — this
+        // passive handler is the only delivery path for follow-ups. Apply
+        // the payload directly: the debounced full refetch below races the
+        // server's own persistence of the suggestions (the event is emitted
+        // before the upsert) and can be rejected by adoption guards.
+        if (_applyPassiveFollowUpsEvent(event)) {
+          return;
+        }
         if (!_shouldRefreshFromPassiveSocketEvent(
           event,
           localSessionId: socket.sessionId,
@@ -2483,6 +2528,27 @@ class ChatMessagesNotifier extends Notifier<List<ChatMessage>>
         );
       },
     );
+  }
+
+  /// Applies a pushed `chat:message:follow_ups` payload straight to the
+  /// target message. Returns true when the event was consumed.
+  bool _applyPassiveFollowUpsEvent(Map<String, dynamic> event) {
+    final parsed = debugParseFollowUpsSocketEventForTesting(event);
+    if (parsed == null) {
+      return false;
+    }
+    DebugLogger.log(
+      'follow-ups-received',
+      scope: 'chat/passive-sync',
+      data: {'messageId': parsed.messageId, 'count': parsed.followUps.length},
+    );
+    updateMessageById(parsed.messageId, (current) {
+      if (listEquals(current.followUps, parsed.followUps)) {
+        return current;
+      }
+      return current.copyWith(followUps: parsed.followUps);
+    });
+    return true;
   }
 
   List<ChatMessage> _preserveFreshLocalAssistantState(

--- a/lib/features/chat/providers/chat_providers.dart
+++ b/lib/features/chat/providers/chat_providers.dart
@@ -1176,59 +1176,74 @@ bool failedCompactedHermesApprovalRemainsAdoptableForTest() {
 class _ChatMessageListStructure {
   const _ChatMessageListStructure({required this.ids, required this.signature});
 
+  // ChatMessage is immutable and unchanged messages keep their identity
+  // across chatMessagesProvider emissions, so per-message signature fragments
+  // are cached by identity. This factory runs on every message-list emission;
+  // without the cache it re-derived O(messages × versions) string work each
+  // time even when nothing changed.
+  static final Expando<String> _messageSignatureCache = Expando<String>();
+
   factory _ChatMessageListStructure.fromMessages(List<ChatMessage> messages) {
     final ids = List<String>.unmodifiable(
       messages.map((message) => message.id).toList(growable: false),
     );
     final buffer = StringBuffer();
     for (final message in messages) {
-      buffer
-        ..write(message.id)
-        ..write('\u0000')
-        ..write(message.role)
-        ..write('\u0000')
-        ..write(message.model ?? '')
-        ..write('\u0000')
-        ..write(message.attachmentIds?.length ?? 0)
-        ..write('\u0000')
-        ..write(message.files?.length ?? 0)
-        ..write('\u0000')
-        ..write(message.embeds?.length ?? 0)
-        ..write('\u0000')
-        ..write(message.output?.length ?? 0)
-        ..write('\u0000')
-        ..write(message.statusHistory.length)
-        ..write('\u0000')
-        ..write(message.followUps.length)
-        ..write('\u0000')
-        ..write(message.sources.length)
-        ..write('\u0000')
-        ..write(message.codeExecutions.length)
-        ..write('\u0000')
-        ..write(message.error == null ? 0 : 1)
-        ..write('\u0000')
-        ..write(message.metadata?['archivedVariant'] == true ? 1 : 0)
-        ..write('\u0000')
-        // responseDone flips the rendered turn phase (running footer host /
-        // pin-to-top) while isStreaming is still set, so the list shell must
-        // rebuild on this transition to recompute the timeline.
-        ..write(message.metadata?['responseDone'] == true ? 1 : 0)
-        ..write('\u0000')
-        // Include the displayed model-name fallback so the structure signature
-        // changes whenever the label changes, keeping the list-shell rebuild
-        // trigger in agreement with chat_page's layout signature. Use the
-        // normalized extractor so trim/empty handling matches the displayed name.
-        ..write(_messageModelName(message) ?? '')
-        ..write('\u0000')
-        ..write(message.versions.length);
-      for (final version in message.versions) {
-        buffer
-          ..write('\u0000')
-          ..write(version.model ?? '');
-      }
-      buffer.writeln();
+      buffer.write(
+        _messageSignatureCache[message] ??= _buildMessageSignature(message),
+      );
     }
     return _ChatMessageListStructure(ids: ids, signature: buffer.toString());
+  }
+
+  static String _buildMessageSignature(ChatMessage message) {
+    final buffer = StringBuffer();
+    buffer
+      ..write(message.id)
+      ..write('\u0000')
+      ..write(message.role)
+      ..write('\u0000')
+      ..write(message.model ?? '')
+      ..write('\u0000')
+      ..write(message.attachmentIds?.length ?? 0)
+      ..write('\u0000')
+      ..write(message.files?.length ?? 0)
+      ..write('\u0000')
+      ..write(message.embeds?.length ?? 0)
+      ..write('\u0000')
+      ..write(message.output?.length ?? 0)
+      ..write('\u0000')
+      ..write(message.statusHistory.length)
+      ..write('\u0000')
+      ..write(message.followUps.length)
+      ..write('\u0000')
+      ..write(message.sources.length)
+      ..write('\u0000')
+      ..write(message.codeExecutions.length)
+      ..write('\u0000')
+      ..write(message.error == null ? 0 : 1)
+      ..write('\u0000')
+      ..write(message.metadata?['archivedVariant'] == true ? 1 : 0)
+      ..write('\u0000')
+      // responseDone flips the rendered turn phase (running footer host /
+      // pin-to-top) while isStreaming is still set, so the list shell must
+      // rebuild on this transition to recompute the timeline.
+      ..write(message.metadata?['responseDone'] == true ? 1 : 0)
+      ..write('\u0000')
+      // Include the displayed model-name fallback so the structure signature
+      // changes whenever the label changes, keeping the list-shell rebuild
+      // trigger in agreement with chat_page's layout signature. Use the
+      // normalized extractor so trim/empty handling matches the displayed name.
+      ..write(_messageModelName(message) ?? '')
+      ..write('\u0000')
+      ..write(message.versions.length);
+    for (final version in message.versions) {
+      buffer
+        ..write('\u0000')
+        ..write(version.model ?? '');
+    }
+    buffer.writeln();
+    return buffer.toString();
   }
 
   final List<String> ids;

--- a/lib/features/chat/providers/chat_providers.dart
+++ b/lib/features/chat/providers/chat_providers.dart
@@ -6325,6 +6325,10 @@ class ChatMessagesNotifier extends Notifier<List<ChatMessage>>
           'statusHistory': message.statusHistory
               .map((status) => status.toJson())
               .toList(growable: false),
+        if (message.codeExecutions.isNotEmpty)
+          'codeExecutions': message.codeExecutions
+              .map((execution) => execution.toJson())
+              .toList(growable: false),
         if (message.followUps.isNotEmpty)
           'followUps': List<String>.from(message.followUps),
         if (message.error != null) 'error': message.error!.toJson(),

--- a/lib/features/chat/providers/chat_providers.dart
+++ b/lib/features/chat/providers/chat_providers.dart
@@ -2563,7 +2563,10 @@ class ChatMessagesNotifier extends Notifier<List<ChatMessage>>
     }
     // An unknown message id must fall through to the debounced refetch —
     // consuming the event here would silently drop the payload.
-    if (!state.any((message) => message.id == parsed.messageId)) {
+    final messageIndex = state.indexWhere(
+      (message) => message.id == parsed.messageId,
+    );
+    if (messageIndex == -1) {
       return false;
     }
     DebugLogger.log(
@@ -2577,6 +2580,10 @@ class ChatMessagesNotifier extends Notifier<List<ChatMessage>>
       }
       return current.copyWith(followUps: parsed.followUps);
     });
+    // The turn echo was persisted at completion, before this event fired.
+    // Re-persist the message so the suggestions survive a conversation
+    // switch (the local Drift copy would otherwise reload without them).
+    _persistCompletedTurnForMessage(messageIndex);
     return true;
   }
 

--- a/lib/features/chat/providers/chat_providers.dart
+++ b/lib/features/chat/providers/chat_providers.dart
@@ -87,7 +87,12 @@ part 'chat_providers.g.dart';
 /// Returns null when the event is not a usable follow-ups push.
 @visibleForTesting
 ({String messageId, List<String> followUps})?
-debugParseFollowUpsSocketEventForTesting(Map<String, dynamic> event) {
+debugParseFollowUpsSocketEventForTesting(Map<String, dynamic> event) =>
+    _parseFollowUpsSocketEvent(event);
+
+({String messageId, List<String> followUps})? _parseFollowUpsSocketEvent(
+  Map<String, dynamic> event,
+) {
   final data = event['data'];
   if (data is! Map || data['type'] != 'chat:message:follow_ups') {
     return null;
@@ -2533,8 +2538,13 @@ class ChatMessagesNotifier extends Notifier<List<ChatMessage>>
   /// Applies a pushed `chat:message:follow_ups` payload straight to the
   /// target message. Returns true when the event was consumed.
   bool _applyPassiveFollowUpsEvent(Map<String, dynamic> event) {
-    final parsed = debugParseFollowUpsSocketEventForTesting(event);
+    final parsed = _parseFollowUpsSocketEvent(event);
     if (parsed == null) {
+      return false;
+    }
+    // An unknown message id must fall through to the debounced refetch —
+    // consuming the event here would silently drop the payload.
+    if (!state.any((message) => message.id == parsed.messageId)) {
       return false;
     }
     DebugLogger.log(

--- a/lib/features/chat/providers/reasoning_effort_provider.dart
+++ b/lib/features/chat/providers/reasoning_effort_provider.dart
@@ -318,9 +318,10 @@ String reasoningEffortForModel(ReasoningEffortReader read, Model? model) {
         kAutomaticReasoningEffort;
   }
   if (read(apiServiceProvider) != null) {
-    final configured = read(
-      personalizationSettingsProvider,
-    ).asData?.value.reasoningEffort;
+    final configured = read(personalizationSettingsProvider)
+        .asData
+        ?.value
+        .reasoningEffort;
     return policy.effectiveConfiguredEffort(configured) ??
         kAutomaticReasoningEffort;
   }
@@ -433,15 +434,13 @@ Future<void> setReasoningEffortForModel(
     return;
   }
   if (isHermesModel(model)) {
-    await read(
-      localReasoningEffortsProvider.notifier,
-    ).set('hermes:${model.id}', configured);
+    await read(localReasoningEffortsProvider.notifier)
+        .set('hermes:${model.id}', configured);
     return;
   }
   if (read(apiServiceProvider) != null) {
-    await read(
-      personalizationSettingsProvider.notifier,
-    ).setReasoningEffort(configured);
+    await read(personalizationSettingsProvider.notifier)
+        .setReasoningEffort(configured);
   }
 }
 

--- a/lib/features/chat/services/chat_history_reader.dart
+++ b/lib/features/chat/services/chat_history_reader.dart
@@ -5,8 +5,9 @@ import '../../../core/database/mappers/conversation_assembler.dart';
 import '../../../core/models/chat_message.dart';
 import '../../../core/models/conversation.dart';
 
-typedef AuthoritativeConversationLoader =
-    Future<Conversation> Function(Conversation conversation);
+typedef AuthoritativeConversationLoader = Future<Conversation> Function(
+  Conversation conversation,
+);
 
 @immutable
 final class CompleteChatHistory {

--- a/lib/features/chat/services/clipboard_attachment_service.dart
+++ b/lib/features/chat/services/clipboard_attachment_service.dart
@@ -1,16 +1,21 @@
 import 'dart:async';
 import 'dart:io';
 import 'dart:typed_data';
+
 import 'package:path/path.dart' as path;
 import 'package:path_provider/path_provider.dart';
+
 import '../../../core/utils/debug_logger.dart';
 import 'file_attachment_service.dart';
 import 'ios_native_paste_service.dart';
 
-typedef PastedAttachmentUploader =
-    Future<void> Function(LocalAttachment attachment, int fileSize);
-typedef PastedAttachmentRollback =
-    Future<void> Function(LocalAttachment attachment);
+typedef PastedAttachmentUploader = Future<void> Function(
+  LocalAttachment attachment,
+  int fileSize,
+);
+typedef PastedAttachmentRollback = Future<void> Function(
+  LocalAttachment attachment,
+);
 
 const int maxPastedImageBytes = 20 * 1024 * 1024;
 const int _maxNativePasteBatchBytes = 60 * 1024 * 1024;
@@ -108,17 +113,16 @@ Future<void> _prepareAcceptedPastedAttachments({
 
   for (final attachment in attachments) {
     unawaited(
-      Future<void>.sync(
-        () => upload(attachment, fileSizes[attachment]!),
-      ).catchError((Object error, StackTrace stackTrace) {
-        DebugLogger.error(
-          'Pasted attachment upload failed',
-          scope: logScope,
-          error: error,
-          stackTrace: stackTrace,
-          data: {'fileName': attachment.displayName},
-        );
-      }),
+      Future<void>.sync(() => upload(attachment, fileSizes[attachment]!))
+          .catchError((Object error, StackTrace stackTrace) {
+            DebugLogger.error(
+              'Pasted attachment upload failed',
+              scope: logScope,
+              error: error,
+              stackTrace: stackTrace,
+              data: {'fileName': attachment.displayName},
+            );
+          }),
     );
   }
 }
@@ -295,9 +299,8 @@ class ClipboardAttachmentService {
                 FileSystemEntityType.notFound &&
             _entityType(prepared.reclaimingMarkerPath) ==
                 FileSystemEntityType.notFound) {
-          File(
-            prepared.dartOwnedMarkerPath,
-          ).renameSync(prepared.pendingMarkerPath);
+          File(prepared.dartOwnedMarkerPath)
+              .renameSync(prepared.pendingMarkerPath);
         }
       } catch (_) {}
       rethrow;

--- a/lib/features/chat/services/ios_native_paste_service.dart
+++ b/lib/features/chat/services/ios_native_paste_service.dart
@@ -5,11 +5,10 @@ import 'package:flutter/foundation.dart';
 import '../../../core/platform/conduit_platform_apis.g.dart';
 import '../../../core/utils/debug_logger.dart';
 
-typedef IosNativePasteHandler =
-    Future<void> Function(
-      IosNativePastePayload payload,
-      IosNativePasteDispatchLease lease,
-    );
+typedef IosNativePasteHandler = Future<void> Function(
+  IosNativePastePayload payload,
+  IosNativePasteDispatchLease lease,
+);
 
 enum _IosNativePasteDispatchLeaseState { active, committed, invalidated }
 
@@ -120,9 +119,8 @@ class IosNativePasteService {
     IosNativePastePayload nativePayload,
     Duration timeout,
   ) {
-    if (nativePayload case IosNativeImagePaste(
-      :final deliveryId,
-    ) when !isValidIosNativePasteDeliveryId(deliveryId)) {
+    if (nativePayload case IosNativeImagePaste(:final deliveryId)
+        when !isValidIosNativePasteDeliveryId(deliveryId)) {
       return Future<bool>.value(false);
     }
     final lease = IosNativePasteDispatchLease._();

--- a/lib/features/chat/services/native_stt_service.dart
+++ b/lib/features/chat/services/native_stt_service.dart
@@ -210,14 +210,16 @@ class NativeSttService {
     );
 
     try {
-      final response = await _methodChannel
-          .invokeMapMethod<Object?, Object?>('start', <String, Object?>{
-            'localeId': localeId,
-            'preserveAudioSession': preserveAudioSession,
-            'emitPartialResults': emitPartialResults,
-            'accumulateResults': accumulateResults,
-            'allowOnlineFallback': allowOnlineFallback,
-          });
+      final response = await _methodChannel.invokeMapMethod<Object?, Object?>(
+        'start',
+        <String, Object?>{
+          'localeId': localeId,
+          'preserveAudioSession': preserveAudioSession,
+          'emitPartialResults': emitPartialResults,
+          'accumulateResults': accumulateResults,
+          'allowOnlineFallback': allowOnlineFallback,
+        },
+      );
       final availability = NativeSttAvailability.fromMap(response);
       if (!availability.available) {
         throw NativeSttException(

--- a/lib/features/chat/utils/follow_ups_socket_event.dart
+++ b/lib/features/chat/utils/follow_ups_socket_event.dart
@@ -1,0 +1,34 @@
+/// Parses the Open WebUI `chat:message:follow_ups` socket envelope:
+/// `{chat_id, message_id, data: {type, data: {follow_ups: [...]}}}`.
+/// Returns null when the event is not a usable follow-ups push.
+({String messageId, List<String> followUps})? parseFollowUpsSocketEvent(
+  Map<String, dynamic> event,
+) {
+  final data = event['data'];
+  if (data is! Map || data['type'] != 'chat:message:follow_ups') {
+    return null;
+  }
+  final messageId = (event['message_id'] ?? data['message_id'])?.toString();
+  if (messageId == null || messageId.isEmpty) {
+    return null;
+  }
+  final inner = data['data'];
+  final rawFollowUps = inner is Map
+      ? (inner['follow_ups'] ?? inner['followUps'])
+      : null;
+  if (rawFollowUps is! List) {
+    return null;
+  }
+  final followUps = <String>[
+    for (final item in rawFollowUps)
+      if (item != null && item.toString().trim().isNotEmpty)
+        item.toString().trim(),
+  ];
+  if (followUps.isEmpty) {
+    return null;
+  }
+  return (
+    messageId: messageId,
+    followUps: List<String>.unmodifiable(followUps),
+  );
+}

--- a/lib/features/chat/views/chat_page.dart
+++ b/lib/features/chat/views/chat_page.dart
@@ -162,8 +162,7 @@ class _ScrollableCenteredEmptyState extends StatelessWidget {
 // A 120 px streaming cache extent evicted rows almost immediately when
 // scrolling up mid-stream; remounting a settled row runs a synchronous
 // markdown compile, so the small extent bought hitches, not savings.
-@visibleForTesting
-double debugChatMessageScrollCachePixels({required bool streaming}) => 600.0;
+const double _chatMessageScrollCachePixels = 600.0;
 
 @visibleForTesting
 bool shouldShowChatModelDropdown({
@@ -2742,7 +2741,7 @@ class _ChatPageState extends ConsumerState<ChatPage> {
       topContentInset: topPadding,
       bottomPadding: bottomPadding,
       horizontalPadding: Spacing.inputPadding,
-      cacheExtent: debugChatMessageScrollCachePixels(streaming: isStreaming),
+      cacheExtent: _chatMessageScrollCachePixels,
       physics: platformAlwaysScrollablePhysics(context),
       isLoadingOlder: paging.isLoadingOlder,
       maintainVisibleAnchor:
@@ -3034,7 +3033,10 @@ class _ChatPageState extends ConsumerState<ChatPage> {
                 chatMessageByIdProvider(messageId),
               );
               if (currentMessage != null) {
-                _copyMessage(currentMessage.content);
+                // User content is stored raw (never presentation-escaped) and
+                // owns its markup; copy it verbatim — the assistant clipboard
+                // sanitizer would decode entities the user actually typed.
+                Clipboard.setData(ClipboardData(text: currentMessage.content));
               }
             },
             onDelete: () {

--- a/lib/features/chat/views/chat_page.dart
+++ b/lib/features/chat/views/chat_page.dart
@@ -1743,11 +1743,18 @@ class _ChatPageState extends ConsumerState<ChatPage> {
   _recomputeBottomAnchorState() {
     final hasScrollableContent = _hasScrollableTranscriptContent();
     final distanceFromBottom = _latestPresentationDistance();
+    final wasAnchored = _bottomAnchorController.isAnchoredToBottom;
     _bottomAnchorController.updateAnchor(
       hasScrollableContent: hasScrollableContent,
       distanceFromBottom: distanceFromBottom,
     );
-    _syncLayoutBottomAnchor();
+    // Only re-arm layout maintenance when the anchored state actually
+    // transitions. This runs on every metrics tick; while streaming and
+    // anchored, an unconditional sync scheduled a full measurement pass
+    // (row-rect snapshot + pin geometry) every frame of a downward scroll.
+    if (_bottomAnchorController.isAnchoredToBottom != wasAnchored) {
+      _syncLayoutBottomAnchor();
+    }
     return (
       hasScrollableContent: hasScrollableContent,
       distanceFromBottom: distanceFromBottom,

--- a/lib/features/chat/views/chat_page.dart
+++ b/lib/features/chat/views/chat_page.dart
@@ -159,9 +159,11 @@ class _ScrollableCenteredEmptyState extends StatelessWidget {
   }
 }
 
+// A 120 px streaming cache extent evicted rows almost immediately when
+// scrolling up mid-stream; remounting a settled row runs a synchronous
+// markdown compile, so the small extent bought hitches, not savings.
 @visibleForTesting
-double debugChatMessageScrollCachePixels({required bool streaming}) =>
-    streaming ? 120.0 : 600.0;
+double debugChatMessageScrollCachePixels({required bool streaming}) => 600.0;
 
 @visibleForTesting
 bool shouldShowChatModelDropdown({
@@ -336,6 +338,21 @@ class _ChatPageState extends ConsumerState<ChatPage> {
   _ChatTimelineScrollMode _timelineScrollMode =
       _ChatTimelineScrollMode.followingLatest;
   final _stableLayoutCache = _ChatListStableLayoutCache();
+  // Identity-stable transcript window, render model, and rowBuilder. The shell
+  // rebuilds far more often than the transcript changes (drag setState,
+  // keyboard insets, pin transitions); keeping these identities stable lets
+  // the viewport's sliver delegate skip rebuilding every mounted row, and lets
+  // the stable-layout cache hit its identity fast path.
+  List<ChatMessage>? _transcriptWindowSource;
+  int _transcriptWindowCount = -1;
+  List<ChatMessage> _transcriptWindowMemo = const <ChatMessage>[];
+  List<ChatMessage>? _timelineModelSource;
+  int _timelineModelGeneration = -1;
+  ChatTimelineRenderModel? _timelineModelMemo;
+  ChatTimelineRenderModel? _rowBuilderTimeline;
+  _ChatListStableLayoutMetadata? _rowBuilderLayout;
+  bool _rowBuilderSuppressHaptics = false;
+  ChatTimelineRowBuilder? _rowBuilderMemo;
   String? _cachedGreetingName;
   bool _greetingReady = false;
   ProviderSubscription<String?>? _screenContextSub;
@@ -1023,7 +1040,7 @@ class _ChatPageState extends ConsumerState<ChatPage> {
     _bottomAnchorController.requestBottomAnchor();
     final generation = ++_pinPositionGeneration;
     final topInset =
-        MediaQuery.of(context).padding.top +
+        MediaQuery.paddingOf(context).top +
         conduitAdaptiveToolbarHeightOf(context) +
         Spacing.md;
     _pinToTopEndSpaceExtent = math.max(
@@ -1872,10 +1889,14 @@ class _ChatPageState extends ConsumerState<ChatPage> {
     List<ChatMessage> completeMessages,
     ChatTranscriptPagingState paging,
   ) {
-    return latestTranscriptWindow(
-      completeMessages,
-      _renderedTranscriptCount(completeMessages, paging),
-    );
+    final count = _renderedTranscriptCount(completeMessages, paging);
+    if (!identical(_transcriptWindowSource, completeMessages) ||
+        count != _transcriptWindowCount) {
+      _transcriptWindowSource = completeMessages;
+      _transcriptWindowCount = count;
+      _transcriptWindowMemo = latestTranscriptWindow(completeMessages, count);
+    }
+    return _transcriptWindowMemo;
   }
 
   bool _hasScrollableTranscriptContent() {
@@ -2563,7 +2584,7 @@ class _ChatPageState extends ConsumerState<ChatPage> {
     // list owns it.
     // Add padding for the floating app bar and overlaid composer skeleton.
     final topPadding =
-        MediaQuery.of(context).padding.top +
+        MediaQuery.paddingOf(context).top +
         conduitAdaptiveToolbarHeightOf(context) +
         Spacing.md;
     final bottomPadding = _messageListBottomPadding();
@@ -2614,7 +2635,7 @@ class _ChatPageState extends ConsumerState<ChatPage> {
       child: Container(
         margin: const EdgeInsets.only(bottom: Spacing.md),
         constraints: BoxConstraints(
-          maxWidth: MediaQuery.of(context).size.width * 0.82,
+          maxWidth: MediaQuery.sizeOf(context).width * 0.82,
         ),
         padding: const EdgeInsets.all(Spacing.md),
         decoration: BoxDecoration(
@@ -2650,7 +2671,7 @@ class _ChatPageState extends ConsumerState<ChatPage> {
     final paging = watchRef.watch(chatTranscriptPagingProvider);
 
     final topPadding =
-        MediaQuery.of(context).padding.top +
+        MediaQuery.paddingOf(context).top +
         conduitAdaptiveToolbarHeightOf(context) +
         Spacing.md;
     final bottomPadding = _messageListBottomPadding();
@@ -2666,11 +2687,7 @@ class _ChatPageState extends ConsumerState<ChatPage> {
       models: models,
       apiService: apiService,
     );
-    final timeline = ChatTimelineRenderModel.fromMessages(
-      messages,
-      duplicateReportScope:
-          '${identityHashCode(this)}:$_conversationOwnerGeneration',
-    );
+    final timeline = _resolveTimelineRenderModel(messages);
     _scheduleMarkdownPrewarm(messages, layoutMetadata: layoutMetadata);
     _syncLayoutBottomAnchor();
 
@@ -2687,19 +2704,6 @@ class _ChatPageState extends ConsumerState<ChatPage> {
     }
 
     final messageIds = timeline.messageIds;
-    // Reversed iteration plus map overwrite preserves the first source row for
-    // malformed duplicate IDs while keeping the indexed fast path allocation-free.
-    late final historyMessagesById = <String, ChatMessage>{
-      for (final message in timeline.historyMessages.reversed)
-        message.id: message,
-    };
-    late final layoutRowsByMessageId = <String, _ChatRowLayoutMetadata>{
-      for (final row in layoutMetadata.rows.reversed) row.messageId: row,
-    };
-    ChatMessage? historyMessageById(String messageId) =>
-        historyMessagesById[messageId];
-    _ChatRowLayoutMetadata? layoutRowByMessageId(String messageId) =>
-        layoutRowsByMessageId[messageId];
     final hideForInitialPin = debugShouldHideTranscriptForInitialPinForTesting(
       settleImmediately: _pinShouldSettleImmediately,
       positionSettled: _pinToTopPositionSettled,
@@ -2788,33 +2792,94 @@ class _ChatPageState extends ConsumerState<ChatPage> {
       onOldestThresholdReached: _maybeLoadOlderMessages,
       onTrailingRefresh: _refreshActiveConversation,
       onNativeScrollToTop: _handleNativeScrollToTop,
-      rowBuilder: (context, renderIndex) {
-        final sourceIndex = timeline.sourceIndexAtRenderIndex(renderIndex);
-        if (sourceIndex == null || renderIndex >= messageIds.length) {
-          return const SizedBox.shrink();
-        }
-        final renderedMessageId = messageIds[renderIndex];
-        final tailRenderIndex = timeline.tailAssistantRenderIndex;
-        if (tailRenderIndex != null && renderIndex == tailRenderIndex) {
-          return _buildTailAssistantRow(
-            timeline: timeline,
-            layoutMetadata: layoutMetadata,
-            sourceIndex: sourceIndex,
-            layoutRowByMessageId: layoutRowByMessageId,
-            suppressStreamingHaptics: suppressAssistantStreamingHaptics,
-          );
-        }
-        return _buildHistoryRow(
+      rowBuilder: _resolveTimelineRowBuilder(
+        timeline: timeline,
+        layoutMetadata: layoutMetadata,
+        suppressStreamingHaptics: suppressAssistantStreamingHaptics,
+      ),
+    );
+  }
+
+  ChatTimelineRenderModel _resolveTimelineRenderModel(
+    List<ChatMessage> messages,
+  ) {
+    final memo = _timelineModelMemo;
+    if (memo != null &&
+        identical(_timelineModelSource, messages) &&
+        _timelineModelGeneration == _conversationOwnerGeneration) {
+      return memo;
+    }
+    _timelineModelSource = messages;
+    _timelineModelGeneration = _conversationOwnerGeneration;
+    return _timelineModelMemo = ChatTimelineRenderModel.fromMessages(
+      messages,
+      duplicateReportScope:
+          '${identityHashCode(this)}:$_conversationOwnerGeneration',
+    );
+  }
+
+  /// Returns an identity-stable rowBuilder for unchanged inputs so the
+  /// viewport's sliver delegate can skip rebuilding mounted rows on
+  /// shell-only rebuilds. Rows read live message state through their own
+  /// Consumers, so the closure only needs to change when the timeline
+  /// structure or stable layout metadata does.
+  ChatTimelineRowBuilder _resolveTimelineRowBuilder({
+    required ChatTimelineRenderModel timeline,
+    required _ChatListStableLayoutMetadata layoutMetadata,
+    required bool suppressStreamingHaptics,
+  }) {
+    final memo = _rowBuilderMemo;
+    if (memo != null &&
+        identical(_rowBuilderTimeline, timeline) &&
+        identical(_rowBuilderLayout, layoutMetadata) &&
+        _rowBuilderSuppressHaptics == suppressStreamingHaptics) {
+      return memo;
+    }
+    final messageIds = timeline.messageIds;
+    // Reversed iteration plus map overwrite preserves the first source row for
+    // malformed duplicate IDs while keeping the indexed fast path allocation-free.
+    late final historyMessagesById = <String, ChatMessage>{
+      for (final message in timeline.historyMessages.reversed)
+        message.id: message,
+    };
+    late final layoutRowsByMessageId = <String, _ChatRowLayoutMetadata>{
+      for (final row in layoutMetadata.rows.reversed) row.messageId: row,
+    };
+    ChatMessage? historyMessageById(String messageId) =>
+        historyMessagesById[messageId];
+    _ChatRowLayoutMetadata? layoutRowByMessageId(String messageId) =>
+        layoutRowsByMessageId[messageId];
+    Widget rowBuilder(BuildContext context, int renderIndex) {
+      final sourceIndex = timeline.sourceIndexAtRenderIndex(renderIndex);
+      if (sourceIndex == null || renderIndex >= messageIds.length) {
+        return const SizedBox.shrink();
+      }
+      final renderedMessageId = messageIds[renderIndex];
+      final tailRenderIndex = timeline.tailAssistantRenderIndex;
+      if (tailRenderIndex != null && renderIndex == tailRenderIndex) {
+        return _buildTailAssistantRow(
           timeline: timeline,
           layoutMetadata: layoutMetadata,
-          requestedMessageId: renderedMessageId,
           sourceIndex: sourceIndex,
-          historyMessageById: historyMessageById,
           layoutRowByMessageId: layoutRowByMessageId,
-          suppressStreamingHaptics: suppressAssistantStreamingHaptics,
+          suppressStreamingHaptics: suppressStreamingHaptics,
         );
-      },
-    );
+      }
+      return _buildHistoryRow(
+        timeline: timeline,
+        layoutMetadata: layoutMetadata,
+        requestedMessageId: renderedMessageId,
+        sourceIndex: sourceIndex,
+        historyMessageById: historyMessageById,
+        layoutRowByMessageId: layoutRowByMessageId,
+        suppressStreamingHaptics: suppressStreamingHaptics,
+      );
+    }
+
+    _rowBuilderTimeline = timeline;
+    _rowBuilderLayout = layoutMetadata;
+    _rowBuilderSuppressHaptics = suppressStreamingHaptics;
+    return _rowBuilderMemo = rowBuilder;
   }
 
   Widget _buildTailAssistantRow({
@@ -3262,7 +3327,7 @@ class _ChatPageState extends ConsumerState<ChatPage> {
     // Add top padding for the floating app bar and bottom padding for the
     // overlaid composer section.
     final topPadding =
-        MediaQuery.of(context).padding.top +
+        MediaQuery.paddingOf(context).top +
         conduitAdaptiveToolbarHeightOf(context) +
         Spacing.md;
     final bottomPadding = _messageListBottomPadding();

--- a/lib/features/chat/views/chat_timeline_render_model.dart
+++ b/lib/features/chat/views/chat_timeline_render_model.dart
@@ -74,10 +74,7 @@ class ChatTimelineRenderModel {
     if (duplicateCount > 0) {
       final newlyObservedIds = <String>[];
       for (final messageId in duplicateMessageIds) {
-        final reportKey = (
-          scope: duplicateReportScope,
-          messageId: messageId,
-        );
+        final reportKey = (scope: duplicateReportScope, messageId: messageId);
         if (_reportedDuplicateMessageIds.remove(reportKey)) {
           _reportedDuplicateMessageIds.add(reportKey);
           continue;

--- a/lib/features/chat/voice_call/presentation/voice_call_launcher.dart
+++ b/lib/features/chat/voice_call/presentation/voice_call_launcher.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../../../../core/providers/app_providers.dart';

--- a/lib/features/chat/widgets/assistant_message_widget.dart
+++ b/lib/features/chat/widgets/assistant_message_widget.dart
@@ -1831,6 +1831,24 @@ class _AssistantMessageWidgetState extends ConsumerState<AssistantMessageWidget>
     );
   }
 
+  // The error heuristics are four full-content scans; the footer rebuilds far
+  // more often than the content changes, so memoize by string identity.
+  String? _errorScanContent;
+  bool _errorScanResult = false;
+
+  bool get _displayedContentLooksLikeError {
+    final content = _displayedContent;
+    if (!identical(_errorScanContent, content)) {
+      _errorScanContent = content;
+      _errorScanResult =
+          content.contains('⚠️') ||
+          content.contains('Error') ||
+          content.contains('timeout') ||
+          content.contains('retry options');
+    }
+    return _errorScanResult;
+  }
+
   List<_AssistantFooterAction> _buildFooterActions() {
     final l10n = AppLocalizations.of(context)!;
     final ttsState = ref.read(textToSpeechControllerProvider);
@@ -1839,12 +1857,7 @@ class _AssistantMessageWidgetState extends ConsumerState<AssistantMessageWidget>
     final messageId = _messageId;
     final activeError = _getActiveError();
     final hasErrorField = activeError != null;
-    final isErrorMessage =
-        hasErrorField ||
-        _displayedContent.contains('⚠️') ||
-        _displayedContent.contains('Error') ||
-        _displayedContent.contains('timeout') ||
-        _displayedContent.contains('retry options');
+    final isErrorMessage = hasErrorField || _displayedContentLooksLikeError;
 
     final isActiveMessage = ttsState.activeMessageId == messageId;
     final isSpeaking =

--- a/lib/features/chat/widgets/assistant_message_widget.dart
+++ b/lib/features/chat/widgets/assistant_message_widget.dart
@@ -1134,7 +1134,10 @@ class _AssistantMessageWidgetState extends ConsumerState<AssistantMessageWidget>
           ),
 
           // Footer slot: keep completion actions inside the message while the
-          // running turn indicator is owned by the timeline.
+          // running turn indicator is owned by the timeline. The plain action
+          // row is extent-matched to the timeline's typing indicator (16+32
+          // vs 16+28+4) so the settle swap does not shift the
+          // bottom-anchored viewport; see settle_height_test.dart.
           if (!hasQueuedCompletion)
             AnimatedSwitcher(
               // The running indicator is owned by the timeline footer now, so

--- a/lib/features/chat/widgets/chat_timeline_viewport.dart
+++ b/lib/features/chat/widgets/chat_timeline_viewport.dart
@@ -699,6 +699,9 @@ class _ChatTimelineViewportState extends State<ChatTimelineViewport>
     });
   }
 
+  // Deliberately uncached: anchor settlement and pin seeks measure across
+  // intra-frame jumpTo corrections, where a per-frame snapshot would serve a
+  // pre-jump rect and double-apply corrections.
   Rect? _rowRect(String messageId) {
     final key = _rowKeys[messageId];
     return key == null ? null : _globalRectFor(key);
@@ -1059,6 +1062,14 @@ class _ChatTimelineViewportState extends State<ChatTimelineViewport>
         _pinGeometryReported = true;
         widget.onPinEndSpaceChanged(0);
       }
+      return;
+    }
+    // Mid-scroll the pin's fixed pixel target and viewport-sized support
+    // cannot change; once geometry has been reported, skip the global
+    // measurements until the motion settles (drag end re-runs maintenance).
+    if (_pinGeometryReported &&
+        _scrollController.hasClients &&
+        _scrollController.position.isScrollingNotifier.value) {
       return;
     }
     final viewport = _viewportRect;
@@ -1712,12 +1723,16 @@ class _ChatTimelineViewportState extends State<ChatTimelineViewport>
     } else if (notification is ScrollEndNotification) {
       _handleUserDragEnd();
     } else if (notification is UserScrollNotification) {
-      if (notification.direction == ScrollDirection.idle) {
-        _handleUserDragEnd();
-      } else {
-        // Pointer-signal scrolling (mouse wheels and trackpads) has no
-        // dragDetails, but it does publish a non-idle user direction. Driven
-        // animateTo activity does not, so it cannot steal manual ownership.
+      // Pointer-signal scrolling (mouse wheels and trackpads) has no
+      // dragDetails, but it does publish a non-idle user direction. Driven
+      // animateTo activity does not, so it cannot steal manual ownership.
+      //
+      // direction == idle is deliberately NOT treated as drag end: Flutter
+      // publishes it when the ballistic phase STARTS (goBallistic), not when
+      // motion stops. Ending the drag there ran mode flips and jump-to-latest
+      // arming mid-fling; ScrollEndNotification above fires at actual rest
+      // for drags, flings, and pointer-signal scrolling alike.
+      if (notification.direction != ScrollDirection.idle) {
         _handleUserDragStart();
       }
     }

--- a/lib/features/chat/widgets/chat_timeline_viewport.dart
+++ b/lib/features/chat/widgets/chat_timeline_viewport.dart
@@ -1859,13 +1859,15 @@ class _ChatTimelineViewportState extends State<ChatTimelineViewport>
                   horizontal: widget.horizontalPadding,
                 ),
                 sliver: SliverList(
-                  delegate: SliverChildBuilderDelegate(
+                  delegate: _TimelineRowDelegate(
                     (context, index) =>
                         _buildRow(context, centerIndex - 1 - index),
                     childCount: centerIndex,
-                    addSemanticIndexes: false,
                     findChildIndexCallback: (key) =>
                         _olderChildIndexForKey(key, centerIndex),
+                    rowBuilder: widget.rowBuilder,
+                    entries: _timelineEntries,
+                    centerIndex: centerIndex,
                   ),
                 ),
               ),
@@ -1875,12 +1877,14 @@ class _ChatTimelineViewportState extends State<ChatTimelineViewport>
                   horizontal: widget.horizontalPadding,
                 ),
                 sliver: SliverList(
-                  delegate: SliverChildBuilderDelegate(
+                  delegate: _TimelineRowDelegate(
                     (context, index) => _buildRow(context, centerIndex + index),
                     childCount: _messageIds.length - centerIndex,
-                    addSemanticIndexes: false,
                     findChildIndexCallback: (key) =>
                         _centerChildIndexForKey(key, centerIndex),
+                    rowBuilder: widget.rowBuilder,
+                    entries: _timelineEntries,
+                    centerIndex: centerIndex,
                   ),
                 ),
               ),
@@ -1966,6 +1970,33 @@ class _ChatTimelineViewportState extends State<ChatTimelineViewport>
           ),
       ],
     );
+  }
+}
+
+/// SliverChildBuilderDelegate whose `shouldRebuild` defaults to true, which
+/// made every shell rebuild (drag-start setState, keyboard insets, pin
+/// transitions) rebuild every mounted row. Row content is derived entirely
+/// from [rowBuilder] and [entries]; per-row Consumers pick up message-level
+/// changes on their own, so identical inputs mean no rebuild is needed.
+class _TimelineRowDelegate extends SliverChildBuilderDelegate {
+  const _TimelineRowDelegate(
+    super.builder, {
+    required super.childCount,
+    required super.findChildIndexCallback,
+    required this.rowBuilder,
+    required this.entries,
+    required this.centerIndex,
+  }) : super(addSemanticIndexes: false);
+
+  final ChatTimelineRowBuilder rowBuilder;
+  final List<({String id, int sourceIndex})> entries;
+  final int centerIndex;
+
+  @override
+  bool shouldRebuild(covariant _TimelineRowDelegate oldDelegate) {
+    return !identical(rowBuilder, oldDelegate.rowBuilder) ||
+        !identical(entries, oldDelegate.entries) ||
+        centerIndex != oldDelegate.centerIndex;
   }
 }
 

--- a/lib/features/chat/widgets/streaming_status_widget.dart
+++ b/lib/features/chat/widgets/streaming_status_widget.dart
@@ -21,7 +21,14 @@ List<ChatStatusUpdate> filterVisibleStatusUpdates(
   if (isStreaming) {
     return visible;
   }
-  return visible.where((u) => u.done != false).toList(growable: false);
+  final settled = visible.where((u) => u.done != false).toList(growable: false);
+  if (settled.isEmpty && visible.isNotEmpty) {
+    // A turn whose only status updates never reported done would drop the
+    // whole status row at settle — a visible layout jump — and lose the best
+    // description of what the turn did. Keep the last update instead.
+    return [visible.last];
+  }
+  return settled;
 }
 
 /// A minimal, unobtrusive streaming status widget inspired by OpenWebUI.

--- a/lib/features/direct_connections/controllers/direct_connection_editor_workflow.dart
+++ b/lib/features/direct_connections/controllers/direct_connection_editor_workflow.dart
@@ -233,10 +233,12 @@ final class DirectEditorMessages {
   final String Function(DirectConnectionProbe probe) probeMessage;
 }
 
-typedef DirectCredentialTransferConfirmation =
-    Future<bool> Function(DirectConnectionProfile draft);
-typedef DirectDeleteConfirmation =
-    Future<bool> Function(DirectConnectionProfile savedProfile);
+typedef DirectCredentialTransferConfirmation = Future<bool> Function(
+  DirectConnectionProfile draft,
+);
+typedef DirectDeleteConfirmation = Future<bool> Function(
+  DirectConnectionProfile savedProfile,
+);
 
 /// Owns persistence and the save/test/delete operation state machine.
 final class DirectConnectionEditorWorkflow extends ChangeNotifier {

--- a/lib/features/direct_connections/models/ollama_thinking.dart
+++ b/lib/features/direct_connections/models/ollama_thinking.dart
@@ -34,9 +34,8 @@ Map<String, String> normalizeOllamaThinkingByModel(Map<String, String> values) {
         modelId.contains('\u0000')) {
       throw const FormatException('Ollama model id is invalid.');
     }
-    normalized[modelId] = OllamaThinkingSetting.fromStorage(
-      entry.value,
-    ).storageValue;
+    normalized[modelId] = OllamaThinkingSetting.fromStorage(entry.value)
+        .storageValue;
   }
   return normalized;
 }

--- a/lib/features/direct_connections/providers/direct_connection_providers.dart
+++ b/lib/features/direct_connections/providers/direct_connection_providers.dart
@@ -57,8 +57,9 @@ enum DirectHistoryPolicy {
       syncWithOpenWebUI;
 }
 
-typedef DirectHistoryPolicyWriter =
-    Future<void> Function(DirectHistoryPolicy policy);
+typedef DirectHistoryPolicyWriter = Future<void> Function(
+  DirectHistoryPolicy policy,
+);
 
 /// Persistence seam kept separate so ordering can be verified without relying
 /// on platform-specific preference write timing.
@@ -115,9 +116,9 @@ final directConnectionProfileStoreProvider =
 /// provider-facing model id for server-backed chats, so this device-local key
 /// does not affect cross-device history/model rebinding.
 final directDeviceTrustKeyProvider = FutureProvider<List<int>>(
-  (ref) => SecureCredentialStorage(
-    instance: ref.watch(secureStorageProvider),
-  ).getOrCreateOpenWebUiDirectIdentityKey(),
+  (ref) =>
+      SecureCredentialStorage(instance: ref.watch(secureStorageProvider))
+          .getOrCreateOpenWebUiDirectIdentityKey(),
 );
 
 /// Compatibility name retained for the Open WebUI record-identity callers.
@@ -774,9 +775,8 @@ class OllamaModelLifecycle extends _$OllamaModelLifecycle {
     final previous = state.value ?? OllamaModelLifecycleState();
     try {
       final profile = await _readProfile();
-      final loaded = await _requireLifecycleAdapter(
-        profile,
-      ).listRunningModelIds(profile);
+      final loaded = await _requireLifecycleAdapter(profile)
+          .listRunningModelIds(profile);
       if (ref.mounted && generation == _operationGeneration) {
         final latest = state.value ?? previous;
         state = AsyncData(latest.copyWith(loadedModelIds: loaded));

--- a/lib/features/direct_connections/services/direct_chat_bridge.dart
+++ b/lib/features/direct_connections/services/direct_chat_bridge.dart
@@ -26,8 +26,10 @@ final RegExp _directOpenWebUiFileReferencePattern = RegExp(
   r'/api/v1/files/([^/]+)(?:/content)?/?$',
 );
 
-typedef DirectImageResolver =
-    Future<String?> Function(String fileId, int maxDecodedBytes);
+typedef DirectImageResolver = Future<String?> Function(
+  String fileId,
+  int maxDecodedBytes,
+);
 
 final class DirectChatInputException implements Exception {
   const DirectChatInputException(this.message);

--- a/lib/features/direct_connections/services/direct_model_registry.dart
+++ b/lib/features/direct_connections/services/direct_model_registry.dart
@@ -123,9 +123,8 @@ List<Model> reconcileDirectModelsForDisplay({
       .toList(growable: false);
   final activeDirectIds = activeDirectModels.map((model) => model.id).toSet();
   return List.unmodifiable([
-    ...sanitizeRemoteDirectModels(
-      remoteModels,
-    ).where((model) => !activeDirectIds.contains(model.id)),
+    ...sanitizeRemoteDirectModels(remoteModels)
+        .where((model) => !activeDirectIds.contains(model.id)),
     ...activeDirectModels,
   ]);
 }

--- a/lib/features/direct_connections/services/ollama_cloud_tools.dart
+++ b/lib/features/direct_connections/services/ollama_cloud_tools.dart
@@ -18,8 +18,7 @@ const List<Map<String, dynamic>> kOllamaCloudWebToolDefinitions = [
     'type': 'function',
     'function': {
       'name': 'web_search',
-      'description':
-          'Search the web for current information. Use web_fetch to read a result in detail.',
+      'description': 'Search the web for current information. Use web_fetch to read a result in detail.',
       'parameters': {
         'type': 'object',
         'required': ['query'],

--- a/lib/features/direct_connections/services/openwebui_direct_completion_relay.dart
+++ b/lib/features/direct_connections/services/openwebui_direct_completion_relay.dart
@@ -9,8 +9,10 @@ import '../models/direct_connection_profile.dart';
 import 'direct_adapter_helpers.dart';
 import 'direct_http_client.dart';
 
-typedef OpenWebUiDirectChannelEmitter =
-    bool Function(String channel, Object payload);
+typedef OpenWebUiDirectChannelEmitter = bool Function(
+  String channel,
+  Object payload,
+);
 typedef OpenWebUiDirectRpcAcknowledgement = void Function(Object? payload);
 
 /// Executes Open WebUI's client-side half of a direct chat completion RPC.

--- a/lib/features/direct_connections/services/openwebui_direct_connection_store.dart
+++ b/lib/features/direct_connections/services/openwebui_direct_connection_store.dart
@@ -7,10 +7,12 @@ import '../models/direct_connection_profile.dart';
 import '../models/openwebui_direct_connection.dart';
 
 typedef OpenWebUiUserSettingsReader = Future<Map<String, dynamic>> Function();
-typedef OpenWebUiUserSettingsWriter =
-    Future<void> Function(Map<String, dynamic> settings);
-typedef OpenWebUiUserSettingsMutationSerializer =
-    Future<T> Function<T>(Future<T> Function() operation);
+typedef OpenWebUiUserSettingsWriter = Future<void> Function(
+  Map<String, dynamic> settings,
+);
+typedef OpenWebUiUserSettingsMutationSerializer = Future<T> Function<T>(
+  Future<T> Function() operation,
+);
 
 /// Raised when a server-backed record changed after an editor loaded it.
 final class OpenWebUiDirectConnectionConflictException implements Exception {
@@ -454,12 +456,12 @@ final class OpenWebUiDirectConnectionsCodec {
     final mutableDirectConnections = _mutableJsonMap(directConnections);
     ui['directConnections'] = mutableDirectConnections;
 
-    final urls = _jsonList(
-      mutableDirectConnections['OPENAI_API_BASE_URLS'],
-    ).map(_stringValue).toList(growable: true);
-    final keys = _jsonList(
-      mutableDirectConnections['OPENAI_API_KEYS'],
-    ).map(_stringValue).toList(growable: true);
+    final urls = _jsonList(mutableDirectConnections['OPENAI_API_BASE_URLS'])
+        .map(_stringValue)
+        .toList(growable: true);
+    final keys = _jsonList(mutableDirectConnections['OPENAI_API_KEYS'])
+        .map(_stringValue)
+        .toList(growable: true);
     final configs = _mutableJsonMap(
       _jsonMap(mutableDirectConnections['OPENAI_API_CONFIGS']) ??
           const <String, dynamic>{},

--- a/lib/features/hermes/services/hermes_run_transport.dart
+++ b/lib/features/hermes/services/hermes_run_transport.dart
@@ -9,6 +9,7 @@ import 'package:flutter/foundation.dart' show visibleForTesting;
 import '../../../core/models/chat_message.dart';
 import '../../../core/services/openai_responses_codec.dart';
 import '../../../core/utils/debug_logger.dart';
+import '../../../core/utils/semantic_details.dart';
 import '../../../core/utils/unicode_prefix.dart';
 import '../models/hermes_run_event.dart';
 import '../providers/hermes_providers.dart';
@@ -765,8 +766,7 @@ void _appendAuthoritativeOutput(
     // a lagging aggregate (multi-item runs, incomplete recovery) — replacing
     // with it would truncate content the user already received. Keep the
     // longer streamed text in that case.
-    if (output.length < streamedText.length &&
-        streamedText.startsWith(output)) {
+    if (isStaleServerPrefix(localBody: streamedText, serverBody: output)) {
       return;
     }
     // Terminal/recovered output is authoritative even when the server corrected

--- a/lib/features/hermes/services/hermes_run_transport.dart
+++ b/lib/features/hermes/services/hermes_run_transport.dart
@@ -761,6 +761,14 @@ void _appendAuthoritativeOutput(
   if (output.length > streamedText.length && output.startsWith(streamedText)) {
     appendContent(output.substring(streamedText.length));
   } else if (output != streamedText) {
+    // An authoritative output that is a strict prefix of the streamed text is
+    // a lagging aggregate (multi-item runs, incomplete recovery) — replacing
+    // with it would truncate content the user already received. Keep the
+    // longer streamed text in that case.
+    if (output.length < streamedText.length &&
+        streamedText.startsWith(output)) {
+      return;
+    }
     // Terminal/recovered output is authoritative even when the server corrected
     // or normalized an earlier delta instead of merely extending it.
     replaceContent?.call(output);

--- a/lib/features/navigation/providers/sidebar_providers.dart
+++ b/lib/features/navigation/providers/sidebar_providers.dart
@@ -107,9 +107,8 @@ class SidebarTabletWidth extends _$SidebarTabletWidth {
   double build() {
     ref.onDispose(() => _persistTimer?.cancel());
     return _clamp(
-      PreferencesStore.get<num>(
-            PreferenceKeys.sidebarTabletWidth,
-          )?.toDouble() ??
+      PreferencesStore.get<num>(PreferenceKeys.sidebarTabletWidth)
+              ?.toDouble() ??
           defaultSidebarTabletWidth,
     );
   }

--- a/lib/features/notes/services/note_audio_upload_service.dart
+++ b/lib/features/notes/services/note_audio_upload_service.dart
@@ -120,9 +120,8 @@ class PendingNoteAudioUpload {
         !RegExp(r'^recording\.[a-z0-9]{1,8}$').hasMatch(localFileName) ||
         (sourceCacheFileName != null &&
             (path.basename(sourceCacheFileName) != sourceCacheFileName ||
-                !RegExp(
-                  r'^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$',
-                ).hasMatch(sourceCacheFileName)))) {
+                !RegExp(r'^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$')
+                    .hasMatch(sourceCacheFileName)))) {
       throw const FormatException('Invalid note audio manifest');
     }
 
@@ -147,10 +146,14 @@ class PendingNoteAudioUpload {
   }
 }
 
-typedef NoteAudioUploadCallback =
-    Future<String> Function(PendingNoteAudioUpload item, File file);
-typedef NoteAudioAttachCallback =
-    Future<void> Function(PendingNoteAudioUpload item, String fileId);
+typedef NoteAudioUploadCallback = Future<String> Function(
+  PendingNoteAudioUpload item,
+  File file,
+);
+typedef NoteAudioAttachCallback = Future<void> Function(
+  PendingNoteAudioUpload item,
+  String fileId,
+);
 typedef NoteAudioUploadChanged = void Function(PendingNoteAudioUpload? item);
 
 /// Durable, account-scoped storage for note recordings awaiting upload.

--- a/lib/features/notifications/services/notification_event_classifier.dart
+++ b/lib/features/notifications/services/notification_event_classifier.dart
@@ -100,7 +100,10 @@ class NotificationEventClassifier {
 
   /// Builds the headline: author name, suffixed with `(#channel)` for non-DM
   /// channels, matching upstream's `+layout.svelte` formatting.
-  String _channelTitle(Map<String, dynamic> event, Map<String, dynamic>? author) {
+  String _channelTitle(
+    Map<String, dynamic> event,
+    Map<String, dynamic>? author,
+  ) {
     final authorName = _asString(author?['name']);
     final channel = _asMap(event['channel']);
     final channelType = _asString(channel?['type']);

--- a/lib/features/terminal/controllers/terminal_browser_controller.dart
+++ b/lib/features/terminal/controllers/terminal_browser_controller.dart
@@ -88,12 +88,7 @@ class TerminalBrowserController extends ChangeNotifier {
 
     final currentPath = _gateway.currentPath;
     await Future.wait([
-      loadDirectory(
-        service,
-        server,
-        path: currentPath,
-        updateServerCwd: false,
-      ),
+      loadDirectory(service, server, path: currentPath, updateServerCwd: false),
       loadPorts(service, server),
     ]);
   }

--- a/lib/features/terminal/controllers/terminal_session_controller.dart
+++ b/lib/features/terminal/controllers/terminal_session_controller.dart
@@ -10,8 +10,10 @@ import '../models/terminal_models.dart';
 import '../services/terminal_service.dart';
 import 'terminal_controller_gateways.dart';
 
-typedef TerminalContextValidator =
-    bool Function(TerminalServerInfo server, String sessionScopeId);
+typedef TerminalContextValidator = bool Function(
+  TerminalServerInfo server,
+  String sessionScopeId,
+);
 
 /// Owns the interactive terminal session and its WebSocket lifecycle.
 ///

--- a/lib/features/terminal/providers/terminal_providers.dart
+++ b/lib/features/terminal/providers/terminal_providers.dart
@@ -11,8 +11,10 @@ import '../../tools/providers/tools_providers.dart';
 import '../models/terminal_models.dart';
 import '../services/terminal_service.dart';
 
-typedef TerminalChannelConnector =
-    WebSocketChannel Function(Uri uri, {required TerminalServerKind kind});
+typedef TerminalChannelConnector = WebSocketChannel Function(
+  Uri uri, {
+  required TerminalServerKind kind,
+});
 
 final terminalServiceProvider = Provider<TerminalService?>((ref) {
   final api = ref.watch(apiServiceProvider);

--- a/lib/features/terminal/services/terminal_service.dart
+++ b/lib/features/terminal/services/terminal_service.dart
@@ -169,9 +169,8 @@ String parentTerminalPath(String value) {
       ? normalized.substring(0, normalized.length - 1)
       : normalized;
 
-  final windowsDriveMatch = RegExp(
-    r'^[A-Za-z]:$',
-  ).firstMatch(withoutTrailingSlash);
+  final windowsDriveMatch = RegExp(r'^[A-Za-z]:$')
+      .firstMatch(withoutTrailingSlash);
   if (withoutTrailingSlash == '/' || windowsDriveMatch != null) {
     return ensureTerminalDirectoryPath(withoutTrailingSlash);
   }
@@ -653,9 +652,8 @@ class TerminalService {
         response.headers.value(Headers.contentTypeHeader)?.toLowerCase() ??
         'application/octet-stream';
     final disposition = response.headers.value('content-disposition') ?? '';
-    final fileNameMatch = RegExp(
-      r'filename="?([^"]+)"?',
-    ).firstMatch(disposition);
+    final fileNameMatch = RegExp(r'filename="?([^"]+)"?')
+        .firstMatch(disposition);
     final fileName = fileNameMatch?.group(1) ?? p.basename(normalizedPath);
 
     return TerminalDownloadedFile(

--- a/lib/features/workspace/models/workspace_common.dart
+++ b/lib/features/workspace/models/workspace_common.dart
@@ -158,9 +158,9 @@ class WorkspacePagedResponse<T> {
     T Function(Map<String, dynamic>) fromJson,
   ) {
     if (json is List) {
-      final items = workspaceJsonList(
-        json,
-      ).map(fromJson).toList(growable: false);
+      final items = workspaceJsonList(json)
+          .map(fromJson)
+          .toList(growable: false);
       return WorkspacePagedResponse(items: items, total: items.length);
     }
     final map = workspaceJsonMap(json);
@@ -174,9 +174,10 @@ class WorkspacePagedResponse<T> {
   }
 }
 
-List<WorkspaceAccessGrant> workspaceGrants(dynamic value) => workspaceJsonList(
-  value,
-).map(WorkspaceAccessGrant.fromJson).toList(growable: false);
+List<WorkspaceAccessGrant> workspaceGrants(dynamic value) =>
+    workspaceJsonList(value)
+        .map(WorkspaceAccessGrant.fromJson)
+        .toList(growable: false);
 
 List<Map<String, dynamic>> workspaceGrantInputs(
   List<WorkspaceAccessGrantInput> grants,

--- a/lib/features/workspace/models/workspace_knowledge.dart
+++ b/lib/features/workspace/models/workspace_knowledge.dart
@@ -178,23 +178,23 @@ class WorkspaceKnowledgeFilePage {
 
   factory WorkspaceKnowledgeFilePage.fromJson(dynamic json) {
     if (json is List) {
-      final items = workspaceJsonList(
-        json,
-      ).map(WorkspaceKnowledgeFile.fromJson).toList(growable: false);
+      final items = workspaceJsonList(json)
+          .map(WorkspaceKnowledgeFile.fromJson)
+          .toList(growable: false);
       return WorkspaceKnowledgeFilePage(items: items, total: items.length);
     }
     final map = workspaceJsonMap(json);
-    final items = workspaceJsonList(
-      map['items'] ?? map['files'],
-    ).map(WorkspaceKnowledgeFile.fromJson).toList(growable: false);
+    final items = workspaceJsonList(map['items'] ?? map['files'])
+        .map(WorkspaceKnowledgeFile.fromJson)
+        .toList(growable: false);
     return WorkspaceKnowledgeFilePage(
       items: items,
-      directories: workspaceJsonList(
-        map['directories'],
-      ).map(WorkspaceKnowledgeDirectory.fromJson).toList(growable: false),
-      breadcrumbs: workspaceJsonList(
-        map['breadcrumbs'],
-      ).map(WorkspaceKnowledgeDirectory.fromJson).toList(growable: false),
+      directories: workspaceJsonList(map['directories'])
+          .map(WorkspaceKnowledgeDirectory.fromJson)
+          .toList(growable: false),
+      breadcrumbs: workspaceJsonList(map['breadcrumbs'])
+          .map(WorkspaceKnowledgeDirectory.fromJson)
+          .toList(growable: false),
       total: workspaceInt(map['total'], items.length),
     );
   }
@@ -238,9 +238,9 @@ class WorkspaceKnowledgeDetail {
   factory WorkspaceKnowledgeDetail.fromJson(Map<String, dynamic> json) =>
       WorkspaceKnowledgeDetail(
         summary: WorkspaceKnowledgeSummary.fromJson(json),
-        files: workspaceJsonList(
-          json['files'],
-        ).map(WorkspaceKnowledgeFile.fromJson).toList(growable: false),
+        files: workspaceJsonList(json['files'])
+            .map(WorkspaceKnowledgeFile.fromJson)
+            .toList(growable: false),
       );
 }
 

--- a/lib/features/workspace/models/workspace_model_draft.dart
+++ b/lib/features/workspace/models/workspace_model_draft.dart
@@ -262,9 +262,9 @@ class WorkspaceModelDraft {
       stop: _stringList(params['stop']),
       suggestionPrompts: _stringList(meta['suggestion_prompts']),
       capabilities: _capabilityMap(meta['capabilities']),
-      knowledge: workspaceJsonList(
-        meta['knowledge'],
-      ).map(WorkspaceModelKnowledgeRef.fromJson).toList(),
+      knowledge: workspaceJsonList(meta['knowledge'])
+          .map(WorkspaceModelKnowledgeRef.fromJson)
+          .toList(),
       toolIds: _stringList(meta['toolIds']),
       skillIds: _stringList(meta['skillIds']),
       filterIds: _stringList(meta['filterIds']),

--- a/lib/features/workspace/widgets/workspace_section_editors.dart
+++ b/lib/features/workspace/widgets/workspace_section_editors.dart
@@ -26,8 +26,10 @@ class WorkspaceEditorArgs {
   final String? resourceId;
 }
 
-typedef WorkspaceSectionEditorBuilder =
-    Widget Function(BuildContext context, WorkspaceEditorArgs args);
+typedef WorkspaceSectionEditorBuilder = Widget Function(
+  BuildContext context,
+  WorkspaceEditorArgs args,
+);
 
 /// Registry mapping a [WorkspaceSection] to the widget that renders its
 /// create/detail/edit editor.

--- a/lib/shared/widgets/markdown/compiled_markdown_document.dart
+++ b/lib/shared/widgets/markdown/compiled_markdown_document.dart
@@ -370,6 +370,9 @@ class CompiledMarkdownDocument {
 
   @override
   bool operator ==(Object other) {
+    if (identical(other, this)) {
+      return true;
+    }
     return other is CompiledMarkdownDocument &&
         other.normalizedContent == normalizedContent &&
         other.renderTier == renderTier &&
@@ -456,13 +459,11 @@ CompiledMarkdownBlock _rebaseCompiledMarkdownBlock(
   if (block is CompiledMarkdownDetailsGroup) {
     final items = block.items
         .map(
-          (item) =>
-              _rebaseCompiledMarkdownBlock(
-                    item,
-                    rootNodeOffset,
-                    rebasedRootNodesByOldId,
-                  )
-                  as CompiledMarkdownDetailsBlock,
+          (item) => _rebaseCompiledMarkdownBlock(
+            item,
+            rootNodeOffset,
+            rebasedRootNodesByOldId,
+          ) as CompiledMarkdownDetailsBlock,
         )
         .toList(growable: false);
     final blockId = items.isEmpty

--- a/lib/shared/widgets/markdown/markdown_config.dart
+++ b/lib/shared/widgets/markdown/markdown_config.dart
@@ -1246,27 +1246,45 @@ class _CodeBlockBody extends StatefulWidget {
   static const largeJsonPlainPreviewLineThreshold = 60;
   static const largeJsonPlainPreviewCharThreshold = 4000;
 
+  /// Above this size, code renders unhighlighted in any language.
+  /// `highlight.parse` runs synchronously in build; on an expanded block that
+  /// is still streaming it would re-parse the whole source on every flush.
+  // ponytail: hard cap instead of incremental/off-thread highlighting; move
+  // highlighting into the compiler isolate if large code blocks matter.
+  static const largePlainRenderCharThreshold = 50000;
+
   @override
   State<_CodeBlockBody> createState() => _CodeBlockBodyState();
 }
 
 class _CodeBlockBodyState extends State<_CodeBlockBody> {
   bool _isCollapsed = true;
+  String? _linesSource;
+  List<String> _lines = const <String>[];
+
+  List<String> _splitLines() {
+    if (!identical(_linesSource, widget.code)) {
+      _linesSource = widget.code;
+      _lines = widget.code.split('\n');
+    }
+    return _lines;
+  }
 
   @override
   Widget build(BuildContext context) {
-    final lines = widget.code.split('\n');
+    final lines = _splitLines();
     final isCollapsible = lines.length > _CodeBlockBody.collapseThreshold;
     final displayCode = (isCollapsible && _isCollapsed)
         ? lines.take(_CodeBlockBody.previewLines).join('\n')
         : widget.code;
     final hiddenCount = lines.length - _CodeBlockBody.previewLines;
     final renderPlainPreview =
-        _isCollapsed &&
-        widget.highlightLanguage == 'json' &&
-        (lines.length > _CodeBlockBody.largeJsonPlainPreviewLineThreshold ||
-            widget.code.length >
-                _CodeBlockBody.largeJsonPlainPreviewCharThreshold);
+        displayCode.length > _CodeBlockBody.largePlainRenderCharThreshold ||
+        (_isCollapsed &&
+            widget.highlightLanguage == 'json' &&
+            (lines.length > _CodeBlockBody.largeJsonPlainPreviewLineThreshold ||
+                widget.code.length >
+                    _CodeBlockBody.largeJsonPlainPreviewCharThreshold));
 
     return Column(
       mainAxisSize: MainAxisSize.min,

--- a/lib/shared/widgets/markdown/markdown_document_controller.dart
+++ b/lib/shared/widgets/markdown/markdown_document_controller.dart
@@ -39,13 +39,17 @@ final RegExp _streamingDetailsInlineOpenPattern = RegExp(
   caseSensitive: false,
 );
 
-int _streamingDetailsOpenCount(String candidate) {
-  final count = _streamingDetailsInlineOpenPattern.allMatches(candidate).length;
-  if (count == 0 && _streamingDetailsOpenPattern.hasMatch(candidate)) {
-    // A line-leading `<details` whose tag is still incomplete (no `>` yet)
+int _streamingDetailsOpenCount(String line) {
+  final count = _streamingDetailsInlineOpenPattern.allMatches(line).length;
+  if (count == 0) {
+    // A block-starting `<details` whose tag is still incomplete (no `>` yet)
     // must still open scanner details mode: the parser will once the tag
-    // completes, and closing here would freeze an unterminated block.
-    return 1;
+    // completes, and closing here would freeze an unterminated block. The
+    // line is dedented first so a <=3-space-indented partial open counts.
+    final candidate = _streamingBlockStarterCandidate(line);
+    if (candidate != null && _streamingDetailsOpenPattern.hasMatch(candidate)) {
+      return 1;
+    }
   }
   return count;
 }
@@ -958,6 +962,26 @@ List<_StreamingPreparedLine> _splitStreamingPreparedLines(String content) {
   // inside a details body must not open a phantom outer fence that would hide
   // a definition appearing after the block.
   for (final line in lines) {
+    if (detailsDepth > 0) {
+      // The parser counts nested opens/closes on the RAW line — indentation
+      // is irrelevant inside a details block — so this must not go through
+      // the dedented candidate, which is null for indented lines and would
+      // miss tags the parser counts, exiting details mode a level early.
+      // (Depth can only be non-zero while firstRawHtmlOffset is null: raw
+      // HTML detection runs outside details mode and ends the other checks.)
+      detailsDepth += _streamingDetailsOpenCount(line.text);
+      detailsDepth -= _streamingDetailsClosePattern
+          .allMatches(line.text)
+          .length;
+      if (detailsDepth < 0) {
+        detailsDepth = 0;
+      }
+      // Definition-shaped lines inside a details body are not document-scoped:
+      // the parser lifts the body into a `body_markdown` attribute compiled as
+      // its own document, so they cannot couple frozen and mutable segments.
+      continue;
+    }
+
     final candidate = _streamingBlockStarterCandidate(line.text);
     if (candidate == null) {
       continue;
@@ -970,20 +994,6 @@ List<_StreamingPreparedLine> _splitStreamingPreparedLines(String content) {
       continue;
     }
 
-    if (detailsDepth > 0) {
-      detailsDepth += _streamingDetailsOpenCount(candidate);
-      detailsDepth -= _streamingDetailsClosePattern
-          .allMatches(candidate)
-          .length;
-      if (detailsDepth < 0) {
-        detailsDepth = 0;
-      }
-      // Definition-shaped lines inside a details body are not document-scoped:
-      // the parser lifts the body into a `body_markdown` attribute compiled as
-      // its own document, so they cannot couple frozen and mutable segments.
-      continue;
-    }
-
     if (fenceCharacter != null) {
       if (_isStreamingFenceClose(candidate, fenceCharacter, fenceLength)) {
         fenceCharacter = null;
@@ -993,9 +1003,9 @@ List<_StreamingPreparedLine> _splitStreamingPreparedLines(String content) {
     }
 
     if (_streamingDetailsOpenPattern.hasMatch(candidate)) {
-      detailsDepth = _streamingDetailsOpenCount(candidate);
+      detailsDepth = _streamingDetailsOpenCount(line.text);
       detailsDepth -= _streamingDetailsClosePattern
-          .allMatches(candidate)
+          .allMatches(line.text)
           .length;
       if (detailsDepth < 0) {
         detailsDepth = 0;
@@ -1083,15 +1093,13 @@ _StreamingBlockScanResult? _scanStreamingPreparedBlock(
     var depth = 0;
     for (var lineIndex = index; lineIndex < lines.length; lineIndex += 1) {
       final currentLine = lines[lineIndex];
-      final currentCandidate = _streamingBlockStarterCandidate(
-        currentLine.text,
-      );
-      if (currentCandidate != null) {
-        depth += _streamingDetailsOpenCount(currentCandidate);
-        depth -= _streamingDetailsClosePattern
-            .allMatches(currentCandidate)
-            .length;
-      }
+      // Count on the RAW line: the parser counts tags regardless of
+      // indentation inside the block, and the dedented candidate is null
+      // for indented lines, which would drop tags the parser counts.
+      depth += _streamingDetailsOpenCount(currentLine.text);
+      depth -= _streamingDetailsClosePattern
+          .allMatches(currentLine.text)
+          .length;
       if (depth > 0) {
         continue;
       }

--- a/lib/shared/widgets/markdown/markdown_document_controller.dart
+++ b/lib/shared/widgets/markdown/markdown_document_controller.dart
@@ -914,9 +914,23 @@ List<_StreamingPreparedLine> _splitStreamingPreparedLines(String content) {
   // after a raw HTML block still rebinds links before it — so the scan never
   // stops at the first raw HTML line; only its offset is recorded as the
   // freeze cap.
+  //
+  // Once a raw HTML block has started, fence tracking is unreliable: backtick
+  // lines inside raw HTML are content, not fences, and an odd count would
+  // leave the tracker "inside" a fence and skip a later real definition. From
+  // that point every line is checked for a definition regardless of fence
+  // state — at worst more conservative than the pre-split whole-document
+  // check this replaced.
   for (final line in lines) {
     final candidate = _streamingBlockStarterCandidate(line.text);
     if (candidate == null) {
+      continue;
+    }
+
+    if (firstRawHtmlOffset != null) {
+      if (_streamingReferenceDefinitionPattern.hasMatch(candidate)) {
+        return (offset: line.start, isReferenceDefinition: true);
+      }
       continue;
     }
 
@@ -939,8 +953,7 @@ List<_StreamingPreparedLine> _splitStreamingPreparedLines(String content) {
     if (_streamingReferenceDefinitionPattern.hasMatch(candidate)) {
       return (offset: line.start, isReferenceDefinition: true);
     }
-    if (firstRawHtmlOffset == null &&
-        _streamingRawHtmlBlockPattern.hasMatch(candidate)) {
+    if (_streamingRawHtmlBlockPattern.hasMatch(candidate)) {
       firstRawHtmlOffset = line.start;
     }
   }

--- a/lib/shared/widgets/markdown/markdown_document_controller.dart
+++ b/lib/shared/widgets/markdown/markdown_document_controller.dart
@@ -30,6 +30,26 @@ final RegExp _streamingDetailsOpenPattern = RegExp(
   r'^<details\b',
   caseSensitive: false,
 );
+// The details parser counts nested opens ANYWHERE in a line with the
+// complete-tag pattern (details_block_syntax.dart _openingTagPattern), not
+// just at line starts. Depth counting must match it, or an inline nested
+// open makes the first close exit scanner details mode one level early.
+final RegExp _streamingDetailsInlineOpenPattern = RegExp(
+  r'<details(?:\s+[^>]*)?>',
+  caseSensitive: false,
+);
+
+int _streamingDetailsOpenCount(String candidate) {
+  final count = _streamingDetailsInlineOpenPattern.allMatches(candidate).length;
+  if (count == 0 && _streamingDetailsOpenPattern.hasMatch(candidate)) {
+    // A line-leading `<details` whose tag is still incomplete (no `>` yet)
+    // must still open scanner details mode: the parser will once the tag
+    // completes, and closing here would freeze an unterminated block.
+    return 1;
+  }
+  return count;
+}
+
 // Must match exactly what the details parser recognizes as a close
 // (details_block_syntax.dart uses the literal `</details>`): counting a
 // looser `</details >` as a close exits details tracking early, and a
@@ -951,7 +971,7 @@ List<_StreamingPreparedLine> _splitStreamingPreparedLines(String content) {
     }
 
     if (detailsDepth > 0) {
-      detailsDepth += _streamingDetailsOpenPattern.allMatches(candidate).length;
+      detailsDepth += _streamingDetailsOpenCount(candidate);
       detailsDepth -= _streamingDetailsClosePattern
           .allMatches(candidate)
           .length;
@@ -973,7 +993,7 @@ List<_StreamingPreparedLine> _splitStreamingPreparedLines(String content) {
     }
 
     if (_streamingDetailsOpenPattern.hasMatch(candidate)) {
-      detailsDepth = _streamingDetailsOpenPattern.allMatches(candidate).length;
+      detailsDepth = _streamingDetailsOpenCount(candidate);
       detailsDepth -= _streamingDetailsClosePattern
           .allMatches(candidate)
           .length;
@@ -1067,9 +1087,7 @@ _StreamingBlockScanResult? _scanStreamingPreparedBlock(
         currentLine.text,
       );
       if (currentCandidate != null) {
-        depth += _streamingDetailsOpenPattern
-            .allMatches(currentCandidate)
-            .length;
+        depth += _streamingDetailsOpenCount(currentCandidate);
         depth -= _streamingDetailsClosePattern
             .allMatches(currentCandidate)
             .length;

--- a/lib/shared/widgets/markdown/markdown_document_controller.dart
+++ b/lib/shared/widgets/markdown/markdown_document_controller.dart
@@ -30,8 +30,13 @@ final RegExp _streamingDetailsOpenPattern = RegExp(
   r'^<details\b',
   caseSensitive: false,
 );
+// Must match exactly what the details parser recognizes as a close
+// (details_block_syntax.dart uses the literal `</details>`): counting a
+// looser `</details >` as a close exits details tracking early, and a
+// subsequent backtick line inside the still-open body then poisons fence
+// state and hides later reference definitions.
 final RegExp _streamingDetailsClosePattern = RegExp(
-  r'</details\s*>',
+  r'</details>',
   caseSensitive: false,
 );
 final RegExp _streamingRawHtmlBlockPattern = RegExp(

--- a/lib/shared/widgets/markdown/markdown_document_controller.dart
+++ b/lib/shared/widgets/markdown/markdown_document_controller.dart
@@ -42,8 +42,10 @@ final RegExp _streamingRawHtmlBlockPattern = RegExp(
   caseSensitive: false,
   multiLine: true,
 );
+// Labels may contain backslash-escaped brackets ("[a\]b]:"), so escaped
+// pairs are consumed before the closing bracket.
 final RegExp _streamingReferenceDefinitionPattern = RegExp(
-  r'^\s{0,3}\[[^\]\n]+\]:',
+  r'^\s{0,3}\[(?:\\.|[^\]\n])+\]:',
   multiLine: true,
 );
 

--- a/lib/shared/widgets/markdown/markdown_document_controller.dart
+++ b/lib/shared/widgets/markdown/markdown_document_controller.dart
@@ -43,9 +43,12 @@ final RegExp _streamingRawHtmlBlockPattern = RegExp(
   multiLine: true,
 );
 // Labels may contain backslash-escaped brackets ("[a\]b]:"), so escaped
-// pairs are consumed before the closing bracket.
+// pairs are consumed before the closing bracket. The character class
+// excludes the backslash so the two branches cannot overlap — an overlap
+// backtracks exponentially on long malformed labels, and this pattern runs
+// on the UI isolate during streamed flushes.
 final RegExp _streamingReferenceDefinitionPattern = RegExp(
-  r'^\s{0,3}\[(?:\\.|[^\]\n])+\]:',
+  r'^\s{0,3}\[(?:\\.|[^\]\\\n])+\]:',
   multiLine: true,
 );
 
@@ -910,6 +913,7 @@ List<_StreamingPreparedLine> _splitStreamingPreparedLines(String content) {
 ) {
   String? fenceCharacter;
   var fenceLength = 0;
+  var detailsDepth = 0;
   int? firstRawHtmlOffset;
 
   // Reference definitions must be detected across the whole region — one
@@ -923,6 +927,11 @@ List<_StreamingPreparedLine> _splitStreamingPreparedLines(String content) {
   // that point every line is checked for a definition regardless of fence
   // state — at worst more conservative than the pre-split whole-document
   // check this replaced.
+  //
+  // <details> bodies are treated the same way the block scanner treats them:
+  // as opaque content tracked by open/close depth. An unmatched backtick line
+  // inside a details body must not open a phantom outer fence that would hide
+  // a definition appearing after the block.
   for (final line in lines) {
     final candidate = _streamingBlockStarterCandidate(line.text);
     if (candidate == null) {
@@ -936,10 +945,35 @@ List<_StreamingPreparedLine> _splitStreamingPreparedLines(String content) {
       continue;
     }
 
+    if (detailsDepth > 0) {
+      detailsDepth += _streamingDetailsOpenPattern.allMatches(candidate).length;
+      detailsDepth -= _streamingDetailsClosePattern
+          .allMatches(candidate)
+          .length;
+      if (detailsDepth < 0) {
+        detailsDepth = 0;
+      }
+      if (_streamingReferenceDefinitionPattern.hasMatch(candidate)) {
+        return (offset: line.start, isReferenceDefinition: true);
+      }
+      continue;
+    }
+
     if (fenceCharacter != null) {
       if (_isStreamingFenceClose(candidate, fenceCharacter, fenceLength)) {
         fenceCharacter = null;
         fenceLength = 0;
+      }
+      continue;
+    }
+
+    if (_streamingDetailsOpenPattern.hasMatch(candidate)) {
+      detailsDepth = _streamingDetailsOpenPattern.allMatches(candidate).length;
+      detailsDepth -= _streamingDetailsClosePattern
+          .allMatches(candidate)
+          .length;
+      if (detailsDepth < 0) {
+        detailsDepth = 0;
       }
       continue;
     }

--- a/lib/shared/widgets/markdown/markdown_document_controller.dart
+++ b/lib/shared/widgets/markdown/markdown_document_controller.dart
@@ -6,8 +6,9 @@ import 'compiled_markdown_document.dart';
 import 'markdown_compile_service.dart';
 import 'streaming_markdown_preparation.dart';
 
-typedef MarkdownDocumentControllerListener =
-    void Function(CompiledMarkdownDocument? document);
+typedef MarkdownDocumentControllerListener = void Function(
+  CompiledMarkdownDocument? document,
+);
 
 enum _MarkdownResolveMode { full, streamingIncremental, streamingPatch }
 
@@ -817,28 +818,29 @@ _StreamingPreparedSplit _splitStreamingPreparedContent(String preparedContent) {
     return const _StreamingPreparedSplit(frozenPrefix: '', mutableTail: '');
   }
 
-  // Reference definitions can retroactively change earlier blocks, so keep
-  // the full document mutable while they are present.
-  if (_streamingReferenceDefinitionPattern.hasMatch(preparedContent)) {
+  final lines = _splitStreamingPreparedLines(preparedContent);
+
+  // One fence-aware pass finds the first line with possible non-local effects.
+  // Reference definitions can retroactively rebind earlier links in this
+  // region, so they keep the whole region mutable — but only when they appear
+  // outside fenced code; previously a definition-shaped line (or any raw HTML
+  // block) anywhere, including inside code fences, disabled incremental
+  // compilation for the entire message on every streamed flush.
+  //
+  // Raw HTML blocks have tag-specific termination rules the scanner does not
+  // model, but they cannot affect blocks before them, so freezing is capped
+  // at the first HTML block start instead of keeping the whole document
+  // mutable.
+  final unsafe = _firstStreamingUnsafeLine(lines);
+  if (unsafe != null && unsafe.isReferenceDefinition) {
     return _StreamingPreparedSplit(
       frozenPrefix: '',
       mutableTail: preparedContent,
       fallbackReason: 'referenceDefinitions',
     );
   }
+  final freezeCap = unsafe?.offset ?? preparedContent.length;
 
-  // CommonMark raw HTML blocks have tag-specific termination rules. Until the
-  // splitter models those rules, parsing the document as one mutable segment
-  // is safer than freezing at a blank line inside the raw block.
-  if (_containsStreamingRawHtmlBlock(preparedContent)) {
-    return _StreamingPreparedSplit(
-      frozenPrefix: '',
-      mutableTail: preparedContent,
-      fallbackReason: 'rawHtmlBlock',
-    );
-  }
-
-  final lines = _splitStreamingPreparedLines(preparedContent);
   var index = 0;
   var safeBoundary = 0;
 
@@ -853,7 +855,7 @@ _StreamingPreparedSplit _splitStreamingPreparedContent(String preparedContent) {
       index,
       preparedContent.length,
     );
-    if (result == null) {
+    if (result == null || result.safeBoundary > freezeCap) {
       break;
     }
 
@@ -901,11 +903,13 @@ List<_StreamingPreparedLine> _splitStreamingPreparedLines(String content) {
   return lines;
 }
 
-bool _containsStreamingRawHtmlBlock(String content) {
+({int offset, bool isReferenceDefinition})? _firstStreamingUnsafeLine(
+  List<_StreamingPreparedLine> lines,
+) {
   String? fenceCharacter;
   var fenceLength = 0;
 
-  for (final line in _splitStreamingPreparedLines(content)) {
+  for (final line in lines) {
     final candidate = _streamingBlockStarterCandidate(line.text);
     if (candidate == null) {
       continue;
@@ -927,12 +931,15 @@ bool _containsStreamingRawHtmlBlock(String content) {
       continue;
     }
 
+    if (_streamingReferenceDefinitionPattern.hasMatch(candidate)) {
+      return (offset: line.start, isReferenceDefinition: true);
+    }
     if (_streamingRawHtmlBlockPattern.hasMatch(candidate)) {
-      return true;
+      return (offset: line.start, isReferenceDefinition: false);
     }
   }
 
-  return false;
+  return null;
 }
 
 bool _isStreamingFenceClose(
@@ -972,15 +979,12 @@ _StreamingBlockScanResult? _scanStreamingPreparedBlock(
       : _streamingFenceStartPattern.firstMatch(starterCandidate);
   if (fenceMatch != null) {
     final fence = fenceMatch.group(1)!;
-    final closingPattern = RegExp(
-      '^\\s*${RegExp.escape(fence[0])}{${fence.length},}\\s*\$',
-    );
     for (var lineIndex = index + 1; lineIndex < lines.length; lineIndex += 1) {
       final closingCandidate = _streamingBlockStarterCandidate(
         lines[lineIndex].text,
       );
       if (closingCandidate == null ||
-          !closingPattern.hasMatch(closingCandidate)) {
+          !_isStreamingFenceClose(closingCandidate, fence[0], fence.length)) {
         continue;
       }
       final nextIndex = _skipBlankStreamingLines(lines, lineIndex + 1);

--- a/lib/shared/widgets/markdown/markdown_document_controller.dart
+++ b/lib/shared/widgets/markdown/markdown_document_controller.dart
@@ -978,9 +978,9 @@ List<_StreamingPreparedLine> _splitStreamingPreparedLines(String content) {
       if (detailsDepth < 0) {
         detailsDepth = 0;
       }
-      if (_streamingReferenceDefinitionPattern.hasMatch(candidate)) {
-        return (offset: line.start, isReferenceDefinition: true);
-      }
+      // Definition-shaped lines inside a details body are not document-scoped:
+      // the parser lifts the body into a `body_markdown` attribute compiled as
+      // its own document, so they cannot couple frozen and mutable segments.
       continue;
     }
 

--- a/lib/shared/widgets/markdown/markdown_document_controller.dart
+++ b/lib/shared/widgets/markdown/markdown_document_controller.dart
@@ -39,20 +39,14 @@ final RegExp _streamingDetailsInlineOpenPattern = RegExp(
   caseSensitive: false,
 );
 
-int _streamingDetailsOpenCount(String line) {
-  final count = _streamingDetailsInlineOpenPattern.allMatches(line).length;
-  if (count == 0) {
-    // A block-starting `<details` whose tag is still incomplete (no `>` yet)
-    // must still open scanner details mode: the parser will once the tag
-    // completes, and closing here would freeze an unterminated block. The
-    // line is dedented first so a <=3-space-indented partial open counts.
-    final candidate = _streamingBlockStarterCandidate(line);
-    if (candidate != null && _streamingDetailsOpenPattern.hasMatch(candidate)) {
-      return 1;
-    }
-  }
-  return count;
-}
+// Complete tags only, exactly like the parser: crediting a partial
+// line-leading `<details` here left scanner depth permanently stale when a
+// body contained a literal `<details` that never completed, keeping the
+// scanner "inside" a block the parser had already closed. Incomplete ENTRY
+// tags are handled structurally instead (the tail stays mutable until the
+// tag completes).
+int _streamingDetailsOpenCount(String line) =>
+    _streamingDetailsInlineOpenPattern.allMatches(line).length;
 
 // Must match exactly what the details parser recognizes as a close
 // (details_block_syntax.dart uses the literal `</details>`): counting a
@@ -1090,6 +1084,13 @@ _StreamingBlockScanResult? _scanStreamingPreparedBlock(
   }
 
   if (_startsStreamingDetailsBlock(line.text)) {
+    if (_streamingDetailsOpenCount(line.text) == 0) {
+      // The entry tag is still incomplete (`<details` without `>`): the
+      // parser sees only a paragraph until the tag completes, so keep the
+      // tail mutable rather than freezing a boundary that shifts on the
+      // next flush.
+      return null;
+    }
     var depth = 0;
     for (var lineIndex = index; lineIndex < lines.length; lineIndex += 1) {
       final currentLine = lines[lineIndex];

--- a/lib/shared/widgets/markdown/markdown_document_controller.dart
+++ b/lib/shared/widgets/markdown/markdown_document_controller.dart
@@ -908,7 +908,12 @@ List<_StreamingPreparedLine> _splitStreamingPreparedLines(String content) {
 ) {
   String? fenceCharacter;
   var fenceLength = 0;
+  int? firstRawHtmlOffset;
 
+  // Reference definitions must be detected across the whole region — one
+  // after a raw HTML block still rebinds links before it — so the scan never
+  // stops at the first raw HTML line; only its offset is recorded as the
+  // freeze cap.
   for (final line in lines) {
     final candidate = _streamingBlockStarterCandidate(line.text);
     if (candidate == null) {
@@ -934,11 +939,15 @@ List<_StreamingPreparedLine> _splitStreamingPreparedLines(String content) {
     if (_streamingReferenceDefinitionPattern.hasMatch(candidate)) {
       return (offset: line.start, isReferenceDefinition: true);
     }
-    if (_streamingRawHtmlBlockPattern.hasMatch(candidate)) {
-      return (offset: line.start, isReferenceDefinition: false);
+    if (firstRawHtmlOffset == null &&
+        _streamingRawHtmlBlockPattern.hasMatch(candidate)) {
+      firstRawHtmlOffset = line.start;
     }
   }
 
+  if (firstRawHtmlOffset != null) {
+    return (offset: firstRawHtmlOffset, isReferenceDefinition: false);
+  }
   return null;
 }
 

--- a/lib/shared/widgets/markdown/markdown_preprocessor.dart
+++ b/lib/shared/widgets/markdown/markdown_preprocessor.dart
@@ -315,9 +315,22 @@ class ConduitMarkdownPreprocessor {
     return buffer.toString();
   }
 
+  /// True when [input] contains a line shaped like a Markdown link reference
+  /// definition.
+  ///
+  /// This is the exact trigger for [_stripLinkReferenceDefinitions]'s global
+  /// rewrite (strip + newline collapse + trim), so the incremental streaming
+  /// preparation engine gates on the same predicate: whenever this is false,
+  /// normalization is guaranteed to have no non-local effects from reference
+  /// definitions. A bare `contains(']:')` was previously used for both, which
+  /// forced full re-preparation for any message merely mentioning `]:` (for
+  /// example inside code).
+  static bool hasLinkReferenceDefinitionLine(String input) =>
+      input.contains(']:') && _linkReferenceDefinition.hasMatch(input);
+
   /// Strips Markdown link reference definitions outside code spans.
   static String _stripLinkReferenceDefinitions(String input) {
-    if (!input.contains(']:')) return input;
+    if (!hasLinkReferenceDefinitionLine(input)) return input;
 
     final stripped = _removeMatchesOutsideCode(input, _linkReferenceDefinition);
     return stripped.replaceAll(_multipleNewlines, '\n\n').trim();

--- a/lib/shared/widgets/markdown/markdown_preprocessor.dart
+++ b/lib/shared/widgets/markdown/markdown_preprocessor.dart
@@ -196,10 +196,14 @@ class ConduitMarkdownPreprocessor {
     if (input.isEmpty) return input;
 
     final sanitized = sanitize(input);
-    return _removeMatchesOutsideCode(
-      sanitized,
-      _toolCallBlocks,
-    ).replaceAll(_multipleNewlines, '\n\n').trim();
+    return _removeMatchesOutsideCode(sanitized, _toolCallBlocks)
+        // Stored assistant content is HTML-escaped for the renderer; the
+        // clipboard needs the literal text back (`"` not `&quot;`). API
+        // replay deliberately does NOT decode — it cannot distinguish
+        // model-typed entities from presentation escaping.
+        .transform(_htmlUnescape.convert)
+        .replaceAll(_multipleNewlines, '\n\n')
+        .trim();
   }
 
   /// Converts markdown to plain text for text-to-speech.
@@ -239,7 +243,9 @@ class ConduitMarkdownPreprocessor {
     final trimmed = input.trim();
     if (trimmed.isEmpty) return '';
 
-    return _openWebUiCleanText(trimmed).trim();
+    // Presentation content is HTML-escaped for the renderer; TTS must speak
+    // the literal text (`"` not "ampersand quot semicolon").
+    return _htmlUnescape.convert(_openWebUiCleanText(trimmed)).trim();
   }
 
   /// Removes all `<details>` blocks the way OpenWebUI does outside code spans.

--- a/lib/shared/widgets/markdown/renderer/conduit_markdown_widget.dart
+++ b/lib/shared/widgets/markdown/renderer/conduit_markdown_widget.dart
@@ -337,20 +337,24 @@ class _CompiledMarkdownViewState extends State<_CompiledMarkdownView>
 
   @override
   Widget build(BuildContext context) {
-    final taskKey = PerformanceProfiler.instance.startTask(
-      'markdown_build',
-      scope: 'markdown',
-      data: {
-        'length': widget.document.normalizedContentLength,
-        'tier': widget.document.renderTier,
-        'heavyBlocks': widget.document.heavyBlockCount,
-      },
-    );
+    final profiler = PerformanceProfiler.instance;
+    // Skip the per-build data map allocations entirely when profiling is off
+    // (release builds); this runs for every markdown block on every rebuild.
+    final taskKey = PerformanceProfiler.isEnabled
+        ? profiler.startTask(
+            'markdown_build',
+            scope: 'markdown',
+            data: {
+              'length': widget.document.normalizedContentLength,
+              'tier': widget.document.renderTier,
+              'heavyBlocks': widget.document.heavyBlockCount,
+            },
+          )
+        : null;
     if (widget.document.isEmpty) {
-      PerformanceProfiler.instance.finishTask(
-        taskKey,
-        data: const {'status': 'empty'},
-      );
+      if (taskKey != null) {
+        profiler.finishTask(taskKey, data: const {'status': 'empty'});
+      }
       return const SizedBox.shrink();
     }
 
@@ -373,14 +377,16 @@ class _CompiledMarkdownViewState extends State<_CompiledMarkdownView>
       }
       return _cachedView!;
     } finally {
-      PerformanceProfiler.instance.finishTask(
-        taskKey,
-        data: {
-          'tier': widget.document.renderTier,
-          'nodeCount': widget.document.nodes.length,
-          'blockCount': widget.document.blocks.length,
-        },
-      );
+      if (taskKey != null) {
+        profiler.finishTask(
+          taskKey,
+          data: {
+            'tier': widget.document.renderTier,
+            'nodeCount': widget.document.nodes.length,
+            'blockCount': widget.document.blocks.length,
+          },
+        );
+      }
     }
   }
 

--- a/lib/shared/widgets/markdown/renderer/latex_preprocessor.dart
+++ b/lib/shared/widgets/markdown/renderer/latex_preprocessor.dart
@@ -104,6 +104,11 @@ class LatexPreprocessor {
   /// Use [splitOnPlaceholders] during rendering to recover
   /// the original LaTeX content.
   String extract(String content) {
+    // Every delimiter starts with '$' or '\'; skip the four full regex passes
+    // for the common all-prose case.
+    if (!content.contains(r'$') && !content.contains('\\')) {
+      return content;
+    }
     var result = content;
 
     // Extract \[...\] block LaTeX.

--- a/lib/shared/widgets/markdown/streaming_markdown_preparation.dart
+++ b/lib/shared/widgets/markdown/streaming_markdown_preparation.dart
@@ -452,9 +452,10 @@ class PreparedMarkdownText {
 
   @override
   bool operator ==(Object other) =>
-      other is PreparedMarkdownText &&
-      length == other.length &&
-      materialize() == other.materialize();
+      identical(other, this) ||
+      (other is PreparedMarkdownText &&
+          length == other.length &&
+          startsWith(other));
 
   @override
   int get hashCode => Object.hash(length, materialize());
@@ -538,7 +539,9 @@ class StreamingMarkdownPreparationEngine {
     if (commonRawPrefix < checkpoint.rawOffset ||
         checkpoint.rawOffset == 0 ||
         state.hasReferenceDefinitions ||
-        request.content.contains(']:')) {
+        ConduitMarkdownPreprocessor.hasLinkReferenceDefinitionLine(
+          request.content,
+        )) {
       return null;
     }
 
@@ -661,7 +664,10 @@ class StreamingMarkdownPreparationEngine {
           ? previousPrepared.utf8Length(preparedRetainLength)
           : 0,
     );
-    final hasReferences = request.content.contains(']:');
+    final hasReferences =
+        ConduitMarkdownPreprocessor.hasLinkReferenceDefinitionLine(
+          request.content,
+        );
     final checkpoint = hasReferences
         ? const _MarkdownPreparationCheckpoint.empty()
         : _advanceCheckpoint(
@@ -766,7 +772,9 @@ class StreamingMarkdownPreparationEngine {
     }
 
     final rawPrefixTail = rawTail.substring(0, localRawBoundary);
-    if (rawPrefixTail.contains(']:')) {
+    if (ConduitMarkdownPreprocessor.hasLinkReferenceDefinitionLine(
+      rawPrefixTail,
+    )) {
       return _MarkdownPreparationCheckpoint(
         rawOffset: baseRawOffset,
         preparedOffset: basePreparedOffset,
@@ -828,7 +836,10 @@ int _commonPrefixLength(String left, String right) {
 }
 
 int _lastSafeRawBoundary(String input) {
-  if (input.isEmpty || input.contains(']:')) return 0;
+  if (input.isEmpty ||
+      ConduitMarkdownPreprocessor.hasLinkReferenceDefinitionLine(input)) {
+    return 0;
+  }
 
   var openTicks = 0;
   var detailsDepth = 0;

--- a/lib/shared/widgets/markdown/streaming_markdown_preparation.dart
+++ b/lib/shared/widgets/markdown/streaming_markdown_preparation.dart
@@ -16,6 +16,10 @@ String prepareMarkdownContentCanonical(
 }
 
 final _detailsOpenPattern = RegExp(r'<details\b', caseSensitive: false);
+// Exactly the close the details parser recognizes; a looser match would
+// let the checkpoint think it left a details block the parser is still
+// inside, splitting prepared content mid-block.
+final _detailsClosePattern = RegExp(r'</details>', caseSensitive: false);
 final _toolCallDetailsOpenPattern = RegExp(
   r'<details\b[^>]*type="tool_calls"[^>]*>',
   caseSensitive: false,
@@ -852,17 +856,12 @@ int _lastSafeRawBoundary(String input) {
     final line = input.substring(lineStart, lineEnd);
     final lower = line.toLowerCase();
 
-    detailsDepth += RegExp(
-      r'<details\b',
-      caseSensitive: false,
-    ).allMatches(line).length;
-    // Exactly the close the details parser recognizes; a looser match would
-    // let the checkpoint think it left a details block the parser is still
-    // inside, splitting prepared content mid-block.
-    detailsDepth -= RegExp(
-      r'</details>',
-      caseSensitive: false,
-    ).allMatches(line).length;
+    // Counting the partial `<details\b` (vs the parser's complete-tag
+    // count) can only overcount, which keeps content mutable longer —
+    // the safe direction for a checkpoint. This loop runs on the UI
+    // isolate during streamed flushes, so the patterns are hoisted.
+    detailsDepth += _detailsOpenPattern.allMatches(line).length;
+    detailsDepth -= _detailsClosePattern.allMatches(line).length;
     if (detailsDepth < 0) detailsDepth = 0;
 
     var index = 0;

--- a/lib/shared/widgets/markdown/streaming_markdown_preparation.dart
+++ b/lib/shared/widgets/markdown/streaming_markdown_preparation.dart
@@ -856,8 +856,11 @@ int _lastSafeRawBoundary(String input) {
       r'<details\b',
       caseSensitive: false,
     ).allMatches(line).length;
+    // Exactly the close the details parser recognizes; a looser match would
+    // let the checkpoint think it left a details block the parser is still
+    // inside, splitting prepared content mid-block.
     detailsDepth -= RegExp(
-      r'</details\s*>',
+      r'</details>',
       caseSensitive: false,
     ).allMatches(line).length;
     if (detailsDepth < 0) detailsDepth = 0;

--- a/lib/shared/widgets/markdown/streaming_markdown_widget.dart
+++ b/lib/shared/widgets/markdown/streaming_markdown_widget.dart
@@ -613,6 +613,12 @@ class _StreamingMarkdownWidgetState
         generation != _snapshotGeneration ||
         widget.isStreaming ||
         widget.content != content) {
+      // A stale refresh must not leave the pending flag set forever: when no
+      // newer settled snapshot is queued to clear it, a blank snapshot would
+      // otherwise render an indefinite loading skeleton.
+      if (mounted && _pendingSettledSnapshot == null) {
+        _settledPreparationPending = false;
+      }
       return;
     }
 

--- a/lib/shared/widgets/markdown/streaming_markdown_widget.dart
+++ b/lib/shared/widgets/markdown/streaming_markdown_widget.dart
@@ -164,6 +164,13 @@ class _StreamingMarkdownWidgetState
   final GlobalKey _markdownContentKey = GlobalKey();
   final Map<String, CompiledMarkdownDocument> _displayPartDocumentCache =
       <String, CompiledMarkdownDocument>{};
+  // buildMarkdownDisplayParts re-derives one sub-document per root block and
+  // deep-compares each against the cache — O(whole message) string work. The
+  // widget rebuilds far more often than the compiled document changes (shell
+  // rebuilds, fade frames), so memoize the split by document identity.
+  CompiledMarkdownDocument? _displayPartsSourceDocument;
+  bool _displayPartsWereStreaming = false;
+  List<MarkdownDisplayPart>? _displayPartsMemo;
   // Unique per-instance prefix used when no stateScopeId is supplied, so two
   // scope-less StreamingMarkdownWidgets on the same route don't share
   // PageStorage keys (markdown_compile_service reuses block ids across unrelated
@@ -424,6 +431,8 @@ class _StreamingMarkdownWidgetState
   @override
   void didHaveMemoryPressure() {
     _displayPartDocumentCache.clear();
+    _displayPartsSourceDocument = null;
+    _displayPartsMemo = null;
     _compileService.handleMemoryPressure();
   }
 
@@ -769,11 +778,22 @@ class _StreamingMarkdownWidgetState
   }
 
   Widget _buildMarkdownDisplayParts(CompiledMarkdownDocument document) {
-    final parts = buildMarkdownDisplayParts(
-      document,
-      isStreaming: widget.isStreaming,
-    );
-    if (parts.isEmpty) {
+    var stableParts = _displayPartsMemo;
+    if (stableParts == null ||
+        !identical(document, _displayPartsSourceDocument) ||
+        widget.isStreaming != _displayPartsWereStreaming) {
+      final parts = buildMarkdownDisplayParts(
+        document,
+        isStreaming: widget.isStreaming,
+      );
+      stableParts = parts.isEmpty
+          ? const <MarkdownDisplayPart>[]
+          : _reuseStableDisplayPartDocuments(parts);
+      _displayPartsSourceDocument = document;
+      _displayPartsWereStreaming = widget.isStreaming;
+      _displayPartsMemo = stableParts;
+    }
+    if (stableParts.isEmpty) {
       _displayPartDocumentCache.clear();
       return _buildMarkdownWithCitations(
         document: document,
@@ -783,7 +803,6 @@ class _StreamingMarkdownWidgetState
         trimLastBlockBottomPadding: true,
       );
     }
-    final stableParts = _reuseStableDisplayPartDocuments(parts);
 
     return Column(
       mainAxisSize: MainAxisSize.min,

--- a/lib/shared/widgets/middle_ellipsis_text.dart
+++ b/lib/shared/widgets/middle_ellipsis_text.dart
@@ -34,9 +34,8 @@ class MiddleEllipsisText extends StatelessWidget {
 
     return LayoutBuilder(
       builder: (context, constraints) {
-        final TextStyle effectiveStyle = DefaultTextStyle.of(
-          context,
-        ).style.merge(style);
+        final TextStyle effectiveStyle = DefaultTextStyle.of(context).style
+            .merge(style);
         final TextDirection direction = Directionality.of(context);
         final TextScaler textScaler = MediaQuery.textScalerOf(context);
         final double maxWidth = constraints.maxWidth;

--- a/lib/shared/widgets/sheet_handle.dart
+++ b/lib/shared/widgets/sheet_handle.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/widgets.dart';
+
 import '../theme/theme_extensions.dart';
 
 class SheetHandle extends StatelessWidget {

--- a/test/core/auth/auth_state_manager_bootstrap_revision_test.dart
+++ b/test/core/auth/auth_state_manager_bootstrap_revision_test.dart
@@ -42,23 +42,20 @@ void main() {
       ).isFalse();
     });
 
-    test(
-      'suppressed when a newer auth attempt bumped the revision mid-flight',
-      () {
-        // e.g. a log, logout, or token-invalidation started while the background
-        // login was running: the revision moved on, so this stale bootstrap task
-        // must not publish unauthenticated over the newer attempt.
-        check(
-          bootstrapShouldFallbackToUnauthenticated(
-            committed: false,
-            capturedRevision: capturedRevision,
-            currentRevision: capturedRevision + 1,
-            status: AuthStatus.loading,
-            hasValidToken: false,
-          ),
-        ).isFalse();
-      },
-    );
+    test('suppressed when a newer auth attempt bumped the revision mid-flight', () {
+      // e.g. a log, logout, or token-invalidation started while the background
+      // login was running: the revision moved on, so this stale bootstrap task
+      // must not publish unauthenticated over the newer attempt.
+      check(
+        bootstrapShouldFallbackToUnauthenticated(
+          committed: false,
+          capturedRevision: capturedRevision,
+          currentRevision: capturedRevision + 1,
+          status: AuthStatus.loading,
+          hasValidToken: false,
+        ),
+      ).isFalse();
+    });
 
     test(
       'suppressed once a session has been published (status off loading)',

--- a/test/core/auth/auth_state_manager_error_sanitization_test.dart
+++ b/test/core/auth/auth_state_manager_error_sanitization_test.dart
@@ -51,20 +51,18 @@ void main() {
         for (final mode in _AuthMode.values) {
           final storage = _Storage();
           when(() => storage.getAuthTokenStrict()).thenAnswer((_) async => '');
-          when(
-            () => storage.getSavedCredentialsStrict(),
-          ).thenAnswer((_) async => null);
+          when(() => storage.getSavedCredentialsStrict())
+              .thenAnswer((_) async => null);
           when(() => storage.saveLocalUser(any())).thenAnswer((_) async {});
           when(() => storage.clearAuthData()).thenAnswer((_) async {});
-          when(
-            () => storage.clearAuthDataIf(canClear: any(named: 'canClear')),
-          ).thenAnswer((invocation) async {
-            final canClear =
-                invocation.namedArguments[#canClear] as bool Function();
-            if (!canClear()) return false;
-            await storage.clearAuthData();
-            return true;
-          });
+          when(() => storage.clearAuthDataIf(canClear: any(named: 'canClear')))
+              .thenAnswer((invocation) async {
+                final canClear =
+                    invocation.namedArguments[#canClear] as bool Function();
+                if (!canClear()) return false;
+                await storage.clearAuthData();
+                return true;
+              });
 
           final api = _ReflectingAuthApi(mode);
           _stubOwnershipCapture(storage, api.serverConfig);
@@ -112,9 +110,8 @@ void main() {
             }
 
             await notifier.logout();
-            check(
-              container.read(authStateManagerProvider).requireValue.status,
-            ).equals(AuthStatus.unauthenticated);
+            check(container.read(authStateManagerProvider).requireValue.status)
+                .equals(AuthStatus.unauthenticated);
           } finally {
             container.dispose();
           }
@@ -145,12 +142,10 @@ void main() {
     'background stored-token validation never logs reflected secrets',
     () async {
       final storage = _Storage();
-      when(
-        () => storage.getAuthTokenStrict(),
-      ).thenAnswer((_) async => _tokenSecret);
-      when(
-        () => storage.getLocalUserWithAvatar(),
-      ).thenAnswer((_) async => null);
+      when(() => storage.getAuthTokenStrict())
+          .thenAnswer((_) async => _tokenSecret);
+      when(() => storage.getLocalUserWithAvatar())
+          .thenAnswer((_) async => null);
       when(() => storage.saveLocalUser(any())).thenAnswer((_) async {});
 
       final api = _ReflectingAuthApi(_AuthMode.token);
@@ -207,9 +202,8 @@ void main() {
     () async {
       final storage = _Storage();
       when(() => storage.getAuthTokenStrict()).thenAnswer((_) async => '');
-      when(
-        () => storage.getSavedCredentialsStrict(),
-      ).thenAnswer((_) async => null);
+      when(() => storage.getSavedCredentialsStrict())
+          .thenAnswer((_) async => null);
       when(() => storage.saveLocalUser(any())).thenAnswer((_) async {});
       final api = _LdapDisabledAuthApi();
       _stubOwnershipCapture(storage, api.serverConfig);
@@ -232,9 +226,8 @@ void main() {
       }
 
       check(thrown).isNotNull();
-      check(
-        thrown.toString(),
-      ).equals('Exception: LDAP authentication is not enabled');
+      check(thrown.toString())
+          .equals('Exception: LDAP authentication is not enabled');
       final auth = container.read(authStateManagerProvider).requireValue;
       check(auth.status).equals(AuthStatus.error);
       check(auth.error).equals('LDAP authentication is not enabled');

--- a/test/core/auth/auth_state_manager_prevalidated_proxy_test.dart
+++ b/test/core/auth/auth_state_manager_prevalidated_proxy_test.dart
@@ -77,9 +77,8 @@ void main() {
     addTearDown(PreferencesStore.debugReset);
     final storage = _Storage();
     when(() => storage.getAuthTokenStrict()).thenAnswer((_) async => '');
-    when(
-      () => storage.getSavedCredentialsStrict(),
-    ).thenAnswer((_) async => null);
+    when(() => storage.getSavedCredentialsStrict())
+        .thenAnswer((_) async => null);
     when(() => storage.saveLocalUser(null)).thenAnswer((_) async {});
     final firstEntered = Completer<void>();
     final releaseFirst = Completer<void>();
@@ -127,9 +126,8 @@ void main() {
     await olderSelection;
 
     check(publishedServerIds).deepEquals([candidate.id]);
-    check(
-      container.read(authStateManagerProvider).requireValue.status,
-    ).equals(AuthStatus.unauthenticated);
+    check(container.read(authStateManagerProvider).requireValue.status)
+        .equals(AuthStatus.unauthenticated);
   });
 
   test('a rolled-back login publication restores in-memory auth', () async {
@@ -138,9 +136,8 @@ void main() {
     addTearDown(PreferencesStore.debugReset);
     final storage = _Storage();
     when(() => storage.getAuthTokenStrict()).thenAnswer((_) async => '');
-    when(
-      () => storage.getSavedCredentialsStrict(),
-    ).thenAnswer((_) async => null);
+    when(() => storage.getSavedCredentialsStrict())
+        .thenAnswer((_) async => null);
     when(() => storage.saveLocalUser(null)).thenAnswer((_) async {});
     when(
       () => storage.captureServerSessionOwnership(
@@ -202,9 +199,8 @@ void main() {
 
       final storage = _Storage();
       when(() => storage.getAuthTokenStrict()).thenAnswer((_) async => '');
-      when(
-        () => storage.getSavedCredentialsStrict(),
-      ).thenAnswer((_) async => null);
+      when(() => storage.getSavedCredentialsStrict())
+          .thenAnswer((_) async => null);
       when(() => storage.saveLocalUser(null)).thenAnswer((_) async {});
       when(
         () =>
@@ -283,9 +279,8 @@ void main() {
     () async {
       final storage = _Storage();
       when(() => storage.getAuthTokenStrict()).thenAnswer((_) async => '');
-      when(
-        () => storage.getSavedCredentialsStrict(),
-      ).thenAnswer((_) async => null);
+      when(() => storage.getSavedCredentialsStrict())
+          .thenAnswer((_) async => null);
       when(() => storage.saveLocalUser(null)).thenAnswer((_) async {});
       when(() => storage.stageServerConfigCandidate(candidate)).thenAnswer(
         (_) async => (
@@ -348,13 +343,11 @@ void main() {
   test('prevalidated proxy publishes only after token persistence', () async {
     final storage = _Storage();
     when(() => storage.getAuthTokenStrict()).thenAnswer((_) async => '');
-    when(
-      () => storage.getSavedCredentialsStrict(),
-    ).thenAnswer((_) async => null);
+    when(() => storage.getSavedCredentialsStrict())
+        .thenAnswer((_) async => null);
     when(() => storage.saveLocalUser(null)).thenAnswer((_) async {});
-    when(
-      () => storage.saveLocalUserWithAvatar(user, avatarUrl: null),
-    ).thenAnswer((_) async {});
+    when(() => storage.saveLocalUserWithAvatar(user, avatarUrl: null))
+        .thenAnswer((_) async {});
     when(() => storage.stageServerConfigCandidate(candidate)).thenAnswer(
       (_) async => (
         configs: const [previousConfig],
@@ -429,85 +422,79 @@ void main() {
     );
   });
 
-  test(
-    'authenticated publication replaced synchronously cannot cache a stale user',
-    () async {
-      final storage = _Storage();
-      when(() => storage.getAuthTokenStrict()).thenAnswer((_) async => '');
-      when(
-        () => storage.getSavedCredentialsStrict(),
-      ).thenAnswer((_) async => null);
-      when(() => storage.saveLocalUser(null)).thenAnswer((_) async {});
-      when(() => storage.stageServerConfigCandidate(candidate)).thenAnswer(
-        (_) async => (
-          configs: const [previousConfig],
-          activeServerId: previousConfig.id,
-          transactionId: 13,
-        ),
-      );
-      when(
-        () => storage.commitServerConfigCandidateSession(
-          candidate: candidate,
-          transactionId: 13,
-          token: token,
-          canCommit: any(named: 'canCommit'),
-          publish: any(named: 'publish'),
-          onRollbackUncertain: any(named: 'onRollbackUncertain'),
-        ),
-      ).thenAnswer((invocation) async {
-        final publish =
-            invocation.namedArguments[#publish] as FutureOr<void> Function();
-        await publish();
-        return true;
-      });
+  test('authenticated publication replaced synchronously cannot cache a stale user', () async {
+    final storage = _Storage();
+    when(() => storage.getAuthTokenStrict()).thenAnswer((_) async => '');
+    when(() => storage.getSavedCredentialsStrict())
+        .thenAnswer((_) async => null);
+    when(() => storage.saveLocalUser(null)).thenAnswer((_) async {});
+    when(() => storage.stageServerConfigCandidate(candidate)).thenAnswer(
+      (_) async => (
+        configs: const [previousConfig],
+        activeServerId: previousConfig.id,
+        transactionId: 13,
+      ),
+    );
+    when(
+      () => storage.commitServerConfigCandidateSession(
+        candidate: candidate,
+        transactionId: 13,
+        token: token,
+        canCommit: any(named: 'canCommit'),
+        publish: any(named: 'publish'),
+        onRollbackUncertain: any(named: 'onRollbackUncertain'),
+      ),
+    ).thenAnswer((invocation) async {
+      final publish =
+          invocation.namedArguments[#publish] as FutureOr<void> Function();
+      await publish();
+      return true;
+    });
 
-      final container = ProviderContainer(
-        overrides: [
-          optimizedStorageServiceProvider.overrideWithValue(storage),
-          apiServiceProvider.overrideWithValue(null),
-          defaultModelProvider.overrideWith((ref) async => null),
-        ],
-      );
-      addTearDown(container.dispose);
-      await container.read(authStateManagerProvider.future);
-      await _waitForAuthStatus(container, AuthStatus.unauthenticated);
+    final container = ProviderContainer(
+      overrides: [
+        optimizedStorageServiceProvider.overrideWithValue(storage),
+        apiServiceProvider.overrideWithValue(null),
+        defaultModelProvider.overrideWith((ref) async => null),
+      ],
+    );
+    addTearDown(container.dispose);
+    await container.read(authStateManagerProvider.future);
+    await _waitForAuthStatus(container, AuthStatus.unauthenticated);
 
-      var replaced = false;
-      final subscription = container.listen(authStateManagerProvider, (
-        previous,
-        next,
-      ) {
-        if (replaced || next.asData?.value.isAuthenticated != true) return;
-        replaced = true;
-        container.read(authStateManagerProvider.notifier).onAuthIssue();
-      });
-      addTearDown(subscription.close);
+    var replaced = false;
+    final subscription = container.listen(authStateManagerProvider, (
+      previous,
+      next,
+    ) {
+      if (replaced || next.asData?.value.isAuthenticated != true) return;
+      replaced = true;
+      container.read(authStateManagerProvider.notifier).onAuthIssue();
+    });
+    addTearDown(subscription.close);
 
-      check(
-        await container
-            .read(authStateManagerProvider.notifier)
-            .commitPrevalidatedProxySession(
-              serverConfig: candidate,
-              token: token,
-              user: user,
-            ),
-      ).isTrue();
-      await Future<void>.delayed(Duration.zero);
+    check(
+      await container
+          .read(authStateManagerProvider.notifier)
+          .commitPrevalidatedProxySession(
+            serverConfig: candidate,
+            token: token,
+            user: user,
+          ),
+    ).isTrue();
+    await Future<void>.delayed(Duration.zero);
 
-      check(replaced).isTrue();
-      check(
-        container.read(authStateManagerProvider).requireValue.status,
-      ).equals(AuthStatus.error);
-      verifyNever(() => storage.saveLocalUserWithAvatar(user, avatarUrl: null));
-    },
-  );
+    check(replaced).isTrue();
+    check(container.read(authStateManagerProvider).requireValue.status)
+        .equals(AuthStatus.error);
+    verifyNever(() => storage.saveLocalUserWithAvatar(user, avatarUrl: null));
+  });
 
   test('overlapping failures restore the last settled auth state', () async {
     final storage = _Storage();
     when(() => storage.getAuthTokenStrict()).thenAnswer((_) async => '');
-    when(
-      () => storage.getSavedCredentialsStrict(),
-    ).thenAnswer((_) async => null);
+    when(() => storage.getSavedCredentialsStrict())
+        .thenAnswer((_) async => null);
     when(() => storage.saveLocalUser(null)).thenAnswer((_) async {});
     var stageCall = 0;
     when(() => storage.stageServerConfigCandidate(candidate)).thenAnswer(
@@ -587,13 +574,11 @@ void main() {
     () async {
       final storage = _Storage();
       when(() => storage.getAuthTokenStrict()).thenAnswer((_) async => '');
-      when(
-        () => storage.getSavedCredentialsStrict(),
-      ).thenAnswer((_) async => null);
+      when(() => storage.getSavedCredentialsStrict())
+          .thenAnswer((_) async => null);
       when(() => storage.saveLocalUser(null)).thenAnswer((_) async {});
-      when(
-        () => storage.saveLocalUserWithAvatar(user, avatarUrl: null),
-      ).thenAnswer((_) async {});
+      when(() => storage.saveLocalUserWithAvatar(user, avatarUrl: null))
+          .thenAnswer((_) async {});
       var stageCall = 17;
       when(() => storage.stageServerConfigCandidate(candidate)).thenAnswer(
         (_) async => (
@@ -656,9 +641,8 @@ void main() {
           user: user,
         ),
       ).isTrue();
-      check(
-        container.read(authStateManagerProvider).requireValue.status,
-      ).equals(AuthStatus.authenticated);
+      check(container.read(authStateManagerProvider).requireValue.status)
+          .equals(AuthStatus.authenticated);
 
       await expectLater(
         notifier.commitPrevalidatedProxySession(
@@ -683,13 +667,11 @@ void main() {
     () async {
       final storage = _Storage();
       when(() => storage.getAuthTokenStrict()).thenAnswer((_) async => '');
-      when(
-        () => storage.getSavedCredentialsStrict(),
-      ).thenAnswer((_) async => null);
+      when(() => storage.getSavedCredentialsStrict())
+          .thenAnswer((_) async => null);
       when(() => storage.saveLocalUser(null)).thenAnswer((_) async {});
-      when(
-        () => storage.saveLocalUserWithAvatar(user, avatarUrl: null),
-      ).thenAnswer((_) async {});
+      when(() => storage.saveLocalUserWithAvatar(user, avatarUrl: null))
+          .thenAnswer((_) async {});
       var stageCall = 29;
       when(() => storage.stageServerConfigCandidate(candidate)).thenAnswer(
         (_) async => (
@@ -798,13 +780,11 @@ void main() {
       for (final mode in _MixedAuthMode.values) {
         final storage = _Storage();
         when(() => storage.getAuthTokenStrict()).thenAnswer((_) async => '');
-        when(
-          () => storage.getSavedCredentialsStrict(),
-        ).thenAnswer((_) async => null);
+        when(() => storage.getSavedCredentialsStrict())
+            .thenAnswer((_) async => null);
         when(() => storage.saveLocalUser(null)).thenAnswer((_) async {});
-        when(
-          () => storage.saveLocalUserWithAvatar(user, avatarUrl: null),
-        ).thenAnswer((_) async {});
+        when(() => storage.saveLocalUserWithAvatar(user, avatarUrl: null))
+            .thenAnswer((_) async {});
         when(
           () => storage.captureServerSessionOwnership(
             validatedConfig: any(named: 'validatedConfig'),
@@ -860,9 +840,8 @@ void main() {
   test('logout supersedes a login before its first network request', () async {
     final storage = _Storage();
     when(() => storage.getAuthTokenStrict()).thenAnswer((_) async => '');
-    when(
-      () => storage.getSavedCredentialsStrict(),
-    ).thenAnswer((_) async => null);
+    when(() => storage.getSavedCredentialsStrict())
+        .thenAnswer((_) async => null);
     when(() => storage.saveLocalUser(null)).thenAnswer((_) async {});
     when(() => storage.clearAuthData()).thenAnswer((_) async {});
     _routeConditionalAuthClearToLegacyMock(storage);
@@ -914,13 +893,11 @@ void main() {
       addTearDown(PreferencesStore.debugReset);
       final storage = _Storage();
       when(() => storage.getAuthTokenStrict()).thenAnswer((_) async => '');
-      when(
-        () => storage.getSavedCredentialsStrict(),
-      ).thenAnswer((_) async => null);
+      when(() => storage.getSavedCredentialsStrict())
+          .thenAnswer((_) async => null);
       when(() => storage.saveLocalUser(null)).thenAnswer((_) async {});
-      when(
-        () => storage.saveLocalUserWithAvatar(user, avatarUrl: null),
-      ).thenAnswer((_) async {});
+      when(() => storage.saveLocalUserWithAvatar(user, avatarUrl: null))
+          .thenAnswer((_) async {});
       when(() => storage.clearAuthData()).thenAnswer((_) async {});
       _routeConditionalAuthClearToLegacyMock(storage);
       when(
@@ -998,13 +975,11 @@ void main() {
     addTearDown(PreferencesStore.debugReset);
     final storage = _Storage();
     when(() => storage.getAuthTokenStrict()).thenAnswer((_) async => '');
-    when(
-      () => storage.getSavedCredentialsStrict(),
-    ).thenAnswer((_) async => null);
+    when(() => storage.getSavedCredentialsStrict())
+        .thenAnswer((_) async => null);
     when(() => storage.saveLocalUser(null)).thenAnswer((_) async {});
-    when(
-      () => storage.saveLocalUserWithAvatar(user, avatarUrl: null),
-    ).thenAnswer((_) async {});
+    when(() => storage.saveLocalUserWithAvatar(user, avatarUrl: null))
+        .thenAnswer((_) async {});
     _routeConditionalAuthClearToLegacyMock(storage);
     when(
       () => storage.captureServerSessionOwnership(
@@ -1073,13 +1048,11 @@ void main() {
       addTearDown(PreferencesStore.debugReset);
       final storage = _Storage();
       when(() => storage.getAuthTokenStrict()).thenAnswer((_) async => '');
-      when(
-        () => storage.getSavedCredentialsStrict(),
-      ).thenAnswer((_) async => null);
+      when(() => storage.getSavedCredentialsStrict())
+          .thenAnswer((_) async => null);
       when(() => storage.saveLocalUser(null)).thenAnswer((_) async {});
-      when(
-        () => storage.saveLocalUserWithAvatar(user, avatarUrl: null),
-      ).thenAnswer((_) async {});
+      when(() => storage.saveLocalUserWithAvatar(user, avatarUrl: null))
+          .thenAnswer((_) async {});
       when(() => storage.clearAuthData()).thenAnswer((_) async {});
       _routeConditionalAuthClearToLegacyMock(storage);
       when(
@@ -1156,19 +1129,15 @@ void main() {
       addTearDown(PreferencesStore.debugReset);
       final storage = _Storage();
       String? storedToken;
-      when(
-        () => storage.getAuthTokenStrict(),
-      ).thenAnswer((_) async => storedToken ?? '');
-      when(
-        () => storage.getSavedCredentialsStrict(),
-      ).thenAnswer((_) async => null);
-      when(
-        () => storage.getLocalUserWithAvatar(),
-      ).thenAnswer((_) async => user);
+      when(() => storage.getAuthTokenStrict())
+          .thenAnswer((_) async => storedToken ?? '');
+      when(() => storage.getSavedCredentialsStrict())
+          .thenAnswer((_) async => null);
+      when(() => storage.getLocalUserWithAvatar())
+          .thenAnswer((_) async => user);
       when(() => storage.saveLocalUser(null)).thenAnswer((_) async {});
-      when(
-        () => storage.saveLocalUserWithAvatar(user, avatarUrl: null),
-      ).thenAnswer((_) async {});
+      when(() => storage.saveLocalUserWithAvatar(user, avatarUrl: null))
+          .thenAnswer((_) async {});
       when(() => storage.clearAuthData()).thenAnswer((_) async {});
       _routeConditionalAuthClearToLegacyMock(storage);
       when(
@@ -1245,13 +1214,11 @@ void main() {
       addTearDown(PreferencesStore.debugReset);
       final storage = _Storage();
       when(() => storage.getAuthTokenStrict()).thenAnswer((_) async => '');
-      when(
-        () => storage.getSavedCredentialsStrict(),
-      ).thenAnswer((_) async => null);
+      when(() => storage.getSavedCredentialsStrict())
+          .thenAnswer((_) async => null);
       when(() => storage.saveLocalUser(null)).thenAnswer((_) async {});
-      when(
-        () => storage.saveLocalUserWithAvatar(user, avatarUrl: null),
-      ).thenAnswer((_) async {});
+      when(() => storage.saveLocalUserWithAvatar(user, avatarUrl: null))
+          .thenAnswer((_) async {});
       when(() => storage.clearAuthData()).thenAnswer((_) async {});
       _routeConditionalAuthClearToLegacyMock(storage);
       when(
@@ -1300,9 +1267,8 @@ void main() {
 
       final logout = notifier.logout();
       await logoutEntered.future;
-      await check(
-        notifier.login('same-token-user', 'password'),
-      ).throws<Exception>();
+      await check(notifier.login('same-token-user', 'password'))
+          .throws<Exception>();
       releaseLogout.complete();
       await logout;
 
@@ -1324,13 +1290,11 @@ void main() {
       addTearDown(PreferencesStore.debugReset);
       final storage = _Storage();
       when(() => storage.getAuthTokenStrict()).thenAnswer((_) async => '');
-      when(
-        () => storage.getSavedCredentialsStrict(),
-      ).thenAnswer((_) async => null);
+      when(() => storage.getSavedCredentialsStrict())
+          .thenAnswer((_) async => null);
       when(() => storage.saveLocalUser(null)).thenAnswer((_) async {});
-      when(
-        () => storage.saveLocalUserWithAvatar(user, avatarUrl: null),
-      ).thenAnswer((_) async {});
+      when(() => storage.saveLocalUserWithAvatar(user, avatarUrl: null))
+          .thenAnswer((_) async {});
       when(() => storage.clearAuthData()).thenAnswer((_) async {});
       _routeConditionalAuthClearToLegacyMock(storage);
       when(
@@ -1380,9 +1344,8 @@ void main() {
 
       final logout = notifier.logout();
       await logoutEntered.future;
-      await check(
-        notifier.login('same-token-user', 'password'),
-      ).throws<Exception>();
+      await check(notifier.login('same-token-user', 'password'))
+          .throws<Exception>();
       releaseLogout.complete();
       await logout;
 
@@ -1404,13 +1367,11 @@ void main() {
       addTearDown(PreferencesStore.debugReset);
       final storage = _Storage();
       when(() => storage.getAuthTokenStrict()).thenAnswer((_) async => '');
-      when(
-        () => storage.getSavedCredentialsStrict(),
-      ).thenAnswer((_) async => null);
+      when(() => storage.getSavedCredentialsStrict())
+          .thenAnswer((_) async => null);
       when(() => storage.saveLocalUser(null)).thenAnswer((_) async {});
-      when(
-        () => storage.saveLocalUserWithAvatar(user, avatarUrl: null),
-      ).thenAnswer((_) async {});
+      when(() => storage.saveLocalUserWithAvatar(user, avatarUrl: null))
+          .thenAnswer((_) async {});
       when(() => storage.clearAuthData()).thenAnswer((_) async {});
       _routeConditionalAuthClearToLegacyMock(storage);
       when(
@@ -1476,13 +1437,11 @@ void main() {
       addTearDown(PreferencesStore.debugReset);
       final storage = _Storage();
       when(() => storage.getAuthTokenStrict()).thenAnswer((_) async => '');
-      when(
-        () => storage.getSavedCredentialsStrict(),
-      ).thenAnswer((_) async => null);
+      when(() => storage.getSavedCredentialsStrict())
+          .thenAnswer((_) async => null);
       when(() => storage.saveLocalUser(null)).thenAnswer((_) async {});
-      when(
-        () => storage.saveLocalUserWithAvatar(user, avatarUrl: null),
-      ).thenAnswer((_) async {});
+      when(() => storage.saveLocalUserWithAvatar(user, avatarUrl: null))
+          .thenAnswer((_) async {});
       when(() => storage.clearAuthData()).thenAnswer((_) async {});
       _routeConditionalAuthClearToLegacyMock(storage);
       when(
@@ -1574,9 +1533,8 @@ void main() {
 
     final storage = _Storage();
     when(() => storage.getAuthTokenStrict()).thenAnswer((_) async => '');
-    when(
-      () => storage.getSavedCredentialsStrict(),
-    ).thenAnswer((_) async => null);
+    when(() => storage.getSavedCredentialsStrict())
+        .thenAnswer((_) async => null);
     when(() => storage.saveLocalUser(null)).thenAnswer((_) async {});
     when(() => storage.clearAuthData()).thenAnswer((_) async {});
     _routeConditionalAuthClearToLegacyMock(storage);
@@ -1631,9 +1589,8 @@ void main() {
     await _waitForAuthStatus(container, AuthStatus.unauthenticated);
     final notifier = container.read(authStateManagerProvider.notifier);
     check(await notifier.login('account-a', 'password')).isTrue();
-    check(
-      container.read(authStateManagerProvider).requireValue.user,
-    ).equals(user);
+    check(container.read(authStateManagerProvider).requireValue.user)
+        .equals(user);
     api.loginFailure = StateError('new login rejected');
 
     final logout = notifier.logout();
@@ -1666,13 +1623,11 @@ void main() {
       addTearDown(PreferencesStore.debugReset);
       final storage = _Storage();
       when(() => storage.getAuthTokenStrict()).thenAnswer((_) async => '');
-      when(
-        () => storage.getSavedCredentialsStrict(),
-      ).thenAnswer((_) async => null);
+      when(() => storage.getSavedCredentialsStrict())
+          .thenAnswer((_) async => null);
       when(() => storage.saveLocalUser(null)).thenAnswer((_) async {});
-      when(
-        () => storage.saveLocalUserWithAvatar(user, avatarUrl: null),
-      ).thenAnswer((_) async {});
+      when(() => storage.saveLocalUserWithAvatar(user, avatarUrl: null))
+          .thenAnswer((_) async {});
       when(() => storage.clearAuthData()).thenAnswer((_) async {});
       _routeConditionalAuthClearToLegacyMock(storage);
       when(
@@ -1763,13 +1718,11 @@ void main() {
 
       final storage = _Storage();
       when(() => storage.getAuthTokenStrict()).thenAnswer((_) async => '');
-      when(
-        () => storage.getSavedCredentialsStrict(),
-      ).thenAnswer((_) async => null);
+      when(() => storage.getSavedCredentialsStrict())
+          .thenAnswer((_) async => null);
       when(() => storage.saveLocalUser(null)).thenAnswer((_) async {});
-      when(
-        () => storage.clearAuthData(),
-      ).thenThrow(StateError('secure config rewrite failed'));
+      when(() => storage.clearAuthData())
+          .thenThrow(StateError('secure config rewrite failed'));
       _routeConditionalAuthClearToLegacyMock(storage);
       const cookieConfig = ServerConfig(
         id: 'proxy',
@@ -1793,9 +1746,8 @@ void main() {
 
       await container.read(authStateManagerProvider.notifier).logout();
 
-      check(
-        PreferencesStore.getBool(PreferenceKeys.incompleteLogoutFence),
-      ).equals(true);
+      check(PreferencesStore.getBool(PreferenceKeys.incompleteLogoutFence))
+          .equals(true);
       check(container.read(incompleteLogoutFenceProvider)).isTrue();
       final liveAdapter = _RecordingAdapter();
       api.dio.httpClientAdapter = liveAdapter;
@@ -1912,9 +1864,8 @@ void main() {
 
       final storage = _Storage();
       when(() => storage.saveLocalUser(null)).thenAnswer((_) async {});
-      when(
-        () => storage.clearAuthData(),
-      ).thenThrow(StateError('Keychain still unavailable'));
+      when(() => storage.clearAuthData())
+          .thenThrow(StateError('Keychain still unavailable'));
       final container = ProviderContainer(
         overrides: [
           optimizedStorageServiceProvider.overrideWithValue(storage),
@@ -1942,9 +1893,8 @@ void main() {
     () async {
       final storage = _Storage();
       when(() => storage.getAuthTokenStrict()).thenAnswer((_) async => null);
-      when(
-        () => storage.getSavedCredentialsStrict(),
-      ).thenThrow(PlatformException(code: 'keychain-unavailable'));
+      when(() => storage.getSavedCredentialsStrict())
+          .thenThrow(PlatformException(code: 'keychain-unavailable'));
       when(() => storage.saveLocalUser(null)).thenAnswer((_) async {});
       final container = ProviderContainer(
         overrides: [
@@ -1977,16 +1927,13 @@ void main() {
         role: 'user',
       );
       final storage = _Storage();
-      when(
-        () => storage.getAuthTokenStrict(),
-      ).thenAnswer((_) async => storedToken);
-      when(
-        () => storage.getLocalUserWithAvatar(),
-      ).thenAnswer((_) async => null);
+      when(() => storage.getAuthTokenStrict())
+          .thenAnswer((_) async => storedToken);
+      when(() => storage.getLocalUserWithAvatar())
+          .thenAnswer((_) async => null);
       when(() => storage.saveLocalUser(null)).thenAnswer((_) async {});
-      when(
-        () => storage.saveLocalUserWithAvatar(user, avatarUrl: null),
-      ).thenAnswer((_) async {});
+      when(() => storage.saveLocalUserWithAvatar(user, avatarUrl: null))
+          .thenAnswer((_) async {});
       when(() => storage.stageServerConfigCandidate(candidate)).thenAnswer(
         (_) async => (
           configs: const [previousConfig],
@@ -2060,13 +2007,11 @@ void main() {
       await releaseRefreshRead.future;
       return null;
     });
-    when(
-      () => storage.getSavedCredentialsStrict(),
-    ).thenAnswer((_) async => null);
+    when(() => storage.getSavedCredentialsStrict())
+        .thenAnswer((_) async => null);
     when(() => storage.saveLocalUser(null)).thenAnswer((_) async {});
-    when(
-      () => storage.saveLocalUserWithAvatar(user, avatarUrl: null),
-    ).thenAnswer((_) async {});
+    when(() => storage.saveLocalUserWithAvatar(user, avatarUrl: null))
+        .thenAnswer((_) async {});
     when(
       () => storage.captureServerSessionOwnership(
         validatedConfig: any(named: 'validatedConfig'),
@@ -2132,24 +2077,21 @@ void main() {
         tokenReads++;
         return tokenReads == 1 ? token : rejectedApiKey;
       });
-      when(
-        () => storage.getLocalUserWithAvatar(),
-      ).thenAnswer((_) async => user);
+      when(() => storage.getLocalUserWithAvatar())
+          .thenAnswer((_) async => user);
       when(() => storage.saveLocalUser(null)).thenAnswer((_) async {});
-      when(
-        () => storage.saveLocalUserWithAvatar(user, avatarUrl: null),
-      ).thenAnswer((_) async {});
+      when(() => storage.saveLocalUserWithAvatar(user, avatarUrl: null))
+          .thenAnswer((_) async {});
       final cleanupEntered = Completer<void>();
       final releaseCleanup = Completer<void>();
-      when(
-        () => storage.clearAuthDataIf(canClear: any(named: 'canClear')),
-      ).thenAnswer((invocation) async {
-        cleanupEntered.complete();
-        await releaseCleanup.future;
-        final canClear =
-            invocation.namedArguments[#canClear] as bool Function();
-        return canClear();
-      });
+      when(() => storage.clearAuthDataIf(canClear: any(named: 'canClear')))
+          .thenAnswer((invocation) async {
+            cleanupEntered.complete();
+            await releaseCleanup.future;
+            final canClear =
+                invocation.namedArguments[#canClear] as bool Function();
+            return canClear();
+          });
 
       final api = _SuccessfulAuthApi();
       final container = ProviderContainer(
@@ -2197,9 +2139,8 @@ void main() {
       };
       final storage = _Storage();
       when(() => storage.getAuthTokenStrict()).thenAnswer((_) async => null);
-      when(
-        () => storage.getSavedCredentialsStrict(),
-      ).thenAnswer((_) async => savedCredentials);
+      when(() => storage.getSavedCredentialsStrict())
+          .thenAnswer((_) async => savedCredentials);
       when(
         () => storage.captureSavedServerSessionOwnership(previousConfig.id),
       ).thenAnswer(
@@ -2221,9 +2162,8 @@ void main() {
         await publish();
         return true;
       });
-      when(
-        () => storage.saveLocalUserWithAvatar(user, avatarUrl: null),
-      ).thenAnswer((_) async {});
+      when(() => storage.saveLocalUserWithAvatar(user, avatarUrl: null))
+          .thenAnswer((_) async {});
       final tempApis = <_SuccessfulAuthApi>[];
       final container = ProviderContainer(
         overrides: [
@@ -2304,9 +2244,8 @@ void main() {
           (_) async =>
               (revision: 1, serverConfig: previousConfig, requireActive: false),
         );
-        when(
-          () => storage.deleteSavedCredentialsIfMatches(savedCredentials),
-        ).thenAnswer((_) async => true);
+        when(() => storage.deleteSavedCredentialsIfMatches(savedCredentials))
+            .thenAnswer((_) async => true);
 
         final tempApis = <_SuccessfulAuthApi>[];
         final container = ProviderContainer(
@@ -2399,9 +2338,8 @@ void main() {
 
         final storage = _Storage();
         when(() => storage.getAuthTokenStrict()).thenAnswer((_) async => '');
-        when(
-          () => storage.getSavedCredentialsStrict(),
-        ).thenAnswer((_) async => null);
+        when(() => storage.getSavedCredentialsStrict())
+            .thenAnswer((_) async => null);
         when(() => storage.saveLocalUser(null)).thenAnswer((_) async {});
         when(
           () => storage.captureServerSessionOwnership(
@@ -2466,9 +2404,8 @@ void main() {
           check(settled.user).isNull();
           check(settled.isLoading).isFalse();
           check(container.read(incompleteLogoutFenceProvider)).isTrue();
-          check(
-            PreferencesStore.getBool(PreferenceKeys.incompleteLogoutFence),
-          ).equals(true);
+          check(PreferencesStore.getBool(PreferenceKeys.incompleteLogoutFence))
+              .equals(true);
         } finally {
           container.dispose();
           api.dispose();
@@ -2487,13 +2424,11 @@ void main() {
 
       final storage = _Storage();
       when(() => storage.getAuthTokenStrict()).thenAnswer((_) async => '');
-      when(
-        () => storage.getSavedCredentialsStrict(),
-      ).thenAnswer((_) async => null);
+      when(() => storage.getSavedCredentialsStrict())
+          .thenAnswer((_) async => null);
       when(() => storage.saveLocalUser(null)).thenAnswer((_) async {});
-      when(
-        () => storage.saveLocalUserWithAvatar(user, avatarUrl: null),
-      ).thenAnswer((_) async {});
+      when(() => storage.saveLocalUserWithAvatar(user, avatarUrl: null))
+          .thenAnswer((_) async {});
       when(() => storage.clearAuthData()).thenAnswer((_) async {});
       _routeConditionalAuthClearToLegacyMock(storage);
       when(
@@ -2573,9 +2508,8 @@ void main() {
         check(
           container.read(authStateManagerProvider).requireValue.isAuthenticated,
         ).isFalse();
-        check(
-          PreferencesStore.getBool(PreferenceKeys.incompleteLogoutFence),
-        ).equals(true);
+        check(PreferencesStore.getBool(PreferenceKeys.incompleteLogoutFence))
+            .equals(true);
 
         releaseLogout.complete();
         await logout;
@@ -2598,13 +2532,11 @@ void main() {
 
       final storage = _Storage();
       when(() => storage.getAuthTokenStrict()).thenAnswer((_) async => '');
-      when(
-        () => storage.getSavedCredentialsStrict(),
-      ).thenAnswer((_) async => null);
+      when(() => storage.getSavedCredentialsStrict())
+          .thenAnswer((_) async => null);
       when(() => storage.saveLocalUser(null)).thenAnswer((_) async {});
-      when(
-        () => storage.saveLocalUserWithAvatar(user, avatarUrl: null),
-      ).thenAnswer((_) async {});
+      when(() => storage.saveLocalUserWithAvatar(user, avatarUrl: null))
+          .thenAnswer((_) async {});
       when(() => storage.clearAuthData()).thenAnswer((_) async {});
       _routeConditionalAuthClearToLegacyMock(storage);
       when(
@@ -2671,9 +2603,8 @@ void main() {
 
         check(await login).isTrue();
         await logoutEntered.future;
-        check(
-          PreferencesStore.getBool(PreferenceKeys.incompleteLogoutFence),
-        ).isNull();
+        check(PreferencesStore.getBool(PreferenceKeys.incompleteLogoutFence))
+            .isNull();
         releaseLogout.complete();
         await logout;
 
@@ -2681,9 +2612,8 @@ void main() {
         check(settled.status).equals(AuthStatus.authenticated);
         check(settled.token).equals(token);
         check(settled.user).equals(user);
-        check(
-          PreferencesStore.getBool(PreferenceKeys.incompleteLogoutFence),
-        ).isNull();
+        check(PreferencesStore.getBool(PreferenceKeys.incompleteLogoutFence))
+            .isNull();
       } finally {
         if (!releaseTrueWrite.isCompleted) releaseTrueWrite.complete();
         if (!releaseLogout.isCompleted) releaseLogout.complete();
@@ -2697,13 +2627,11 @@ void main() {
   test('stale token invalidation cannot overwrite a newer login', () async {
     final storage = _Storage();
     when(() => storage.getAuthTokenStrict()).thenAnswer((_) async => '');
-    when(
-      () => storage.getSavedCredentialsStrict(),
-    ).thenAnswer((_) async => null);
+    when(() => storage.getSavedCredentialsStrict())
+        .thenAnswer((_) async => null);
     when(() => storage.saveLocalUser(null)).thenAnswer((_) async {});
-    when(
-      () => storage.saveLocalUserWithAvatar(user, avatarUrl: null),
-    ).thenAnswer((_) async {});
+    when(() => storage.saveLocalUserWithAvatar(user, avatarUrl: null))
+        .thenAnswer((_) async {});
     when(() => storage.stageServerConfigCandidate(candidate)).thenAnswer(
       (_) async => (
         configs: const [previousConfig],
@@ -2804,18 +2732,15 @@ void main() {
     () async {
       final storage = _Storage();
       when(() => storage.getAuthTokenStrict()).thenAnswer((_) async => '');
-      when(
-        () => storage.getSavedCredentialsStrict(),
-      ).thenAnswer((_) async => null);
+      when(() => storage.getSavedCredentialsStrict())
+          .thenAnswer((_) async => null);
       when(() => storage.getSavedCredentials()).thenAnswer((_) async => null);
-      when(
-        () => storage.deleteAuthTokenIfMatches(token),
-      ).thenAnswer((_) async => true);
+      when(() => storage.deleteAuthTokenIfMatches(token))
+          .thenAnswer((_) async => true);
       when(() => storage.clearUserScopedAuthData()).thenAnswer((_) async {});
       when(() => storage.saveLocalUser(null)).thenAnswer((_) async {});
-      when(
-        () => storage.saveLocalUserWithAvatar(user, avatarUrl: null),
-      ).thenAnswer((_) async {});
+      when(() => storage.saveLocalUserWithAvatar(user, avatarUrl: null))
+          .thenAnswer((_) async {});
       when(
         () => storage.captureServerSessionOwnership(
           validatedConfig: any(named: 'validatedConfig'),
@@ -2876,13 +2801,11 @@ void main() {
       for (final mode in _MixedAuthMode.values) {
         final storage = _Storage();
         when(() => storage.getAuthTokenStrict()).thenAnswer((_) async => '');
-        when(
-          () => storage.getSavedCredentialsStrict(),
-        ).thenAnswer((_) async => null);
+        when(() => storage.getSavedCredentialsStrict())
+            .thenAnswer((_) async => null);
         when(() => storage.saveLocalUser(null)).thenAnswer((_) async {});
-        when(
-          () => storage.saveLocalUserWithAvatar(user, avatarUrl: null),
-        ).thenAnswer((_) async {});
+        when(() => storage.saveLocalUserWithAvatar(user, avatarUrl: null))
+            .thenAnswer((_) async {});
         var stageCall = 39;
         when(() => storage.stageServerConfigCandidate(candidate)).thenAnswer(
           (_) async => (
@@ -3029,15 +2952,13 @@ void main() {
       return strictCredentialReads == 1 ? null : savedCredentials;
     });
     when(() => storage.saveLocalUser(null)).thenAnswer((_) async {});
-    when(
-      () => storage.saveLocalUserWithAvatar(user, avatarUrl: null),
-    ).thenAnswer((_) async {});
-    when(
-      () => storage.captureSavedServerSessionOwnership(previousConfig.id),
-    ).thenAnswer(
-      (_) async =>
-          (revision: 1, serverConfig: previousConfig, requireActive: false),
-    );
+    when(() => storage.saveLocalUserWithAvatar(user, avatarUrl: null))
+        .thenAnswer((_) async {});
+    when(() => storage.captureSavedServerSessionOwnership(previousConfig.id))
+        .thenAnswer(
+          (_) async =>
+              (revision: 1, serverConfig: previousConfig, requireActive: false),
+        );
     var stageCall = 49;
     when(() => storage.stageServerConfigCandidate(candidate)).thenAnswer(
       (_) async => (
@@ -3340,7 +3261,6 @@ Future<void> _waitForAuthStatus(
     if (state?.status == expected) return;
     await Future<void>.delayed(const Duration(milliseconds: 5));
   }
-  check(
-    container.read(authStateManagerProvider).requireValue.status,
-  ).equals(expected);
+  check(container.read(authStateManagerProvider).requireValue.status)
+      .equals(expected);
 }

--- a/test/core/database/chat_blob_mapper_test.dart
+++ b/test/core/database/chat_blob_mapper_test.dart
@@ -76,21 +76,16 @@ void main() {
           final rows = rowsFromFixture(fixture);
           check(rows.chat.id).equals(fixture.envelope['id'] as String);
           check(rows.chat.title).equals(fixture.envelope['title'] as String);
-          check(
-            rows.chat.folderId,
-          ).equals(fixture.envelope['folder_id'] as String?);
-          check(
-            rows.chat.pinned,
-          ).equals((fixture.envelope['pinned'] as bool?) ?? false);
-          check(
-            rows.chat.archived,
-          ).equals((fixture.envelope['archived'] as bool?) ?? false);
-          check(
-            rows.chat.createdAt,
-          ).equals(fixture.envelope['created_at'] as int);
-          check(
-            rows.chat.updatedAt,
-          ).equals(fixture.envelope['updated_at'] as int);
+          check(rows.chat.folderId)
+              .equals(fixture.envelope['folder_id'] as String?);
+          check(rows.chat.pinned)
+              .equals((fixture.envelope['pinned'] as bool?) ?? false);
+          check(rows.chat.archived)
+              .equals((fixture.envelope['archived'] as bool?) ?? false);
+          check(rows.chat.createdAt)
+              .equals(fixture.envelope['created_at'] as int);
+          check(rows.chat.updatedAt)
+              .equals(fixture.envelope['updated_at'] as int);
 
           final history = fixture.blob['history'];
           // Tolerate fixtures with a missing or non-string currentId: only a
@@ -383,12 +378,10 @@ void main() {
       final rebuiltWithout = ChatBlobMapper.rowsToBlob(
         rowsFor(deepCopyJson(without)),
       );
-      check(
-        (rebuiltWithNull['history'] as Map).containsKey('currentId'),
-      ).isTrue();
-      check(
-        (rebuiltWithout['history'] as Map).containsKey('currentId'),
-      ).isFalse();
+      check((rebuiltWithNull['history'] as Map).containsKey('currentId'))
+          .isTrue();
+      check((rebuiltWithout['history'] as Map).containsKey('currentId'))
+          .isFalse();
       check(_deepEq.equals(rebuiltWithNull, withNull)).isTrue();
       check(_deepEq.equals(rebuiltWithout, without)).isTrue();
     });
@@ -437,9 +430,8 @@ void main() {
       final rows = rowsFor(deepCopyJson(blob));
       check(rows.chat.title).equals('Envelope Title');
       final rebuilt = ChatBlobMapper.rowsToBlob(rows);
-      check(
-        rebuilt['title'],
-      ).equals('Blob Title that diverged from the envelope');
+      check(rebuilt['title'])
+          .equals('Blob Title that diverged from the envelope');
       check(_deepEq.equals(rebuilt, blob)).isTrue();
     });
   });
@@ -464,9 +456,8 @@ void main() {
       check(rows.blobHadHistory).isFalse();
       check(rows.messages).isEmpty();
       check(rows.chat.currentMessageId).isNull();
-      check(
-        _deepEq.equals(rows.chat.rawExtra['history'], blob()['history']),
-      ).isTrue();
+      check(_deepEq.equals(rows.chat.rawExtra['history'], blob()['history']))
+          .isTrue();
       final rebuilt = ChatBlobMapper.rowsToBlob(rows);
       check(_deepEq.equals(rebuilt, blob())).isTrue();
     });
@@ -564,9 +555,8 @@ void main() {
         );
         check(rows.messages.length).equals(1);
         check(rows.messages.single.id).equals('real');
-        check(
-          rows.unmappableMessages.keys,
-        ).unorderedEquals(['nullish', 'ghost', 'garbage']);
+        check(rows.unmappableMessages.keys)
+            .unorderedEquals(['nullish', 'ghost', 'garbage']);
         check(rows.unmappableMessages['nullish']).isNull();
         check(_deepEq.equals(rows.unmappableMessages['ghost'], ghost)).isTrue();
         check(rows.unmappableMessages['garbage']).equals('just a string');
@@ -684,9 +674,8 @@ void main() {
       final content = {'type': 'rich', 'blocks': []};
       final rows = rowsFor(content);
       check(rows.messages.single.content).equals(jsonEncode(content));
-      check(
-        _deepEq.equals(rows.messages.single.payload['content'], content),
-      ).isTrue();
+      check(_deepEq.equals(rows.messages.single.payload['content'], content))
+          .isTrue();
     });
   });
 
@@ -705,9 +694,8 @@ void main() {
         ),
         _row('root-sibling', parentId: null, createdAt: 60, orderIndex: 5),
       ];
-      check(
-        ChatBlobMapper.deriveChildrenIds('parent', all),
-      ).deepEquals(['early', 'middle', 'late']);
+      check(ChatBlobMapper.deriveChildrenIds('parent', all))
+          .deepEquals(['early', 'middle', 'late']);
     });
 
     test('breaks createdAt ties with orderIndex ascending', () {
@@ -718,9 +706,8 @@ void main() {
         _row('tie-a', parentId: 'parent', createdAt: tiedSecond, orderIndex: 1),
         _row('tie-b', parentId: 'parent', createdAt: tiedSecond, orderIndex: 2),
       ];
-      check(
-        ChatBlobMapper.deriveChildrenIds('parent', all),
-      ).deepEquals(['tie-a', 'tie-b', 'tie-c']);
+      check(ChatBlobMapper.deriveChildrenIds('parent', all))
+          .deepEquals(['tie-a', 'tie-b', 'tie-c']);
     });
 
     test('is deterministic regardless of input list order', () {
@@ -733,9 +720,8 @@ void main() {
       ];
       final expected = ['c', 'b', 'a', 'd'];
       check(ChatBlobMapper.deriveChildrenIds('p', rows)).deepEquals(expected);
-      check(
-        ChatBlobMapper.deriveChildrenIds('p', rows.reversed.toList()),
-      ).deepEquals(expected);
+      check(ChatBlobMapper.deriveChildrenIds('p', rows.reversed.toList()))
+          .deepEquals(expected);
       check(
         ChatBlobMapper.deriveChildrenIds('p', [
           rows[2],

--- a/test/core/database/chat_database_repository_test.dart
+++ b/test/core/database/chat_database_repository_test.dart
@@ -81,12 +81,10 @@ void main() {
         rows: _chatRows(id: 'server-chat', updatedAt: 20),
       );
 
-      check(
-        (await repository.resolveChat('local-chat'))!.storage,
-      ).equals(ChatStorageKind.directLocal);
-      check(
-        (await repository.resolveChat('server-chat'))!.storage,
-      ).equals(ChatStorageKind.openWebUi);
+      check((await repository.resolveChat('local-chat'))!.storage)
+          .equals(ChatStorageKind.directLocal);
+      check((await repository.resolveChat('server-chat'))!.storage)
+          .equals(ChatStorageKind.openWebUi);
       check(await repository.resolveChat('missing')).isNull();
 
       await serverDatabase.chatsDao.upsertServerChat(
@@ -96,9 +94,8 @@ void main() {
         rows: _chatRows(id: 'duplicate', updatedAt: 40),
       );
 
-      await check(
-        repository.resolveChat('duplicate'),
-      ).throws<AmbiguousChatStorageException>();
+      await check(repository.resolveChat('duplicate'))
+          .throws<AmbiguousChatStorageException>();
       check(
         (await repository.resolveChat(
           'duplicate',
@@ -138,9 +135,8 @@ void main() {
       await localDatabase.chatsDao.upsertLocalOnlyChat(
         rows: _chatRows(id: 'live-local-wins', updatedAt: 21),
       );
-      check(
-        (await repository.resolveChat('live-local-wins'))!.storage,
-      ).equals(ChatStorageKind.directLocal);
+      check((await repository.resolveChat('live-local-wins'))!.storage)
+          .equals(ChatStorageKind.directLocal);
 
       await serverDatabase.chatsDao.upsertServerChat(
         rows: _chatRows(id: 'live-server-wins', updatedAt: 30),
@@ -151,9 +147,8 @@ void main() {
       await (localDatabase.update(localDatabase.chats)
             ..where((chat) => chat.id.equals('live-server-wins')))
           .write(const ChatsCompanion(deleted: Value(true)));
-      check(
-        (await repository.resolveChat('live-server-wins'))!.storage,
-      ).equals(ChatStorageKind.openWebUi);
+      check((await repository.resolveChat('live-server-wins'))!.storage)
+          .equals(ChatStorageKind.openWebUi);
     });
   });
 
@@ -196,9 +191,8 @@ void main() {
       check(chat.updatedAt).equals(200);
       check(chat.dirty).isFalse();
       final messages = await localDatabase.messagesDao.getForChat('direct-1');
-      check(
-        messages.map((message) => message.id).toList(),
-      ).deepEquals(['message-direct-1', 'assistant-2']);
+      check(messages.map((message) => message.id).toList())
+          .deepEquals(['message-direct-1', 'assistant-2']);
       check(messages.every((message) => !message.dirty)).isTrue();
       check(await localDatabase.outboxDao.pendingForChat('direct-1')).isEmpty();
 
@@ -231,9 +225,8 @@ void main() {
       check(reparsed.storage).equals(ChatStorageKind.openWebUi);
       check(scoped.scopedId).startsWith('conduit-chat://scoped/v1/');
       check(
-        RegExp(
-          r'^conduit-chat://scoped/v1/[0-9a-f]{32}/openWebUi/',
-        ).hasMatch(scoped.scopedId),
+        RegExp(r'^conduit-chat://scoped/v1/[0-9a-f]{32}/openWebUi/')
+            .hasMatch(scoped.scopedId),
       ).isTrue();
       check(scoped.scopedId).not((it) => it.equals(rawIds[1]));
     });
@@ -283,25 +276,19 @@ void main() {
       );
 
       final entries = await repository.watchMergedChatList().first;
-      check(
-        entries.map((item) => item.entry.id).toList(),
-      ).deepEquals(['local-new', 'server-old']);
-      check(
-        entries.map((item) => item.storage).toList(),
-      ).deepEquals([ChatStorageKind.directLocal, ChatStorageKind.openWebUi]);
-      check(
-        ChatStorageIdentity.parse(entries.first.scopedId).rawId,
-      ).equals('local-new');
-      check(
-        ChatStorageIdentity.parse(entries.first.scopedId).storage,
-      ).equals(ChatStorageKind.directLocal);
+      check(entries.map((item) => item.entry.id).toList())
+          .deepEquals(['local-new', 'server-old']);
+      check(entries.map((item) => item.storage).toList())
+          .deepEquals([ChatStorageKind.directLocal, ChatStorageKind.openWebUi]);
+      check(ChatStorageIdentity.parse(entries.first.scopedId).rawId)
+          .equals('local-new');
+      check(ChatStorageIdentity.parse(entries.first.scopedId).storage)
+          .equals(ChatStorageKind.directLocal);
       final summary = entries.first.toConversation();
-      check(
-        chatStorageFromConversation(summary),
-      ).equals(ChatStorageKind.directLocal);
-      check(
-        summary.metadata[kChatStorageKindMetadataKey],
-      ).equals('directLocal');
+      check(chatStorageFromConversation(summary))
+          .equals(ChatStorageKind.directLocal);
+      check(summary.metadata[kChatStorageKindMetadataKey])
+          .equals('directLocal');
     });
 
     test('sums archived counts across both storage domains', () async {
@@ -389,9 +376,8 @@ void main() {
       addTearDown(subscription.cancel);
       await initialEmission.future.timeout(const Duration(seconds: 1));
 
-      check(
-        emissions.single.map((entry) => entry.entry.id).toList(),
-      ).deepEquals(['device-only']);
+      check(emissions.single.map((entry) => entry.entry.id).toList())
+          .deepEquals(['device-only']);
       check(
         emissions.single.every(
           (entry) => entry.storage == ChatStorageKind.directLocal,
@@ -423,9 +409,8 @@ void main() {
       check(loaded!.location.storage).equals(ChatStorageKind.directLocal);
       check(loaded.conversation.id).equals('load-local');
       check(loaded.conversation.messages.single.content).equals('loaded body');
-      check(
-        chatStorageFromConversation(loaded.conversation),
-      ).equals(ChatStorageKind.directLocal);
+      check(chatStorageFromConversation(loaded.conversation))
+          .equals(ChatStorageKind.directLocal);
     });
 
     test(
@@ -479,12 +464,10 @@ void main() {
       );
 
       final hits = await repository.searchMergedChats('needle');
-      check(
-        hits.map((item) => item.hit.chatId).toSet(),
-      ).deepEquals({'server-search', 'local-search'});
-      check(
-        hits.map((item) => item.storage).toSet(),
-      ).deepEquals({ChatStorageKind.openWebUi, ChatStorageKind.directLocal});
+      check(hits.map((item) => item.hit.chatId).toSet())
+          .deepEquals({'server-search', 'local-search'});
+      check(hits.map((item) => item.storage).toSet())
+          .deepEquals({ChatStorageKind.openWebUi, ChatStorageKind.directLocal});
     });
 
     test(
@@ -514,9 +497,8 @@ void main() {
           limit: 50,
         );
 
-        check(
-          hits.map((hit) => hit.hit.chatId).toList(),
-        ).deepEquals(['direct-result']);
+        check(hits.map((hit) => hit.hit.chatId).toList())
+            .deepEquals(['direct-result']);
         check(hits.single.storage).equals(ChatStorageKind.directLocal);
       },
     );
@@ -544,16 +526,14 @@ void main() {
 
         final entries = await repository.watchMergedChatList().first;
         check(entries.length).equals(2);
-        check(
-          entries.map((entry) => entry.entry.id).toSet(),
-        ).deepEquals({'collision'});
+        check(entries.map((entry) => entry.entry.id).toSet())
+            .deepEquals({'collision'});
         check(entries.map((entry) => entry.scopedId).toSet().length).equals(2);
 
         final hits = await repository.searchMergedChats('collision needle');
         check(hits.length).equals(2);
-        check(
-          hits.map((hit) => hit.hit.chatId).toSet(),
-        ).deepEquals({'collision'});
+        check(hits.map((hit) => hit.hit.chatId).toSet())
+            .deepEquals({'collision'});
         check(hits.map((hit) => hit.scopedId).toSet().length).equals(2);
       },
     );
@@ -578,9 +558,8 @@ void main() {
         async.flushMicrotasks();
 
         check(emissions).length.equals(1);
-        check(
-          emissions.single.map((entry) => entry.entry.id).toList(),
-        ).deepEquals(['local', 'server']);
+        check(emissions.single.map((entry) => entry.entry.id).toList())
+            .deepEquals(['local', 'server']);
 
         unawaited(subscription.cancel());
         unawaited(server.close());
@@ -867,9 +846,8 @@ void main() {
 
         await serverDatabase.chatsDao.purgeReconciledChat(serverId);
 
-        check(
-          await serverDatabase.syncMetaDao.getChatRemapTarget(localId),
-        ).isNull();
+        check(await serverDatabase.syncMetaDao.getChatRemapTarget(localId))
+            .isNull();
         check(
           await repository.resolveCommittedChatRemapTarget(
             location,
@@ -902,9 +880,8 @@ void main() {
         currentMessageId: 'direct-answer',
         updatedAt: 101,
       );
-      check(
-        await localDatabase.outboxDao.pendingForChat('direct-local'),
-      ).isEmpty();
+      check(await localDatabase.outboxDao.pendingForChat('direct-local'))
+          .isEmpty();
 
       final serverLocation = repository.chooseForNewDirectChat(
         DirectChatSyncPreference.syncWithOpenWebUiWhenAvailable,

--- a/test/core/database/chat_list_index_migration_test.dart
+++ b/test/core/database/chat_list_index_migration_test.dart
@@ -214,9 +214,8 @@ Future<void> _expectChatListIndex(AppDatabase database) async {
   final normalizedSql = indexRow
       .read<String>('sql')
       .replaceAll(RegExp(r'\s+'), ' ');
-  check(
-    normalizedSql,
-  ).contains('(deleted, pinned, archived, updated_at DESC, id ASC)');
+  check(normalizedSql)
+      .contains('(deleted, pinned, archived, updated_at DESC, id ASC)');
   final attachmentColumns = await database
       .customSelect('PRAGMA table_info(attachment_queue)')
       .get();
@@ -241,7 +240,6 @@ Future<void> _expectChatListIndex(AppDatabase database) async {
   final normalizedMessageSql = messageIndex
       .read<String>('sql')
       .replaceAll(RegExp(r'\s+'), ' ');
-  check(
-    normalizedMessageSql,
-  ).contains('(chat_id, parent_id, role, created_at, order_index, id)');
+  check(normalizedMessageSql)
+      .contains('(chat_id, parent_id, role, created_at, order_index, id)');
 }

--- a/test/core/database/daos/chats_dao_outbox_test.dart
+++ b/test/core/database/daos/chats_dao_outbox_test.dart
@@ -156,9 +156,8 @@ void main() {
           toolIds: <String>[],
         ),
       );
-      check(
-        (await db.outboxDao.pendingForChat(localId)).map((op) => op.kind),
-      ).deepEquals(['createChat', 'requestCompletion']);
+      check((await db.outboxDao.pendingForChat(localId)).map((op) => op.kind))
+          .deepEquals(['createChat', 'requestCompletion']);
       check(await db.messagesDao.getForChat(localId)).isNotEmpty();
 
       await db.chatsDao.tombstoneWithOutbox(localId);
@@ -193,52 +192,49 @@ void main() {
   });
 
   group('insertLocalChatWithCreateOp', () {
-    test(
-      'writes local chat + messages dirty, createChat then completion op',
-      () async {
-        const localId = 'local:new';
-        final rows = newLocalRows(localId);
-        await db.chatsDao.insertLocalChatWithCreateOp(
-          chat: rows.chat,
-          messages: rows.messages,
-          blobRows: rows,
-          contentHash: 'hash-1',
-          completion: const RequestCompletionPayload(
-            assistantMessageId: 'a1',
-            model: 'gpt',
-            toolIds: <String>['tool-a'],
-            filterIds: <String>['filter-a'],
-            terminalId: 'terminal-a',
-            enableWebSearch: true,
-            enableImageGeneration: true,
-          ),
-        );
+    test('writes local chat + messages dirty, createChat then completion op', () async {
+      const localId = 'local:new';
+      final rows = newLocalRows(localId);
+      await db.chatsDao.insertLocalChatWithCreateOp(
+        chat: rows.chat,
+        messages: rows.messages,
+        blobRows: rows,
+        contentHash: 'hash-1',
+        completion: const RequestCompletionPayload(
+          assistantMessageId: 'a1',
+          model: 'gpt',
+          toolIds: <String>['tool-a'],
+          filterIds: <String>['filter-a'],
+          terminalId: 'terminal-a',
+          enableWebSearch: true,
+          enableImageGeneration: true,
+        ),
+      );
 
-        final chat = await db.chatsDao.getChat(localId);
-        check(chat!.dirty).isTrue();
-        check(chat.bodySynced).isTrue();
-        check(chat.serverUpdatedAt).isNull();
-        final msgs = await db.messagesDao.getForChat(localId);
-        check(msgs.length).equals(2);
-        check(msgs.every((m) => m.dirty)).isTrue();
+      final chat = await db.chatsDao.getChat(localId);
+      check(chat!.dirty).isTrue();
+      check(chat.bodySynced).isTrue();
+      check(chat.serverUpdatedAt).isNull();
+      final msgs = await db.messagesDao.getForChat(localId);
+      check(msgs.length).equals(2);
+      check(msgs.every((m) => m.dirty)).isTrue();
 
-        final ops = await db.outboxDao.pendingForChat(localId);
-        check(ops.length).equals(2);
-        // createChat seq < requestCompletion seq (drainer creates+remaps first).
-        check(ops[0].kind).equals('createChat');
-        check(ops[0].contentHash).equals('hash-1');
-        check(ops[1].kind).equals('requestCompletion');
-        check(ops[1].seq).isGreaterThan(ops[0].seq);
-        final completionPayload = RequestCompletionPayload.fromJson(
-          jsonDecode(ops[1].payload) as Map<String, dynamic>,
-        );
-        check(completionPayload.toolIds).deepEquals(['tool-a']);
-        check(completionPayload.filterIds).deepEquals(['filter-a']);
-        check(completionPayload.terminalId).equals('terminal-a');
-        check(completionPayload.enableWebSearch).isTrue();
-        check(completionPayload.enableImageGeneration).isTrue();
-      },
-    );
+      final ops = await db.outboxDao.pendingForChat(localId);
+      check(ops.length).equals(2);
+      // createChat seq < requestCompletion seq (drainer creates+remaps first).
+      check(ops[0].kind).equals('createChat');
+      check(ops[0].contentHash).equals('hash-1');
+      check(ops[1].kind).equals('requestCompletion');
+      check(ops[1].seq).isGreaterThan(ops[0].seq);
+      final completionPayload = RequestCompletionPayload.fromJson(
+        jsonDecode(ops[1].payload) as Map<String, dynamic>,
+      );
+      check(completionPayload.toolIds).deepEquals(['tool-a']);
+      check(completionPayload.filterIds).deepEquals(['filter-a']);
+      check(completionPayload.terminalId).equals('terminal-a');
+      check(completionPayload.enableWebSearch).isTrue();
+      check(completionPayload.enableImageGeneration).isTrue();
+    });
 
     test('no completion payload enqueues only createChat', () async {
       const localId = 'local:nocomp';
@@ -323,9 +319,8 @@ void main() {
         check(a2.dirty).isTrue();
 
         final ops = await db.outboxDao.pendingForChat('c1');
-        check(
-          ops.map((o) => o.kind).toList(),
-        ).deepEquals(['updateChat', 'requestCompletion']);
+        check(ops.map((o) => o.kind).toList())
+            .deepEquals(['updateChat', 'requestCompletion']);
       },
     );
 
@@ -393,15 +388,14 @@ void main() {
         final blobMessages = history['messages'] as Map<String, dynamic>;
         check(blobMessages.containsKey('a2')).isFalse();
         final parentPayload = blobMessages['u2'] as Map<String, dynamic>;
-        check(
-          parentPayload['childrenIds'] as List<dynamic>,
-        ).deepEquals(<String>[]);
+        check(parentPayload['childrenIds'] as List<dynamic>)
+            .deepEquals(<String>[]);
         final metadata = parentPayload['metadata'] as Map<String, dynamic>;
         check(metadata['childrenIds'] as List<dynamic>).deepEquals(<String>[]);
         check(
-          (await db.outboxDao.pendingForChat(
-            'c1',
-          )).map((op) => op.kind).toList(),
+          (await db.outboxDao.pendingForChat('c1'))
+              .map((op) => op.kind)
+              .toList(),
         ).deepEquals(['updateChat']);
       },
     );
@@ -457,9 +451,9 @@ void main() {
             model: 'gpt',
           ),
         );
-        final completionOp = (await db.outboxDao.pendingForChat(
-          'c1',
-        )).where((op) => op.kind == OutboxKind.requestCompletion.name).single;
+        final completionOp = (await db.outboxDao.pendingForChat('c1'))
+            .where((op) => op.kind == OutboxKind.requestCompletion.name)
+            .single;
         await db.outboxDao.markParked(completionOp.seq, error: 'boom');
 
         final removed = await db.chatsDao.cancelQueuedCompletion(
@@ -471,239 +465,222 @@ void main() {
         final messages = await db.messagesDao.getForChat('c1');
         check(messages.map((m) => m.id).toSet()).deepEquals({'m1', 'u2'});
         check((await db.chatsDao.getChat('c1'))!.currentMessageId).equals('u2');
+        check(await db.outboxDao.watchQueuedCompletionsForChat('c1').first)
+            .isEmpty();
         check(
-          await db.outboxDao.watchQueuedCompletionsForChat('c1').first,
-        ).isEmpty();
-        check(
-          (await db.outboxDao.pendingForChat(
-            'c1',
-          )).map((op) => op.kind).toList(),
+          (await db.outboxDao.pendingForChat('c1'))
+              .map((op) => op.kind)
+              .toList(),
         ).deepEquals(['updateChat']);
       },
     );
 
-    test(
-      'cancelQueuedCompletion enqueues an update after a failed partial response',
-      () async {
-        await seedServerChat('c1');
-        await db.chatsDao.appendMessagesWithUpdateOp(
-          chatId: 'c1',
-          currentMessageId: 'a2',
-          updatedAt: 500,
-          messages: <MessageRowData>[
-            MessageRowData(
-              id: 'u2',
-              chatId: 'c1',
-              parentId: 'm1',
-              role: 'user',
-              content: 'next',
-              createdAt: 400,
-              orderIndex: 0,
-              payload: const <String, dynamic>{
-                'id': 'u2',
-                'parentId': 'm1',
+    test('cancelQueuedCompletion enqueues an update after a failed partial response', () async {
+      await seedServerChat('c1');
+      await db.chatsDao.appendMessagesWithUpdateOp(
+        chatId: 'c1',
+        currentMessageId: 'a2',
+        updatedAt: 500,
+        messages: <MessageRowData>[
+          MessageRowData(
+            id: 'u2',
+            chatId: 'c1',
+            parentId: 'm1',
+            role: 'user',
+            content: 'next',
+            createdAt: 400,
+            orderIndex: 0,
+            payload: const <String, dynamic>{
+              'id': 'u2',
+              'parentId': 'm1',
+              'childrenIds': <String>['a2'],
+              'role': 'user',
+              'content': 'next',
+              'metadata': <String, dynamic>{
                 'childrenIds': <String>['a2'],
-                'role': 'user',
-                'content': 'next',
-                'metadata': <String, dynamic>{
-                  'childrenIds': <String>['a2'],
-                },
               },
-            ),
-            MessageRowData(
-              id: 'a2',
-              chatId: 'c1',
-              parentId: 'u2',
-              role: 'assistant',
-              content: '',
-              createdAt: 401,
-              orderIndex: 0,
-              payload: const <String, dynamic>{
-                'id': 'a2',
-                'parentId': 'u2',
-                'childrenIds': <String>[],
-                'role': 'assistant',
-                'content': '',
-              },
-            ),
-          ],
-          enqueueCompletion: true,
-          completion: const RequestCompletionPayload(
-            assistantMessageId: 'a2',
-            model: 'gpt',
+            },
           ),
-        );
-        final initialOps = await db.outboxDao.pendingForChat('c1');
-        final updateSeq = initialOps
-            .where((op) => op.kind == OutboxKind.updateChat.name)
-            .single
-            .seq;
-        final completionSeq = initialOps
-            .where((op) => op.kind == OutboxKind.requestCompletion.name)
-            .single
-            .seq;
-        await db.outboxDao.markDone(updateSeq);
-        await (db.update(db.messages)..where((t) => t.id.equals('a2'))).write(
-          const MessagesCompanion(
-            content: Value('partial'),
-            payload: Value(
-              '{"id":"a2","role":"assistant","content":"partial"}',
-            ),
+          MessageRowData(
+            id: 'a2',
+            chatId: 'c1',
+            parentId: 'u2',
+            role: 'assistant',
+            content: '',
+            createdAt: 401,
+            orderIndex: 0,
+            payload: const <String, dynamic>{
+              'id': 'a2',
+              'parentId': 'u2',
+              'childrenIds': <String>[],
+              'role': 'assistant',
+              'content': '',
+            },
           ),
-        );
-        await db.outboxDao.markParked(completionSeq, error: 'boom');
-
-        final removed = await db.chatsDao.cancelQueuedCompletion(
-          'c1',
+        ],
+        enqueueCompletion: true,
+        completion: const RequestCompletionPayload(
           assistantMessageId: 'a2',
-        );
+          model: 'gpt',
+        ),
+      );
+      final initialOps = await db.outboxDao.pendingForChat('c1');
+      final updateSeq = initialOps
+          .where((op) => op.kind == OutboxKind.updateChat.name)
+          .single
+          .seq;
+      final completionSeq = initialOps
+          .where((op) => op.kind == OutboxKind.requestCompletion.name)
+          .single
+          .seq;
+      await db.outboxDao.markDone(updateSeq);
+      await (db.update(db.messages)..where((t) => t.id.equals('a2'))).write(
+        const MessagesCompanion(
+          content: Value('partial'),
+          payload: Value('{"id":"a2","role":"assistant","content":"partial"}'),
+        ),
+      );
+      await db.outboxDao.markParked(completionSeq, error: 'boom');
 
-        check(removed).equals(1);
-        final messages = await db.messagesDao.getForChat('c1');
-        check(messages.map((m) => m.id).toSet()).deepEquals({'m1', 'u2'});
-        final chat = (await db.chatsDao.getChat('c1'))!;
-        check(chat.currentMessageId).equals('u2');
-        check(chat.dirty).isTrue();
-        check(messages.singleWhere((m) => m.id == 'u2').dirty).isTrue();
-        final blob = await rebuiltBlob('c1');
-        final history = blob['history'] as Map<String, dynamic>;
-        final blobMessages = history['messages'] as Map<String, dynamic>;
-        check(blobMessages.containsKey('a2')).isFalse();
-        final parentPayload = blobMessages['u2'] as Map<String, dynamic>;
-        check(
-          parentPayload['childrenIds'] as List<dynamic>,
-        ).deepEquals(<String>[]);
-        final metadata = parentPayload['metadata'] as Map<String, dynamic>;
-        check(metadata['childrenIds'] as List<dynamic>).deepEquals(<String>[]);
-        check(
-          (await db.outboxDao.pendingForChat(
-            'c1',
-          )).map((op) => op.kind).toList(),
-        ).deepEquals(['updateChat']);
-      },
-    );
+      final removed = await db.chatsDao.cancelQueuedCompletion(
+        'c1',
+        assistantMessageId: 'a2',
+      );
 
-    test(
-      'cancelQueuedCompletion enqueues an update after a pending response was pushed',
-      () async {
-        await seedServerChat('c1');
-        await db.chatsDao.appendMessagesWithUpdateOp(
-          chatId: 'c1',
-          currentMessageId: 'a2',
-          updatedAt: 500,
-          messages: <MessageRowData>[
-            MessageRowData(
-              id: 'u2',
-              chatId: 'c1',
-              parentId: 'm1',
-              role: 'user',
-              content: 'next',
-              createdAt: 400,
-              orderIndex: 0,
-              payload: const <String, dynamic>{
-                'id': 'u2',
-                'parentId': 'm1',
+      check(removed).equals(1);
+      final messages = await db.messagesDao.getForChat('c1');
+      check(messages.map((m) => m.id).toSet()).deepEquals({'m1', 'u2'});
+      final chat = (await db.chatsDao.getChat('c1'))!;
+      check(chat.currentMessageId).equals('u2');
+      check(chat.dirty).isTrue();
+      check(messages.singleWhere((m) => m.id == 'u2').dirty).isTrue();
+      final blob = await rebuiltBlob('c1');
+      final history = blob['history'] as Map<String, dynamic>;
+      final blobMessages = history['messages'] as Map<String, dynamic>;
+      check(blobMessages.containsKey('a2')).isFalse();
+      final parentPayload = blobMessages['u2'] as Map<String, dynamic>;
+      check(parentPayload['childrenIds'] as List<dynamic>)
+          .deepEquals(<String>[]);
+      final metadata = parentPayload['metadata'] as Map<String, dynamic>;
+      check(metadata['childrenIds'] as List<dynamic>).deepEquals(<String>[]);
+      check(
+        (await db.outboxDao.pendingForChat('c1')).map((op) => op.kind).toList(),
+      ).deepEquals(['updateChat']);
+    });
+
+    test('cancelQueuedCompletion enqueues an update after a pending response was pushed', () async {
+      await seedServerChat('c1');
+      await db.chatsDao.appendMessagesWithUpdateOp(
+        chatId: 'c1',
+        currentMessageId: 'a2',
+        updatedAt: 500,
+        messages: <MessageRowData>[
+          MessageRowData(
+            id: 'u2',
+            chatId: 'c1',
+            parentId: 'm1',
+            role: 'user',
+            content: 'next',
+            createdAt: 400,
+            orderIndex: 0,
+            payload: const <String, dynamic>{
+              'id': 'u2',
+              'parentId': 'm1',
+              'childrenIds': <String>['a2'],
+              'role': 'user',
+              'content': 'next',
+              'metadata': <String, dynamic>{
                 'childrenIds': <String>['a2'],
-                'role': 'user',
-                'content': 'next',
-                'metadata': <String, dynamic>{
-                  'childrenIds': <String>['a2'],
-                },
               },
-            ),
-            MessageRowData(
-              id: 'a2',
-              chatId: 'c1',
-              parentId: 'u2',
-              role: 'assistant',
-              content: '',
-              createdAt: 401,
-              orderIndex: 0,
-              payload: const <String, dynamic>{
-                'id': 'a2',
-                'parentId': 'u2',
-                'childrenIds': <String>[],
-                'role': 'assistant',
-                'content': '',
-              },
-            ),
-          ],
-          enqueueCompletion: true,
-          completion: const RequestCompletionPayload(
-            assistantMessageId: 'a2',
-            model: 'gpt',
+            },
           ),
-        );
-        final updateSeq = (await db.outboxDao.pendingForChat(
-          'c1',
-        )).where((op) => op.kind == OutboxKind.updateChat.name).single.seq;
-        await db.outboxDao.markDone(updateSeq);
-
-        final removed = await db.chatsDao.cancelQueuedCompletion(
-          'c1',
+          MessageRowData(
+            id: 'a2',
+            chatId: 'c1',
+            parentId: 'u2',
+            role: 'assistant',
+            content: '',
+            createdAt: 401,
+            orderIndex: 0,
+            payload: const <String, dynamic>{
+              'id': 'a2',
+              'parentId': 'u2',
+              'childrenIds': <String>[],
+              'role': 'assistant',
+              'content': '',
+            },
+          ),
+        ],
+        enqueueCompletion: true,
+        completion: const RequestCompletionPayload(
           assistantMessageId: 'a2',
-        );
+          model: 'gpt',
+        ),
+      );
+      final updateSeq = (await db.outboxDao.pendingForChat('c1'))
+          .where((op) => op.kind == OutboxKind.updateChat.name)
+          .single
+          .seq;
+      await db.outboxDao.markDone(updateSeq);
 
-        check(removed).equals(1);
-        final messages = await db.messagesDao.getForChat('c1');
-        check(messages.map((m) => m.id).toSet()).deepEquals({'m1', 'u2'});
-        final chat = (await db.chatsDao.getChat('c1'))!;
-        check(chat.currentMessageId).equals('u2');
-        check(chat.dirty).isTrue();
-        check(messages.singleWhere((m) => m.id == 'u2').dirty).isTrue();
-        final blob = await rebuiltBlob('c1');
-        final history = blob['history'] as Map<String, dynamic>;
-        final blobMessages = history['messages'] as Map<String, dynamic>;
-        check(blobMessages.containsKey('a2')).isFalse();
-        final parentPayload = blobMessages['u2'] as Map<String, dynamic>;
-        check(
-          parentPayload['childrenIds'] as List<dynamic>,
-        ).deepEquals(<String>[]);
-        final metadata = parentPayload['metadata'] as Map<String, dynamic>;
-        check(metadata['childrenIds'] as List<dynamic>).deepEquals(<String>[]);
-        check(
-          (await db.outboxDao.pendingForChat(
-            'c1',
-          )).map((op) => op.kind).toList(),
-        ).deepEquals(['updateChat']);
-      },
-    );
+      final removed = await db.chatsDao.cancelQueuedCompletion(
+        'c1',
+        assistantMessageId: 'a2',
+      );
+
+      check(removed).equals(1);
+      final messages = await db.messagesDao.getForChat('c1');
+      check(messages.map((m) => m.id).toSet()).deepEquals({'m1', 'u2'});
+      final chat = (await db.chatsDao.getChat('c1'))!;
+      check(chat.currentMessageId).equals('u2');
+      check(chat.dirty).isTrue();
+      check(messages.singleWhere((m) => m.id == 'u2').dirty).isTrue();
+      final blob = await rebuiltBlob('c1');
+      final history = blob['history'] as Map<String, dynamic>;
+      final blobMessages = history['messages'] as Map<String, dynamic>;
+      check(blobMessages.containsKey('a2')).isFalse();
+      final parentPayload = blobMessages['u2'] as Map<String, dynamic>;
+      check(parentPayload['childrenIds'] as List<dynamic>)
+          .deepEquals(<String>[]);
+      final metadata = parentPayload['metadata'] as Map<String, dynamic>;
+      check(metadata['childrenIds'] as List<dynamic>).deepEquals(<String>[]);
+      check(
+        (await db.outboxDao.pendingForChat('c1')).map((op) => op.kind).toList(),
+      ).deepEquals(['updateChat']);
+    });
   });
 
   group('R2: rollback leaves NEITHER rows nor op', () {
-    test(
-      'a throw inside insertLocalChatWithCreateOp rolls back rows + op',
-      () async {
-        const localId = 'local:dup';
-        final rows = newLocalRows(localId);
-        // Pre-insert the chat row so the in-txn insert hits a PK conflict and
-        // throws — AFTER which the op enqueue must never persist (txn rollback).
-        await db
-            .into(db.chats)
-            .insert(
-              ChatsCompanion.insert(
-                id: localId,
-                title: 'pre',
-                createdAt: 1,
-                updatedAt: 1,
-              ),
-            );
+    test('a throw inside insertLocalChatWithCreateOp rolls back rows + op', () async {
+      const localId = 'local:dup';
+      final rows = newLocalRows(localId);
+      // Pre-insert the chat row so the in-txn insert hits a PK conflict and
+      // throws — AFTER which the op enqueue must never persist (txn rollback).
+      await db
+          .into(db.chats)
+          .insert(
+            ChatsCompanion.insert(
+              id: localId,
+              title: 'pre',
+              createdAt: 1,
+              updatedAt: 1,
+            ),
+          );
 
-        await check(
-          db.chatsDao.insertLocalChatWithCreateOp(
-            chat: rows.chat,
-            messages: rows.messages,
-            blobRows: rows,
-            contentHash: 'h',
-          ),
-        ).throws<Object>();
+      await check(
+        db.chatsDao.insertLocalChatWithCreateOp(
+          chat: rows.chat,
+          messages: rows.messages,
+          blobRows: rows,
+          contentHash: 'h',
+        ),
+      ).throws<Object>();
 
-        // No messages inserted, no outbox op — both rolled back.
-        check(await db.messagesDao.getForChat(localId)).isEmpty();
-        check(await db.outboxDao.pendingForChat(localId)).isEmpty();
-        // The pre-existing stub row is untouched (title still 'pre').
-        check((await db.chatsDao.getChat(localId))!.title).equals('pre');
-      },
-    );
+      // No messages inserted, no outbox op — both rolled back.
+      check(await db.messagesDao.getForChat(localId)).isEmpty();
+      check(await db.outboxDao.pendingForChat(localId)).isEmpty();
+      // The pre-existing stub row is untouched (title still 'pre').
+      check((await db.chatsDao.getChat(localId))!.title).equals('pre');
+    });
   });
 }

--- a/test/core/database/daos/chats_dao_test.dart
+++ b/test/core/database/daos/chats_dao_test.dart
@@ -52,9 +52,8 @@ void main() {
         check(chatRow.bodySynced).isTrue();
         check(chatRow.dirty).isFalse();
         check(chatRow.deleted).isFalse();
-        check(
-          chatRow.serverUpdatedAt,
-        ).equals(fixture.envelope['updated_at'] as int);
+        check(chatRow.serverUpdatedAt)
+            .equals(fixture.envelope['updated_at'] as int);
       });
     }
   });
@@ -67,9 +66,8 @@ void main() {
       );
       final rows = rowsFromFixture(fixture);
       await db.chatsDao.upsertServerChat(rows: rows);
-      final firstCount = (await db.messagesDao.getForChat(
-        fixture.chatId,
-      )).length;
+      final firstCount = (await db.messagesDao.getForChat(fixture.chatId))
+          .length;
       await db.chatsDao.upsertServerChat(rows: rowsFromFixture(fixture));
       final messageRows = await db.messagesDao.getForChat(fixture.chatId);
       check(messageRows.length).equals(firstCount);
@@ -233,9 +231,8 @@ void main() {
 
         final entries = await db.chatsDao.watchChatList(regularLimit: 2).first;
 
-        check(
-          entries.map((entry) => entry.id).toList(),
-        ).deepEquals(['regular-3', 'regular-2', 'old-pinned']);
+        check(entries.map((entry) => entry.id).toList())
+            .deepEquals(['regular-3', 'regular-2', 'old-pinned']);
       },
     );
 
@@ -308,9 +305,8 @@ void main() {
       final collapsed = await db.chatsDao
           .watchChatList(regularLimit: 2, archivedLimit: 0)
           .first;
-      check(
-        collapsed.map((entry) => entry.id).toList(),
-      ).deepEquals(['active-3', 'active-2', 'old-pinned']);
+      check(collapsed.map((entry) => entry.id).toList())
+          .deepEquals(['active-3', 'active-2', 'old-pinned']);
     });
 
     test('archived count is exact, live, and excludes pinned rows', () async {
@@ -445,30 +441,26 @@ void main() {
         rows: rowsFromFixture(fixture),
         listLastReadAt: 100,
       );
-      check(
-        (await db.chatsDao.getChat(fixture.chatId))!.lastReadAt,
-      ).equals(100);
+      check((await db.chatsDao.getChat(fixture.chatId))!.lastReadAt)
+          .equals(100);
 
       await db.chatsDao.upsertServerChat(
         rows: rowsFromFixture(fixture),
         listLastReadAt: 50,
       );
-      check(
-        (await db.chatsDao.getChat(fixture.chatId))!.lastReadAt,
-      ).equals(100);
+      check((await db.chatsDao.getChat(fixture.chatId))!.lastReadAt)
+          .equals(100);
 
       await db.chatsDao.upsertServerChat(rows: rowsFromFixture(fixture));
-      check(
-        (await db.chatsDao.getChat(fixture.chatId))!.lastReadAt,
-      ).equals(100);
+      check((await db.chatsDao.getChat(fixture.chatId))!.lastReadAt)
+          .equals(100);
 
       await db.chatsDao.upsertServerChat(
         rows: rowsFromFixture(fixture),
         listLastReadAt: 200,
       );
-      check(
-        (await db.chatsDao.getChat(fixture.chatId))!.lastReadAt,
-      ).equals(200);
+      check((await db.chatsDao.getChat(fixture.chatId))!.lastReadAt)
+          .equals(200);
     });
 
     test('upsertServerChat keeps null when both sides are null', () async {
@@ -565,9 +557,8 @@ void main() {
 
         final after = await db.chatsDao.getChat(fixture.chatId);
         check(after!.title).equals('Renamed via list');
-        check(
-          after.updatedAt,
-        ).equals((fixture.envelope['updated_at'] as int) + 5);
+        check(after.updatedAt)
+            .equals((fixture.envelope['updated_at'] as int) + 5);
         check(after.pinned).isTrue();
         check(after.folderId).equals('f-9');
         // Untouched:

--- a/test/core/database/daos/messages_dao_test.dart
+++ b/test/core/database/daos/messages_dao_test.dart
@@ -57,9 +57,8 @@ void main() {
         'window-120',
         before: middle.olderCursor,
       );
-      check(
-        oldest.primaryRows.map((row) => row.id).toList(),
-      ).deepEquals([for (var index = 0; index < 20; index += 1) 'm$index']);
+      check(oldest.primaryRows.map((row) => row.id).toList())
+          .deepEquals([for (var index = 0; index < 20; index += 1) 'm$index']);
       check(oldest.hasOlder).isFalse();
 
       final allIds = [
@@ -68,9 +67,8 @@ void main() {
         ...newest.primaryRows,
       ].map((row) => row.id).toList();
       check(allIds.toSet().length).equals(120);
-      check(
-        allIds,
-      ).deepEquals([for (var index = 0; index < 120; index += 1) 'm$index']);
+      check(allIds)
+          .deepEquals([for (var index = 0; index < 120; index += 1) 'm$index']);
     });
 
     test(
@@ -149,18 +147,16 @@ void main() {
 
       final cycle = await db.messagesDao.getActiveBranchPage('window-cycle');
       check(cycle.primaryRows.length).equals(2);
-      check(
-        cycle.primaryRows.map((row) => row.id).toSet(),
-      ).deepEquals({'m1', 'm2'});
+      check(cycle.primaryRows.map((row) => row.id).toSet())
+          .deepEquals({'m1', 'm2'});
 
       await (db.update(db.messages)..where(
             (row) => row.chatId.equals('window-cycle') & row.id.equals('m1'),
           ))
           .write(const MessagesCompanion(parentId: Value('missing')));
       final missing = await db.messagesDao.getActiveBranchPage('window-cycle');
-      check(
-        missing.primaryRows.map((row) => row.id).toList(),
-      ).deepEquals(['m1', 'm2']);
+      check(missing.primaryRows.map((row) => row.id).toList())
+          .deepEquals(['m1', 'm2']);
     });
 
     test('cursor rooted at the oldest row returns an empty page', () async {
@@ -248,9 +244,8 @@ void main() {
           if (byCreatedAt != 0) return byCreatedAt;
           return a.orderIndex.compareTo(b.orderIndex);
         });
-      check(
-        fetched.map((m) => m.id).toList(),
-      ).deepEquals(expectedOrder.map((m) => m.id).toList());
+      check(fetched.map((m) => m.id).toList())
+          .deepEquals(expectedOrder.map((m) => m.id).toList());
 
       // The three regenerated siblings share one timestamp second; their
       // relative order must be their original map iteration order.
@@ -273,9 +268,8 @@ void main() {
 
       final watched = await db.messagesDao.watchForChat(fixture.chatId).first;
       final fetched = await db.messagesDao.getForChat(fixture.chatId);
-      check(
-        watched.map((m) => m.id).toList(),
-      ).deepEquals(fetched.map((m) => m.id).toList());
+      check(watched.map((m) => m.id).toList())
+          .deepEquals(fetched.map((m) => m.id).toList());
     });
 
     test('only returns rows of the requested chat', () async {
@@ -425,9 +419,8 @@ void main() {
         final rows = await db.messagesDao.getForChat('chat-turn');
         check(rows.singleWhere((m) => m.id == 'u-2').parentId).equals('prev-a');
         check(rows.singleWhere((m) => m.id == 'a-2').parentId).equals('u-2');
-        check(
-          (await db.chatsDao.getChat('chat-turn'))!.currentMessageId,
-        ).equals('a-2');
+        check((await db.chatsDao.getChat('chat-turn'))!.currentMessageId)
+            .equals('a-2');
       },
     );
 
@@ -478,9 +471,8 @@ void main() {
         final assistantRow = rows.singleWhere((m) => m.id == 'a-2');
         check(assistantRow.parentId).equals('u-2');
         check(assistantRow.content).equals('final answer');
-        check(
-          (await db.chatsDao.getChat('chat-replay'))!.currentMessageId,
-        ).equals('a-2');
+        check((await db.chatsDao.getChat('chat-replay'))!.currentMessageId)
+            .equals('a-2');
       },
     );
 
@@ -547,12 +539,10 @@ void main() {
         final payload = jsonDecode(row.payload) as Map<String, dynamic>;
         check(payload['isStreaming']).equals(false);
         check(payload['done']).equals(true);
-        check(
-          (payload['metadata'] as Map<String, dynamic>)['responseDone'],
-        ).equals(true);
-        check(
-          (payload['metadata'] as Map<String, dynamic>)['checkpoint'],
-        ).equals(true);
+        check((payload['metadata'] as Map<String, dynamic>)['responseDone'])
+            .equals(true);
+        check((payload['metadata'] as Map<String, dynamic>)['checkpoint'])
+            .equals(true);
         check(payload.containsKey('error')).isFalse();
         check(row.content).equals('');
         check(row.dirty).isFalse();

--- a/test/core/database/daos/outbox_dao_test.dart
+++ b/test/core/database/daos/outbox_dao_test.dart
@@ -105,9 +105,8 @@ void main() {
         ),
       ).throws<ArgumentError>();
 
-      await check(
-        enqueue(kind: OutboxKind.createChat, chatId: 'local:c'),
-      ).throws<ArgumentError>();
+      await check(enqueue(kind: OutboxKind.createChat, chatId: 'local:c'))
+          .throws<ArgumentError>();
     });
 
     test('updateChat/deleteChat require empty payloads', () async {
@@ -225,12 +224,10 @@ void main() {
 
         final queued = await dao.watchQueuedCompletionsForChat('c1').first;
 
-        check(
-          queued.map((op) => op.seq).toList(),
-        ).deepEquals([pendingCompletion, failedCompletion]);
-        check(
-          queued.map((op) => op.kind).toSet(),
-        ).deepEquals({OutboxKind.requestCompletion.name});
+        check(queued.map((op) => op.seq).toList())
+            .deepEquals([pendingCompletion, failedCompletion]);
+        check(queued.map((op) => op.kind).toSet())
+            .deepEquals({OutboxKind.requestCompletion.name});
       },
     );
   });
@@ -277,9 +274,8 @@ void main() {
         check(pending).length.equals(1);
         check(pending.single.seq).equals(surviving);
         check(pending.single.kind).equals('createChat');
-        check(
-          pending.single.contentHash,
-        ).equals(createChatContentHash(editedRows));
+        check(pending.single.contentHash)
+            .equals(createChatContentHash(editedRows));
       },
     );
 
@@ -410,9 +406,9 @@ void main() {
         final mergedPayload =
             jsonDecode(pendingUpserts.single.payload) as Map<String, dynamic>;
         check(mergedPayload['name']).equals('n2');
-        check(
-          mergedPayload['meta'],
-        ).isA<Map<String, dynamic>>().deepEquals({'color': 'red'});
+        check(mergedPayload['meta'])
+            .isA<Map<String, dynamic>>()
+            .deepEquals({'color': 'red'});
         check(mergedPayload['createIfAbsent']).equals(true);
 
         // folderDelete over a brand-new local folder create drops both.
@@ -563,9 +559,8 @@ void main() {
       await enqueue(kind: OutboxKind.deleteChat, chatId: 'shared-id');
 
       final pending = await dao.pendingForChat('shared-id');
-      check(
-        pending.map((op) => op.kind).toList(),
-      ).deepEquals(['noteUpdate', 'deleteChat']);
+      check(pending.map((op) => op.kind).toList())
+          .deepEquals(['noteUpdate', 'deleteChat']);
     });
 
     test(
@@ -714,9 +709,8 @@ void main() {
       final seq = await enqueue(kind: OutboxKind.updateChat, chatId: 'c1');
       await dao.markFailedRetryable(seq, error: 'boom', nextAttemptAt: 200);
 
-      check(
-        await dao.claimNextRunnable(nowEpochSeconds: 150, busyChatIds: {}),
-      ).isNull();
+      check(await dao.claimNextRunnable(nowEpochSeconds: 150, busyChatIds: {}))
+          .isNull();
 
       final due = await dao.claimNextRunnable(
         nowEpochSeconds: 200,
@@ -875,66 +869,59 @@ void main() {
   });
 
   group('resetInFlightToPending (crash recovery §7.2/§11)', () {
-    test(
-      'reclaims a stranded inFlight op back to pending, attempts intact',
-      () async {
-        final seq = await enqueue(kind: OutboxKind.updateChat, chatId: 'c1');
-        await dao.markFailedRetryable(seq, error: 'e', nextAttemptAt: 7);
-        // Simulate a kill mid-push: the op was flipped to inFlight by a claim.
-        final claimed = await dao.claimNextRunnable(
-          nowEpochSeconds: 99,
-          busyChatIds: {},
-        );
-        check(claimed!.status).equals('inFlight');
+    test('reclaims a stranded inFlight op back to pending, attempts intact', () async {
+      final seq = await enqueue(kind: OutboxKind.updateChat, chatId: 'c1');
+      await dao.markFailedRetryable(seq, error: 'e', nextAttemptAt: 7);
+      // Simulate a kill mid-push: the op was flipped to inFlight by a claim.
+      final claimed = await dao.claimNextRunnable(
+        nowEpochSeconds: 99,
+        busyChatIds: {},
+      );
+      check(claimed!.status).equals('inFlight');
 
-        final reclaimed = await dao.resetInFlightToPending();
-        check(reclaimed).equals(1);
-        final pending = await dao.pendingForChat('c1');
-        check(pending.single.status).equals('pending');
-        // attempts/nextAttemptAt preserved so backoff/N=5 survive process death.
-        check(pending.single.attempts).equals(1);
-        check(pending.single.nextAttemptAt).equals(7);
-      },
-    );
+      final reclaimed = await dao.resetInFlightToPending();
+      check(reclaimed).equals(1);
+      final pending = await dao.pendingForChat('c1');
+      check(pending.single.status).equals('pending');
+      // attempts/nextAttemptAt preserved so backoff/N=5 survive process death.
+      check(pending.single.attempts).equals(1);
+      check(pending.single.nextAttemptAt).equals(7);
+    });
 
-    test(
-      'a stranded inFlight op no longer blocks its chat head after reset',
-      () async {
-        // createChat (will be stranded inFlight) then a dependent completion.
-        await enqueue(
-          kind: OutboxKind.createChat,
-          chatId: 'local:c',
-          contentHash: 'h',
-        );
-        await enqueue(
-          kind: OutboxKind.requestCompletion,
-          chatId: 'local:c',
-          payload: {
-            'assistantMessageId': 'a',
-            'model': 'm',
-            'toolIds': <String>[],
-          },
-        );
-        // Claim the create -> inFlight. The completion is now blocked behind it.
-        final create = await dao.claimNextRunnable(
-          nowEpochSeconds: 1,
-          busyChatIds: {},
-        );
-        check(OutboxKind.fromName(create!.kind)).equals(OutboxKind.createChat);
-        // Without reset, the inFlight create blocks the completion forever.
-        check(
-          await dao.claimNextRunnable(nowEpochSeconds: 1, busyChatIds: {}),
-        ).isNull();
+    test('a stranded inFlight op no longer blocks its chat head after reset', () async {
+      // createChat (will be stranded inFlight) then a dependent completion.
+      await enqueue(
+        kind: OutboxKind.createChat,
+        chatId: 'local:c',
+        contentHash: 'h',
+      );
+      await enqueue(
+        kind: OutboxKind.requestCompletion,
+        chatId: 'local:c',
+        payload: {
+          'assistantMessageId': 'a',
+          'model': 'm',
+          'toolIds': <String>[],
+        },
+      );
+      // Claim the create -> inFlight. The completion is now blocked behind it.
+      final create = await dao.claimNextRunnable(
+        nowEpochSeconds: 1,
+        busyChatIds: {},
+      );
+      check(OutboxKind.fromName(create!.kind)).equals(OutboxKind.createChat);
+      // Without reset, the inFlight create blocks the completion forever.
+      check(await dao.claimNextRunnable(nowEpochSeconds: 1, busyChatIds: {}))
+          .isNull();
 
-        await dao.resetInFlightToPending();
-        // Now the create is the claimable head again (not the completion).
-        final head = await dao.claimNextRunnable(
-          nowEpochSeconds: 1,
-          busyChatIds: {},
-        );
-        check(OutboxKind.fromName(head!.kind)).equals(OutboxKind.createChat);
-      },
-    );
+      await dao.resetInFlightToPending();
+      // Now the create is the claimable head again (not the completion).
+      final head = await dao.claimNextRunnable(
+        nowEpochSeconds: 1,
+        busyChatIds: {},
+      );
+      check(OutboxKind.fromName(head!.kind)).equals(OutboxKind.createChat);
+    });
   });
 
   group('pendingCreateForHash (§7.3 crash heal)', () {
@@ -1101,9 +1088,8 @@ void main() {
         // Park the create (terminal 401/403 in the real drainer).
         await dao.markParked(createSeq, error: '403');
         // The completion must NOT become claimable while its predecessor is parked.
-        check(
-          await dao.claimNextRunnable(nowEpochSeconds: 1, busyChatIds: {}),
-        ).isNull();
+        check(await dao.claimNextRunnable(nowEpochSeconds: 1, busyChatIds: {}))
+            .isNull();
 
         // Manual retry re-arms the create as the head; it (not the completion)
         // is claimed next.

--- a/test/core/database/daos/search_dao_test.dart
+++ b/test/core/database/daos/search_dao_test.dart
@@ -368,9 +368,8 @@ void main() {
             'ORDER BY kind',
           )
           .get();
-      check(
-        rows.map((row) => row.read<String>('kind')).toList(),
-      ).deepEquals(['note_text', 'note_title']);
+      check(rows.map((row) => row.read<String>('kind')).toList())
+          .deepEquals(['note_text', 'note_title']);
       check(rows.first.read<String>('text')).equals('clementine markdown body');
 
       final noteHits = await db.searchDao.searchNotes('clementine');

--- a/test/core/database/daos/sync_meta_dao_test.dart
+++ b/test/core/database/daos/sync_meta_dao_test.dart
@@ -21,13 +21,11 @@ void main() {
 
     test('round-trips and overwrites values', () async {
       await db.syncMetaDao.setValue('schema_fixture_hash', 'abc123');
-      check(
-        await db.syncMetaDao.getValue('schema_fixture_hash'),
-      ).equals('abc123');
+      check(await db.syncMetaDao.getValue('schema_fixture_hash'))
+          .equals('abc123');
       await db.syncMetaDao.setValue('schema_fixture_hash', 'def456');
-      check(
-        await db.syncMetaDao.getValue('schema_fixture_hash'),
-      ).equals('def456');
+      check(await db.syncMetaDao.getValue('schema_fixture_hash'))
+          .equals('def456');
     });
   });
 
@@ -38,15 +36,12 @@ void main() {
       await db.syncMetaDao.setChatRemapTarget('local:a', 'server:a');
       await db.syncMetaDao.setChatRemapTarget('local:a', 'server:a');
 
-      check(
-        await db.syncMetaDao.getChatRemapTarget('local:a'),
-      ).equals('server:a');
-      await check(
-        db.syncMetaDao.setChatRemapTarget('local:a', 'server:other'),
-      ).throws<StateError>();
-      check(
-        await db.syncMetaDao.getChatRemapTarget('local:a'),
-      ).equals('server:a');
+      check(await db.syncMetaDao.getChatRemapTarget('local:a'))
+          .equals('server:a');
+      await check(db.syncMetaDao.setChatRemapTarget('local:a', 'server:other'))
+          .throws<StateError>();
+      check(await db.syncMetaDao.getChatRemapTarget('local:a'))
+          .equals('server:a');
     });
 
     test('can delete a source mapping or every mapping to a target', () async {
@@ -57,18 +52,15 @@ void main() {
 
       await db.syncMetaDao.deleteChatRemapTarget('local:a');
       check(await db.syncMetaDao.getChatRemapTarget('local:a')).isNull();
-      check(
-        await db.syncMetaDao.getChatRemapTarget('local:b'),
-      ).equals('server:shared');
+      check(await db.syncMetaDao.getChatRemapTarget('local:b'))
+          .equals('server:shared');
 
       await db.syncMetaDao.deleteChatRemapTargetsForServer('server:shared');
       check(await db.syncMetaDao.getChatRemapTarget('local:b')).isNull();
-      check(
-        await db.syncMetaDao.getChatRemapTarget('local:c'),
-      ).equals('server:other');
-      check(
-        await db.syncMetaDao.getValue('chatXremap:not-a-map'),
-      ).equals('server:shared');
+      check(await db.syncMetaDao.getChatRemapTarget('local:c'))
+          .equals('server:other');
+      check(await db.syncMetaDao.getValue('chatXremap:not-a-map'))
+          .equals('server:shared');
     });
   });
 

--- a/test/core/database/database_manager_test.dart
+++ b/test/core/database/database_manager_test.dart
@@ -74,9 +74,8 @@ void main() {
       await second.customSelect('SELECT 1').get();
 
       check(openedFileNames.toSet().length).equals(2);
-      check(
-        fileFor(DatabaseManager.fileNameFor('alpha')).existsSync(),
-      ).isTrue();
+      check(fileFor(DatabaseManager.fileNameFor('alpha')).existsSync())
+          .isTrue();
       check(fileFor(DatabaseManager.fileNameFor('beta')).existsSync()).isTrue();
     });
 
@@ -117,9 +116,8 @@ void main() {
         final reopenedAlpha = (reopened as DatabaseOpenReady).database;
         check(identical(reopenedAlpha, originalAlpha)).isFalse();
         check(databases[alphaFile]!.length).equals(2);
-        check(
-          (await reopenedAlpha.customSelect('SELECT 1').get()),
-        ).isNotEmpty();
+        check((await reopenedAlpha.customSelect('SELECT 1').get()))
+            .isNotEmpty();
       },
     );
   });
@@ -220,9 +218,8 @@ void main() {
         await Future<void>.delayed(Duration.zero);
         check(closeCompleted).isFalse();
         check((await db.customSelect('SELECT 1').get())).isNotEmpty();
-        check(
-          manager.openForIfReady(_server('alpha')),
-        ).isA<DatabaseOpenDeferred>();
+        check(manager.openForIfReady(_server('alpha')))
+            .isA<DatabaseOpenDeferred>();
         check(manager.tryAcquireLease(db)).isNull();
 
         await lease.release();
@@ -291,9 +288,8 @@ void main() {
         // Deleting C likewise awaits only C's exact executor.
         await manager.deleteFor('gamma');
         check(alphaGate.isCompleted).isFalse();
-        check(
-          fileFor(DatabaseManager.fileNameFor('gamma')).existsSync(),
-        ).isFalse();
+        check(fileFor(DatabaseManager.fileNameFor('gamma')).existsSync())
+            .isFalse();
 
         alphaGate.complete();
         await _waitForClosed(alpha);
@@ -387,64 +383,61 @@ void main() {
       },
     );
 
-    test(
-      'active close joins an older failed executor and every waiter settles both',
-      () async {
-        await manager.closeActive();
-        final databases = <String, GatedCloseDatabase>{};
-        manager = DatabaseManager(
-          databaseDirectory: () async => tempDir,
-          openDatabase: (fileName) {
-            final database = GatedCloseDatabase(
-              NativeDatabase(fileFor(fileName)),
-            );
-            databases[fileName] = database;
-            return database;
-          },
-        );
-        final alphaFile = DatabaseManager.fileNameFor('alpha');
-        final betaFile = DatabaseManager.fileNameFor('beta');
+    test('active close joins an older failed executor and every waiter settles both', () async {
+      await manager.closeActive();
+      final databases = <String, GatedCloseDatabase>{};
+      manager = DatabaseManager(
+        databaseDirectory: () async => tempDir,
+        openDatabase: (fileName) {
+          final database = GatedCloseDatabase(
+            NativeDatabase(fileFor(fileName)),
+          );
+          databases[fileName] = database;
+          return database;
+        },
+      );
+      final alphaFile = DatabaseManager.fileNameFor('alpha');
+      final betaFile = DatabaseManager.fileNameFor('beta');
 
-        final alpha = manager.openFor(_server('alpha'));
-        await alpha.customSelect('SELECT 1').get();
-        await check(manager.closeActive()).throws<StateError>();
-        final alphaDatabase = databases[alphaFile]!;
+      final alpha = manager.openFor(_server('alpha'));
+      await alpha.customSelect('SELECT 1').get();
+      await check(manager.closeActive()).throws<StateError>();
+      final alphaDatabase = databases[alphaFile]!;
 
-        final beta = manager.openFor(_server('beta'));
-        await beta.customSelect('SELECT 1').get();
-        final betaDatabase = databases[betaFile]!..failClose = false;
-        alphaDatabase.failClose = false;
-        final alphaRetryGate = Completer<void>();
-        final betaCloseGate = Completer<void>();
-        addTearDown(() {
-          if (!alphaRetryGate.isCompleted) alphaRetryGate.complete();
-          if (!betaCloseGate.isCompleted) betaCloseGate.complete();
-        });
-        alphaDatabase.closeGate = alphaRetryGate;
-        betaDatabase.closeGate = betaCloseGate;
+      final beta = manager.openFor(_server('beta'));
+      await beta.customSelect('SELECT 1').get();
+      final betaDatabase = databases[betaFile]!..failClose = false;
+      alphaDatabase.failClose = false;
+      final alphaRetryGate = Completer<void>();
+      final betaCloseGate = Completer<void>();
+      addTearDown(() {
+        if (!alphaRetryGate.isCompleted) alphaRetryGate.complete();
+        if (!betaCloseGate.isCompleted) betaCloseGate.complete();
+      });
+      alphaDatabase.closeGate = alphaRetryGate;
+      betaDatabase.closeGate = betaCloseGate;
 
-        var firstCompleted = false;
-        final first = manager.closeActive().whenComplete(
-          () => firstCompleted = true,
-        );
-        await _waitForCloseAttempts(alphaDatabase, 2);
-        await _waitForCloseAttempts(betaDatabase, 1);
+      var firstCompleted = false;
+      final first = manager.closeActive().whenComplete(
+        () => firstCompleted = true,
+      );
+      await _waitForCloseAttempts(alphaDatabase, 2);
+      await _waitForCloseAttempts(betaDatabase, 1);
 
-        var joinedCompleted = false;
-        final joined = manager.closeActive().whenComplete(
-          () => joinedCompleted = true,
-        );
-        betaCloseGate.complete();
-        await Future<void>.delayed(Duration.zero);
-        check(firstCompleted).isFalse();
-        check(joinedCompleted).isFalse();
+      var joinedCompleted = false;
+      final joined = manager.closeActive().whenComplete(
+        () => joinedCompleted = true,
+      );
+      betaCloseGate.complete();
+      await Future<void>.delayed(Duration.zero);
+      check(firstCompleted).isFalse();
+      check(joinedCompleted).isFalse();
 
-        alphaRetryGate.complete();
-        await Future.wait<void>([first, joined]);
-        check(alphaDatabase.closeAttempts).equals(2);
-        check(betaDatabase.closeAttempts).equals(1);
-      },
-    );
+      alphaRetryGate.complete();
+      await Future.wait<void>([first, joined]);
+      check(alphaDatabase.closeAttempts).equals(2);
+      check(betaDatabase.closeAttempts).equals(1);
+    });
   });
 
   group('deleteFor', () {

--- a/test/core/database/fts_migration_test.dart
+++ b/test/core/database/fts_migration_test.dart
@@ -186,9 +186,8 @@ void main() {
     final outboxColumns = await db
         .customSelect('PRAGMA table_info(outbox_ops)')
         .get();
-    check(
-      outboxColumns.map((row) => row.read<String>('name')).toList(),
-    ).contains('content_hash');
+    check(outboxColumns.map((row) => row.read<String>('name')).toList())
+        .contains('content_hash');
 
     final noteTable = await db
         .customSelect(

--- a/test/core/database/fts_perf_test.dart
+++ b/test/core/database/fts_perf_test.dart
@@ -117,9 +117,8 @@ void main() {
     // Ordering is identical to watchChatList: updatedAt DESC, id ASC. The
     // fixture's strictly-decreasing updatedAt makes chat-0000 the newest.
     final firstFromStream = await db.chatsDao.watchChatList().first;
-    check(
-      page.map((e) => e.id).toList(),
-    ).deepEquals(firstFromStream.take(200).map((e) => e.id).toList());
+    check(page.map((e) => e.id).toList())
+        .deepEquals(firstFromStream.take(200).map((e) => e.id).toList());
 
     // Pagination composes: second page continues with no gaps/overlaps.
     final page2 = await db.chatsDao.getChatPage(limit: 200, offset: 200);
@@ -173,52 +172,44 @@ void main() {
   // -------------------------------------------------------------------------
   // BUDGET 3 — one list emission per merge transaction (no per-row jank).
   // -------------------------------------------------------------------------
-  test(
-    'BUDGET 3: upsertServerChat emits the list stream EXACTLY ONCE per merge tx',
-    () async {
-      final file = dbFile('emissions-1');
-      final db = AppDatabase(NativeDatabase(file));
-      addTearDown(db.close);
-      await seedAndBuildFts(
-        db,
-        chats: 50,
-        msgsPerChat: 10,
-        bigChatMessages: 50,
-      );
+  test('BUDGET 3: upsertServerChat emits the list stream EXACTLY ONCE per merge tx', () async {
+    final file = dbFile('emissions-1');
+    final db = AppDatabase(NativeDatabase(file));
+    addTearDown(db.close);
+    await seedAndBuildFts(db, chats: 50, msgsPerChat: 10, bigChatMessages: 50);
 
-      // Subscribe and drain the initial emission, then count only NEW ones.
-      final emissions = <int>[];
-      final ready = Completer<void>();
-      final sub = db.chatsDao.watchChatList().listen((rows) {
-        if (!ready.isCompleted) {
-          ready.complete();
-          return;
-        }
-        emissions.add(rows.length);
-      });
-      await ready.future;
+    // Subscribe and drain the initial emission, then count only NEW ones.
+    final emissions = <int>[];
+    final ready = Completer<void>();
+    final sub = db.chatsDao.watchChatList().listen((rows) {
+      if (!ready.isCompleted) {
+        ready.complete();
+        return;
+      }
+      emissions.add(rows.length);
+    });
+    await ready.future;
 
-      // One chat re-upserted = a full delete+reinsert of its messages inside
-      // ONE transaction (and chat_fts trigger writes). Drift coalesces table
-      // notifications to the commit; chat_fts is not a watched table, so its
-      // trigger writes raise no extra notification on chats/messages.
-      await _reupsert(db, 'chat-0000');
+    // One chat re-upserted = a full delete+reinsert of its messages inside
+    // ONE transaction (and chat_fts trigger writes). Drift coalesces table
+    // notifications to the commit; chat_fts is not a watched table, so its
+    // trigger writes raise no extra notification on chats/messages.
+    await _reupsert(db, 'chat-0000');
 
-      await _waitUntil(
-        () => emissions.isNotEmpty,
-        timeout: const Duration(seconds: 2),
-      );
-      await _settleQueuedEmissions();
-      await sub.cancel();
+    await _waitUntil(
+      () => emissions.isNotEmpty,
+      timeout: const Duration(seconds: 2),
+    );
+    await _settleQueuedEmissions();
+    await sub.cancel();
 
-      DebugLogger.log(
-        'sync-emissions',
-        scope: 'perf/sync',
-        data: {'emissions': emissions.length},
-      );
-      check(emissions.length).equals(1);
-    },
-  );
+    DebugLogger.log(
+      'sync-emissions',
+      scope: 'perf/sync',
+      data: {'emissions': emissions.length},
+    );
+    check(emissions.length).equals(1);
+  });
 
   test(
     'BUDGET 3: a batch of 10 chats each in its own tx emits EXACTLY 10 times',
@@ -278,9 +269,8 @@ void main() {
 
       // Before any build: fts_built is absent/'0' and search short-circuits to
       // [] without relying on FTS contents.
-      check(
-        await db.syncMetaDao.getValue('fts_built'),
-      ).anyOf([(it) => it.isNull(), (it) => it.equals('0')]);
+      check(await db.syncMetaDao.getValue('fts_built'))
+          .anyOf([(it) => it.isNull(), (it) => it.equals('0')]);
       // search() sanitizes its raw argument internally (toFtsMatchQuery), so we
       // pass the raw sentinel word, not a pre-built MATCH expression.
       //
@@ -349,9 +339,8 @@ void main() {
 
     final chatIds = results.map((r) => r.chatId).toList();
     // Exactly the three planted chats, grouped one row each.
-    check(
-      chatIds.toSet(),
-    ).deepEquals(fixture.sentinelHitsByChatId.keys.toSet());
+    check(chatIds.toSet())
+        .deepEquals(fixture.sentinelHitsByChatId.keys.toSet());
     check(chatIds.length).equals(3);
 
     // bm25 ranking: equal-length corpus, so most/earliest sentinel hits rank

--- a/test/core/database/mappers/conversation_assembler_guarded_test.dart
+++ b/test/core/database/mappers/conversation_assembler_guarded_test.dart
@@ -23,8 +23,9 @@ void main() {
   });
 
   Future<(ChatRow, List<MessageRow>)> seedFixture() async {
-    final fixture = loadChatBlobFixtures()
-        .singleWhere((f) => f.name == '02_linear_multi_turn');
+    final fixture = loadChatBlobFixtures().singleWhere(
+      (f) => f.name == '02_linear_multi_turn',
+    );
     await db.chatsDao.upsertServerChat(rows: rowsFromFixture(fixture));
     final chat = (await db.chatsDao.getChat(fixture.chatId))!;
     final messages = await db.messagesDao.getForChat(fixture.chatId);
@@ -32,92 +33,83 @@ void main() {
   }
 
   group('assembleConversationGuarded', () {
-    test(
-      'messages.length <= threshold: offload NOT called; result matches sync parse',
-      () async {
-        final (chat, messages) = await seedFixture();
+    test('messages.length <= threshold: offload NOT called; result matches sync parse', () async {
+      final (chat, messages) = await seedFixture();
 
-        // The fixture has far fewer than kLocalConversationWorkerThreshold messages.
-        check(messages.length).isLessThan(kLocalConversationWorkerThreshold);
+      // The fixture has far fewer than kLocalConversationWorkerThreshold messages.
+      check(messages.length).isLessThan(kLocalConversationWorkerThreshold);
 
-        var offloadCallCount = 0;
-        // This branch must never be entered.
-        Future<Conversation> offload(Object? envelope) async {
-          offloadCallCount++;
-          return assembleConversation(chat, messages);
-        }
+      var offloadCallCount = 0;
+      // This branch must never be entered.
+      Future<Conversation> offload(Object? envelope) async {
+        offloadCallCount++;
+        return assembleConversation(chat, messages);
+      }
 
-        final result = await assembleConversationGuarded(
-          chat,
-          messages,
-          offload: offload,
-        );
+      final result = await assembleConversationGuarded(
+        chat,
+        messages,
+        offload: offload,
+      );
 
-        check(offloadCallCount).equals(0);
-        final expected = assembleConversation(chat, messages);
-        check(result.id).equals(expected.id);
-        check(result.title).equals(expected.title);
-        check(result.messages.length).equals(expected.messages.length);
-      },
-    );
+      check(offloadCallCount).equals(0);
+      final expected = assembleConversation(chat, messages);
+      check(result.id).equals(expected.id);
+      check(result.title).equals(expected.title);
+      check(result.messages.length).equals(expected.messages.length);
+    });
 
-    test(
-      'messages.length > threshold: offload IS called exactly once with non-null envelope',
-      () async {
-        final (chat, realMessages) = await seedFixture();
+    test('messages.length > threshold: offload IS called exactly once with non-null envelope', () async {
+      final (chat, realMessages) = await seedFixture();
 
-        // Pad the list past the threshold; the guarded helper only checks length.
-        final padded = <MessageRow>[
-          ...realMessages,
-          for (var i = 0; i < kLocalConversationWorkerThreshold; i++)
-            realMessages.first,
-        ];
-        check(padded.length).isGreaterThan(kLocalConversationWorkerThreshold);
+      // Pad the list past the threshold; the guarded helper only checks length.
+      final padded = <MessageRow>[
+        ...realMessages,
+        for (var i = 0; i < kLocalConversationWorkerThreshold; i++)
+          realMessages.first,
+      ];
+      check(padded.length).isGreaterThan(kLocalConversationWorkerThreshold);
 
-        var offloadCallCount = 0;
-        Object? capturedEnvelope;
-        final syncResult = assembleConversation(chat, realMessages);
-        Future<Conversation> offload(Object? envelope) async {
-          offloadCallCount++;
-          capturedEnvelope = envelope;
-          return syncResult;
-        }
+      var offloadCallCount = 0;
+      Object? capturedEnvelope;
+      final syncResult = assembleConversation(chat, realMessages);
+      Future<Conversation> offload(Object? envelope) async {
+        offloadCallCount++;
+        capturedEnvelope = envelope;
+        return syncResult;
+      }
 
-        final result = await assembleConversationGuarded(
-          chat,
-          padded,
-          offload: offload,
-        );
+      final result = await assembleConversationGuarded(
+        chat,
+        padded,
+        offload: offload,
+      );
 
-        check(offloadCallCount).equals(1);
-        check(capturedEnvelope).isNotNull();
-        check(identical(result, syncResult)).isTrue();
-      },
-    );
+      check(offloadCallCount).equals(1);
+      check(capturedEnvelope).isNotNull();
+      check(identical(result, syncResult)).isTrue();
+    });
 
-    test(
-      'messages.length > threshold, offload null: falls back to synchronous parse without throwing',
-      () async {
-        final (chat, realMessages) = await seedFixture();
+    test('messages.length > threshold, offload null: falls back to synchronous parse without throwing', () async {
+      final (chat, realMessages) = await seedFixture();
 
-        // Pad the list past the threshold.
-        final padded = <MessageRow>[
-          ...realMessages,
-          for (var i = 0; i < kLocalConversationWorkerThreshold; i++)
-            realMessages.first,
-        ];
-        check(padded.length).isGreaterThan(kLocalConversationWorkerThreshold);
+      // Pad the list past the threshold.
+      final padded = <MessageRow>[
+        ...realMessages,
+        for (var i = 0; i < kLocalConversationWorkerThreshold; i++)
+          realMessages.first,
+      ];
+      check(padded.length).isGreaterThan(kLocalConversationWorkerThreshold);
 
-        // Must not throw even with offload == null.
-        final result = await assembleConversationGuarded(
-          chat,
-          padded,
-          offload: null,
-        );
+      // Must not throw even with offload == null.
+      final result = await assembleConversationGuarded(
+        chat,
+        padded,
+        offload: null,
+      );
 
-        check(result).isA<Conversation>();
-        check(result.id).equals(chat.id);
-      },
-    );
+      check(result).isA<Conversation>();
+      check(result.id).equals(chat.id);
+    });
   });
 }

--- a/test/core/database/mappers/conversation_assembler_test.dart
+++ b/test/core/database/mappers/conversation_assembler_test.dart
@@ -24,71 +24,78 @@ void main() {
   });
 
   group('buildChatResponseEnvelope', () {
-    test('rebuilds the exact ChatResponse-shaped map (ints stay seconds)',
-        () async {
-      final fixture = loadChatBlobFixtures()
-          .singleWhere((f) => f.name == '02_linear_multi_turn');
-      await db.chatsDao.upsertServerChat(
-        rows: rowsFromFixture(fixture),
-        shareId: 'share-abc',
-        meta: const {
-          'tags': ['work'],
-        },
-        listLastReadAt: 1749700123,
-      );
+    test(
+      'rebuilds the exact ChatResponse-shaped map (ints stay seconds)',
+      () async {
+        final fixture = loadChatBlobFixtures().singleWhere(
+          (f) => f.name == '02_linear_multi_turn',
+        );
+        await db.chatsDao.upsertServerChat(
+          rows: rowsFromFixture(fixture),
+          shareId: 'share-abc',
+          meta: const {
+            'tags': ['work'],
+          },
+          listLastReadAt: 1749700123,
+        );
 
-      final chatRow = (await db.chatsDao.getChat(fixture.chatId))!;
-      final messageRows = await db.messagesDao.getForChat(fixture.chatId);
-      final envelope = buildChatResponseEnvelope(chatRow, messageRows);
+        final chatRow = (await db.chatsDao.getChat(fixture.chatId))!;
+        final messageRows = await db.messagesDao.getForChat(fixture.chatId);
+        final envelope = buildChatResponseEnvelope(chatRow, messageRows);
 
-      final expected = <String, dynamic>{
-        'id': fixture.chatId,
-        'title': fixture.envelope['title'],
-        'chat': fixture.blob,
-        'updated_at': fixture.envelope['updated_at'],
-        'created_at': fixture.envelope['created_at'],
-        'last_read_at': 1749700123,
-        'pinned': fixture.envelope['pinned'] ?? false,
-        'archived': fixture.envelope['archived'] ?? false,
-        'folder_id': fixture.envelope['folder_id'],
-        'share_id': 'share-abc',
-        'meta': {
-          'tags': ['work'],
-        },
-      };
-      check(
-        _deepEq.equals(envelope, expected),
-        because: 'envelope must match what /api/v1/chats/{id} returns today\n'
-            'got: ${jsonEncode(envelope)}',
-      ).isTrue();
-    });
+        final expected = <String, dynamic>{
+          'id': fixture.chatId,
+          'title': fixture.envelope['title'],
+          'chat': fixture.blob,
+          'updated_at': fixture.envelope['updated_at'],
+          'created_at': fixture.envelope['created_at'],
+          'last_read_at': 1749700123,
+          'pinned': fixture.envelope['pinned'] ?? false,
+          'archived': fixture.envelope['archived'] ?? false,
+          'folder_id': fixture.envelope['folder_id'],
+          'share_id': 'share-abc',
+          'meta': {
+            'tags': ['work'],
+          },
+        };
+        check(
+          _deepEq.equals(envelope, expected),
+          because:
+              'envelope must match what /api/v1/chats/{id} returns today\n'
+              'got: ${jsonEncode(envelope)}',
+        ).isTrue();
+      },
+    );
   });
 
   group('assembleConversation', () {
-    test('parses a full conversation through parseFullConversationModel',
-        () async {
-      final fixture = loadChatBlobFixtures()
-          .singleWhere((f) => f.name == '02_linear_multi_turn');
-      await db.chatsDao.upsertServerChat(rows: rowsFromFixture(fixture));
+    test(
+      'parses a full conversation through parseFullConversationModel',
+      () async {
+        final fixture = loadChatBlobFixtures().singleWhere(
+          (f) => f.name == '02_linear_multi_turn',
+        );
+        await db.chatsDao.upsertServerChat(rows: rowsFromFixture(fixture));
 
-      final chatRow = (await db.chatsDao.getChat(fixture.chatId))!;
-      final messageRows = await db.messagesDao.getForChat(fixture.chatId);
-      final conversation = assembleConversation(chatRow, messageRows);
+        final chatRow = (await db.chatsDao.getChat(fixture.chatId))!;
+        final messageRows = await db.messagesDao.getForChat(fixture.chatId);
+        final conversation = assembleConversation(chatRow, messageRows);
 
-      check(conversation.id).equals(fixture.chatId);
-      check(conversation.title).equals(fixture.envelope['title'] as String);
-      check(conversation.messages).isNotEmpty();
-      check(conversation.createdAt).equals(
-        DateTime.fromMillisecondsSinceEpoch(
-          (fixture.envelope['created_at'] as int) * 1000,
-        ),
-      );
-      check(conversation.updatedAt).equals(
-        DateTime.fromMillisecondsSinceEpoch(
-          (fixture.envelope['updated_at'] as int) * 1000,
-        ),
-      );
-    });
+        check(conversation.id).equals(fixture.chatId);
+        check(conversation.title).equals(fixture.envelope['title'] as String);
+        check(conversation.messages).isNotEmpty();
+        check(conversation.createdAt).equals(
+          DateTime.fromMillisecondsSinceEpoch(
+            (fixture.envelope['created_at'] as int) * 1000,
+          ),
+        );
+        check(conversation.updatedAt).equals(
+          DateTime.fromMillisecondsSinceEpoch(
+            (fixture.envelope['updated_at'] as int) * 1000,
+          ),
+        );
+      },
+    );
   });
 
   group('conversationFromListEntry', () {

--- a/test/core/error/api_error_test.dart
+++ b/test/core/error/api_error_test.dart
@@ -17,9 +17,9 @@ void main() {
       );
       check(error.type).equals(ApiErrorType.timeout);
       check(error.isRetryable).isTrue();
-      check(
-        error.timeoutDuration,
-      ).isNotNull().equals(const Duration(seconds: 30));
+      check(error.timeoutDuration)
+          .isNotNull()
+          .equals(const Duration(seconds: 30));
     });
 
     test('authentication is not retryable', () {

--- a/test/core/error/error_parser_test.dart
+++ b/test/core/error/error_parser_test.dart
@@ -106,9 +106,9 @@ void main() {
         },
       });
       check(result.message).equals('Validation failed');
-      check(
-        result.fieldErrors['email'],
-      ).isNotNull().deepEquals(['is required', 'must be valid']);
+      check(result.fieldErrors['email'])
+          .isNotNull()
+          .deepEquals(['is required', 'must be valid']);
       check(result.fieldErrors['name']).isNotNull().deepEquals(['too short']);
     });
 
@@ -125,12 +125,12 @@ void main() {
           },
         ],
       });
-      check(
-        result.fieldErrors['email'],
-      ).isNotNull().deepEquals(['field required']);
-      check(
-        result.fieldErrors['age'],
-      ).isNotNull().deepEquals(['must be positive']);
+      check(result.fieldErrors['email'])
+          .isNotNull()
+          .deepEquals(['field required']);
+      check(result.fieldErrors['age'])
+          .isNotNull()
+          .deepEquals(['must be positive']);
     });
   });
 

--- a/test/core/models/file_info_test.dart
+++ b/test/core/models/file_info_test.dart
@@ -60,12 +60,10 @@ void main() {
         'updated_at': 1713786305987654,
       });
 
-      check(
-        file.createdAt,
-      ).equals(DateTime.fromMicrosecondsSinceEpoch(1713786305123456));
-      check(
-        file.updatedAt,
-      ).equals(DateTime.fromMicrosecondsSinceEpoch(1713786305987654));
+      check(file.createdAt)
+          .equals(DateTime.fromMicrosecondsSinceEpoch(1713786305123456));
+      check(file.updatedAt)
+          .equals(DateTime.fromMicrosecondsSinceEpoch(1713786305987654));
     });
   });
 }

--- a/test/core/network/conduit_user_agent_test.dart
+++ b/test/core/network/conduit_user_agent_test.dart
@@ -7,15 +7,13 @@ import 'package:flutter_test/flutter_test.dart';
 void main() {
   group('ConduitUserAgent', () {
     test('builds a product and app-version token', () {
-      check(
-        ConduitUserAgent.build(appVersion: ' 3.4.3 '),
-      ).equals('Conduit/3.4.3');
+      check(ConduitUserAgent.build(appVersion: ' 3.4.3 '))
+          .equals('Conduit/3.4.3');
     });
 
     test('sanitizes characters that are invalid in a product token', () {
-      check(
-        ConduitUserAgent.build(appVersion: '3.4 beta/1'),
-      ).equals('Conduit/3.4-beta-1');
+      check(ConduitUserAgent.build(appVersion: '3.4 beta/1'))
+          .equals('Conduit/3.4-beta-1');
     });
 
     test('falls back to the product name when the version is empty', () {
@@ -46,9 +44,8 @@ void main() {
       final merged = ConduitUserAgent.mergeHeaders(original);
 
       check(merged[ConduitUserAgent.headerName]).equals(ConduitUserAgent.value);
-      check(
-        merged.keys.where(ConduitUserAgent.isHeaderName),
-      ).deepEquals([ConduitUserAgent.headerName]);
+      check(merged.keys.where(ConduitUserAgent.isHeaderName))
+          .deepEquals([ConduitUserAgent.headerName]);
       check(merged['X-Custom']).equals('value');
       check(original['user-agent']).equals('spoofed');
     });

--- a/test/core/network/self_signed_image_cache_manager_factory_io_test.dart
+++ b/test/core/network/self_signed_image_cache_manager_factory_io_test.dart
@@ -131,10 +131,7 @@ void main() {
 
       expect(defaultCached, isNotNull);
       expect(tlsCached, isNotNull);
-      expect(
-        await defaultCached!.file.readAsBytes(),
-        orderedEquals([9, 9, 9]),
-      );
+      expect(await defaultCached!.file.readAsBytes(), orderedEquals([9, 9, 9]));
       expect(await tlsCached!.file.readAsBytes(), orderedEquals([7, 7, 7]));
     } finally {
       await tlsManager?.dispose();

--- a/test/core/persistence/hive_prefs_migrator_test.dart
+++ b/test/core/persistence/hive_prefs_migrator_test.dart
@@ -26,7 +26,8 @@ void main() {
     metadata: metadata,
   );
 
-  Future<void> migrate() => HivePrefsMigrator(hiveBoxes: boxes()).migrateIfNeeded();
+  Future<void> migrate() =>
+      HivePrefsMigrator(hiveBoxes: boxes()).migrateIfNeeded();
 
   String transportKey(String serverId) =>
       '${PreferenceKeys.transportOptionsPrefix}:'
@@ -72,21 +73,16 @@ void main() {
     await migrate();
 
     check(PreferencesStore.getBool(PreferenceKeys.darkMode)).equals(false);
-    check(
-      PreferencesStore.getDouble(PreferenceKeys.animationSpeed),
-    ).equals(0.75);
-    check(
-      PreferencesStore.getString(PreferenceKeys.defaultModel),
-    ).equals('gpt-4.1');
-    check(
-      PreferencesStore.getStringList(PreferenceKeys.quickPills)!,
-    ).deepEquals(['web', 'image']);
-    check(
-      PreferencesStore.getInt(PreferenceKeys.voiceSilenceDuration),
-    ).equals(1500);
-    check(
-      PreferencesStore.getString(PreferenceKeys.androidAssistantTrigger),
-    ).equals('new_chat');
+    check(PreferencesStore.getDouble(PreferenceKeys.animationSpeed))
+        .equals(0.75);
+    check(PreferencesStore.getString(PreferenceKeys.defaultModel))
+        .equals('gpt-4.1');
+    check(PreferencesStore.getStringList(PreferenceKeys.quickPills)!)
+        .deepEquals(['web', 'image']);
+    check(PreferencesStore.getInt(PreferenceKeys.voiceSilenceDuration))
+        .equals(1500);
+    check(PreferencesStore.getString(PreferenceKeys.androidAssistantTrigger))
+        .equals('new_chat');
 
     final flagsJson = PreferencesStore.getString(
       PreferenceKeys.serverFeatureAvailability,
@@ -97,9 +93,8 @@ void main() {
     });
 
     // Gate set.
-    check(
-      PreferencesStore.getBool(PreferenceKeys.hiveToPrefsMigrationV1),
-    ).equals(true);
+    check(PreferencesStore.getBool(PreferenceKeys.hiveToPrefsMigrationV1))
+        .equals(true);
   });
 
   test('copies the server-scoped transport options cache slot', () async {
@@ -112,10 +107,8 @@ void main() {
 
     final raw = PreferencesStore.getString(transportKey('server-a'));
     check(raw).isNotNull();
-    check(jsonDecode(raw!) as Map).deepEquals({
-      'allowPolling': false,
-      'allowWebsocketOnly': true,
-    });
+    check(jsonDecode(raw!) as Map)
+        .deepEquals({'allowPolling': false, 'allowWebsocketOnly': true});
   });
 
   test('is gated: a second run does not overwrite changed prefs', () async {
@@ -134,8 +127,7 @@ void main() {
 
   test('empty Hive still sets the gate', () async {
     await migrate();
-    check(
-      PreferencesStore.getBool(PreferenceKeys.hiveToPrefsMigrationV1),
-    ).equals(true);
+    check(PreferencesStore.getBool(PreferenceKeys.hiveToPrefsMigrationV1))
+        .equals(true);
   });
 }

--- a/test/core/persistence/persistence_migrator_test.dart
+++ b/test/core/persistence/persistence_migrator_test.dart
@@ -61,82 +61,76 @@ void main() {
     }
   });
 
-  test(
-    'migrates legacy caches/queues into Hive but leaves preferences in '
-    'shared_preferences',
-    () async {
-      final prefs = await SharedPreferences.getInstance();
-      final conversations = [
-        {
-          'id': 'conversation-1',
-          'title': 'First conversation',
-          'updated_at': 1710000000,
-        },
-        {
-          'id': 'conversation-2',
-          'title': 'Second conversation',
-          'folder_id': 'folder-1',
-        },
-      ];
-      final folders = [
-        {'id': 'folder-1', 'name': 'Work'},
-      ];
-      final attachmentUploads = [
-        {'id': 'upload-1', 'path': '/tmp/example.txt', 'mimeType': 'text/plain'},
-      ];
-      final tasks = [
-        {'id': 'task-1', 'type': 'chat-sync', 'attempt': 2},
-      ];
+  test('migrates legacy caches/queues into Hive but leaves preferences in '
+      'shared_preferences', () async {
+    final prefs = await SharedPreferences.getInstance();
+    final conversations = [
+      {
+        'id': 'conversation-1',
+        'title': 'First conversation',
+        'updated_at': 1710000000,
+      },
+      {
+        'id': 'conversation-2',
+        'title': 'Second conversation',
+        'folder_id': 'folder-1',
+      },
+    ];
+    final folders = [
+      {'id': 'folder-1', 'name': 'Work'},
+    ];
+    final attachmentUploads = [
+      {'id': 'upload-1', 'path': '/tmp/example.txt', 'mimeType': 'text/plain'},
+    ];
+    final tasks = [
+      {'id': 'task-1', 'type': 'chat-sync', 'attempt': 2},
+    ];
 
-      // Preferences are NO LONGER migrated to Hive — shared_preferences is the
-      // live store for them again.
-      await prefs.setBool(PreferenceKeys.reduceMotion, true);
-      await prefs.setString(PreferenceKeys.defaultModel, 'gpt-4.1');
+    // Preferences are NO LONGER migrated to Hive — shared_preferences is the
+    // live store for them again.
+    await prefs.setBool(PreferenceKeys.reduceMotion, true);
+    await prefs.setString(PreferenceKeys.defaultModel, 'gpt-4.1');
 
-      await prefs.setString(
-        HiveStoreKeys.localConversations,
-        jsonEncode(conversations),
-      );
-      await prefs.setString(HiveStoreKeys.localFolders, jsonEncode(folders));
-      await prefs.setString(
-        LegacyPreferenceKeys.attachmentUploadQueue,
-        jsonEncode(attachmentUploads),
-      );
-      await prefs.setString(LegacyPreferenceKeys.taskQueue, jsonEncode(tasks));
+    await prefs.setString(
+      HiveStoreKeys.localConversations,
+      jsonEncode(conversations),
+    );
+    await prefs.setString(HiveStoreKeys.localFolders, jsonEncode(folders));
+    await prefs.setString(
+      LegacyPreferenceKeys.attachmentUploadQueue,
+      jsonEncode(attachmentUploads),
+    );
+    await prefs.setString(LegacyPreferenceKeys.taskQueue, jsonEncode(tasks));
 
-      await migrate();
+    await migrate();
 
-      // Caches/queues still migrate into Hive (they move to Drift in PR-2).
-      check(
-        caches.get(HiveStoreKeys.localConversations) as List<dynamic>,
-      ).deepEquals(conversations);
-      check(
-        caches.get(HiveStoreKeys.localFolders) as List<dynamic>,
-      ).deepEquals(folders);
-      check(
-        attachmentQueue.get(HiveStoreKeys.attachmentQueueEntries)
-            as List<dynamic>,
-      ).deepEquals(attachmentUploads);
-      check(
-        caches.get(HiveStoreKeys.taskQueue) as List<dynamic>,
-      ).deepEquals(tasks);
-      check(metadata.get(HiveStoreKeys.migrationVersion)).equals(1);
+    // Caches/queues still migrate into Hive (they move to Drift in PR-2).
+    check(caches.get(HiveStoreKeys.localConversations) as List<dynamic>)
+        .deepEquals(conversations);
+    check(caches.get(HiveStoreKeys.localFolders) as List<dynamic>)
+        .deepEquals(folders);
+    check(
+      attachmentQueue.get(HiveStoreKeys.attachmentQueueEntries)
+          as List<dynamic>,
+    ).deepEquals(attachmentUploads);
+    check(caches.get(HiveStoreKeys.taskQueue) as List<dynamic>)
+        .deepEquals(tasks);
+    check(metadata.get(HiveStoreKeys.migrationVersion)).equals(1);
 
-      // Preferences are neither copied into Hive nor removed from prefs.
-      check(preferences.containsKey(PreferenceKeys.reduceMotion)).isFalse();
-      check(preferences.containsKey(PreferenceKeys.defaultModel)).isFalse();
-      check(prefs.getBool(PreferenceKeys.reduceMotion)).equals(true);
-      check(prefs.getString(PreferenceKeys.defaultModel)).equals('gpt-4.1');
+    // Preferences are neither copied into Hive nor removed from prefs.
+    check(preferences.containsKey(PreferenceKeys.reduceMotion)).isFalse();
+    check(preferences.containsKey(PreferenceKeys.defaultModel)).isFalse();
+    check(prefs.getBool(PreferenceKeys.reduceMotion)).equals(true);
+    check(prefs.getString(PreferenceKeys.defaultModel)).equals('gpt-4.1');
 
-      // Only the legacy cache/queue keys are removed from shared_preferences.
-      checkSharedPreferencesRemoved(prefs, [
-        HiveStoreKeys.localConversations,
-        HiveStoreKeys.localFolders,
-        LegacyPreferenceKeys.attachmentUploadQueue,
-        LegacyPreferenceKeys.taskQueue,
-      ]);
-    },
-  );
+    // Only the legacy cache/queue keys are removed from shared_preferences.
+    checkSharedPreferencesRemoved(prefs, [
+      HiveStoreKeys.localConversations,
+      HiveStoreKeys.localFolders,
+      LegacyPreferenceKeys.attachmentUploadQueue,
+      LegacyPreferenceKeys.taskQueue,
+    ]);
+  });
 
   test('empty SharedPreferences still records migration version', () async {
     await migrate();
@@ -161,9 +155,8 @@ void main() {
       await migrate();
 
       check(caches.get(HiveStoreKeys.localConversations)).isNull();
-      check(
-        caches.get(HiveStoreKeys.localFolders) as List<dynamic>,
-      ).deepEquals(folders);
+      check(caches.get(HiveStoreKeys.localFolders) as List<dynamic>)
+          .deepEquals(folders);
       check(metadata.get(HiveStoreKeys.migrationVersion)).equals(1);
       checkSharedPreferencesRemoved(prefs, [
         HiveStoreKeys.localConversations,
@@ -192,9 +185,8 @@ void main() {
     );
     await migrate();
 
-    check(
-      caches.get(HiveStoreKeys.localConversations) as List<dynamic>,
-    ).deepEquals(conversations);
+    check(caches.get(HiveStoreKeys.localConversations) as List<dynamic>)
+        .deepEquals(conversations);
     check(metadata.get(HiveStoreKeys.migrationVersion)).equals(1);
   });
 }

--- a/test/core/providers/active_chats_sync_test.dart
+++ b/test/core/providers/active_chats_sync_test.dart
@@ -303,9 +303,8 @@ void main() {
           _activeEnvelope(chatId: 'background-chat', active: true),
           null,
         );
-        check(
-          container.read(activeChatIdsProvider),
-        ).contains('background-chat');
+        check(container.read(activeChatIdsProvider))
+            .contains('background-chat');
       },
     );
 
@@ -325,12 +324,10 @@ void main() {
         null,
       );
 
-      check(
-        container.read(conversationsProvider).requireValue.single.title,
-      ).equals('Generated title');
-      check(
-        container.read(activeConversationProvider)?.title,
-      ).equals('Generated title');
+      check(container.read(conversationsProvider).requireValue.single.title)
+          .equals('Generated title');
+      check(container.read(activeConversationProvider)?.title)
+          .equals('Generated title');
       check(container.read(activeChatIdsProvider)).isEmpty();
     });
 
@@ -352,9 +349,8 @@ void main() {
         null,
       );
 
-      check(
-        container.read(conversationsProvider).requireValue.single.title,
-      ).equals('Mapped title');
+      check(container.read(conversationsProvider).requireValue.single.title)
+          .equals('Mapped title');
     });
   });
 

--- a/test/core/providers/app_startup_providers_test.dart
+++ b/test/core/providers/app_startup_providers_test.dart
@@ -126,9 +126,9 @@ typedef _WarmupNotifiers = ({
 
 _WarmupNotifiers _readWarmupNotifiers(ProviderContainer container) {
   return (
-    conversations:
-        container.read(conversationsProvider.notifier)
-            as _RecordingWarmupConversations,
+    conversations: container.read(
+      conversationsProvider.notifier,
+    ) as _RecordingWarmupConversations,
     folders: container.read(foldersProvider.notifier) as _TrackingWarmupFolders,
   );
 }
@@ -221,9 +221,8 @@ void main() {
     container.read(_authOwnerSignalProvider.notifier).signOut();
     await _flushMicrotasks(2);
     check(container.read(authTokenProvider3)).isNull();
-    check(
-      container.read(authNavigationStateProvider),
-    ).equals(AuthNavigationState.needsLogin);
+    check(container.read(authNavigationStateProvider))
+        .equals(AuthNavigationState.needsLogin);
 
     for (var attempt = 0; attempt < 50; attempt++) {
       if (container.read(attachedFilesProvider).isEmpty &&
@@ -328,9 +327,8 @@ void main() {
       authOwner.signOut();
       await _flushMicrotasks();
       check(container.read(authTokenProvider3)).isNull();
-      check(
-        container.read(authNavigationStateProvider),
-      ).equals(AuthNavigationState.needsLogin);
+      check(container.read(authNavigationStateProvider))
+          .equals(AuthNavigationState.needsLogin);
       authOwner.signIn(token: 'test-token');
       container.read(attachedFilesProvider.notifier).addFiles([
         LocalAttachment(file: replacementImage, displayName: 'new.png'),
@@ -469,9 +467,8 @@ void main() {
       authOwner.signOut();
       await _flushMicrotasks(2);
       check(container.read(authTokenProvider3)).isNull();
-      check(
-        container.read(authNavigationStateProvider),
-      ).equals(AuthNavigationState.needsLogin);
+      check(container.read(authNavigationStateProvider))
+          .equals(AuthNavigationState.needsLogin);
       await cleanupStarted.future.timeout(const Duration(seconds: 1));
       authOwner.signIn();
       final replacementConversation = _conversation('replacement-chat');
@@ -482,9 +479,8 @@ void main() {
       await _waitForFileDeletion(oldImage);
 
       check(container.read(authTokenProvider3)).equals('replacement-token');
-      check(
-        container.read(activeConversationProvider),
-      ).identicalTo(replacementConversation);
+      check(container.read(activeConversationProvider))
+          .identicalTo(replacementConversation);
       check(await oldImage.exists()).isFalse();
     },
   );
@@ -509,39 +505,36 @@ void main() {
     },
   );
 
-  test(
-    'forced warmup queued during an in-flight warmup reruns after folders finish',
-    () async {
-      final conversations = _RecordingWarmupConversations();
-      final folders = _BlockingWarmupFolders();
-      final container = await _createAuthenticatedWarmupContainer(
-        conversationsOverride: conversationsProvider.overrideWith(
-          () => conversations,
-        ),
-        foldersOverride: foldersProvider.overrideWith(() => folders),
-      );
+  test('forced warmup queued during an in-flight warmup reruns after folders finish', () async {
+    final conversations = _RecordingWarmupConversations();
+    final folders = _BlockingWarmupFolders();
+    final container = await _createAuthenticatedWarmupContainer(
+      conversationsOverride: conversationsProvider.overrideWith(
+        () => conversations,
+      ),
+      foldersOverride: foldersProvider.overrideWith(() => folders),
+    );
 
-      container
-          .read(appStartupFlowProvider.notifier)
-          .scheduleConversationWarmup();
-      await _flushMicrotasks(2);
+    container
+        .read(appStartupFlowProvider.notifier)
+        .scheduleConversationWarmup();
+    await _flushMicrotasks(2);
 
-      expect(folders.warmIfNeededCalls, 1);
-      expect(conversations.refreshCalls, 0);
+    expect(folders.warmIfNeededCalls, 1);
+    expect(conversations.refreshCalls, 0);
 
-      container
-          .read(appStartupFlowProvider.notifier)
-          .scheduleConversationWarmup(force: true);
-      await _flushMicrotasks();
+    container
+        .read(appStartupFlowProvider.notifier)
+        .scheduleConversationWarmup(force: true);
+    await _flushMicrotasks();
 
-      expect(conversations.refreshCalls, 0);
+    expect(conversations.refreshCalls, 0);
 
-      folders.completeFirstWarmup();
-      await _flushMicrotasks(3);
+    folders.completeFirstWarmup();
+    await _flushMicrotasks(3);
 
-      _expectForcedWarmup(conversations, folders, warmIfNeededCalls: 2);
-    },
-  );
+    _expectForcedWarmup(conversations, folders, warmIfNeededCalls: 2);
+  });
 
   test(
     'already-authenticated startup runs post-auth warmup on start',
@@ -595,66 +588,60 @@ void main() {
     },
   );
 
-  test(
-    'already-authenticated startup retries when api service becomes ready after the initial wait',
-    () async {
-      ApiService? currentApi;
-      final container = await _createAuthenticatedWarmupContainer(
-        apiOverride: apiServiceProvider.overrideWith((ref) => currentApi),
-      );
+  test('already-authenticated startup retries when api service becomes ready after the initial wait', () async {
+    ApiService? currentApi;
+    final container = await _createAuthenticatedWarmupContainer(
+      apiOverride: apiServiceProvider.overrideWith((ref) => currentApi),
+    );
 
-      container
-          .read(appStartupFlowProvider.notifier)
-          .activateForTesting(apiWaitTimeout: const Duration(milliseconds: 40));
+    container
+        .read(appStartupFlowProvider.notifier)
+        .activateForTesting(apiWaitTimeout: const Duration(milliseconds: 40));
 
-      final notifiers = _readWarmupNotifiers(container);
+    final notifiers = _readWarmupNotifiers(container);
 
-      await Future<void>.delayed(const Duration(milliseconds: 80));
-      expect(notifiers.conversations.refreshCalls, 0);
-      expect(notifiers.folders.warmIfNeededCalls, 0);
+    await Future<void>.delayed(const Duration(milliseconds: 80));
+    expect(notifiers.conversations.refreshCalls, 0);
+    expect(notifiers.folders.warmIfNeededCalls, 0);
 
-      currentApi = _StubApiService();
-      container.invalidate(apiServiceProvider);
+    currentApi = _StubApiService();
+    container.invalidate(apiServiceProvider);
 
-      await Future<void>.delayed(const Duration(milliseconds: 80));
-      await _flushMicrotasks();
+    await Future<void>.delayed(const Duration(milliseconds: 80));
+    await _flushMicrotasks();
 
-      _expectForcedWarmup(
-        notifiers.conversations,
-        notifiers.folders,
-        warmIfNeededCalls: 1,
-      );
-    },
-  );
+    _expectForcedWarmup(
+      notifiers.conversations,
+      notifiers.folders,
+      warmIfNeededCalls: 1,
+    );
+  });
 
-  test(
-    'post-auth startup cancels delayed model preload after leaving authenticated flow',
-    () async {
-      var navState = AuthNavigationState.authenticated;
-      var defaultModelLoads = 0;
-      final container = await _createAuthenticatedWarmupContainer(
-        authNavigationOverride: authNavigationStateProvider.overrideWith(
-          (ref) => navState,
-        ),
-        extraOverrides: [
-          defaultModelProvider.overrideWith((ref) async {
-            defaultModelLoads += 1;
-            return null;
-          }),
-        ],
-      );
+  test('post-auth startup cancels delayed model preload after leaving authenticated flow', () async {
+    var navState = AuthNavigationState.authenticated;
+    var defaultModelLoads = 0;
+    final container = await _createAuthenticatedWarmupContainer(
+      authNavigationOverride: authNavigationStateProvider.overrideWith(
+        (ref) => navState,
+      ),
+      extraOverrides: [
+        defaultModelProvider.overrideWith((ref) async {
+          defaultModelLoads += 1;
+          return null;
+        }),
+      ],
+    );
 
-      container.read(appStartupFlowProvider.notifier).activateForTesting();
-      await Future<void>.delayed(const Duration(milliseconds: 50));
+    container.read(appStartupFlowProvider.notifier).activateForTesting();
+    await Future<void>.delayed(const Duration(milliseconds: 50));
 
-      navState = AuthNavigationState.needsLogin;
-      container.invalidate(authNavigationStateProvider);
+    navState = AuthNavigationState.needsLogin;
+    container.invalidate(authNavigationStateProvider);
 
-      await Future<void>.delayed(const Duration(milliseconds: 250));
+    await Future<void>.delayed(const Duration(milliseconds: 250));
 
-      expect(defaultModelLoads, 0);
-    },
-  );
+    expect(defaultModelLoads, 0);
+  });
 
   test(
     'direct completion relay is owned only by an authenticated session',
@@ -714,9 +701,8 @@ void main() {
     final binding = TestWidgetsFlutterBinding.ensureInitialized();
     final api = _StubApiService(
       conversations: {
-        'active-chat': _conversation(
-          'active-chat',
-        ).copyWith(title: 'Server copy'),
+        'active-chat': _conversation('active-chat')
+            .copyWith(title: 'Server copy'),
       },
     );
     final container = await _createAuthenticatedWarmupContainer(
@@ -773,9 +759,8 @@ void main() {
     final getConversationGate = Completer<void>();
     final api = _StubApiService(
       conversations: {
-        'active-chat': _conversation(
-          'active-chat',
-        ).copyWith(title: 'Server copy'),
+        'active-chat': _conversation('active-chat')
+            .copyWith(title: 'Server copy'),
       },
       getConversationGate: getConversationGate,
     );
@@ -807,9 +792,8 @@ void main() {
       final binding = TestWidgetsFlutterBinding.ensureInitialized();
       final api = _StubApiService(
         conversations: {
-          'active-chat': _conversation(
-            'active-chat',
-          ).copyWith(title: 'Server copy'),
+          'active-chat': _conversation('active-chat')
+              .copyWith(title: 'Server copy'),
         },
       );
       final container = await _createAuthenticatedWarmupContainer(

--- a/test/core/providers/backend_mode_providers_test.dart
+++ b/test/core/providers/backend_mode_providers_test.dart
@@ -28,41 +28,36 @@ void main() {
   group('preferredBackendProvider', () {
     test('defaults to unset when nothing is persisted', () {
       final container = makeContainer();
-      check(
-        container.read(preferredBackendProvider),
-      ).equals(PreferredBackend.unset);
+      check(container.read(preferredBackendProvider))
+          .equals(PreferredBackend.unset);
     });
 
     test('parses a persisted owui value at build time', () async {
       await PreferencesStore.put(PreferenceKeys.preferredBackend, 'owui');
       final container = makeContainer();
-      check(
-        container.read(preferredBackendProvider),
-      ).equals(PreferredBackend.owui);
+      check(container.read(preferredBackendProvider))
+          .equals(PreferredBackend.owui);
     });
 
     test('parses a persisted hermes value at build time', () async {
       await PreferencesStore.put(PreferenceKeys.preferredBackend, 'hermes');
       final container = makeContainer();
-      check(
-        container.read(preferredBackendProvider),
-      ).equals(PreferredBackend.hermes);
+      check(container.read(preferredBackendProvider))
+          .equals(PreferredBackend.hermes);
     });
 
     test('parses a persisted direct value at build time', () async {
       await PreferencesStore.put(PreferenceKeys.preferredBackend, 'direct');
       final container = makeContainer();
-      check(
-        container.read(preferredBackendProvider),
-      ).equals(PreferredBackend.direct);
+      check(container.read(preferredBackendProvider))
+          .equals(PreferredBackend.direct);
     });
 
     test('falls back to unset for an unrecognized persisted value', () async {
       await PreferencesStore.put(PreferenceKeys.preferredBackend, 'garbage');
       final container = makeContainer();
-      check(
-        container.read(preferredBackendProvider),
-      ).equals(PreferredBackend.unset);
+      check(container.read(preferredBackendProvider))
+          .equals(PreferredBackend.unset);
     });
 
     test('set() updates state and persists the enum name', () async {
@@ -71,12 +66,10 @@ void main() {
           .read(preferredBackendProvider.notifier)
           .set(PreferredBackend.direct);
 
-      check(
-        container.read(preferredBackendProvider),
-      ).equals(PreferredBackend.direct);
-      check(
-        PreferencesStore.getString(PreferenceKeys.preferredBackend),
-      ).equals('direct');
+      check(container.read(preferredBackendProvider))
+          .equals(PreferredBackend.direct);
+      check(PreferencesStore.getString(PreferenceKeys.preferredBackend))
+          .equals('direct');
     });
 
     test('set() round-trips through a fresh container (persistence)', () async {
@@ -88,9 +81,8 @@ void main() {
       // A new container rebuilds the controller from persisted prefs.
       final second = ProviderContainer();
       addTearDown(second.dispose);
-      check(
-        second.read(preferredBackendProvider),
-      ).equals(PreferredBackend.owui);
+      check(second.read(preferredBackendProvider))
+          .equals(PreferredBackend.owui);
     });
   });
 }

--- a/test/core/providers/conversations_provider_test.dart
+++ b/test/core/providers/conversations_provider_test.dart
@@ -224,9 +224,8 @@ void main() {
       for (final conversation in conversations) {
         check(conversation.messages).isEmpty();
       }
-      check(
-        conversations.first.updatedAt,
-      ).equals(DateTime.fromMillisecondsSinceEpoch(200 * 1000));
+      check(conversations.first.updatedAt)
+          .equals(DateTime.fromMillisecondsSinceEpoch(200 * 1000));
     });
 
     test('later database writes stream into provider state', () async {
@@ -240,9 +239,8 @@ void main() {
         final state = container.read(conversationsProvider);
         return idsOf(state.asData?.value ?? const []).contains('chat-2');
       });
-      check(
-        idsOf(container.read(conversationsProvider).requireValue),
-      ).deepEquals(['chat-2', 'chat-1']);
+      check(idsOf(container.read(conversationsProvider).requireValue))
+          .deepEquals(['chat-2', 'chat-1']);
     });
 
     test('surfaces a cold replacement-watch failure', () async {
@@ -306,9 +304,8 @@ void main() {
         await replacement;
         final retained = await container.read(conversationsProvider.future);
 
-        check(
-          retained.map((chat) => chat.id),
-        ).deepEquals(firstPage.map((chat) => chat.id));
+        check(retained.map((chat) => chat.id))
+            .deepEquals(firstPage.map((chat) => chat.id));
       },
     );
 
@@ -323,17 +320,15 @@ void main() {
           conversationsProvider.future,
         );
         check(conversations.length).equals(2);
-        check(
-          conversations.map((conversation) => conversation.id).toSet(),
-        ).deepEquals({'collision'});
+        check(conversations.map((conversation) => conversation.id).toSet())
+            .deepEquals({'collision'});
         final server = conversations.singleWhere(
           (conversation) =>
               chatStorageKindOf(conversation) == ChatStorageKind.openWebUi,
         );
         final direct = conversations.singleWhere(isDirectLocalConversation);
-        check(
-          conversationScopedId(server) == conversationScopedId(direct),
-        ).isFalse();
+        check(conversationScopedId(server) == conversationScopedId(direct))
+            .isFalse();
 
         final loadedServer = await container.read(
           loadConversationProvider(conversationScopedId(server)).future,
@@ -341,18 +336,14 @@ void main() {
         final loadedDirect = await container.read(
           loadConversationProvider(conversationScopedId(direct)).future,
         );
-        check(
-          chatStorageKindOf(loadedServer),
-        ).equals(ChatStorageKind.openWebUi);
-        check(
-          chatStorageKindOf(loadedDirect),
-        ).equals(ChatStorageKind.directLocal);
-        check(
-          loadedServer.messages.single.content,
-        ).equals('hello from collision');
-        check(
-          loadedDirect.messages.single.content,
-        ).equals('hello from direct collision');
+        check(chatStorageKindOf(loadedServer))
+            .equals(ChatStorageKind.openWebUi);
+        check(chatStorageKindOf(loadedDirect))
+            .equals(ChatStorageKind.directLocal);
+        check(loadedServer.messages.single.content)
+            .equals('hello from collision');
+        check(loadedDirect.messages.single.content)
+            .equals('hello from direct collision');
 
         container
             .read(conversationsProvider.notifier)
@@ -370,16 +361,14 @@ void main() {
               )
               .title,
         ).equals('Server renamed');
-        check(
-          afterRename.singleWhere(isDirectLocalConversation).title,
-        ).equals('Device copy');
+        check(afterRename.singleWhere(isDirectLocalConversation).title)
+            .equals('Device copy');
 
         container
             .read(conversationsProvider.notifier)
             .removeConversation(conversationScopedId(direct));
-        check(
-          container.read(conversationsProvider).requireValue.length,
-        ).equals(1);
+        check(container.read(conversationsProvider).requireValue.length)
+            .equals(1);
         check(
           chatStorageKindOf(
             container.read(conversationsProvider).requireValue.single,
@@ -501,63 +490,55 @@ void main() {
 
         check(socket.emits.length).equals(1);
         check(socket.emits.single.$1).equals('events:chat');
-        check(
-          (socket.emits.single.$2 as Map<String, dynamic>)['chat_id'],
-        ).equals('chat-1');
+        check((socket.emits.single.$2 as Map<String, dynamic>)['chat_id'])
+            .equals('chat-1');
       },
     );
 
-    test(
-      'scoped read mark retains outgoing ownership after active collision switch',
-      () async {
-        await seedServerChat('collision', updatedAt: 100);
-        await seedDirectChat('collision', updatedAt: 200);
-        final socket = _RecordingSocketService();
-        final container = makeContainer(
-          extraOverrides: [socketServiceProvider.overrideWithValue(socket)],
-        );
-        final conversations = await container.read(
-          conversationsProvider.future,
-        );
-        final direct = conversations.singleWhere(isDirectLocalConversation);
-        final openWebUi = conversations.singleWhere(
-          (conversation) => !isDirectLocalConversation(conversation),
-        );
-        final outgoingSelection = conversationScopedId(direct);
-        final outgoingIdentity = ChatStorageIdentity.parse(outgoingSelection);
-        check(outgoingIdentity.rawId).equals(direct.id);
-        check(outgoingIdentity.storage).equals(ChatStorageKind.directLocal);
-        check(conversationScopedId(direct)).equals(outgoingSelection);
-        check(conversationMatchesScopedId(direct, outgoingSelection)).isTrue();
-        check(
-          conversationMatchesScopedId(openWebUi, outgoingSelection),
-        ).isFalse();
-        container.read(activeConversationProvider.notifier).set(openWebUi);
-        final readAt = DateTime.fromMillisecondsSinceEpoch(500 * 1000);
+    test('scoped read mark retains outgoing ownership after active collision switch', () async {
+      await seedServerChat('collision', updatedAt: 100);
+      await seedDirectChat('collision', updatedAt: 200);
+      final socket = _RecordingSocketService();
+      final container = makeContainer(
+        extraOverrides: [socketServiceProvider.overrideWithValue(socket)],
+      );
+      final conversations = await container.read(conversationsProvider.future);
+      final direct = conversations.singleWhere(isDirectLocalConversation);
+      final openWebUi = conversations.singleWhere(
+        (conversation) => !isDirectLocalConversation(conversation),
+      );
+      final outgoingSelection = conversationScopedId(direct);
+      final outgoingIdentity = ChatStorageIdentity.parse(outgoingSelection);
+      check(outgoingIdentity.rawId).equals(direct.id);
+      check(outgoingIdentity.storage).equals(ChatStorageKind.directLocal);
+      check(conversationScopedId(direct)).equals(outgoingSelection);
+      check(conversationMatchesScopedId(direct, outgoingSelection)).isTrue();
+      check(conversationMatchesScopedId(openWebUi, outgoingSelection))
+          .isFalse();
+      container.read(activeConversationProvider.notifier).set(openWebUi);
+      final readAt = DateTime.fromMillisecondsSinceEpoch(500 * 1000);
 
-        // ChatPage captures the outgoing scoped selection before the active
-        // row changes. The newly active colliding row must not steal the mark.
-        markConversationRead(container, outgoingSelection, readAt: readAt);
+      // ChatPage captures the outgoing scoped selection before the active
+      // row changes. The newly active colliding row must not steal the mark.
+      markConversationRead(container, outgoingSelection, readAt: readAt);
 
-        final updated = container.read(conversationsProvider).requireValue;
-        check(
-          updated.singleWhere(isDirectLocalConversation).lastReadAt,
-        ).equals(readAt);
-        check(
-          updated
-              .singleWhere(
-                (conversation) => !isDirectLocalConversation(conversation),
-              )
-              .lastReadAt,
-        ).isNull();
-        await waitForAsync(
-          () => directDb.chatsDao.getChat('collision'),
-          condition: (chat) => chat?.lastReadAt == 500,
-        );
-        check((await db.chatsDao.getChat('collision'))?.lastReadAt).isNull();
-        check(socket.emits).isEmpty();
-      },
-    );
+      final updated = container.read(conversationsProvider).requireValue;
+      check(updated.singleWhere(isDirectLocalConversation).lastReadAt)
+          .equals(readAt);
+      check(
+        updated
+            .singleWhere(
+              (conversation) => !isDirectLocalConversation(conversation),
+            )
+            .lastReadAt,
+      ).isNull();
+      await waitForAsync(
+        () => directDb.chatsDao.getChat('collision'),
+        condition: (chat) => chat?.lastReadAt == 500,
+      );
+      check((await db.chatsDao.getChat('collision'))?.lastReadAt).isNull();
+      check(socket.emits).isEmpty();
+    });
 
     test('storage-scoped collisions never match a native Hermes shell', () {
       const rawId = 'local:hermes_collision';
@@ -575,9 +556,8 @@ void main() {
       check(
         conversationMatchesScopedId(native, conversationScopedId(openWebUi)),
       ).isFalse();
-      check(
-        conversationMatchesScopedId(native, conversationScopedId(direct)),
-      ).isFalse();
+      check(conversationMatchesScopedId(native, conversationScopedId(direct)))
+          .isFalse();
       check(
         conversationMatchesScopedId(openWebUi, conversationScopedId(openWebUi)),
       ).isTrue();
@@ -599,9 +579,8 @@ void main() {
       ).scopedId;
 
       check(conversationMatchesScopedId(directShell, rawId)).isTrue();
-      check(
-        conversationMatchesScopedId(directShell, openWebUiSelection),
-      ).isFalse();
+      check(conversationMatchesScopedId(directShell, openWebUiSelection))
+          .isFalse();
       check(isSameStoredConversation(directShell, legacyOpenWebUi)).isFalse();
       check(
         conversationMatchesScopedId(
@@ -624,9 +603,8 @@ void main() {
           .upsertConversation(_conversation('chat-new', updatedAtSeconds: 300));
 
       // Synchronous in-memory upsert.
-      check(
-        idsOf(container.read(conversationsProvider).requireValue),
-      ).deepEquals(['chat-new']);
+      check(idsOf(container.read(conversationsProvider).requireValue))
+          .deepEquals(['chat-new']);
 
       // The stub row materializes and the stream emission keeps the chat
       // (no flicker revert — risk guard 6).
@@ -636,9 +614,8 @@ void main() {
       );
       check(row!.bodySynced).isFalse();
       await Future<void>.delayed(const Duration(milliseconds: 50));
-      check(
-        idsOf(container.read(conversationsProvider).requireValue),
-      ).deepEquals(['chat-new']);
+      check(idsOf(container.read(conversationsProvider).requireValue))
+          .deepEquals(['chat-new']);
     });
 
     test('updateConversation persists the rename across emissions', () async {
@@ -656,9 +633,8 @@ void main() {
             ),
           );
 
-      check(
-        container.read(conversationsProvider).requireValue.single.title,
-      ).equals('Renamed');
+      check(container.read(conversationsProvider).requireValue.single.title)
+          .equals('Renamed');
 
       await waitForAsync<ChatRow?>(
         () => db.chatsDao.getChat('chat-1'),
@@ -666,9 +642,8 @@ void main() {
       );
       // The next emission agrees with the optimistic state.
       await Future<void>.delayed(const Duration(milliseconds: 50));
-      check(
-        container.read(conversationsProvider).requireValue.single.title,
-      ).equals('Renamed');
+      check(container.read(conversationsProvider).requireValue.single.title)
+          .equals('Renamed');
     });
 
     test(
@@ -685,9 +660,8 @@ void main() {
               (conversation) => conversation.copyWith(title: 'Remote rename'),
             );
 
-        check(
-          container.read(conversationsProvider).requireValue.single.title,
-        ).equals('Remote rename');
+        check(container.read(conversationsProvider).requireValue.single.title)
+            .equals('Remote rename');
       },
     );
 
@@ -736,9 +710,8 @@ void main() {
           .read(conversationsProvider.notifier)
           .applyServerGeneratedTitle('chat-1', 'Generated title');
 
-      check(
-        container.read(conversationsProvider).requireValue.single.title,
-      ).equals('My local title');
+      check(container.read(conversationsProvider).requireValue.single.title)
+          .equals('My local title');
 
       final row = await waitForAsync<ChatRow?>(
         () => db.chatsDao.getChat('chat-1'),
@@ -792,18 +765,16 @@ void main() {
           .read(conversationsProvider.notifier)
           .removeConversation('chat-1');
 
-      check(
-        idsOf(container.read(conversationsProvider).requireValue),
-      ).deepEquals(['chat-2']);
+      check(idsOf(container.read(conversationsProvider).requireValue))
+          .deepEquals(['chat-2']);
 
       await waitForAsync<ChatRow?>(
         () => db.chatsDao.getChat('chat-1'),
         condition: (row) => row == null,
       );
       await Future<void>.delayed(const Duration(milliseconds: 50));
-      check(
-        idsOf(container.read(conversationsProvider).requireValue),
-      ).deepEquals(['chat-2']);
+      check(idsOf(container.read(conversationsProvider).requireValue))
+          .deepEquals(['chat-2']);
     });
 
     test('trustConversation and exhausted loadMore are no-ops', () async {
@@ -815,9 +786,8 @@ void main() {
       notifier.trustConversation('chat-1');
       await notifier.loadMore();
 
-      check(
-        container.read(conversationsProvider).requireValue,
-      ).deepEquals(before);
+      check(container.read(conversationsProvider).requireValue)
+          .deepEquals(before);
       check(notifier.hasMoreRegularChats()).isFalse();
       check(notifier.isLoadingMoreRegularChats()).isFalse();
     });
@@ -998,9 +968,8 @@ void main() {
         );
         await container.read(conversationsProvider.future);
 
-        check(
-          idsOf(container.read(conversationsProvider).requireValue),
-        ).contains('deleted-remotely');
+        check(idsOf(container.read(conversationsProvider).requireValue))
+            .contains('deleted-remotely');
 
         await container.read(conversationsProvider.notifier).refresh();
 

--- a/test/core/providers/folders_provider_test.dart
+++ b/test/core/providers/folders_provider_test.dart
@@ -124,9 +124,8 @@ void main() {
         final state = container.read(foldersProvider);
         return (state.asData?.value ?? const <Folder>[]).length == 2;
       });
-      check(
-        namesOf(container.read(foldersProvider).requireValue),
-      ).deepEquals(['Archive', 'Work']);
+      check(namesOf(container.read(foldersProvider).requireValue))
+          .deepEquals(['Archive', 'Work']);
     });
 
     test(
@@ -147,9 +146,8 @@ void main() {
             );
 
         // Synchronous in-memory upsert.
-        check(
-          namesOf(container.read(foldersProvider).requireValue),
-        ).deepEquals(['Fresh']);
+        check(namesOf(container.read(foldersProvider).requireValue))
+            .deepEquals(['Fresh']);
 
         // Row write lands and the next emission agrees (no flicker revert).
         await waitFor(() async {
@@ -157,9 +155,8 @@ void main() {
           return rows.any((row) => row.name == 'Fresh');
         });
         await Future<void>.delayed(const Duration(milliseconds: 50));
-        check(
-          namesOf(container.read(foldersProvider).requireValue),
-        ).deepEquals(['Fresh']);
+        check(namesOf(container.read(foldersProvider).requireValue))
+            .deepEquals(['Fresh']);
       },
     );
 
@@ -182,18 +179,16 @@ void main() {
               ),
             );
 
-        check(
-          namesOf(container.read(foldersProvider).requireValue),
-        ).deepEquals(['Renamed']);
+        check(namesOf(container.read(foldersProvider).requireValue))
+            .deepEquals(['Renamed']);
 
         await waitFor(() async {
           final rows = await folderRows();
           return rows.any((row) => row.name == 'Renamed');
         });
         await Future<void>.delayed(const Duration(milliseconds: 50));
-        check(
-          namesOf(container.read(foldersProvider).requireValue),
-        ).deepEquals(['Renamed']);
+        check(namesOf(container.read(foldersProvider).requireValue))
+            .deepEquals(['Renamed']);
       },
     );
 
@@ -247,18 +242,16 @@ void main() {
 
       container.read(foldersProvider.notifier).removeFolderFromRemote('f1');
 
-      check(
-        namesOf(container.read(foldersProvider).requireValue),
-      ).deepEquals(['Play']);
+      check(namesOf(container.read(foldersProvider).requireValue))
+          .deepEquals(['Play']);
 
       await waitFor(() async {
         final rows = await folderRows();
         return rows.every((row) => row.id != 'f1');
       });
       await Future<void>.delayed(const Duration(milliseconds: 50));
-      check(
-        namesOf(container.read(foldersProvider).requireValue),
-      ).deepEquals(['Play']);
+      check(namesOf(container.read(foldersProvider).requireValue))
+          .deepEquals(['Play']);
     });
 
     test('warmIfNeeded and refresh converge on the sync engine pull', () async {

--- a/test/core/providers/knowledge_bases_provider_test.dart
+++ b/test/core/providers/knowledge_bases_provider_test.dart
@@ -59,17 +59,15 @@ void main() {
         final afterUpserts = container
             .read(knowledgeBasesProvider)
             .requireValue;
-        check(
-          afterUpserts.map((base) => base.id).toList(),
-        ).deepEquals(['kb-1', 'kb-3', 'kb-2']);
+        check(afterUpserts.map((base) => base.id).toList())
+            .deepEquals(['kb-1', 'kb-3', 'kb-2']);
         check(afterUpserts.first.name).equals('KB 1 Updated');
 
         notifier.remove('kb-2');
 
         final afterRemove = container.read(knowledgeBasesProvider).requireValue;
-        check(
-          afterRemove.map((base) => base.id).toList(),
-        ).deepEquals(['kb-1', 'kb-3']);
+        check(afterRemove.map((base) => base.id).toList())
+            .deepEquals(['kb-1', 'kb-3']);
       },
     );
 

--- a/test/core/providers/offline_search_provider_test.dart
+++ b/test/core/providers/offline_search_provider_test.dart
@@ -77,8 +77,7 @@ void main() {
     );
   }
 
-  List<String> idsOf(List<Conversation> list) =>
-      list.map((c) => c.id).toList();
+  List<String> idsOf(List<Conversation> list) => list.map((c) => c.id).toList();
 
   test('empty query short-circuits to [] without touching the DB', () async {
     final container = makeContainer();
@@ -96,39 +95,33 @@ void main() {
     check(results).isEmpty();
   });
 
-  test(
-    'offline search returns ranked results across synced history once built',
-    () async {
-      // Three chats contain the sentinel at decreasing relevance via repetition.
-      await seedChat(
-        'chat-most',
-        updatedAt: 1000,
-        content: 'platypus platypus platypus river',
-      );
-      await seedChat(
-        'chat-mid',
-        updatedAt: 1001,
-        content: 'platypus platypus delta',
-      );
-      await seedChat('chat-one', updatedAt: 1002, content: 'platypus marsh');
-      await seedChat('chat-none', updatedAt: 1003, content: 'unrelated text');
-      await db.buildFtsIfNeeded();
+  test('offline search returns ranked results across synced history once built', () async {
+    // Three chats contain the sentinel at decreasing relevance via repetition.
+    await seedChat(
+      'chat-most',
+      updatedAt: 1000,
+      content: 'platypus platypus platypus river',
+    );
+    await seedChat(
+      'chat-mid',
+      updatedAt: 1001,
+      content: 'platypus platypus delta',
+    );
+    await seedChat('chat-one', updatedAt: 1002, content: 'platypus marsh');
+    await seedChat('chat-none', updatedAt: 1003, content: 'unrelated text');
+    await db.buildFtsIfNeeded();
 
-      final container = makeContainer();
-      final results = await container.read(
-        serverSearchProvider('platypus').future,
-      );
+    final container = makeContainer();
+    final results = await container.read(
+      serverSearchProvider('platypus').future,
+    );
 
-      // Only the three sentinel-bearing chats, grouped one row each.
-      check(idsOf(results).toSet()).deepEquals({
-        'chat-most',
-        'chat-mid',
-        'chat-one',
-      });
-      // bm25-ranked: most repetitions first.
-      check(idsOf(results)).deepEquals(['chat-most', 'chat-mid', 'chat-one']);
-    },
-  );
+    // Only the three sentinel-bearing chats, grouped one row each.
+    check(idsOf(results).toSet())
+        .deepEquals({'chat-most', 'chat-mid', 'chat-one'});
+    // bm25-ranked: most repetitions first.
+    check(idsOf(results)).deepEquals(['chat-most', 'chat-mid', 'chat-one']);
+  });
 
   test('offline search matches chat titles, not just message bodies', () async {
     await seedChat(

--- a/test/core/providers/openwebui_account_storage_isolation_test.dart
+++ b/test/core/providers/openwebui_account_storage_isolation_test.dart
@@ -462,16 +462,14 @@ _harness({
   await container.read(authStateManagerProvider.future);
   await Future<void>.delayed(Duration.zero);
   if (expectInitiallyOpen) {
-    check(
-      container.read(openWebUiDatabaseAccessProvider),
-    ).equals(OpenWebUiDatabaseAccessPhase.open);
+    check(container.read(openWebUiDatabaseAccessProvider))
+        .equals(OpenWebUiDatabaseAccessPhase.open);
   } else {
     await container
         .read(openWebUiAccountStorageIsolationProvider.notifier)
         .settled;
-    check(
-      container.read(openWebUiDatabaseAccessProvider),
-    ).equals(OpenWebUiDatabaseAccessPhase.closed);
+    check(container.read(openWebUiDatabaseAccessProvider))
+        .equals(OpenWebUiDatabaseAccessPhase.closed);
   }
 
   return (
@@ -553,9 +551,8 @@ void main() {
                 message.contains('visible-state-provider-reset-failed'),
           ),
         ).isTrue();
-        check(
-          harness.container.read(openWebUiDatabaseAccessProvider),
-        ).equals(OpenWebUiDatabaseAccessPhase.closed);
+        check(harness.container.read(openWebUiDatabaseAccessProvider))
+            .equals(OpenWebUiDatabaseAccessPhase.closed);
       } finally {
         debugPrint = previousDebugPrint;
       }
@@ -571,9 +568,8 @@ void main() {
       metadata: <String, dynamic>{'backend': backend},
     );
 
-    check(
-      conversationUsesOpenWebUiStorage(transport(kDirectTransport)),
-    ).isFalse();
+    check(conversationUsesOpenWebUiStorage(transport(kDirectTransport)))
+        .isFalse();
     // Serialized backend metadata is server-controlled and therefore cannot
     // claim a process-owned native Hermes shell.
     check(conversationUsesOpenWebUiStorage(transport('hermes'))).isTrue();
@@ -638,9 +634,8 @@ void main() {
       try {
         container.read(_apiSelectionProvider.notifier).set(apiA);
         await container.read(authStateManagerProvider.future);
-        check(
-          (await container.read(activeServerProvider.future))?.id,
-        ).equals(_server.id);
+        check((await container.read(activeServerProvider.future))?.id)
+            .equals(_server.id);
         container
             .read(openWebUiCertifiedDatabaseServerProvider.notifier)
             .set(_server.id);
@@ -662,18 +657,16 @@ void main() {
         container
             .read(openWebUiCertifiedDatabaseServerProvider.notifier)
             .set(_serverTwo.id);
-        check(
-          (await container.read(activeServerProvider.future))?.id,
-        ).equals(_serverTwo.id);
+        check((await container.read(activeServerProvider.future))?.id)
+            .equals(_serverTwo.id);
         container.invalidate(currentUserProvider);
 
         responseA.complete(_userA);
         final latest = await container.read(currentUserProvider.future);
 
         check(latest?.id).equals(_userB.id);
-        check(
-          storage.savedUsers.map((user) => user.id),
-        ).not((ids) => ids.contains(_userA.id));
+        check(storage.savedUsers.map((user) => user.id))
+            .not((ids) => ids.contains(_userA.id));
         check(storage.savedUsers.map((user) => user.id)).contains(_userB.id);
       } finally {
         if (!responseA.isCompleted) responseA.complete(_userA);
@@ -742,9 +735,8 @@ void main() {
       container
           .read(openWebUiCertifiedDatabaseServerProvider.notifier)
           .set(_serverTwo.id);
-      check(
-        (await container.read(activeServerProvider.future))?.id,
-      ).equals(_serverTwo.id);
+      check((await container.read(activeServerProvider.future))?.id)
+          .equals(_serverTwo.id);
 
       responseA.complete(const BackendConfig(version: 'a-version'));
       await apiB.requestStarted.future;
@@ -757,15 +749,12 @@ void main() {
         await Future<void>.delayed(Duration.zero);
       }
 
-      check(
-        storage.savedConfigs.map((config) => config.serverId),
-      ).not((ids) => ids.contains(_server.id));
-      check(
-        storage.savedConfigs.map((config) => config.serverId),
-      ).contains(_serverTwo.id);
-      check(
-        container.read(backendConfigProvider).asData?.value?.serverId,
-      ).equals(_serverTwo.id);
+      check(storage.savedConfigs.map((config) => config.serverId))
+          .not((ids) => ids.contains(_server.id));
+      check(storage.savedConfigs.map((config) => config.serverId))
+          .contains(_serverTwo.id);
+      check(container.read(backendConfigProvider).asData?.value?.serverId)
+          .equals(_serverTwo.id);
     } finally {
       if (!responseA.isCompleted) {
         responseA.complete(const BackendConfig(version: 'a-version'));
@@ -776,74 +765,71 @@ void main() {
     }
   });
 
-  test(
-    'retired backend-config ref does not call API after active-server invalidation',
-    () async {
-      SharedPreferences.setMockInitialValues(<String, Object>{
-        PreferenceKeys.activeServerId: _server.id,
-      });
-      PreferencesStore.debugReset();
-      PreferencesStore.debugOverride(await SharedPreferences.getInstance());
+  test('retired backend-config ref does not call API after active-server invalidation', () async {
+    SharedPreferences.setMockInitialValues(<String, Object>{
+      PreferenceKeys.activeServerId: _server.id,
+    });
+    PreferencesStore.debugReset();
+    PreferencesStore.debugOverride(await SharedPreferences.getInstance());
 
-      final firstServer = Completer<ServerConfig?>();
-      final secondServer = Completer<ServerConfig?>();
-      final firstStarted = Completer<void>();
-      final secondStarted = Completer<void>();
-      var activeServerBuilds = 0;
-      final response = Completer<BackendConfig?>()
-        ..complete(const BackendConfig(version: 'unused'));
-      final api = _GatedBackendConfigApi(server: _server, response: response);
-      final storage = _BackendCacheTrackingStorage();
-      final epoch = Object();
-      final container = ProviderContainer(
-        overrides: [
-          reviewerModeProvider.overrideWithValue(false),
-          activeServerProvider.overrideWith((ref) async {
-            final build = activeServerBuilds++;
-            if (build == 0) {
-              if (!firstStarted.isCompleted) firstStarted.complete();
-              return firstServer.future;
-            }
-            if (!secondStarted.isCompleted) secondStarted.complete();
-            return secondServer.future;
-          }),
-          apiServiceProvider.overrideWithValue(api),
-          optimizedStorageServiceProvider.overrideWithValue(storage),
-          openWebUiAuthSessionEpochProvider.overrideWithValue(epoch),
-        ],
-      );
-      final subscription = container.listen<AsyncValue<BackendConfig?>>(
-        backendConfigProvider,
-        (_, _) {},
-        fireImmediately: true,
-      );
+    final firstServer = Completer<ServerConfig?>();
+    final secondServer = Completer<ServerConfig?>();
+    final firstStarted = Completer<void>();
+    final secondStarted = Completer<void>();
+    var activeServerBuilds = 0;
+    final response = Completer<BackendConfig?>()
+      ..complete(const BackendConfig(version: 'unused'));
+    final api = _GatedBackendConfigApi(server: _server, response: response);
+    final storage = _BackendCacheTrackingStorage();
+    final epoch = Object();
+    final container = ProviderContainer(
+      overrides: [
+        reviewerModeProvider.overrideWithValue(false),
+        activeServerProvider.overrideWith((ref) async {
+          final build = activeServerBuilds++;
+          if (build == 0) {
+            if (!firstStarted.isCompleted) firstStarted.complete();
+            return firstServer.future;
+          }
+          if (!secondStarted.isCompleted) secondStarted.complete();
+          return secondServer.future;
+        }),
+        apiServiceProvider.overrideWithValue(api),
+        optimizedStorageServiceProvider.overrideWithValue(storage),
+        openWebUiAuthSessionEpochProvider.overrideWithValue(epoch),
+      ],
+    );
+    final subscription = container.listen<AsyncValue<BackendConfig?>>(
+      backendConfigProvider,
+      (_, _) {},
+      fireImmediately: true,
+    );
 
-      try {
-        await firstStarted.future;
+    try {
+      await firstStarted.future;
+      await Future<void>.delayed(Duration.zero);
+
+      // Replacing the dependency retires the Ref captured by the first
+      // _loadBackendConfig call while it is awaiting the first future.
+      container.invalidate(activeServerProvider);
+      await secondStarted.future;
+
+      firstServer.complete(_server);
+      for (var attempt = 0; attempt < 10; attempt++) {
         await Future<void>.delayed(Duration.zero);
-
-        // Replacing the dependency retires the Ref captured by the first
-        // _loadBackendConfig call while it is awaiting the first future.
-        container.invalidate(activeServerProvider);
-        await secondStarted.future;
-
-        firstServer.complete(_server);
-        for (var attempt = 0; attempt < 10; attempt++) {
-          await Future<void>.delayed(Duration.zero);
-        }
-
-        check(api.requestCount).equals(0);
-        check(api.requestStarted.isCompleted).isFalse();
-      } finally {
-        subscription.close();
-        container.dispose();
-        if (!firstServer.isCompleted) firstServer.complete(_server);
-        if (!secondServer.isCompleted) secondServer.complete(_server);
-        await Future<void>.delayed(Duration.zero);
-        PreferencesStore.debugReset();
       }
-    },
-  );
+
+      check(api.requestCount).equals(0);
+      check(api.requestStarted.isCompleted).isFalse();
+    } finally {
+      subscription.close();
+      container.dispose();
+      if (!firstServer.isCompleted) firstServer.complete(_server);
+      if (!secondServer.isCompleted) secondServer.complete(_server);
+      await Future<void>.delayed(Duration.zero);
+      PreferencesStore.debugReset();
+    }
+  });
 
   test('backend config survives an ownership-dependency rebuild', () async {
     SharedPreferences.setMockInitialValues(<String, Object>{
@@ -906,9 +892,8 @@ void main() {
 
       check(api.requestCount).equals(2);
       check(storage.savedConfigs.length).equals(2);
-      check(
-        container.read(backendConfigProvider).asData?.value?.version,
-      ).equals('stable-version');
+      check(container.read(backendConfigProvider).asData?.value?.version)
+          .equals('stable-version');
     } finally {
       backendConfigSubscription.close();
       container.dispose();
@@ -1084,185 +1069,176 @@ void main() {
     },
   );
 
-  test(
-    'restart with token B and cached user A purges before publishing identity or chats',
-    () async {
-      const tokenA = 'persisted-token-account-a';
-      const tokenB = 'persisted-token-account-b';
-      SharedPreferences.setMockInitialValues(<String, Object>{
-        PreferenceKeys.activeServerId: _server.id,
-      });
-      PreferencesStore.debugReset();
-      PreferencesStore.debugOverride(await SharedPreferences.getInstance());
+  test('restart with token B and cached user A purges before publishing identity or chats', () async {
+    const tokenA = 'persisted-token-account-a';
+    const tokenB = 'persisted-token-account-b';
+    SharedPreferences.setMockInitialValues(<String, Object>{
+      PreferenceKeys.activeServerId: _server.id,
+    });
+    PreferencesStore.debugReset();
+    PreferencesStore.debugOverride(await SharedPreferences.getInstance());
 
-      final serverA = AppDatabase(NativeDatabase.memory());
-      final serverB = AppDatabase(NativeDatabase.memory());
-      final direct = AppDatabase(NativeDatabase.memory());
-      final directory = await Directory.systemTemp.createTemp(
-        'conduit-restart-owner',
-      );
-      var opens = 0;
-      final manager = DatabaseManager(
-        databaseDirectory: () async => directory,
-        openDatabase: (_) => opens++ == 0 ? serverA : serverB,
-        databaseFileName: (serverId) => '${serverId}_restart_test',
-      );
-      manager.openFor(_server);
-      await _seedChat(
-        serverA,
-        id: 'stale-account-a-chat',
-        title: 'A must stay private',
-        message: 'A private restart body',
-      );
-      await _seedChat(
-        direct,
-        id: 'restart-direct-chat',
-        title: 'Device chat',
-        message: 'Device body',
-      );
+    final serverA = AppDatabase(NativeDatabase.memory());
+    final serverB = AppDatabase(NativeDatabase.memory());
+    final direct = AppDatabase(NativeDatabase.memory());
+    final directory = await Directory.systemTemp.createTemp(
+      'conduit-restart-owner',
+    );
+    var opens = 0;
+    final manager = DatabaseManager(
+      databaseDirectory: () async => directory,
+      openDatabase: (_) => opens++ == 0 ? serverA : serverB,
+      databaseFileName: (serverId) => '${serverId}_restart_test',
+    );
+    manager.openFor(_server);
+    await _seedChat(
+      serverA,
+      id: 'stale-account-a-chat',
+      title: 'A must stay private',
+      message: 'A private restart body',
+    );
+    await _seedChat(
+      direct,
+      id: 'restart-direct-chat',
+      title: 'Device chat',
+      message: 'Device body',
+    );
 
-      final markerStore = _MemoryAccountOwnerMarkerStore();
-      markerStore.markers[_server.id] = openWebUiAccountOwnerMarker(
-        token: tokenA,
-        userId: _userA.id,
-      )!;
-      final validatedUser = Completer<User>();
-      final api = _GatedRestartValidationApi(validatedUser);
-      final storage = _CachedRestartStorage(token: tokenB, cachedUser: _userA);
-      final container = ProviderContainer(
-        overrides: [
-          reviewerModeProvider.overrideWithValue(false),
-          activeServerProvider.overrideWith((ref) async => _server),
-          apiServiceProvider.overrideWithValue(api),
-          socketServiceProvider.overrideWithValue(null),
-          optimizedStorageServiceProvider.overrideWithValue(storage),
-          databaseManagerProvider.overrideWithValue(manager),
-          directLocalDatabaseProvider.overrideWithValue(direct),
-          openWebUiAccountOwnerMarkerStoreProvider.overrideWithValue(
-            markerStore,
-          ),
-          openWebUiAccountCacheClearProvider.overrideWithValue(() async {}),
-          openWebUiPostCertificationSyncKickoffProvider.overrideWithValue(
-            () {},
-          ),
-          openWebUiDatabasePurgeProvider.overrideWithValue(manager.deleteFor),
-        ],
-      );
+    final markerStore = _MemoryAccountOwnerMarkerStore();
+    markerStore.markers[_server.id] = openWebUiAccountOwnerMarker(
+      token: tokenA,
+      userId: _userA.id,
+    )!;
+    final validatedUser = Completer<User>();
+    final api = _GatedRestartValidationApi(validatedUser);
+    final storage = _CachedRestartStorage(token: tokenB, cachedUser: _userA);
+    final container = ProviderContainer(
+      overrides: [
+        reviewerModeProvider.overrideWithValue(false),
+        activeServerProvider.overrideWith((ref) async => _server),
+        apiServiceProvider.overrideWithValue(api),
+        socketServiceProvider.overrideWithValue(null),
+        optimizedStorageServiceProvider.overrideWithValue(storage),
+        databaseManagerProvider.overrideWithValue(manager),
+        directLocalDatabaseProvider.overrideWithValue(direct),
+        openWebUiAccountOwnerMarkerStoreProvider.overrideWithValue(markerStore),
+        openWebUiAccountCacheClearProvider.overrideWithValue(() async {}),
+        openWebUiPostCertificationSyncKickoffProvider.overrideWithValue(() {}),
+        openWebUiDatabasePurgeProvider.overrideWithValue(manager.deleteFor),
+      ],
+    );
 
-      final authEmissions = <AuthState>[];
-      final currentUserIds = <String?>[];
-      final asyncCurrentUserIds = <String?>[];
-      final conversationEmissions = <List<String>>[];
-      final authSubscription = container.listen<AsyncValue<AuthState>>(
-        authStateManagerProvider,
-        (_, next) {
-          final auth = next.asData?.value;
-          if (auth != null) authEmissions.add(auth);
-        },
-        fireImmediately: true,
-      );
-      final currentUserSubscription = container.listen<User?>(
-        currentUserProvider2,
-        (_, next) => currentUserIds.add(next?.id),
-        fireImmediately: true,
-      );
-      final asyncCurrentUserSubscription = container.listen<AsyncValue<User?>>(
-        currentUserProvider,
-        (_, next) {
-          if (next.hasValue) asyncCurrentUserIds.add(next.value?.id);
-        },
-        fireImmediately: true,
-      );
-      final conversationSubscription = container
-          .listen<AsyncValue<List<Conversation>>>(conversationsProvider, (
-            _,
-            next,
-          ) {
-            final chats = next.asData?.value;
-            if (chats != null) {
-              conversationEmissions.add(
-                chats.map((chat) => chat.id).toList(growable: false),
-              );
-            }
-          }, fireImmediately: true);
-
-      try {
-        container.read(userScopedProviderCleanupProvider);
-        await container.read(authStateManagerProvider.future);
-        for (var attempt = 0; attempt < 100; attempt++) {
-          if (container.read(openWebUiDatabaseAccessProvider) ==
-              OpenWebUiDatabaseAccessPhase.closed) {
-            break;
+    final authEmissions = <AuthState>[];
+    final currentUserIds = <String?>[];
+    final asyncCurrentUserIds = <String?>[];
+    final conversationEmissions = <List<String>>[];
+    final authSubscription = container.listen<AsyncValue<AuthState>>(
+      authStateManagerProvider,
+      (_, next) {
+        final auth = next.asData?.value;
+        if (auth != null) authEmissions.add(auth);
+      },
+      fireImmediately: true,
+    );
+    final currentUserSubscription = container.listen<User?>(
+      currentUserProvider2,
+      (_, next) => currentUserIds.add(next?.id),
+      fireImmediately: true,
+    );
+    final asyncCurrentUserSubscription = container.listen<AsyncValue<User?>>(
+      currentUserProvider,
+      (_, next) {
+        if (next.hasValue) asyncCurrentUserIds.add(next.value?.id);
+      },
+      fireImmediately: true,
+    );
+    final conversationSubscription = container
+        .listen<AsyncValue<List<Conversation>>>(conversationsProvider, (
+          _,
+          next,
+        ) {
+          final chats = next.asData?.value;
+          if (chats != null) {
+            conversationEmissions.add(
+              chats.map((chat) => chat.id).toList(growable: false),
+            );
           }
-          await Future<void>.delayed(const Duration(milliseconds: 5));
+        }, fireImmediately: true);
+
+    try {
+      container.read(userScopedProviderCleanupProvider);
+      await container.read(authStateManagerProvider.future);
+      for (var attempt = 0; attempt < 100; attempt++) {
+        if (container.read(openWebUiDatabaseAccessProvider) ==
+            OpenWebUiDatabaseAccessPhase.closed) {
+          break;
         }
-        await container
-            .read(openWebUiAccountStorageIsolationProvider.notifier)
-            .settled;
-
-        check(
-          container.read(openWebUiDatabaseAccessProvider),
-        ).equals(OpenWebUiDatabaseAccessPhase.closed);
-        check(
-          authEmissions.any(
-            (auth) =>
-                auth.status == AuthStatus.authenticated &&
-                auth.user?.id == _userA.id,
-          ),
-        ).isFalse();
-        check(currentUserIds.contains(_userA.id)).isFalse();
-        check(asyncCurrentUserIds.contains(_userA.id)).isFalse();
-        check(
-          conversationEmissions.every(
-            (ids) => !ids.contains('stale-account-a-chat'),
-          ),
-        ).isTrue();
-
-        validatedUser.complete(_userB);
-        for (var attempt = 0; attempt < 100; attempt++) {
-          final auth = container.read(authStateManagerProvider).asData?.value;
-          if (auth?.status == AuthStatus.authenticated &&
-              auth?.user?.id == _userB.id) {
-            break;
-          }
-          await Future<void>.delayed(const Duration(milliseconds: 5));
-        }
-        await Future<void>.delayed(Duration.zero);
-        await container
-            .read(openWebUiAccountStorageIsolationProvider.notifier)
-            .settled;
-
-        check(container.read(currentUserProvider2)?.id).equals(_userB.id);
-        check(
-          container.read(openWebUiDatabaseAccessProvider),
-        ).equals(OpenWebUiDatabaseAccessPhase.open);
-        check(
-          (await container.read(
-            conversationsProvider.future,
-          )).map((chat) => chat.id).toList(),
-        ).deepEquals(<String>['restart-direct-chat']);
-        check(
-          conversationEmissions.every(
-            (ids) => !ids.contains('stale-account-a-chat'),
-          ),
-        ).isTrue();
-        check(
-          markerStore.markers[_server.id],
-        ).equals(openWebUiAccountOwnerMarker(token: tokenB, userId: _userB.id));
-        check(storage.savedUsers.map((user) => user.id)).contains(_userB.id);
-      } finally {
-        conversationSubscription.close();
-        asyncCurrentUserSubscription.close();
-        currentUserSubscription.close();
-        authSubscription.close();
-        container.dispose();
-        await manager.closeActive();
-        await direct.close();
-        if (await directory.exists()) await directory.delete(recursive: true);
-        PreferencesStore.debugReset();
+        await Future<void>.delayed(const Duration(milliseconds: 5));
       }
-    },
-  );
+      await container
+          .read(openWebUiAccountStorageIsolationProvider.notifier)
+          .settled;
+
+      check(container.read(openWebUiDatabaseAccessProvider))
+          .equals(OpenWebUiDatabaseAccessPhase.closed);
+      check(
+        authEmissions.any(
+          (auth) =>
+              auth.status == AuthStatus.authenticated &&
+              auth.user?.id == _userA.id,
+        ),
+      ).isFalse();
+      check(currentUserIds.contains(_userA.id)).isFalse();
+      check(asyncCurrentUserIds.contains(_userA.id)).isFalse();
+      check(
+        conversationEmissions.every(
+          (ids) => !ids.contains('stale-account-a-chat'),
+        ),
+      ).isTrue();
+
+      validatedUser.complete(_userB);
+      for (var attempt = 0; attempt < 100; attempt++) {
+        final auth = container.read(authStateManagerProvider).asData?.value;
+        if (auth?.status == AuthStatus.authenticated &&
+            auth?.user?.id == _userB.id) {
+          break;
+        }
+        await Future<void>.delayed(const Duration(milliseconds: 5));
+      }
+      await Future<void>.delayed(Duration.zero);
+      await container
+          .read(openWebUiAccountStorageIsolationProvider.notifier)
+          .settled;
+
+      check(container.read(currentUserProvider2)?.id).equals(_userB.id);
+      check(container.read(openWebUiDatabaseAccessProvider))
+          .equals(OpenWebUiDatabaseAccessPhase.open);
+      check(
+        (await container.read(conversationsProvider.future))
+            .map((chat) => chat.id)
+            .toList(),
+      ).deepEquals(<String>['restart-direct-chat']);
+      check(
+        conversationEmissions.every(
+          (ids) => !ids.contains('stale-account-a-chat'),
+        ),
+      ).isTrue();
+      check(
+        markerStore.markers[_server.id],
+      ).equals(openWebUiAccountOwnerMarker(token: tokenB, userId: _userB.id));
+      check(storage.savedUsers.map((user) => user.id)).contains(_userB.id);
+    } finally {
+      conversationSubscription.close();
+      asyncCurrentUserSubscription.close();
+      currentUserSubscription.close();
+      authSubscription.close();
+      container.dispose();
+      await manager.closeActive();
+      await direct.close();
+      if (await directory.exists()) await directory.delete(recursive: true);
+      PreferencesStore.debugReset();
+    }
+  });
 
   test(
     'matching token marker with no cached user retains DB until validation',
@@ -1330,13 +1306,11 @@ void main() {
 
         check(bootstrap.status).equals(AuthStatus.loading);
         check(bootstrap.user).isNull();
-        check(
-          container.read(openWebUiDatabaseAccessProvider).allowsAppDatabase,
-        ).isFalse();
+        check(container.read(openWebUiDatabaseAccessProvider).allowsAppDatabase)
+            .isFalse();
         check(purgeCalls).equals(0);
-        check(
-          await serverDatabase.chatsDao.getChat('retained-b-chat'),
-        ).isNotNull();
+        check(await serverDatabase.chatsDao.getChat('retained-b-chat'))
+            .isNotNull();
 
         validatedUser.complete(_userB);
         for (var attempt = 0; attempt < 100; attempt++) {
@@ -1350,15 +1324,13 @@ void main() {
             .read(openWebUiAccountStorageIsolationProvider.notifier)
             .settled;
 
-        check(
-          container.read(openWebUiDatabaseAccessProvider),
-        ).equals(OpenWebUiDatabaseAccessPhase.open);
+        check(container.read(openWebUiDatabaseAccessProvider))
+            .equals(OpenWebUiDatabaseAccessPhase.open);
         check(container.read(currentUserProvider2)?.id).equals(_userB.id);
         check(purgeCalls).equals(0);
         check(container.read(appDatabaseProvider)).identicalTo(serverDatabase);
-        check(
-          await serverDatabase.chatsDao.getChat('retained-b-chat'),
-        ).isNotNull();
+        check(await serverDatabase.chatsDao.getChat('retained-b-chat'))
+            .isNotNull();
         check(storage.savedUsers.map((user) => user.id)).contains(_userB.id);
       } finally {
         container.dispose();
@@ -1376,9 +1348,8 @@ void main() {
       final harness = await _harness();
       final container = harness.container;
       final before = await container.read(conversationsProvider.future);
-      check(
-        before.map((chat) => chat.id),
-      ).containsEqualInOrder(<String>['account-a-chat', 'direct-chat']);
+      check(before.map((chat) => chat.id))
+          .containsEqualInOrder(<String>['account-a-chat', 'direct-chat']);
 
       final postLogoutEmissions = <List<String>>[];
       final subscription = container.listen<AsyncValue<List<Conversation>>>(
@@ -1404,25 +1375,21 @@ void main() {
           .read(openWebUiAccountStorageIsolationProvider.notifier)
           .settled;
 
-      check(
-        container.read(openWebUiDatabaseAccessProvider),
-      ).equals(OpenWebUiDatabaseAccessPhase.closed);
+      check(container.read(openWebUiDatabaseAccessProvider))
+          .equals(OpenWebUiDatabaseAccessPhase.closed);
       check(container.read(activeConversationProvider)).isNull();
       check(container.read(chatMessagesProvider)).isEmpty();
-      check(
-        postLogoutEmissions.every((ids) => !ids.contains('account-a-chat')),
-      ).isTrue();
+      check(postLogoutEmissions.every((ids) => !ids.contains('account-a-chat')))
+          .isTrue();
 
       harness.auth.publish(_authenticated('token-b', _userB));
       await Future<void>.delayed(Duration.zero);
-      check(
-        container.read(openWebUiDatabaseAccessProvider),
-      ).equals(OpenWebUiDatabaseAccessPhase.open);
+      check(container.read(openWebUiDatabaseAccessProvider))
+          .equals(OpenWebUiDatabaseAccessPhase.open);
 
       final after = await container.read(conversationsProvider.future);
-      check(
-        after.map((chat) => chat.id).toList(),
-      ).deepEquals(<String>['direct-chat']);
+      check(after.map((chat) => chat.id).toList())
+          .deepEquals(<String>['direct-chat']);
       check(await loadLocalConversation(container, 'account-a-chat')).isNull();
     },
   );
@@ -1498,37 +1465,33 @@ void main() {
       check(cacheClearCalls).equals(2);
       check(purgeCalls).equals(1);
       check(harness.markerStore.read(_server.id)).isNull();
-      check(
-        harness.container.read(openWebUiDatabaseAccessProvider),
-      ).equals(OpenWebUiDatabaseAccessPhase.closed);
+      check(harness.container.read(openWebUiDatabaseAccessProvider))
+          .equals(OpenWebUiDatabaseAccessPhase.closed);
     },
   );
 
-  test(
-    'local conversation read drops a body when its account gate changes mid-load',
-    () async {
-      final harness = await _harness();
-      final container = harness.container;
-      final transactionStarted = Completer<void>();
-      final releaseTransaction = Completer<void>();
-      final blockingTransaction = harness.serverA.transaction(() async {
-        transactionStarted.complete();
-        await releaseTransaction.future;
-      });
-      await transactionStarted.future;
+  test('local conversation read drops a body when its account gate changes mid-load', () async {
+    final harness = await _harness();
+    final container = harness.container;
+    final transactionStarted = Completer<void>();
+    final releaseTransaction = Completer<void>();
+    final blockingTransaction = harness.serverA.transaction(() async {
+      transactionStarted.complete();
+      await releaseTransaction.future;
+    });
+    await transactionStarted.future;
 
-      final pending = loadLocalConversation(container, 'account-a-chat');
-      await Future<void>.delayed(Duration.zero);
+    final pending = loadLocalConversation(container, 'account-a-chat');
+    await Future<void>.delayed(Duration.zero);
 
-      container.read(openWebUiDatabaseAccessProvider.notifier).beginPurge();
-      container.read(openWebUiCertifiedDatabaseServerProvider.notifier).clear();
-      releaseTransaction.complete();
-      await blockingTransaction;
+    container.read(openWebUiDatabaseAccessProvider.notifier).beginPurge();
+    container.read(openWebUiCertifiedDatabaseServerProvider.notifier).clear();
+    releaseTransaction.complete();
+    await blockingTransaction;
 
-      check(await pending).isNull();
-      check(container.read(activeConversationProvider)).isNull();
-    },
-  );
+    check(await pending).isNull();
+    check(container.read(activeConversationProvider)).isNull();
+  });
 
   test(
     'unlistened conversation provider stays mounted during repository load',
@@ -1569,9 +1532,8 @@ void main() {
 
         final conversation = await pending;
         check(conversation.id).equals('account-a-chat');
-        check(
-          chatStorageKindOf(conversation),
-        ).equals(ChatStorageKind.openWebUi);
+        check(chatStorageKindOf(conversation))
+            .equals(ChatStorageKind.openWebUi);
       } finally {
         if (!releaseTransaction.isCompleted) {
           releaseTransaction.complete();
@@ -1581,61 +1543,55 @@ void main() {
     },
   );
 
-  test(
-    'conversation provider drops a repository body when ownership changes mid-load',
-    () async {
-      final harness = await _harness();
-      final container = harness.container;
-      final transactionStarted = Completer<void>();
-      final releaseTransaction = Completer<void>();
-      final blockingTransaction = harness.serverA.transaction(() async {
-        transactionStarted.complete();
-        await releaseTransaction.future;
-      });
-      await transactionStarted.future;
+  test('conversation provider drops a repository body when ownership changes mid-load', () async {
+    final harness = await _harness();
+    final container = harness.container;
+    final transactionStarted = Completer<void>();
+    final releaseTransaction = Completer<void>();
+    final blockingTransaction = harness.serverA.transaction(() async {
+      transactionStarted.complete();
+      await releaseTransaction.future;
+    });
+    await transactionStarted.future;
 
-      final scopedId = const ChatStorageIdentity(
-        rawId: 'account-a-chat',
-        storage: ChatStorageKind.openWebUi,
-      ).scopedId;
-      final pending = container
-          .read(loadConversationProvider(scopedId).future)
-          .then<Object>(
-            (conversation) => conversation,
-            onError: (Object error, StackTrace _) => error,
-          );
-      await Future<void>.delayed(Duration.zero);
+    final scopedId = const ChatStorageIdentity(
+      rawId: 'account-a-chat',
+      storage: ChatStorageKind.openWebUi,
+    ).scopedId;
+    final pending = container
+        .read(loadConversationProvider(scopedId).future)
+        .then<Object>(
+          (conversation) => conversation,
+          onError: (Object error, StackTrace _) => error,
+        );
+    await Future<void>.delayed(Duration.zero);
 
-      container.read(openWebUiDatabaseAccessProvider.notifier).beginPurge();
-      container.read(openWebUiCertifiedDatabaseServerProvider.notifier).clear();
-      releaseTransaction.complete();
-      await blockingTransaction;
+    container.read(openWebUiDatabaseAccessProvider.notifier).beginPurge();
+    container.read(openWebUiCertifiedDatabaseServerProvider.notifier).clear();
+    releaseTransaction.complete();
+    await blockingTransaction;
 
-      check(await pending).isA<StateError>();
-      check(container.read(activeConversationProvider)).isNull();
-    },
-  );
+    check(await pending).isA<StateError>();
+    check(container.read(activeConversationProvider)).isNull();
+  });
 
-  test(
-    'new ChatMessages notifier cannot reveal stale OpenWebUI active payload while gated',
-    () async {
-      final harness = await _harness();
-      final container = harness.container;
-      harness.auth.publish(const AuthState(status: AuthStatus.unauthenticated));
-      await Future<void>.delayed(Duration.zero);
-      await container
-          .read(openWebUiAccountStorageIsolationProvider.notifier)
-          .settled;
+  test('new ChatMessages notifier cannot reveal stale OpenWebUI active payload while gated', () async {
+    final harness = await _harness();
+    final container = harness.container;
+    harness.auth.publish(const AuthState(status: AuthStatus.unauthenticated));
+    await Future<void>.delayed(Duration.zero);
+    await container
+        .read(openWebUiAccountStorageIsolationProvider.notifier)
+        .settled;
 
-      container
-          .read(activeConversationProvider.notifier)
-          .set(_openWebUiConversation('stale-a', 'must never render'));
-      container.invalidate(chatMessagesProvider);
-      check(container.read(chatMessagesProvider)).isEmpty();
-      await Future<void>.delayed(Duration.zero);
-      check(container.read(activeConversationProvider)).isNull();
-    },
-  );
+    container
+        .read(activeConversationProvider.notifier)
+        .set(_openWebUiConversation('stale-a', 'must never render'));
+    container.invalidate(chatMessagesProvider);
+    check(container.read(chatMessagesProvider)).isEmpty();
+    await Future<void>.delayed(Duration.zero);
+    check(container.read(activeConversationProvider)).isNull();
+  });
 
   test(
     'chat messages keep following selections after sign-out and sign-in',
@@ -1690,13 +1646,11 @@ void main() {
         .read(openWebUiAccountStorageIsolationProvider.notifier)
         .settled;
     check(postCertificationSyncKickoffs).equals(1);
-    check(
-      container.read(openWebUiDatabaseAccessProvider),
-    ).equals(OpenWebUiDatabaseAccessPhase.open);
+    check(container.read(openWebUiDatabaseAccessProvider))
+        .equals(OpenWebUiDatabaseAccessPhase.open);
     final chats = await container.read(conversationsProvider.future);
-    check(
-      chats.map((chat) => chat.id).toList(),
-    ).deepEquals(<String>['direct-chat']);
+    check(chats.map((chat) => chat.id).toList())
+        .deepEquals(<String>['direct-chat']);
     check(await loadLocalConversation(container, 'account-a-chat')).isNull();
   });
 
@@ -1736,27 +1690,24 @@ void main() {
       check(await markerWriteStarted.future).equals(_server.id);
 
       harness.serverSelection.set(_serverTwo);
-      check(
-        (await container.read(activeServerProvider.future))?.id,
-      ).equals(_serverTwo.id);
+      check((await container.read(activeServerProvider.future))?.id)
+          .equals(_serverTwo.id);
       releaseMarkerWrite.complete();
       await container
           .read(openWebUiAccountStorageIsolationProvider.notifier)
           .settled;
 
-      check(
-        container.read(openWebUiCertifiedDatabaseServerProvider),
-      ).equals(_serverTwo.id);
-      check(
-        container.read(openWebUiDatabaseAccessProvider),
-      ).equals(OpenWebUiDatabaseAccessPhase.open);
+      check(container.read(openWebUiCertifiedDatabaseServerProvider))
+          .equals(_serverTwo.id);
+      check(container.read(openWebUiDatabaseAccessProvider))
+          .equals(OpenWebUiDatabaseAccessPhase.open);
       check(
         await harness.serverB.chatsDao.getChat('server-b-marker-race-secret'),
       ).isNull();
       check(
-        (await container.read(
-          conversationsProvider.future,
-        )).map((chat) => chat.id).toList(),
+        (await container.read(conversationsProvider.future))
+            .map((chat) => chat.id)
+            .toList(),
       ).deepEquals(<String>['direct-chat']);
       await Future<void>.delayed(Duration.zero);
       check(emittedChatIds).isNotEmpty();
@@ -1798,19 +1749,15 @@ void main() {
           .read(openWebUiAccountStorageIsolationProvider.notifier)
           .settled;
 
-      check(
-        container.read(openWebUiCertifiedDatabaseServerProvider),
-      ).equals(_serverTwo.id);
-      check(
-        container.read(openWebUiDatabaseAccessProvider),
-      ).equals(OpenWebUiDatabaseAccessPhase.open);
+      check(container.read(openWebUiCertifiedDatabaseServerProvider))
+          .equals(_serverTwo.id);
+      check(container.read(openWebUiDatabaseAccessProvider))
+          .equals(OpenWebUiDatabaseAccessPhase.open);
       final chats = await container.read(conversationsProvider.future);
-      check(
-        chats.map((chat) => chat.id).toList(),
-      ).deepEquals(<String>['direct-chat']);
-      check(
-        emissions.every((ids) => !ids.contains('server-b-prior-account')),
-      ).isTrue();
+      check(chats.map((chat) => chat.id).toList())
+          .deepEquals(<String>['direct-chat']);
+      check(emissions.every((ids) => !ids.contains('server-b-prior-account')))
+          .isTrue();
     },
   );
 
@@ -1867,12 +1814,10 @@ void main() {
 
       check(container.read(activeConversationProvider)).identicalTo(directChat);
       check(container.read(selectedModelProvider)).identicalTo(directModel);
-      check(
-        container.read(chatMessagesProvider).single.content,
-      ).equals('Device body');
-      check(
-        container.read(activeConversationInPlaceRemapProvider),
-      ).identicalTo(localRemap);
+      check(container.read(chatMessagesProvider).single.content)
+          .equals('Device body');
+      check(container.read(activeConversationInPlaceRemapProvider))
+          .identicalTo(localRemap);
     },
   );
 
@@ -1920,12 +1865,10 @@ void main() {
 
       check(container.read(activeConversationProvider)).identicalTo(hermesChat);
       check(container.read(selectedModelProvider)).identicalTo(hermesModel);
-      check(
-        container.read(chatMessagesProvider).single.content,
-      ).equals('Hermes body');
-      check(
-        container.read(activeConversationInPlaceRemapProvider),
-      ).identicalTo(localRemap);
+      check(container.read(chatMessagesProvider).single.content)
+          .equals('Hermes body');
+      check(container.read(activeConversationInPlaceRemapProvider))
+          .identicalTo(localRemap);
     },
   );
 }

--- a/test/core/providers/personalization_settings_provider_test.dart
+++ b/test/core/providers/personalization_settings_provider_test.dart
@@ -49,9 +49,8 @@ void main() {
             .requireValue
             .pinnedModelIds,
       ).deepEquals(['local-a', 'local-b']);
-      check(
-        container.read(appSettingsProvider).pinnedModels,
-      ).deepEquals(['local-a', 'local-b']);
+      check(container.read(appSettingsProvider).pinnedModels)
+          .deepEquals(['local-a', 'local-b']);
     });
 
     test('stale server response cannot overwrite latest pin intent', () async {
@@ -85,9 +84,8 @@ void main() {
             .requireValue
             .pinnedModelIds,
       ).deepEquals(['second']);
-      check(
-        container.read(appSettingsProvider).pinnedModels,
-      ).deepEquals(['second']);
+      check(container.read(appSettingsProvider).pinnedModels)
+          .deepEquals(['second']);
     });
 
     test(
@@ -118,9 +116,8 @@ void main() {
               .requireValue
               .pinnedModelIds,
         ).deepEquals(['new-pin']);
-        check(
-          container.read(effectivePinnedModelIdsProvider),
-        ).deepEquals(['new-pin']);
+        check(container.read(effectivePinnedModelIdsProvider))
+            .deepEquals(['new-pin']);
 
         api.completeSettingsRead(0, ['old-pin']);
         final loaded = await initialRead;
@@ -132,9 +129,8 @@ void main() {
               .requireValue
               .pinnedModelIds,
         ).deepEquals(['new-pin']);
-        check(
-          container.read(appSettingsProvider).pinnedModels,
-        ).deepEquals(['new-pin']);
+        check(container.read(appSettingsProvider).pinnedModels)
+            .deepEquals(['new-pin']);
 
         api.completeRequest(0, ['new-pin']);
         await pinWrite;
@@ -188,9 +184,8 @@ void main() {
         await secondApi.waitForSettingsReadCount(1);
 
         check(container.read(canTogglePinnedModelsProvider)).isFalse();
-        check(
-          container.read(effectivePinnedModelIdsProvider),
-        ).deepEquals(['previous-pin']);
+        check(container.read(effectivePinnedModelIdsProvider))
+            .deepEquals(['previous-pin']);
 
         final pinResult = await container
             .read(personalizationSettingsProvider.notifier)
@@ -199,9 +194,8 @@ void main() {
 
         check(pinResult.pinnedModelIds).isEmpty();
         check(secondApi.requestCount).equals(0);
-        check(
-          container.read(appSettingsProvider).pinnedModels,
-        ).deepEquals(['previous-pin']);
+        check(container.read(appSettingsProvider).pinnedModels)
+            .deepEquals(['previous-pin']);
 
         secondApi.completeSettingsRead(0, ['server-b-pin']);
         final loaded = await switchedRead;
@@ -214,9 +208,8 @@ void main() {
               .pinnedModelIds,
         ).deepEquals(['server-b-pin']);
         await _flushMicrotasks();
-        check(
-          container.read(appSettingsProvider).pinnedModels,
-        ).deepEquals(['server-b-pin']);
+        check(container.read(appSettingsProvider).pinnedModels)
+            .deepEquals(['server-b-pin']);
         check(container.read(canTogglePinnedModelsProvider)).isTrue();
       },
     );
@@ -241,9 +234,8 @@ void main() {
         );
         await api.waitForSettingsReadCount(1);
 
-        check(
-          container.read(effectivePinnedModelIdsProvider),
-        ).deepEquals(['cached-pin']);
+        check(container.read(effectivePinnedModelIdsProvider))
+            .deepEquals(['cached-pin']);
         check(container.read(canTogglePinnedModelsProvider)).isFalse();
 
         final unpinResult = await container
@@ -253,90 +245,83 @@ void main() {
 
         check(unpinResult.pinnedModelIds).isEmpty();
         check(api.requestCount).equals(0);
-        check(
-          container.read(appSettingsProvider).pinnedModels,
-        ).deepEquals(['cached-pin']);
+        check(container.read(appSettingsProvider).pinnedModels)
+            .deepEquals(['cached-pin']);
 
         api.completeSettingsRead(0, ['server-pin']);
         final loaded = await initialRead;
 
         check(loaded.pinnedModelIds).deepEquals(['server-pin']);
         await _flushMicrotasks();
-        check(
-          container.read(appSettingsProvider).pinnedModels,
-        ).deepEquals(['server-pin']);
+        check(container.read(appSettingsProvider).pinnedModels)
+            .deepEquals(['server-pin']);
         check(container.read(canTogglePinnedModelsProvider)).isTrue();
       },
     );
 
-    test(
-      'write response after server switch does not overwrite active server pins',
-      () async {
-        final firstApi = _PinnedModelsApiService(serverConfig: _serverConfig);
-        final secondApi = _PinnedModelsApiService(
-          delaySettingsReads: true,
-          serverConfig: _secondServerConfig,
-        );
-        addTearDown(firstApi.dispose);
-        addTearDown(secondApi.dispose);
-        final activeServer =
-            NotifierProvider<_ActiveServerNotifier, ServerConfig?>(
-              () => _ActiveServerNotifier(_serverConfig),
-            );
-        final container = _container(
-          api: null,
-          apiOverride: (ref) {
-            final server = ref.watch(activeServer);
-            return switch (server?.id) {
-              'test-server' => firstApi,
-              'second-server' => secondApi,
-              _ => null,
-            };
-          },
-          appSettings: const AppSettings(),
-          activeServer: _serverConfig,
-          activeServerOverride: activeServer,
-        );
-        addTearDown(container.dispose);
+    test('write response after server switch does not overwrite active server pins', () async {
+      final firstApi = _PinnedModelsApiService(serverConfig: _serverConfig);
+      final secondApi = _PinnedModelsApiService(
+        delaySettingsReads: true,
+        serverConfig: _secondServerConfig,
+      );
+      addTearDown(firstApi.dispose);
+      addTearDown(secondApi.dispose);
+      final activeServer =
+          NotifierProvider<_ActiveServerNotifier, ServerConfig?>(
+            () => _ActiveServerNotifier(_serverConfig),
+          );
+      final container = _container(
+        api: null,
+        apiOverride: (ref) {
+          final server = ref.watch(activeServer);
+          return switch (server?.id) {
+            'test-server' => firstApi,
+            'second-server' => secondApi,
+            _ => null,
+          };
+        },
+        appSettings: const AppSettings(),
+        activeServer: _serverConfig,
+        activeServerOverride: activeServer,
+      );
+      addTearDown(container.dispose);
 
-        await container.read(personalizationSettingsProvider.future);
+      await container.read(personalizationSettingsProvider.future);
 
-        final writeOnFirstServer = container
-            .read(personalizationSettingsProvider.notifier)
-            .setPinnedModels(['server-a-pin']);
-        await firstApi.waitForRequestCount(1);
-        check(firstApi.requestModelIds(0)).deepEquals(['server-a-pin']);
+      final writeOnFirstServer = container
+          .read(personalizationSettingsProvider.notifier)
+          .setPinnedModels(['server-a-pin']);
+      await firstApi.waitForRequestCount(1);
+      check(firstApi.requestModelIds(0)).deepEquals(['server-a-pin']);
 
-        container.read(activeServer.notifier).set(_secondServerConfig);
-        final switchedRead = container.read(
-          personalizationSettingsProvider.future,
-        );
-        await secondApi.waitForSettingsReadCount(1);
-        secondApi.completeSettingsRead(0, ['server-b-pin']);
-        final loaded = await switchedRead;
+      container.read(activeServer.notifier).set(_secondServerConfig);
+      final switchedRead = container.read(
+        personalizationSettingsProvider.future,
+      );
+      await secondApi.waitForSettingsReadCount(1);
+      secondApi.completeSettingsRead(0, ['server-b-pin']);
+      final loaded = await switchedRead;
 
-        check(loaded.pinnedModelIds).deepEquals(['server-b-pin']);
-        await _flushMicrotasks();
-        check(
-          container.read(appSettingsProvider).pinnedModels,
-        ).deepEquals(['server-b-pin']);
+      check(loaded.pinnedModelIds).deepEquals(['server-b-pin']);
+      await _flushMicrotasks();
+      check(container.read(appSettingsProvider).pinnedModels)
+          .deepEquals(['server-b-pin']);
 
-        firstApi.completeRequest(0, ['server-a-pin']);
-        final staleWriteResult = await writeOnFirstServer;
+      firstApi.completeRequest(0, ['server-a-pin']);
+      final staleWriteResult = await writeOnFirstServer;
 
-        check(staleWriteResult.pinnedModelIds).deepEquals(['server-b-pin']);
-        check(
-          container
-              .read(personalizationSettingsProvider)
-              .requireValue
-              .pinnedModelIds,
-        ).deepEquals(['server-b-pin']);
-        await _flushMicrotasks();
-        check(
-          container.read(appSettingsProvider).pinnedModels,
-        ).deepEquals(['server-b-pin']);
-      },
-    );
+      check(staleWriteResult.pinnedModelIds).deepEquals(['server-b-pin']);
+      check(
+        container
+            .read(personalizationSettingsProvider)
+            .requireValue
+            .pinnedModelIds,
+      ).deepEquals(['server-b-pin']);
+      await _flushMicrotasks();
+      check(container.read(appSettingsProvider).pinnedModels)
+          .deepEquals(['server-b-pin']);
+    });
 
     test(
       'settings read after server switch does not overwrite active server pins',
@@ -387,9 +372,8 @@ void main() {
 
         check(loaded.pinnedModelIds).deepEquals(['server-b-pin']);
         await _flushMicrotasks();
-        check(
-          container.read(appSettingsProvider).pinnedModels,
-        ).deepEquals(['server-b-pin']);
+        check(container.read(appSettingsProvider).pinnedModels)
+            .deepEquals(['server-b-pin']);
 
         firstApi.completeSettingsRead(0, ['server-a-pin']);
         final staleReadResult = await readOnFirstServer;
@@ -402,9 +386,8 @@ void main() {
               .pinnedModelIds,
         ).deepEquals(['server-b-pin']);
         await _flushMicrotasks();
-        check(
-          container.read(appSettingsProvider).pinnedModels,
-        ).deepEquals(['server-b-pin']);
+        check(container.read(appSettingsProvider).pinnedModels)
+            .deepEquals(['server-b-pin']);
       },
     );
   });

--- a/test/core/providers/socket_service_manager_test.dart
+++ b/test/core/providers/socket_service_manager_test.dart
@@ -116,9 +116,9 @@ void main() {
         fireImmediately: true,
       );
       addTearDown(subscription.close);
-      final serviceA =
-          await container.read(socketServiceManagerProvider.future)
-              as _TestSocketService;
+      final serviceA = await container.read(
+        socketServiceManagerProvider.future,
+      ) as _TestSocketService;
       final pendingServerB = Completer<ServerConfig?>();
 
       harness.setServer(container, pendingServerB.future);
@@ -131,9 +131,9 @@ void main() {
       ).isNull();
 
       pendingServerB.complete(serverB);
-      final serviceB =
-          await container.read(socketServiceManagerProvider.future)
-              as _TestSocketService;
+      final serviceB = await container.read(
+        socketServiceManagerProvider.future,
+      ) as _TestSocketService;
       check(serviceB.serverConfig).equals(serverB);
       check(serviceB.authToken).equals('token-a');
       check(harness.services).deepEquals([serviceA, serviceB]);
@@ -152,9 +152,9 @@ void main() {
           (_, _) {},
           fireImmediately: true,
         );
-        final service =
-            await container.read(socketServiceManagerProvider.future)
-                as _TestSocketService;
+        final service = await container.read(
+          socketServiceManagerProvider.future,
+        ) as _TestSocketService;
         final pendingServerB = Completer<ServerConfig?>();
 
         harness.setServer(container, pendingServerB.future);
@@ -182,18 +182,18 @@ void main() {
           (_, _) {},
           fireImmediately: true,
         );
-        final serviceA =
-            await container.read(socketServiceManagerProvider.future)
-                as _TestSocketService;
+        final serviceA = await container.read(
+          socketServiceManagerProvider.future,
+        ) as _TestSocketService;
 
         harness.setAuth(container, (
           authenticated: true,
           token: 'token-b',
           epoch: Object(),
         ));
-        final serviceB =
-            await container.read(socketServiceManagerProvider.future)
-                as _TestSocketService;
+        final serviceB = await container.read(
+          socketServiceManagerProvider.future,
+        ) as _TestSocketService;
 
         check(serviceA.disposeCalls).equals(1);
         check(serviceB.disposeCalls).equals(0);
@@ -203,9 +203,8 @@ void main() {
         subscription.close();
 
         check(serviceB.disposeCalls).equals(1);
-        check(
-          harness.services,
-        ).deepEquals(<_TestSocketService>[serviceA, serviceB]);
+        check(harness.services)
+            .deepEquals(<_TestSocketService>[serviceA, serviceB]);
       },
     );
 
@@ -220,9 +219,9 @@ void main() {
         (_, _) {},
         fireImmediately: true,
       );
-      final service =
-          await container.read(socketServiceManagerProvider.future)
-              as _TestSocketService;
+      final service = await container.read(
+        socketServiceManagerProvider.future,
+      ) as _TestSocketService;
 
       container.invalidate(socketServiceManagerProvider);
       final rebuiltService = await container.read(

--- a/test/core/providers/user_files_provider_test.dart
+++ b/test/core/providers/user_files_provider_test.dart
@@ -15,9 +15,8 @@ void main() {
       final container = _container(api);
       addTearDown(container.dispose);
 
-      await check(
-        container.read(userFilesProvider.future),
-      ).throws<StateError>();
+      await check(container.read(userFilesProvider.future))
+          .throws<StateError>();
       check(api.requestedPages).deepEquals([1]);
     });
 
@@ -47,9 +46,8 @@ void main() {
 
         final initialFiles = await container.read(userFilesProvider.future);
 
-        check(
-          initialFiles.map((file) => file.id).toList(),
-        ).deepEquals(['file-1']);
+        check(initialFiles.map((file) => file.id).toList())
+            .deepEquals(['file-1']);
         check(
           container.read(userFilesProvider).requireValue.map((file) => file.id),
         ).deepEquals(['file-1']);
@@ -57,9 +55,8 @@ void main() {
         await Future<void>.delayed(const Duration(milliseconds: 30));
 
         final allFiles = container.read(userFilesProvider).requireValue;
-        check(
-          allFiles.map((file) => file.id).toList(),
-        ).deepEquals(['file-3', 'file-2', 'file-1']);
+        check(allFiles.map((file) => file.id).toList())
+            .deepEquals(['file-3', 'file-2', 'file-1']);
         check(api.requestedPages).deepEquals([1, 2]);
       },
     );
@@ -90,9 +87,8 @@ void main() {
 
         final files = await container.read(userFilesProvider.future);
 
-        check(
-          files.map((file) => file.id).toList(),
-        ).deepEquals(['server-2', 'server-1']);
+        check(files.map((file) => file.id).toList())
+            .deepEquals(['server-2', 'server-1']);
         check(api.requestedPages).deepEquals([1]);
       },
     );

--- a/test/core/providers/user_memories_provider_test.dart
+++ b/test/core/providers/user_memories_provider_test.dart
@@ -29,9 +29,8 @@ void main() {
 
       final memories = await _loadMemories(container);
 
-      check(
-        memories.map((memory) => memory.id).toList(),
-      ).deepEquals(['memory-2', 'memory-1']);
+      check(memories.map((memory) => memory.id).toList())
+          .deepEquals(['memory-2', 'memory-1']);
     });
 
     test('add, update, and delete keep local state sorted', () async {
@@ -68,15 +67,13 @@ void main() {
 
       final updated = await notifier.updateItem('memory-1', 'revise first');
       check(updated.content).equals('First updated');
-      check(
-        api.updatedRequests,
-      ).deepEquals([(memoryId: 'memory-1', content: 'revise first')]);
+      check(api.updatedRequests)
+          .deepEquals([(memoryId: 'memory-1', content: 'revise first')]);
       final currentAfterUpdate = container
           .read(userMemoriesProvider)
           .requireValue;
-      check(
-        currentAfterUpdate.map((it) => it.id),
-      ).deepEquals(['memory-1', 'memory-3', 'memory-2']);
+      check(currentAfterUpdate.map((it) => it.id))
+          .deepEquals(['memory-1', 'memory-3', 'memory-2']);
       check(currentAfterUpdate.first.content).equals('First updated');
 
       await notifier.deleteItem('memory-2');
@@ -107,9 +104,8 @@ void main() {
           .updateItem('missing', 'ignored locally');
 
       final memories = container.read(userMemoriesProvider).requireValue;
-      check(
-        memories.map((memory) => memory.id).toList(),
-      ).deepEquals(['memory-1']);
+      check(memories.map((memory) => memory.id).toList())
+          .deepEquals(['memory-1']);
     });
 
     test(

--- a/test/core/router/direct_connections_router_policy_test.dart
+++ b/test/core/router/direct_connections_router_policy_test.dart
@@ -48,9 +48,8 @@ void main() {
     });
 
     test('editor path percent-encodes profile ids', () {
-      check(
-        Routes.directConnectionEditorPath('local profile'),
-      ).equals('/profile/direct-connections/local%20profile');
+      check(Routes.directConnectionEditorPath('local profile'))
+          .equals('/profile/direct-connections/local%20profile');
     });
 
     test('native-sheet entry dismisses without a second page transition', () {

--- a/test/core/router/hermes_router_policy_test.dart
+++ b/test/core/router/hermes_router_policy_test.dart
@@ -143,9 +143,8 @@ final _usableDirectProfile = DirectConnectionProfile(
 
 void main() {
   test('native-sheet destinations suppress the second page transition', () {
-    check(
-      usesNoTransitionForNativeSheet(const NativeSheetNavigationOrigin()),
-    ).isTrue();
+    check(usesNoTransitionForNativeSheet(const NativeSheetNavigationOrigin()))
+        .isTrue();
     check(usesNoTransitionForNativeSheet(null)).isFalse();
     check(usesNoTransitionForNativeSheet(true)).isFalse();
   });
@@ -182,12 +181,10 @@ void main() {
     });
 
     test('settled incomplete Hermes config opens settings, not splash', () {
-      check(
-        incompleteHermesDestination(secretsLoading: false),
-      ).equals(Routes.hermesSettings);
-      check(
-        incompleteHermesDestination(secretsLoading: true),
-      ).equals(Routes.splash);
+      check(incompleteHermesDestination(secretsLoading: false))
+          .equals(Routes.hermesSettings);
+      check(incompleteHermesDestination(secretsLoading: true))
+          .equals(Routes.splash);
     });
 
     test('incomplete Hermes waits while the active server is loading', () {
@@ -309,14 +306,13 @@ void main() {
 
         check(notifier.redirect(_MockBuildContext(), state)).isNull();
 
-        (container.read(hermesConfigProvider.notifier)
-                as _FixedHermesConfigController)
-            .publish(_usableHermes);
+        (container.read(
+          hermesConfigProvider.notifier,
+        ) as _FixedHermesConfigController).publish(_usableHermes);
         container.read(hermesSecretsLoadingProvider.notifier).set(false);
 
-        check(
-          notifier.redirect(_MockBuildContext(), state),
-        ).equals(Routes.chat);
+        check(notifier.redirect(_MockBuildContext(), state))
+            .equals(Routes.chat);
       },
     );
 
@@ -399,9 +395,8 @@ void main() {
         }
 
         when(() => state.uri).thenReturn(Uri.parse(Routes.splash));
-        check(
-          notifier.redirect(_MockBuildContext(), state),
-        ).equals(Routes.hermesSettings);
+        check(notifier.redirect(_MockBuildContext(), state))
+            .equals(Routes.hermesSettings);
       },
     );
 
@@ -497,12 +492,12 @@ void main() {
         final state = _MockGoRouterState();
         final notifier = container.read(routerNotifierProvider);
         when(() => state.uri).thenReturn(Uri.parse(Routes.authentication));
-        check(notifier.redirect(_MockBuildContext(), state)).equals(Routes.chat);
+        check(notifier.redirect(_MockBuildContext(), state))
+            .equals(Routes.chat);
 
         when(() => state.uri).thenReturn(Uri.parse(Routes.chat));
-        check(
-          notifier.redirect(_MockBuildContext(), state),
-        ).equals(Routes.connectionIssue);
+        check(notifier.redirect(_MockBuildContext(), state))
+            .equals(Routes.connectionIssue);
 
         when(() => state.uri).thenReturn(Uri.parse(Routes.connectionIssue));
         check(notifier.redirect(_MockBuildContext(), state)).isNull();
@@ -611,9 +606,8 @@ void main() {
         check(notifier.redirect(_MockBuildContext(), state)).isNull();
 
         when(() => state.uri).thenReturn(Uri.parse(Routes.notes));
-        check(
-          notifier.redirect(_MockBuildContext(), state),
-        ).equals(Routes.chat);
+        check(notifier.redirect(_MockBuildContext(), state))
+            .equals(Routes.chat);
 
         when(() => state.uri).thenReturn(Uri.parse(Routes.authentication));
         check(notifier.redirect(_MockBuildContext(), state)).isNull();
@@ -756,9 +750,8 @@ void main() {
       final state = _MockGoRouterState();
       final notifier = container.read(routerNotifierProvider);
       when(() => state.uri).thenReturn(Uri.parse(Routes.chat));
-      check(
-        notifier.redirect(_MockBuildContext(), state),
-      ).equals(Routes.splash);
+      check(notifier.redirect(_MockBuildContext(), state))
+          .equals(Routes.splash);
 
       profiles.complete([_usableDirectProfile]);
       await container.read(directConnectionProfilesProvider.future);
@@ -844,9 +837,8 @@ void main() {
         check(refreshing.isLoading).isTrue();
         check(refreshing.hasValue).isTrue();
         when(() => state.uri).thenReturn(Uri.parse(Routes.chat));
-        check(
-          notifier.redirect(_MockBuildContext(), state),
-        ).equals(Routes.splash);
+        check(notifier.redirect(_MockBuildContext(), state))
+            .equals(Routes.splash);
 
         pending.complete([_usableDirectProfile]);
         await container.read(directConnectionProfilesProvider.future);
@@ -860,9 +852,8 @@ void main() {
         final failed = container.read(directConnectionProfilesProvider);
         check(failed.hasError).isTrue();
         check(failed.hasValue).isTrue();
-        check(
-          notifier.redirect(_MockBuildContext(), state),
-        ).equals('${Routes.directConnections}?onboarding=true');
+        check(notifier.redirect(_MockBuildContext(), state))
+            .equals('${Routes.directConnections}?onboarding=true');
       },
     );
   });

--- a/test/core/services/api_service_active_chats_test.dart
+++ b/test/core/services/api_service_active_chats_test.dart
@@ -173,9 +173,8 @@ void main() {
       );
       final api = _buildApiService(adapter);
 
-      await check(
-        api.checkActiveChats(['regular', 'archived']),
-      ).throws<DioException>();
+      await check(api.checkActiveChats(['regular', 'archived']))
+          .throws<DioException>();
     });
 
     test('0.11 pagination continues after a full 60-row page', () async {

--- a/test/core/services/api_service_auth_token_ownership_test.dart
+++ b/test/core/services/api_service_auth_token_ownership_test.dart
@@ -35,9 +35,8 @@ void main() {
 
     api.updateAuthToken('owned-session-token');
     await api.dio.get<void>('/api/config');
-    check(
-      adapter.requests.last.headers['Authorization'],
-    ).equals('Bearer owned-session-token');
+    check(adapter.requests.last.headers['Authorization'])
+        .equals('Bearer owned-session-token');
   });
 
   test(
@@ -123,9 +122,8 @@ void main() {
     final request = adapter.requests.single;
     check(request.method).equals('POST');
     check(request.path).equals('/api/v1/auths/signout');
-    check(
-      request.headers[HttpHeaders.authorizationHeader],
-    ).equals('Bearer original-session');
+    check(request.headers[HttpHeaders.authorizationHeader])
+        .equals('Bearer original-session');
 
     api.updateAuthToken('newer-session');
     await expectLater(

--- a/test/core/services/api_service_chat_completion_test.dart
+++ b/test/core/services/api_service_chat_completion_test.dart
@@ -241,26 +241,23 @@ void main() {
 
     // 4. httpStream classification when body looks like SSE but has no
     //    content-type header
-    test(
-      'httpStream when body looks like SSE but has no content-type',
-      () async {
-        final sseBody =
-            'data: {"choices":[{"delta":{"content":"hi"}}]}\n\ndata: [DONE]\n\n';
-        final adapter = _FakeAdapter.raw(
-          bytes: utf8.encode(sseBody),
-          headers: {}, // no content-type
-        );
-        final api = _buildApiServiceForTest(adapter);
+    test('httpStream when body looks like SSE but has no content-type', () async {
+      final sseBody =
+          'data: {"choices":[{"delta":{"content":"hi"}}]}\n\ndata: [DONE]\n\n';
+      final adapter = _FakeAdapter.raw(
+        bytes: utf8.encode(sseBody),
+        headers: {}, // no content-type
+      );
+      final api = _buildApiServiceForTest(adapter);
 
-        final session = await api.sendMessageSession(
-          messages: _minimalMessages,
-          model: _model,
-        );
+      final session = await api.sendMessageSession(
+        messages: _minimalMessages,
+        model: _model,
+      );
 
-        check(session.transport).equals(ChatCompletionTransport.httpStream);
-        check(session.byteStream).isNotNull();
-      },
-    );
+      check(session.transport).equals(ChatCompletionTransport.httpStream);
+      check(session.byteStream).isNotNull();
+    });
 
     // 5. taskSocket classification from JSON body split across multiple chunks
     test('taskSocket from JSON split across multiple chunks', () async {
@@ -542,9 +539,9 @@ void main() {
       final modernBody = adapter.requests[0].data as Map<String, dynamic>;
       check(adapter.requests[0].path).equals('/api/chat/completions');
       check(modernBody['parent_id']).equals('assistant-0');
-      check(
-        modernBody['user_message'],
-      ).isA<Map<String, dynamic>>().deepEquals(userMessage1);
+      check(modernBody['user_message'])
+          .isA<Map<String, dynamic>>()
+          .deepEquals(userMessage1);
       check(modernBody.containsKey('parent_message')).isFalse();
 
       check(adapter.requests[1].method).equals('GET');
@@ -564,12 +561,12 @@ void main() {
       final firstPersistParent =
           firstPersistMessages['assistant-0'] as Map<String, dynamic>;
       check(firstPersistHistory['currentId']).equals('assistant-1');
-      check(
-        firstPersistParent['childrenIds'],
-      ).isA<List<dynamic>>().deepEquals(const ['user-1']);
-      check(
-        firstPersistUser['childrenIds'],
-      ).isA<List<dynamic>>().deepEquals(const ['assistant-1']);
+      check(firstPersistParent['childrenIds'])
+          .isA<List<dynamic>>()
+          .deepEquals(const ['user-1']);
+      check(firstPersistUser['childrenIds'])
+          .isA<List<dynamic>>()
+          .deepEquals(const ['assistant-1']);
       check(firstPersistAssistant['parentId']).equals('user-1');
       check(firstPersistAssistant['role']).equals('assistant');
       check(firstPersistAssistant['content']).equals('');
@@ -583,9 +580,9 @@ void main() {
       final legacyRetryBody = adapter.requests[3].data as Map<String, dynamic>;
       check(adapter.requests[3].path).equals('/api/chat/completions');
       check(legacyRetryBody['parent_id']).equals('user-1');
-      check(
-        legacyRetryBody['parent_message'],
-      ).isA<Map<String, dynamic>>().deepEquals(userMessage1);
+      check(legacyRetryBody['parent_message'])
+          .isA<Map<String, dynamic>>()
+          .deepEquals(userMessage1);
       check(legacyRetryBody.containsKey('user_message')).isFalse();
 
       check(adapter.requests[4].method).equals('GET');
@@ -607,12 +604,12 @@ void main() {
       final secondPersistAssistant =
           secondPersistMessages['assistant-2'] as Map<String, dynamic>;
       check(secondPersistHistory['currentId']).equals('assistant-2');
-      check(
-        secondPersistParent['childrenIds'],
-      ).isA<List<dynamic>>().deepEquals(const ['user-2']);
-      check(
-        secondPersistUser['childrenIds'],
-      ).isA<List<dynamic>>().deepEquals(const ['assistant-2']);
+      check(secondPersistParent['childrenIds'])
+          .isA<List<dynamic>>()
+          .deepEquals(const ['user-2']);
+      check(secondPersistUser['childrenIds'])
+          .isA<List<dynamic>>()
+          .deepEquals(const ['assistant-2']);
       check(secondPersistAssistant['parentId']).equals('user-2');
       check(secondPersistAssistant.containsKey('done')).isFalse();
       check(
@@ -631,9 +628,9 @@ void main() {
       final cachedLegacyBody = adapter.requests[6].data as Map<String, dynamic>;
       check(adapter.requests[6].path).equals('/api/chat/completions');
       check(cachedLegacyBody['parent_id']).equals('user-2');
-      check(
-        cachedLegacyBody['parent_message'],
-      ).isA<Map<String, dynamic>>().deepEquals(userMessage2);
+      check(cachedLegacyBody['parent_message'])
+          .isA<Map<String, dynamic>>()
+          .deepEquals(userMessage2);
       check(cachedLegacyBody.containsKey('user_message')).isFalse();
     });
   });
@@ -785,10 +782,9 @@ void main() {
       final first = messages.first as Map<String, dynamic>;
       check(first['content']).isA<List<dynamic>>();
       final content = first['content'] as List<dynamic>;
-      check(content[0]).isA<Map<String, dynamic>>().deepEquals({
-        'type': 'text',
-        'text': 'describe this',
-      });
+      check(content[0])
+          .isA<Map<String, dynamic>>()
+          .deepEquals({'type': 'text', 'text': 'describe this'});
       check(content[1]).isA<Map<String, dynamic>>().deepEquals({
         'type': 'image_url',
         'image_url': {'url': 'file-image-id'},
@@ -949,19 +945,19 @@ void main() {
       check(payload['tool_servers'])
           .isA<List<Map<String, dynamic>>>()
           .deepEquals(const <Map<String, dynamic>>[]);
-      check(
-        payload['background_tasks'],
-      ).isA<Map<String, dynamic>>().deepEquals(backgroundTasks);
+      check(payload['background_tasks'])
+          .isA<Map<String, dynamic>>()
+          .deepEquals(backgroundTasks);
       check(payload['parent_id'] as String).equals('assistant-0');
-      check(
-        payload['user_message'],
-      ).isA<Map<String, dynamic>>().deepEquals(userMessage);
-      check(
-        payload['variables'],
-      ).isA<Map<String, dynamic>>().deepEquals(variables);
-      check(
-        payload['model_item'],
-      ).isA<Map<String, dynamic>>().deepEquals(modelItem);
+      check(payload['user_message'])
+          .isA<Map<String, dynamic>>()
+          .deepEquals(userMessage);
+      check(payload['variables'])
+          .isA<Map<String, dynamic>>()
+          .deepEquals(variables);
+      check(payload['model_item'])
+          .isA<Map<String, dynamic>>()
+          .deepEquals(modelItem);
       check(payload['features']).isA<Map<String, dynamic>>().deepEquals({
         'voice': false,
         'web_search': false,
@@ -994,9 +990,9 @@ void main() {
       );
 
       check(payload['parent_id']).equals('user-1');
-      check(
-        payload['parent_message'],
-      ).isA<Map<String, dynamic>>().deepEquals(userMessage);
+      check(payload['parent_message'])
+          .isA<Map<String, dynamic>>()
+          .deepEquals(userMessage);
       check(payload.containsKey('user_message')).isFalse();
     });
   });
@@ -1005,50 +1001,46 @@ void main() {
   // Conversation persistence payloads
   // -----------------------------------------------------------------------
   group('conversation persistence payloads', () {
-    test(
-      'syncConversationMessages omits done for streaming assistant placeholders',
-      () async {
-        final adapter = _FakeAdapter.json({});
-        final api = _buildApiServiceForTest(adapter);
+    test('syncConversationMessages omits done for streaming assistant placeholders', () async {
+      final adapter = _FakeAdapter.json({});
+      final api = _buildApiServiceForTest(adapter);
 
-        final messages = [
-          ChatMessage(
-            id: 'user-1',
-            role: 'user',
-            content: 'hello',
-            timestamp: DateTime.fromMillisecondsSinceEpoch(1700000000000),
-          ),
-          ChatMessage(
-            id: 'asst-1',
-            role: 'assistant',
-            content: '',
-            timestamp: DateTime.fromMillisecondsSinceEpoch(1700000001000),
-            model: 'gpt-4',
-            isStreaming: true,
-          ),
-        ];
+      final messages = [
+        ChatMessage(
+          id: 'user-1',
+          role: 'user',
+          content: 'hello',
+          timestamp: DateTime.fromMillisecondsSinceEpoch(1700000000000),
+        ),
+        ChatMessage(
+          id: 'asst-1',
+          role: 'assistant',
+          content: '',
+          timestamp: DateTime.fromMillisecondsSinceEpoch(1700000001000),
+          model: 'gpt-4',
+          isStreaming: true,
+        ),
+      ];
 
-        await api.syncConversationMessages('conv-1', messages, model: 'gpt-4');
+      await api.syncConversationMessages('conv-1', messages, model: 'gpt-4');
 
-        final request = adapter.lastRequest!;
-        check(request.path).equals('/api/v1/chats/conv-1');
+      final request = adapter.lastRequest!;
+      check(request.path).equals('/api/v1/chats/conv-1');
 
-        final body = request.data as Map<String, dynamic>;
-        final chat = body['chat'] as Map<String, dynamic>;
-        final serializedMessages =
-            chat['messages'] as List<Map<String, dynamic>>;
-        final history = chat['history'] as Map<String, dynamic>;
-        final historyMessages = history['messages'] as Map<String, dynamic>;
+      final body = request.data as Map<String, dynamic>;
+      final chat = body['chat'] as Map<String, dynamic>;
+      final serializedMessages = chat['messages'] as List<Map<String, dynamic>>;
+      final history = chat['history'] as Map<String, dynamic>;
+      final historyMessages = history['messages'] as Map<String, dynamic>;
 
-        final serializedAssistant = serializedMessages.last;
-        final historyAssistant =
-            historyMessages['asst-1'] as Map<String, dynamic>;
+      final serializedAssistant = serializedMessages.last;
+      final historyAssistant =
+          historyMessages['asst-1'] as Map<String, dynamic>;
 
-        check(serializedAssistant.containsKey('done')).isFalse();
-        check(historyAssistant.containsKey('done')).isFalse();
-        check(history['currentId']).equals('asst-1');
-      },
-    );
+      check(serializedAssistant.containsKey('done')).isFalse();
+      check(historyAssistant.containsKey('done')).isFalse();
+      check(history['currentId']).equals('asst-1');
+    });
 
     test(
       'syncConversationMessages keeps done for completed assistant messages',
@@ -1090,47 +1082,43 @@ void main() {
       },
     );
 
-    test(
-      'syncConversationMessages keeps done for responseDone streaming assistant messages',
-      () async {
-        final adapter = _FakeAdapter.json({});
-        final api = _buildApiServiceForTest(adapter);
+    test('syncConversationMessages keeps done for responseDone streaming assistant messages', () async {
+      final adapter = _FakeAdapter.json({});
+      final api = _buildApiServiceForTest(adapter);
 
-        final messages = [
-          ChatMessage(
-            id: 'user-1',
-            role: 'user',
-            content: 'hello',
-            timestamp: DateTime.fromMillisecondsSinceEpoch(1700000000000),
-          ),
-          ChatMessage(
-            id: 'asst-1',
-            role: 'assistant',
-            content: 'Hi there',
-            timestamp: DateTime.fromMillisecondsSinceEpoch(1700000001000),
-            model: 'gpt-4',
-            isStreaming: true,
-            metadata: const {'responseDone': true},
-          ),
-        ];
+      final messages = [
+        ChatMessage(
+          id: 'user-1',
+          role: 'user',
+          content: 'hello',
+          timestamp: DateTime.fromMillisecondsSinceEpoch(1700000000000),
+        ),
+        ChatMessage(
+          id: 'asst-1',
+          role: 'assistant',
+          content: 'Hi there',
+          timestamp: DateTime.fromMillisecondsSinceEpoch(1700000001000),
+          model: 'gpt-4',
+          isStreaming: true,
+          metadata: const {'responseDone': true},
+        ),
+      ];
 
-        await api.syncConversationMessages('conv-1', messages, model: 'gpt-4');
+      await api.syncConversationMessages('conv-1', messages, model: 'gpt-4');
 
-        final body = adapter.lastRequest!.data as Map<String, dynamic>;
-        final chat = body['chat'] as Map<String, dynamic>;
-        final serializedMessages =
-            chat['messages'] as List<Map<String, dynamic>>;
-        final history = chat['history'] as Map<String, dynamic>;
-        final historyMessages = history['messages'] as Map<String, dynamic>;
+      final body = adapter.lastRequest!.data as Map<String, dynamic>;
+      final chat = body['chat'] as Map<String, dynamic>;
+      final serializedMessages = chat['messages'] as List<Map<String, dynamic>>;
+      final history = chat['history'] as Map<String, dynamic>;
+      final historyMessages = history['messages'] as Map<String, dynamic>;
 
-        final serializedAssistant = serializedMessages.last;
-        final historyAssistant =
-            historyMessages['asst-1'] as Map<String, dynamic>;
+      final serializedAssistant = serializedMessages.last;
+      final historyAssistant =
+          historyMessages['asst-1'] as Map<String, dynamic>;
 
-        check(serializedAssistant['done']).equals(true);
-        check(historyAssistant['done']).equals(true);
-      },
-    );
+      check(serializedAssistant['done']).equals(true);
+      check(historyAssistant['done']).equals(true);
+    });
 
     test(
       'syncConversationMessages preserves assistant version output',
@@ -1276,96 +1264,92 @@ void main() {
       },
     );
 
-    test(
-      'createConversation keeps done for responseDone streaming assistant messages',
-      () async {
-        final adapter = _FakeAdapter.json({
-          'id': 'conv-1',
-          'title': 'New Chat',
-          'created_at': 1700000000,
-          'updated_at': 1700000001,
-          'chat': {
-            'models': ['gpt-4'],
-            'history': {
-              'currentId': 'asst-1',
-              'messages': {
-                'user-1': {
-                  'id': 'user-1',
-                  'role': 'user',
-                  'content': 'hello',
-                  'timestamp': 1700000000,
-                  'childrenIds': ['asst-1', 'asst-newer'],
-                },
-                'asst-1': {
-                  'id': 'asst-1',
-                  'role': 'assistant',
-                  'content': 'Hi there',
-                  'parentId': 'user-1',
-                  'timestamp': 1700000001,
-                  'childrenIds': [],
-                  'done': true,
-                },
-              },
-            },
-            'messages': [
-              {
+    test('createConversation keeps done for responseDone streaming assistant messages', () async {
+      final adapter = _FakeAdapter.json({
+        'id': 'conv-1',
+        'title': 'New Chat',
+        'created_at': 1700000000,
+        'updated_at': 1700000001,
+        'chat': {
+          'models': ['gpt-4'],
+          'history': {
+            'currentId': 'asst-1',
+            'messages': {
+              'user-1': {
                 'id': 'user-1',
                 'role': 'user',
                 'content': 'hello',
                 'timestamp': 1700000000,
+                'childrenIds': ['asst-1', 'asst-newer'],
               },
-              {
+              'asst-1': {
                 'id': 'asst-1',
                 'role': 'assistant',
                 'content': 'Hi there',
+                'parentId': 'user-1',
                 'timestamp': 1700000001,
+                'childrenIds': [],
                 'done': true,
               },
-            ],
+            },
           },
-        });
-        final api = _buildApiServiceForTest(adapter);
-
-        await api.createConversation(
-          title: 'New Chat',
-          model: 'gpt-4',
-          messages: [
-            ChatMessage(
-              id: 'user-1',
-              role: 'user',
-              content: 'hello',
-              timestamp: DateTime.fromMillisecondsSinceEpoch(1700000000000),
-            ),
-            ChatMessage(
-              id: 'asst-1',
-              role: 'assistant',
-              content: 'Hi there',
-              timestamp: DateTime.fromMillisecondsSinceEpoch(1700000001000),
-              model: 'gpt-4',
-              isStreaming: true,
-              metadata: const {'responseDone': true},
-            ),
+          'messages': [
+            {
+              'id': 'user-1',
+              'role': 'user',
+              'content': 'hello',
+              'timestamp': 1700000000,
+            },
+            {
+              'id': 'asst-1',
+              'role': 'assistant',
+              'content': 'Hi there',
+              'timestamp': 1700000001,
+              'done': true,
+            },
           ],
-        );
+        },
+      });
+      final api = _buildApiServiceForTest(adapter);
 
-        final request = adapter.lastRequest!;
-        check(request.path).equals('/api/v1/chats/new');
+      await api.createConversation(
+        title: 'New Chat',
+        model: 'gpt-4',
+        messages: [
+          ChatMessage(
+            id: 'user-1',
+            role: 'user',
+            content: 'hello',
+            timestamp: DateTime.fromMillisecondsSinceEpoch(1700000000000),
+          ),
+          ChatMessage(
+            id: 'asst-1',
+            role: 'assistant',
+            content: 'Hi there',
+            timestamp: DateTime.fromMillisecondsSinceEpoch(1700000001000),
+            model: 'gpt-4',
+            isStreaming: true,
+            metadata: const {'responseDone': true},
+          ),
+        ],
+      );
 
-        final body = request.data as Map<String, dynamic>;
-        final chat = body['chat'] as Map<String, dynamic>;
-        final serializedMessages =
-            chat['messages'] as List<Map<String, dynamic>>;
-        final history = chat['history'] as Map<String, dynamic>;
-        final historyMessages = history['messages'] as Map<String, dynamic>;
+      final request = adapter.lastRequest!;
+      check(request.path).equals('/api/v1/chats/new');
 
-        final serializedAssistant = serializedMessages.last;
-        final historyAssistant =
-            historyMessages['asst-1'] as Map<String, dynamic>;
+      final body = request.data as Map<String, dynamic>;
+      final chat = body['chat'] as Map<String, dynamic>;
+      final serializedMessages = chat['messages'] as List<Map<String, dynamic>>;
+      final history = chat['history'] as Map<String, dynamic>;
+      final historyMessages = history['messages'] as Map<String, dynamic>;
 
-        check(serializedAssistant['done']).equals(true);
-        check(historyAssistant['done']).equals(true);
-      },
-    );
+      final serializedAssistant = serializedMessages.last;
+      final historyAssistant =
+          historyMessages['asst-1'] as Map<String, dynamic>;
+
+      check(serializedAssistant['done']).equals(true);
+      check(historyAssistant['done']).equals(true);
+    });
   });
 
   // -----------------------------------------------------------------------
@@ -1473,9 +1457,8 @@ void main() {
         final model = await api.getDefaultModel();
 
         check(model).equals('gpt-4.1');
-        check(
-          adapter.requests.map((request) => request.path).toList(),
-        ).deepEquals(['/api/v1/users/user/settings', '/api/config']);
+        check(adapter.requests.map((request) => request.path).toList())
+            .deepEquals(['/api/v1/users/user/settings', '/api/config']);
       },
     );
 
@@ -1497,9 +1480,8 @@ void main() {
       final suggestions = await api.getSuggestions();
 
       check(adapter.lastRequest!.path).equals('/api/config');
-      check(
-        suggestions,
-      ).deepEquals(['Draft a concise project update.', 'Fallback title']);
+      check(suggestions)
+          .deepEquals(['Draft a concise project update.', 'Fallback title']);
     });
 
     test('getSuggestions falls back to older suggestions endpoint', () async {
@@ -1523,9 +1505,8 @@ void main() {
 
       final suggestions = await api.getSuggestions();
 
-      check(
-        adapter.requests.map((request) => request.path).toList(),
-      ).deepEquals(['/api/config', '/api/v1/configs/suggestions']);
+      check(adapter.requests.map((request) => request.path).toList())
+          .deepEquals(['/api/config', '/api/v1/configs/suggestions']);
       check(suggestions).deepEquals(['Legacy prompt suggestion.']);
     });
 
@@ -1551,9 +1532,8 @@ void main() {
 
         final request = adapter.lastRequest!;
         check(request.path).equals('/api/v1/chats/chat-1/clone');
-        check(
-          request.data as Map<String, dynamic>,
-        ).deepEquals(<String, dynamic>{});
+        check(request.data as Map<String, dynamic>)
+            .deepEquals(<String, dynamic>{});
       },
     );
 
@@ -1676,12 +1656,10 @@ void main() {
         final assistant = messages['asst-2'] as Map<String, dynamic>;
         final serializedMessages = chat['messages'] as List<dynamic>;
 
-        check(
-          messages.keys.toList(),
-        ).deepEquals(['user-1', 'asst-newer', 'asst-2']);
-        check(
-          user['childrenIds'] as List<dynamic>,
-        ).deepEquals(['asst-newer', 'asst-2']);
+        check(messages.keys.toList())
+            .deepEquals(['user-1', 'asst-newer', 'asst-2']);
+        check(user['childrenIds'] as List<dynamic>)
+            .deepEquals(['asst-newer', 'asst-2']);
         check(assistant['parentId']).equals('user-1');
         check(history['currentId']).equals('asst-2');
         check(
@@ -1704,12 +1682,10 @@ void main() {
       check(
         adapter.requests.map((request) => request.path).toList(),
       ).deepEquals(['/api/v1/chats/chat-1/tags', '/api/v1/chats/chat-1/tags']);
-      check(
-        adapter.requests.first.data as Map<String, dynamic>,
-      ).deepEquals({'name': 'work'});
-      check(
-        adapter.requests.last.data as Map<String, dynamic>,
-      ).deepEquals({'tag': 'work'});
+      check(adapter.requests.first.data as Map<String, dynamic>)
+          .deepEquals({'name': 'work'});
+      check(adapter.requests.last.data as Map<String, dynamic>)
+          .deepEquals({'tag': 'work'});
     });
 
     test('getAllTags falls back to legacy tags route', () async {
@@ -1727,9 +1703,8 @@ void main() {
       final tags = await api.getAllTags();
 
       check(tags).deepEquals(['work', 'personal']);
-      check(
-        adapter.requests.map((request) => request.path).toList(),
-      ).deepEquals(['/api/v1/chats/all/tags', '/api/v1/chats/tags']);
+      check(adapter.requests.map((request) => request.path).toList())
+          .deepEquals(['/api/v1/chats/all/tags', '/api/v1/chats/tags']);
     });
 
     test('removeTagFromConversation falls back to legacy tag route', () async {
@@ -1741,15 +1716,13 @@ void main() {
 
       await api.removeTagFromConversation('chat-1', 'work tag');
 
-      check(
-        adapter.requests.map((request) => request.path).toList(),
-      ).deepEquals([
-        '/api/v1/chats/chat-1/tags',
-        '/api/v1/chats/chat-1/tags/work%20tag',
-      ]);
-      check(
-        adapter.requests.first.data as Map<String, dynamic>,
-      ).deepEquals({'name': 'work tag'});
+      check(adapter.requests.map((request) => request.path).toList())
+          .deepEquals([
+            '/api/v1/chats/chat-1/tags',
+            '/api/v1/chats/chat-1/tags/work%20tag',
+          ]);
+      check(adapter.requests.first.data as Map<String, dynamic>)
+          .deepEquals({'name': 'work tag'});
     });
 
     test('getConversationsByTag falls back to legacy tag route', () async {
@@ -1767,12 +1740,10 @@ void main() {
       final conversations = await api.getConversationsByTag('work');
 
       check(conversations).isEmpty();
-      check(
-        adapter.requests.map((request) => request.path).toList(),
-      ).deepEquals(['/api/v1/chats/tags', '/api/v1/chats/tags/work']);
-      check(
-        adapter.requests.first.data as Map<String, dynamic>,
-      ).deepEquals({'name': 'work', 'skip': 0, 'limit': 50});
+      check(adapter.requests.map((request) => request.path).toList())
+          .deepEquals(['/api/v1/chats/tags', '/api/v1/chats/tags/work']);
+      check(adapter.requests.first.data as Map<String, dynamic>)
+          .deepEquals({'name': 'work', 'skip': 0, 'limit': 50});
       check(adapter.requests.last.method).equals('GET');
     });
 
@@ -1828,9 +1799,8 @@ void main() {
 
         await api.pinConversation('chat-1', true);
 
-        check(
-          adapter.requests.map((request) => request.path).toList(),
-        ).deepEquals(['/api/v1/chats/chat-1/pinned']);
+        check(adapter.requests.map((request) => request.path).toList())
+            .deepEquals(['/api/v1/chats/chat-1/pinned']);
       },
     );
 
@@ -2043,13 +2013,12 @@ void main() {
 
       final config = await api.getBackendConfig();
 
-      check(
-        adapter.requests.map((request) => request.path).toList(),
-      ).deepEquals([
-        '/api/config',
-        '/api/v1/audio/config',
-        '/api/v1/audio/voices',
-      ]);
+      check(adapter.requests.map((request) => request.path).toList())
+          .deepEquals([
+            '/api/config',
+            '/api/v1/audio/config',
+            '/api/v1/audio/voices',
+          ]);
       check(config).isNotNull();
       check(config!.ttsVoice).equals('nova');
       check(config.ttsSplitOn).equals('paragraphs');
@@ -2178,9 +2147,8 @@ void main() {
           'GET /api/v1/knowledge/kb-1',
           'PUT /api/v1/knowledge/kb-1',
         ]);
-        check(
-          adapter.requests.last.data as Map<String, dynamic>,
-        ).deepEquals({'name': 'Docs'});
+        check(adapter.requests.last.data as Map<String, dynamic>)
+            .deepEquals({'name': 'Docs'});
       },
     );
 
@@ -2246,12 +2214,11 @@ void main() {
 
       final items = await api.getKnowledgeBaseItems('kb-1');
 
-      check(
-        adapter.requests.map((request) => request.path).toList(),
-      ).deepEquals([
-        '/api/v1/knowledge/kb-1/files',
-        '/api/v1/knowledge/kb-1/files',
-      ]);
+      check(adapter.requests.map((request) => request.path).toList())
+          .deepEquals([
+            '/api/v1/knowledge/kb-1/files',
+            '/api/v1/knowledge/kb-1/files',
+          ]);
       check(
         adapter.requests
             .map((request) => request.queryParameters['page'])
@@ -2294,12 +2261,11 @@ void main() {
 
       final items = await api.getKnowledgeBaseItems('kb-1');
 
-      check(
-        adapter.requests.map((request) => request.path).toList(),
-      ).deepEquals([
-        '/api/v1/knowledge/kb-1/files',
-        '/api/v1/knowledge/kb-1/items',
-      ]);
+      check(adapter.requests.map((request) => request.path).toList())
+          .deepEquals([
+            '/api/v1/knowledge/kb-1/files',
+            '/api/v1/knowledge/kb-1/items',
+          ]);
       check(items).length.equals(1);
       check(items.single.id).equals('item-1');
       check(items.single.title).equals('Legacy note');
@@ -2337,12 +2303,11 @@ void main() {
 
         final items = await api.getKnowledgeBaseItems('kb-1');
 
-        check(
-          adapter.requests.map((request) => request.path).toList(),
-        ).deepEquals([
-          '/api/v1/knowledge/kb-1/files',
-          '/api/v1/knowledge/kb-1/items',
-        ]);
+        check(adapter.requests.map((request) => request.path).toList())
+            .deepEquals([
+              '/api/v1/knowledge/kb-1/files',
+              '/api/v1/knowledge/kb-1/items',
+            ]);
         check(items).length.equals(1);
         check(items.single.id).equals('item-1');
         check(items.single.content).equals('Saved text');
@@ -2365,9 +2330,8 @@ void main() {
         );
 
         check(file?['id']).equals('file-1');
-        check(
-          adapter.requests.map((request) => request.path).toList(),
-        ).deepEquals(['/api/v1/files/', '/api/v1/knowledge/kb-1/file/add']);
+        check(adapter.requests.map((request) => request.path).toList())
+            .deepEquals(['/api/v1/files/', '/api/v1/knowledge/kb-1/file/add']);
       },
     );
 
@@ -2391,9 +2355,8 @@ void main() {
         'POST /api/v1/files/',
         'POST /api/v1/knowledge/kb-1/file/add',
       ]);
-      check(
-        adapter.requests.last.data as Map<String, dynamic>,
-      ).deepEquals({'file_id': 'file-1'});
+      check(adapter.requests.last.data as Map<String, dynamic>)
+          .deepEquals({'file_id': 'file-1'});
     });
 
     test('addFileToKnowledgeBase recognizes camelCase upload id', () async {
@@ -2416,9 +2379,8 @@ void main() {
         'POST /api/v1/files/',
         'POST /api/v1/knowledge/kb-1/file/add',
       ]);
-      check(
-        adapter.requests.last.data as Map<String, dynamic>,
-      ).deepEquals({'file_id': 'file-1'});
+      check(adapter.requests.last.data as Map<String, dynamic>)
+          .deepEquals({'file_id': 'file-1'});
     });
 
     test(
@@ -2447,9 +2409,8 @@ void main() {
           'POST /api/v1/files/',
           'POST /api/v1/knowledge/kb-1/file/add',
         ]);
-        check(
-          adapter.requests.last.data as Map<String, dynamic>,
-        ).deepEquals({'file_id': 'file-1'});
+        check(adapter.requests.last.data as Map<String, dynamic>)
+            .deepEquals({'file_id': 'file-1'});
       },
     );
 
@@ -2476,9 +2437,8 @@ void main() {
         'POST /api/v1/files/',
         'POST /api/v1/knowledge/kb-1/file/add',
       ]);
-      check(
-        adapter.requests.last.data as Map<String, dynamic>,
-      ).deepEquals({'file_id': 'file-1'});
+      check(adapter.requests.last.data as Map<String, dynamic>)
+          .deepEquals({'file_id': 'file-1'});
     });
 
     test(
@@ -2588,35 +2548,31 @@ void main() {
       },
     );
 
-    test(
-      'addFileToKnowledgeBase falls back when attach route rejects file id body',
-      () async {
-        final adapter = _QueuedFakeAdapter([
-          _FakeAdapter.json({'id': 'file-1'}),
-          _FakeAdapter.json({'detail': 'Invalid body'}, statusCode: 400),
-          _FakeAdapter.json({'status': true}),
-          _FakeAdapter.json({'id': 'legacy-file'}),
-        ]);
-        final api = _buildApiServiceForTest(adapter);
+    test('addFileToKnowledgeBase falls back when attach route rejects file id body', () async {
+      final adapter = _QueuedFakeAdapter([
+        _FakeAdapter.json({'id': 'file-1'}),
+        _FakeAdapter.json({'detail': 'Invalid body'}, statusCode: 400),
+        _FakeAdapter.json({'status': true}),
+        _FakeAdapter.json({'id': 'legacy-file'}),
+      ]);
+      final api = _buildApiServiceForTest(adapter);
 
-        final file = await api.addFileToKnowledgeBase(
-          'kb-1',
-          filename: 'guide.md',
-          content: utf8.encode('hello'),
-        );
+      final file = await api.addFileToKnowledgeBase(
+        'kb-1',
+        filename: 'guide.md',
+        content: utf8.encode('hello'),
+      );
 
-        check(file?['id']).equals('legacy-file');
-        check(
-          adapter.requests.map((request) => request.path).toList(),
-        ).deepEquals([
-          '/api/v1/files/',
-          '/api/v1/knowledge/kb-1/file/add',
-          '/api/v1/files/file-1',
-          '/api/v1/knowledge/kb-1/file/add',
-        ]);
-        check(adapter.requests[2].method).equals('DELETE');
-      },
-    );
+      check(file?['id']).equals('legacy-file');
+      check(adapter.requests.map((request) => request.path).toList())
+          .deepEquals([
+            '/api/v1/files/',
+            '/api/v1/knowledge/kb-1/file/add',
+            '/api/v1/files/file-1',
+            '/api/v1/knowledge/kb-1/file/add',
+          ]);
+      check(adapter.requests[2].method).equals('DELETE');
+    });
   });
 
   group('getChannels feature flag', () {

--- a/test/core/services/api_service_conversation_parsing_test.dart
+++ b/test/core/services/api_service_conversation_parsing_test.dart
@@ -127,9 +127,8 @@ void main() {
         ),
       );
 
-      await check(
-        ApiSyncApiClient(api).probeChatExists('auth-failed'),
-      ).throws<DioException>();
+      await check(ApiSyncApiClient(api).probeChatExists('auth-failed'))
+          .throws<DioException>();
     });
 
     test('getNoteRaw maps 404 to null', () async {
@@ -157,9 +156,8 @@ void main() {
           ),
         );
 
-        await check(
-          api.getNoteRaw('forbidden-note'),
-        ).throws<SyncTerminalException>();
+        await check(api.getNoteRaw('forbidden-note'))
+            .throws<SyncTerminalException>();
       });
     }
 

--- a/test/core/services/api_service_proxy_diagnostics_test.dart
+++ b/test/core/services/api_service_proxy_diagnostics_test.dart
@@ -55,9 +55,8 @@ void main() {
 
       try {
         check(await api.checkHealth()).isTrue();
-        check(
-          receivedUserAgents,
-        ).deepEquals([ConduitUserAgent.value, ConduitUserAgent.value]);
+        check(receivedUserAgents)
+            .deepEquals([ConduitUserAgent.value, ConduitUserAgent.value]);
       } finally {
         api.dispose();
         workerManager.dispose();
@@ -402,9 +401,8 @@ void main() {
 
       try {
         final health = api.checkHealth();
-        check(
-          await upgradeStarted.future.timeout(const Duration(seconds: 2)),
-        ).equals('health-target.invalid');
+        check(await upgradeStarted.future.timeout(const Duration(seconds: 2)))
+            .equals('health-target.invalid');
         await rawPeer.future.timeout(const Duration(seconds: 2));
         check(await health.timeout(const Duration(seconds: 2))).isFalse();
 
@@ -597,9 +595,8 @@ void main() {
 
     try {
       check(await api.checkHealth()).isFalse();
-      check(
-        resolvedHosts,
-      ).deepEquals(['health-target.invalid', 'ipv4only.arpa']);
+      check(resolvedHosts)
+          .deepEquals(['health-target.invalid', 'ipv4only.arpa']);
       check(socketAttempts).equals(0);
     } finally {
       api.dispose();
@@ -658,13 +655,11 @@ void main() {
     server.listen((request) async {
       check(request.uri.path).equals('/health');
       check(request.headers.value('x-proxy-credential')).equals(_headerSecret);
-      check(
-        request.headers.value(HttpHeaders.authorizationHeader),
-      ).equals('Bearer health-session-token');
+      check(request.headers.value(HttpHeaders.authorizationHeader))
+          .equals('Bearer health-session-token');
       check(request.headers.value(HttpHeaders.cookieHeader)).isNull();
-      check(
-        request.headers.value(HttpHeaders.userAgentHeader),
-      ).equals(ConduitUserAgent.value);
+      check(request.headers.value(HttpHeaders.userAgentHeader))
+          .equals(ConduitUserAgent.value);
       if (!requestSeen.isCompleted) requestSeen.complete();
       request.response
         ..statusCode = HttpStatus.temporaryRedirect
@@ -740,9 +735,8 @@ void main() {
       );
 
       try {
-        check(
-          await api.checkHealthWithProxyDetection(),
-        ).equals(HealthCheckResult.proxyAuthRequired);
+        check(await api.checkHealthWithProxyDetection())
+            .equals(HealthCheckResult.proxyAuthRequired);
       } finally {
         api.dispose();
         workerManager.dispose();
@@ -783,9 +777,8 @@ void main() {
     try {
       final health = api.checkHealthWithProxyDetection();
       await bodyStarted.future.timeout(const Duration(seconds: 2));
-      check(
-        await health.timeout(const Duration(seconds: 1)),
-      ).equals(HealthCheckResult.proxyAuthRequired);
+      check(await health.timeout(const Duration(seconds: 1)))
+          .equals(HealthCheckResult.proxyAuthRequired);
     } finally {
       if (!releaseBody.isCompleted) releaseBody.complete();
       api.dispose();
@@ -878,35 +871,29 @@ void main() {
       try {
         ConnectivityService.debugResetTrafficSignals();
         try {
-          check(
-            await api.fetchImageBytes(externalUri.toString()),
-          ).deepEquals([4, 5, 6]);
+          check(await api.fetchImageBytes(externalUri.toString()))
+              .deepEquals([4, 5, 6]);
         } catch (error) {
           throw StateError('external request failed: $error');
         }
         check(await externalAuthorization.future).isNull();
-        check(
-          ConnectivityService.debugHasRecentSuccessfulTraffic(originUri),
-        ).isFalse();
-        check(
-          ConnectivityService.debugHasRecentSuccessfulTraffic(externalUri),
-        ).isFalse();
+        check(ConnectivityService.debugHasRecentSuccessfulTraffic(originUri))
+            .isFalse();
+        check(ConnectivityService.debugHasRecentSuccessfulTraffic(externalUri))
+            .isFalse();
 
-        check(
-          requestUsesServerConnectivityOrigin(externalUri, originUri),
-        ).isFalse();
+        check(requestUsesServerConnectivityOrigin(externalUri, originUri))
+            .isFalse();
 
         try {
           await api.fetchImageBytes(originUri.resolve('/same.png').toString());
         } catch (error) {
           throw StateError('same-origin request failed: $error');
         }
-        check(
-          await originAuthorization.future,
-        ).equals('Bearer connectivity-test-token');
-        check(
-          ConnectivityService.debugHasRecentSuccessfulTraffic(originUri),
-        ).isTrue();
+        check(await originAuthorization.future)
+            .equals('Bearer connectivity-test-token');
+        check(ConnectivityService.debugHasRecentSuccessfulTraffic(originUri))
+            .isTrue();
       } finally {
         api.dispose();
         workerManager.dispose();

--- a/test/core/services/api_service_user_files_test.dart
+++ b/test/core/services/api_service_user_files_test.dart
@@ -41,9 +41,8 @@ void main() {
 
         final files = await api.getUserFiles();
 
-        check(
-          files.map((file) => file.id).toList(),
-        ).deepEquals(['file-1', 'file-2']);
+        check(files.map((file) => file.id).toList())
+            .deepEquals(['file-1', 'file-2']);
         check(adapter.requestedPages).deepEquals([1, 2]);
       },
     );
@@ -61,9 +60,9 @@ void main() {
       final files = await api.getUserFiles();
 
       check(files).has((it) => it.length, 'length').equals(200);
-      check(
-        adapter.requestedPages,
-      ).has((it) => it.length, 'length').equals(200);
+      check(adapter.requestedPages)
+          .has((it) => it.length, 'length')
+          .equals(200);
       check(adapter.requestedPages.first).equals(1);
       check(adapter.requestedPages.last).equals(200);
       check(adapter.requestedPages.contains(201)).isFalse();
@@ -90,9 +89,8 @@ void main() {
       );
       check(noMatches).isNotNull();
       check(noMatches!).isEmpty();
-      check(
-        await unavailableApi.searchFilesForSession(query: 'recording.m4a'),
-      ).isNull();
+      check(await unavailableApi.searchFilesForSession(query: 'recording.m4a'))
+          .isNull();
     });
 
     test('uses a targeted query and forwards cancellation', () async {

--- a/test/core/services/api_service_user_settings_test.dart
+++ b/test/core/services/api_service_user_settings_test.dart
@@ -116,9 +116,9 @@ void main() {
       final result = await api.updateUserReasoningEffort(null);
 
       check(result.reasoningEffort).isNull();
-      check(adapter.settings['params']).isA<Map<String, dynamic>>().deepEquals(
-        <String, dynamic>{'temperature': 0.3},
-      );
+      check(adapter.settings['params'])
+          .isA<Map<String, dynamic>>()
+          .deepEquals(<String, dynamic>{'temperature': 0.3});
     });
   });
 }

--- a/test/core/services/api_service_workspace_test.dart
+++ b/test/core/services/api_service_workspace_test.dart
@@ -236,17 +236,15 @@ void main() {
       check(files.items.single.id).equals('file-1');
       check(requests[0].method).equals('GET');
       check(requests[0].path).equals('/api/v1/knowledge/kb-1/files');
-      check(
-        requests[0].queryParameters,
-      ).deepEquals({'page': 3, 'include_content': true, 'directory_id': ''});
+      check(requests[0].queryParameters)
+          .deepEquals({'page': 3, 'include_content': true, 'directory_id': ''});
       check(requests[1].method).equals('GET');
       check(requests[1].path).equals('/api/v1/knowledge/kb-1/files/pending');
       check(requests[1].queryParameters).deepEquals({'stream': false});
       check(requests[2].method).equals('POST');
       check(requests[2].path).equals('/api/v1/knowledge/kb-1/dirs/create');
-      check(
-        requests[2].data as Map<String, dynamic>,
-      ).deepEquals({'name': 'Docs', 'parent_id': 'root'});
+      check(requests[2].data as Map<String, dynamic>)
+          .deepEquals({'name': 'Docs', 'parent_id': 'root'});
       check(requests[3].method).equals('POST');
       check(requests[3].path).equals('/api/v1/knowledge/kb-1/sync/diff');
       check(requests[3].data as Map<String, dynamic>).deepEquals({
@@ -262,9 +260,8 @@ void main() {
     final adapter = _RecordingAdapter((request) {
       check(request.method).equals('POST');
       check(request.path).equals('/api/v1/skills/id/skill-1/access/update');
-      check(
-        request.data as Map<String, dynamic>,
-      ).deepEquals({'access_grants': <Object?>[]});
+      check(request.data as Map<String, dynamic>)
+          .deepEquals({'access_grants': <Object?>[]});
       return _json({'detail': 'Access prohibited'}, statusCode: 403);
     });
 

--- a/test/core/services/app_intents_service_lifecycle_test.dart
+++ b/test/core/services/app_intents_service_lifecycle_test.dart
@@ -268,9 +268,8 @@ void main() {
       final original = lifecycle.register(_FakeAppIntentHandler());
       await lifecycle.settled;
 
-      check(
-        () => lifecycle.register(_FakeAppIntentHandler()),
-      ).throws<StateError>();
+      check(() => lifecycle.register(_FakeAppIntentHandler()))
+          .throws<StateError>();
       await lifecycle.unregister(original);
 
       check(events).deepEquals([
@@ -559,9 +558,8 @@ void main() {
 
       check(retryExecutions).equals(0);
       check(retry.success).isFalse();
-      check(
-        retry.error,
-      ).equals('The earlier request may not have completed. Please retry.');
+      check(retry.error)
+          .equals('The earlier request may not have completed. Please retry.');
       check(retry.ownedFilePath).isNull();
       releaseOriginal.complete();
       await original;
@@ -607,9 +605,8 @@ void main() {
       return PlatformAppIntentResponse(success: true);
     });
     check(activeRetry.success).isFalse();
-    check(
-      activeRetry.error,
-    ).equals('The earlier request may not have completed. Please retry.');
+    check(activeRetry.error)
+        .equals('The earlier request may not have completed. Please retry.');
     check(activeRetryExecutions).equals(0);
 
     releaseActive.complete();
@@ -657,9 +654,8 @@ void main() {
       return PlatformAppIntentResponse(success: true);
     });
     check(retained.success).isFalse();
-    check(
-      retained.error,
-    ).equals('The earlier request may not have completed. Please retry.');
+    check(retained.error)
+        .equals('The earlier request may not have completed. Please retry.');
     check(retryExecutions).equals(0);
 
     release.complete();

--- a/test/core/services/attachment_upload_queue_test.dart
+++ b/test/core/services/attachment_upload_queue_test.dart
@@ -178,9 +178,8 @@ void main() {
       await firstStarted.future.timeout(const Duration(seconds: 1));
       await queue.retry(id);
       releaseFirst.complete();
-      final terminal = (await completed.timeout(
-        const Duration(seconds: 1),
-      )).single;
+      final terminal = (await completed.timeout(const Duration(seconds: 1)))
+          .single;
 
       check(uploadCalls).equals(1);
       check(terminal.fileId).equals('server-1');
@@ -220,9 +219,8 @@ void main() {
         );
         await cancelSettled.future.timeout(const Duration(seconds: 1));
 
-        check(
-          queue.queue.single.status,
-        ).equals(QueuedAttachmentStatus.completed);
+        check(queue.queue.single.status)
+            .equals(QueuedAttachmentStatus.completed);
         check(queue.queue.single.fileId).equals('server-file-id');
         final row =
             (await resolveLiveDatabase().attachmentQueueDao.getAll()).single;
@@ -323,9 +321,8 @@ void main() {
           async.flushMicrotasks();
 
           check(callCount).equals(1);
-          check(
-            queue.queue.single.status,
-          ).equals(QueuedAttachmentStatus.pending);
+          check(queue.queue.single.status)
+              .equals(QueuedAttachmentStatus.pending);
           check(queue.queue.single.retryCount).equals(0);
           check(queue.queue.single.nextRetryAt).isNotNull();
 
@@ -333,9 +330,8 @@ void main() {
           async.elapse(const Duration(seconds: 7));
           async.flushMicrotasks();
           check(callCount).equals(2);
-          check(
-            queue.queue.single.status,
-          ).equals(QueuedAttachmentStatus.pending);
+          check(queue.queue.single.status)
+              .equals(QueuedAttachmentStatus.pending);
           check(queue.queue.single.retryCount).equals(0);
           queue.dispose();
         });
@@ -507,9 +503,8 @@ void main() {
           fileName: 'terminal-gap',
           fileSize: 1,
         );
-        final completed = (await terminal.timeout(
-          const Duration(seconds: 1),
-        )).single;
+        final completed = (await terminal.timeout(const Duration(seconds: 1)))
+            .single;
 
         check(completed.fileId).equals('remote-id');
         check(uploadCalls).equals(1);
@@ -533,12 +528,11 @@ void main() {
 
         check(restoredUploadCalls).equals(0);
         check(restored.queue).length.equals(1);
-        check(
-          restored.queue.single.status,
-        ).equals(QueuedAttachmentStatus.failed);
-        check(
-          restored.queue.single.lastError,
-        ).isNotNull().contains('outcome is unknown');
+        check(restored.queue.single.status)
+            .equals(QueuedAttachmentStatus.failed);
+        check(restored.queue.single.lastError)
+            .isNotNull()
+            .contains('outcome is unknown');
       },
     );
 
@@ -806,16 +800,14 @@ void main() {
           fileName: 'failed-gap',
           fileSize: 1,
         );
-        final failed = (await terminal.timeout(
-          const Duration(seconds: 1),
-        )).single;
+        final failed = (await terminal.timeout(const Duration(seconds: 1)))
+            .single;
         await Future<void>.delayed(Duration.zero);
 
         check(uploadCalls).equals(1);
         check(failed.status).equals(QueuedAttachmentStatus.failed);
-        check(
-          (await database.attachmentQueueDao.getAll()).single.status,
-        ).equals(QueuedAttachmentStatus.uploading.name);
+        check((await database.attachmentQueueDao.getAll()).single.status)
+            .equals(QueuedAttachmentStatus.uploading.name);
       },
     );
 
@@ -886,9 +878,8 @@ void main() {
         check(cleanupCalls).equals(1);
         check(queue.queue).length.equals(1);
         check(queue.queue.single.id).equals('cleanup-failed');
-        check(
-          queue.queue.single.status,
-        ).equals(QueuedAttachmentStatus.completed);
+        check(queue.queue.single.status)
+            .equals(QueuedAttachmentStatus.completed);
         check(await database.attachmentQueueDao.getAll()).length.equals(1);
       },
     );
@@ -1258,9 +1249,8 @@ void main() {
 
         await check(queue.clearAll()).throws<Exception>();
         check(queue.queue.map((item) => item.id)).deepEquals([id]);
-        check(
-          (await database.attachmentQueueDao.getAll()).map((row) => row.id),
-        ).deepEquals([id]);
+        check((await database.attachmentQueueDao.getAll()).map((row) => row.id))
+            .deepEquals([id]);
 
         queue.releaseOwnerHold(id);
         await queue.processQueue();
@@ -1326,9 +1316,8 @@ void main() {
       await processing;
 
       check(uploaded).deepEquals(['first']);
-      check(
-        (await database.attachmentQueueDao.getAll()).map((row) => row.id),
-      ).deepEquals(['first']);
+      check((await database.attachmentQueueDao.getAll()).map((row) => row.id))
+          .deepEquals(['first']);
     });
 
     test(
@@ -1475,9 +1464,8 @@ void main() {
         await Future.wait([first, second]);
 
         final rows = await database.attachmentQueueDao.getAll();
-        check(
-          rows.map((row) => row.fileName).toSet(),
-        ).deepEquals({'first-owned', 'second-owned'});
+        check(rows.map((row) => row.fileName).toSet())
+            .deepEquals({'first-owned', 'second-owned'});
       },
     );
 
@@ -1671,40 +1659,37 @@ void main() {
       check(threw).isTrue();
     });
 
-    test(
-      'ready rejects on load failure and preserves the existing snapshot',
-      () async {
-        final queue = AttachmentUploadQueue();
-        queue.initialize(
-          onUpload: (filePath, fileName, {cancelToken}) async => 'id',
-          database: resolveLiveDatabase,
-        );
-        await queue.ready;
-        await queue.enqueue(
-          filePath: '/tmp/kept.txt',
-          fileName: 'kept.txt',
-          fileSize: 1,
-        );
-        final before = queue.queue.map((e) => e.id).toList();
+    test('ready rejects on load failure and preserves the existing snapshot', () async {
+      final queue = AttachmentUploadQueue();
+      queue.initialize(
+        onUpload: (filePath, fileName, {cancelToken}) async => 'id',
+        database: resolveLiveDatabase,
+      );
+      await queue.ready;
+      await queue.enqueue(
+        filePath: '/tmp/kept.txt',
+        fileName: 'kept.txt',
+        fileSize: 1,
+      );
+      final before = queue.queue.map((e) => e.id).toList();
 
-        // Re-initialize with a resolver that fails before the DAO read. The
-        // failure must remain visible through `ready`, and staging the load means
-        // the previous in-memory snapshot is not cleared on the failed attempt.
-        queue.initialize(
-          onUpload: (filePath, fileName, {cancelToken}) async => 'id',
-          database: () => throw StateError('load failed'),
-        );
-        var threw = false;
-        try {
-          await queue.ready;
-        } on StateError {
-          threw = true;
-        }
-        check(threw).isTrue();
-        check(queue.queue.map((e) => e.id).toList()).deepEquals(before);
-        queue.dispose();
-      },
-    );
+      // Re-initialize with a resolver that fails before the DAO read. The
+      // failure must remain visible through `ready`, and staging the load means
+      // the previous in-memory snapshot is not cleared on the failed attempt.
+      queue.initialize(
+        onUpload: (filePath, fileName, {cancelToken}) async => 'id',
+        database: () => throw StateError('load failed'),
+      );
+      var threw = false;
+      try {
+        await queue.ready;
+      } on StateError {
+        threw = true;
+      }
+      check(threw).isTrue();
+      check(queue.queue.map((e) => e.id).toList()).deepEquals(before);
+      queue.dispose();
+    });
   });
 }
 

--- a/test/core/services/background_streaming_handler_test.dart
+++ b/test/core/services/background_streaming_handler_test.dart
@@ -66,9 +66,9 @@ void main() {
         ),
       );
 
-      check(
-        failedStreamIds,
-      ).isNotNull().deepEquals(const <String>['chat-stream-assistant-1']);
+      check(failedStreamIds)
+          .isNotNull()
+          .deepEquals(const <String>['chat-stream-assistant-1']);
     },
   );
 }

--- a/test/core/services/chat_completion_transport_test.dart
+++ b/test/core/services/chat_completion_transport_test.dart
@@ -37,19 +37,22 @@ void main() {
       check(session.sessionId).isNull();
     });
 
-    test('resumeSocket carries the discovered task id for stoppable metadata', () {
-      final session = ChatCompletionSession.resumeSocket(
-        messageId: 'assistant-1',
-        conversationId: 'chat-1',
-        taskId: 'task-42',
-      );
+    test(
+      'resumeSocket carries the discovered task id for stoppable metadata',
+      () {
+        final session = ChatCompletionSession.resumeSocket(
+          messageId: 'assistant-1',
+          conversationId: 'chat-1',
+          taskId: 'task-42',
+        );
 
-      // The task id must survive so dispatchChatTransport writes stoppable
-      // metadata onto the resumed message (stop/delete can cancel the server
-      // task, not just the local socket subscription).
-      check(session.taskId).equals('task-42');
-      check(session.sessionId).isNull();
-    });
+        // The task id must survive so dispatchChatTransport writes stoppable
+        // metadata onto the resumed message (stop/delete can cancel the server
+        // task, not just the local socket subscription).
+        check(session.taskId).equals('task-42');
+        check(session.sessionId).isNull();
+      },
+    );
 
     test('httpStream session stores byte stream and abort handle', () {
       final session = ChatCompletionSession.httpStream(

--- a/test/core/services/connectivity_service_lifecycle_test.dart
+++ b/test/core/services/connectivity_service_lifecycle_test.dart
@@ -233,9 +233,8 @@ void main() {
       await dio.getUri<void>(Uri.parse('https://server.example/health'));
 
       check(dio.options.baseUrl).equals('https://server.example');
-      check(
-        adapter.headers.single['X-Proxy-Credential'],
-      ).equals('same-origin-secret');
+      check(adapter.headers.single['X-Proxy-Credential'])
+          .equals('same-origin-secret');
     },
   );
 
@@ -271,9 +270,8 @@ void main() {
       check(
         adapter.headers.last.keys.any((name) => name.toLowerCase() == 'cookie'),
       ).isFalse();
-      check(
-        adapter.headers.last['X-Proxy-Credential'],
-      ).equals('still-required');
+      check(adapter.headers.last['X-Proxy-Credential'])
+          .equals('still-required');
     },
   );
 
@@ -297,9 +295,8 @@ void main() {
       await dio.getUri<void>(Uri.parse('https://foreign.example/health'));
 
       final headers = adapter.headers.single;
-      check(
-        headers.keys.any((name) => name.toLowerCase() == 'cookie'),
-      ).isFalse();
+      check(headers.keys.any((name) => name.toLowerCase() == 'cookie'))
+          .isFalse();
       check(
         headers.keys.any((name) => name.toLowerCase() == 'x-proxy-credential'),
       ).isFalse();

--- a/test/core/services/conversation_parsing_test.dart
+++ b/test/core/services/conversation_parsing_test.dart
@@ -89,12 +89,10 @@ void main() {
         final after = DateTime.now();
 
         final created = DateTime.parse(result['createdAt'] as String);
-        check(
-          created.millisecondsSinceEpoch,
-        ).isGreaterOrEqual(before.millisecondsSinceEpoch);
-        check(
-          created.millisecondsSinceEpoch,
-        ).isLessOrEqual(after.millisecondsSinceEpoch);
+        check(created.millisecondsSinceEpoch)
+            .isGreaterOrEqual(before.millisecondsSinceEpoch);
+        check(created.millisecondsSinceEpoch)
+            .isLessOrEqual(after.millisecondsSinceEpoch);
       });
     });
 
@@ -329,9 +327,9 @@ void main() {
         });
 
         final messages = result['messages'] as List<Map<String, dynamic>>;
-        check(
-          messages.single['files'],
-        ).isA<List<dynamic>>().deepEquals(descriptors);
+        check(messages.single['files'])
+            .isA<List<dynamic>>()
+            .deepEquals(descriptors);
         check(messages.single['attachmentIds']).isNull();
       });
 
@@ -369,9 +367,9 @@ void main() {
         });
 
         final messages = result['messages'] as List<Map<String, dynamic>>;
-        check(
-          messages.single['files'],
-        ).isA<List<dynamic>>().deepEquals([descriptor]);
+        check(messages.single['files'])
+            .isA<List<dynamic>>()
+            .deepEquals([descriptor]);
       });
 
       test(
@@ -413,12 +411,12 @@ void main() {
           });
 
           final messages = result['messages'] as List<Map<String, dynamic>>;
-          check(
-            messages.single['files'],
-          ).isA<List<dynamic>>().deepEquals([safeImageDescriptor]);
-          check(
-            messages.single['attachmentIds'],
-          ).isA<List<dynamic>>().deepEquals(['legacy-file-1', 'image-file-1']);
+          check(messages.single['files'])
+              .isA<List<dynamic>>()
+              .deepEquals([safeImageDescriptor]);
+          check(messages.single['attachmentIds'])
+              .isA<List<dynamic>>()
+              .deepEquals(['legacy-file-1', 'image-file-1']);
         },
       );
 
@@ -445,12 +443,12 @@ void main() {
         });
 
         final messages = result['messages'] as List<Map<String, dynamic>>;
-        check(
-          messages.single['files'],
-        ).isA<List<dynamic>>().deepEquals(descriptors);
-        check(
-          messages.single['attachmentIds'],
-        ).isA<List<dynamic>>().deepEquals(['bare-file-id']);
+        check(messages.single['files'])
+            .isA<List<dynamic>>()
+            .deepEquals(descriptors);
+        check(messages.single['attachmentIds'])
+            .isA<List<dynamic>>()
+            .deepEquals(['bare-file-id']);
       });
 
       test('keeps safe protocol fields on sibling message versions', () {
@@ -501,9 +499,9 @@ void main() {
         final versions =
             messages.last['versions'] as List<Map<String, dynamic>>;
         check(versions.single['id']).equals('assistant-2');
-        check(
-          versions.single['files'],
-        ).isA<List<dynamic>>().deepEquals([safeDescriptor]);
+        check(versions.single['files'])
+            .isA<List<dynamic>>()
+            .deepEquals([safeDescriptor]);
       });
     });
 
@@ -544,9 +542,9 @@ void main() {
           'childrenIds': ['msg-2'],
           'models': ['llama-3'],
         });
-        check(
-          messages[1]['metadata'],
-        ).isA<Map<String, dynamic>>().deepEquals({'parentId': 'msg-1'});
+        check(messages[1]['metadata'])
+            .isA<Map<String, dynamic>>()
+            .deepEquals({'parentId': 'msg-1'});
       });
     });
 
@@ -617,9 +615,10 @@ void main() {
 
         final messages = result['messages'] as List<Map<String, dynamic>>;
         check(messages.first['content']).equals('Structured answer');
-        check(
-          messages.first['output'],
-        ).isA<List>().has((it) => it.length, 'length').equals(1);
+        check(messages.first['output'])
+            .isA<List>()
+            .has((it) => it.length, 'length')
+            .equals(1);
       });
 
       test('preserves structured details with persisted content', () {
@@ -743,9 +742,8 @@ void main() {
 
         final message =
             (result['messages'] as List<Map<String, dynamic>>).single;
-        check(
-          message['content'],
-        ).equals('$reasoning\n&lt;new &amp; answer&gt;');
+        check(message['content'])
+            .equals('$reasoning\n&lt;new &amp; answer&gt;');
         check(
           (message['metadata']
               as Map<
@@ -968,9 +966,8 @@ void main() {
           });
           final message =
               (result['messages'] as List<Map<String, dynamic>>).single;
-          check(
-            message['content'],
-          ).equals(((item['content'] as List).single as Map)['text']);
+          check(message['content'])
+              .equals(((item['content'] as List).single as Map)['text']);
           check(
             (message['metadata'] as Map<String, dynamic>).containsKey(
               kConduitDirectRawAssistantContentMetadataKey,
@@ -1153,9 +1150,10 @@ void main() {
         final messages = result['messages'] as List<Map<String, dynamic>>;
         check(messages).length.equals(2);
         check(messages[1]['content']).equals('Reloaded answer');
-        check(
-          messages[1]['output'],
-        ).isA<List>().has((it) => it.length, 'length').equals(1);
+        check(messages[1]['output'])
+            .isA<List>()
+            .has((it) => it.length, 'length')
+            .equals(1);
       });
 
       test('uses history output when message output list is empty', () {
@@ -1201,9 +1199,10 @@ void main() {
         final messages = result['messages'] as List<Map<String, dynamic>>;
         check(messages).length.equals(1);
         check(messages.first['content']).equals('History answer');
-        check(
-          messages.first['output'],
-        ).isA<List>().has((it) => it.length, 'length').equals(1);
+        check(messages.first['output'])
+            .isA<List>()
+            .has((it) => it.length, 'length')
+            .equals(1);
       });
 
       test('renders structured output for assistant sibling versions', () {
@@ -1257,9 +1256,10 @@ void main() {
         final content = version['content'] as String;
         check(content).contains('<details type="reasoning"');
         check(content).contains('Alt answer');
-        check(
-          version['output'],
-        ).isA<List>().has((it) => it.length, 'length').equals(2);
+        check(version['output'])
+            .isA<List>()
+            .has((it) => it.length, 'length')
+            .equals(2);
       });
 
       test('normalizes assistant embeds from message payloads', () {

--- a/test/core/services/input_validation_service_test.dart
+++ b/test/core/services/input_validation_service_test.dart
@@ -7,15 +7,13 @@ void main() {
   group('InputValidationService', () {
     group('validateEmail', () {
       test('returns null for valid email', () {
-        check(
-          InputValidationService.validateEmail('user@example.com'),
-        ).isNull();
+        check(InputValidationService.validateEmail('user@example.com'))
+            .isNull();
       });
 
       test('returns null for valid email with subdomain', () {
-        check(
-          InputValidationService.validateEmail('user@mail.example.com'),
-        ).isNull();
+        check(InputValidationService.validateEmail('user@mail.example.com'))
+            .isNull();
       });
 
       test('returns null for email with localhost domain', () {
@@ -31,9 +29,8 @@ void main() {
       });
 
       test('returns error for invalid email without @', () {
-        check(
-          InputValidationService.validateEmail('userexample.com'),
-        ).isA<String>();
+        check(InputValidationService.validateEmail('userexample.com'))
+            .isA<String>();
       });
 
       test('returns error for empty string', () {
@@ -47,15 +44,13 @@ void main() {
 
     group('validateUrl', () {
       test('returns null for valid URL with https', () {
-        check(
-          InputValidationService.validateUrl('https://example.com'),
-        ).isNull();
+        check(InputValidationService.validateUrl('https://example.com'))
+            .isNull();
       });
 
       test('returns null for valid URL with http', () {
-        check(
-          InputValidationService.validateUrl('http://example.com'),
-        ).isNull();
+        check(InputValidationService.validateUrl('http://example.com'))
+            .isNull();
       });
 
       test('returns null for URL without scheme (auto-prepends http)', () {
@@ -63,21 +58,18 @@ void main() {
       });
 
       test('returns null for IP with port', () {
-        check(
-          InputValidationService.validateUrl('http://192.168.1.10:3000'),
-        ).isNull();
+        check(InputValidationService.validateUrl('http://192.168.1.10:3000'))
+            .isNull();
       });
 
       test('returns error for invalid IP address', () {
-        check(
-          InputValidationService.validateUrl('http://999.999.999.999'),
-        ).isA<String>();
+        check(InputValidationService.validateUrl('http://999.999.999.999'))
+            .isA<String>();
       });
 
       test('returns error for empty when required', () {
-        check(
-          InputValidationService.validateUrl('', required: true),
-        ).isA<String>();
+        check(InputValidationService.validateUrl('', required: true))
+            .isA<String>();
       });
 
       test('returns null for empty when not required', () {
@@ -96,9 +88,8 @@ void main() {
 
       test('returns error for weak password when checkStrength=true', () {
         // 8 chars but no special char
-        check(
-          InputValidationService.validatePassword('Abcdefg1'),
-        ).isA<String>();
+        check(InputValidationService.validatePassword('Abcdefg1'))
+            .isA<String>();
       });
 
       test('returns null for strong password', () {
@@ -134,9 +125,9 @@ void main() {
       });
 
       test('includes field name in error message', () {
-        check(
-          InputValidationService.validateRequired('', fieldName: 'Name'),
-        ).isA<String>().contains('Name');
+        check(InputValidationService.validateRequired('', fieldName: 'Name'))
+            .isA<String>()
+            .contains('Name');
       });
     });
 
@@ -164,9 +155,8 @@ void main() {
       });
 
       test('returns error when exceeding max length', () {
-        check(
-          InputValidationService.validateMaxLength('abcdef', 5),
-        ).isA<String>();
+        check(InputValidationService.validateMaxLength('abcdef', 5))
+            .isA<String>();
       });
 
       test('returns null for null value', () {
@@ -180,9 +170,8 @@ void main() {
 
     group('validateNumber', () {
       test('returns null for valid number in range', () {
-        check(
-          InputValidationService.validateNumber('5', min: 1, max: 10),
-        ).isNull();
+        check(InputValidationService.validateNumber('5', min: 1, max: 10))
+            .isNull();
       });
 
       test('returns error for number below min', () {
@@ -190,9 +179,8 @@ void main() {
       });
 
       test('returns error for number above max', () {
-        check(
-          InputValidationService.validateNumber('11', max: 10),
-        ).isA<String>();
+        check(InputValidationService.validateNumber('11', max: 10))
+            .isA<String>();
       });
 
       test('returns error for non-numeric string', () {
@@ -200,15 +188,13 @@ void main() {
       });
 
       test('returns error for empty when required', () {
-        check(
-          InputValidationService.validateNumber('', required: true),
-        ).isA<String>();
+        check(InputValidationService.validateNumber('', required: true))
+            .isA<String>();
       });
 
       test('returns null for empty when not required', () {
-        check(
-          InputValidationService.validateNumber('', required: false),
-        ).isNull();
+        check(InputValidationService.validateNumber('', required: false))
+            .isNull();
       });
 
       test('returns null for decimal when allowDecimal is true', () {
@@ -244,15 +230,13 @@ void main() {
       });
 
       test('returns error for username with invalid characters', () {
-        check(
-          InputValidationService.validateUsername('user@name'),
-        ).isA<String>();
+        check(InputValidationService.validateUsername('user@name'))
+            .isA<String>();
       });
 
       test('returns error for username with spaces', () {
-        check(
-          InputValidationService.validateUsername('user name'),
-        ).isA<String>();
+        check(InputValidationService.validateUsername('user name'))
+            .isA<String>();
       });
 
       test('returns error for empty username', () {
@@ -299,9 +283,8 @@ void main() {
       });
 
       test('returns plain text unchanged', () {
-        check(
-          InputValidationService.sanitizeInput('hello world'),
-        ).equals('hello world');
+        check(InputValidationService.sanitizeInput('hello world'))
+            .equals('hello world');
       });
     });
   });

--- a/test/core/services/local_document_extraction_service_test.dart
+++ b/test/core/services/local_document_extraction_service_test.dart
@@ -11,9 +11,8 @@ void main() {
       check(kLocalDocumentPickerExtensions).contains('docx');
       check(isLocalDocumentFileNameSupported('README')).isTrue();
       check(isLocalDocumentFileNameSupported('archive.pdf')).isFalse();
-      check(
-        sanitizeLocalDocumentFilename('../private/bad\nnotes.txt'),
-      ).equals('bad_notes.txt');
+      check(sanitizeLocalDocumentFilename('../private/bad\nnotes.txt'))
+          .equals('bad_notes.txt');
     });
 
     test('extracts text with neutral stable identifiers', () async {
@@ -36,14 +35,13 @@ void main() {
 
     test('supports consumer-specific stable identifier namespaces', () async {
       final document =
-          await LocalDocumentExtractionService(
-            documentIdPrefix: 'consumer_',
-          ).prepare(
-            LocalDocumentSource.fromBytes(
-              name: 'notes.txt',
-              bytes: utf8.encode('Local content'),
-            ),
-          );
+          await LocalDocumentExtractionService(documentIdPrefix: 'consumer_')
+              .prepare(
+                LocalDocumentSource.fromBytes(
+                  name: 'notes.txt',
+                  bytes: utf8.encode('Local content'),
+                ),
+              );
 
       check(document.id).startsWith('consumer_');
     });

--- a/test/core/services/media_upload_controller_test.dart
+++ b/test/core/services/media_upload_controller_test.dart
@@ -448,9 +448,9 @@ void main() {
       );
       addTearDown(container.dispose);
       final controller = container.read(mediaUploadControllerProvider);
-      final notifier =
-          container.read(attachedFilesProvider.notifier)
-              as _SeededAttachedFilesNotifier;
+      final notifier = container.read(
+        attachedFilesProvider.notifier,
+      ) as _SeededAttachedFilesNotifier;
 
       const successfulPaths = 24;
       for (var index = 0; index < successfulPaths; index++) {
@@ -1454,9 +1454,9 @@ void main() {
       await upload;
 
       final successor = container.read(attachedFilesProvider).single;
-      final notifier =
-          container.read(attachedFilesProvider.notifier)
-              as _SeededAttachedFilesNotifier;
+      final notifier = container.read(
+        attachedFilesProvider.notifier,
+      ) as _SeededAttachedFilesNotifier;
       notifier.replaceAttachments([successor, original]);
       await controller.retireAttachmentOwnership(ownership);
 
@@ -1522,9 +1522,9 @@ void main() {
       );
       await firstEncodingStarted.future.timeout(const Duration(seconds: 1));
 
-      final notifier =
-          container.read(attachedFilesProvider.notifier)
-              as _SeededAttachedFilesNotifier;
+      final notifier = container.read(
+        attachedFilesProvider.notifier,
+      ) as _SeededAttachedFilesNotifier;
       notifier.replaceAttachments(const []);
       await controller.cancelUploadsForFile(image.path);
       await image.writeAsBytes([2]);
@@ -1622,9 +1622,9 @@ void main() {
       );
       await firstEncodingStarted.future.timeout(const Duration(seconds: 1));
 
-      final notifier =
-          container.read(attachedFilesProvider.notifier)
-              as _SeededAttachedFilesNotifier;
+      final notifier = container.read(
+        attachedFilesProvider.notifier,
+      ) as _SeededAttachedFilesNotifier;
       final cancellation = controller.removeAttachment(image.path);
       expect(container.read(attachedFilesProvider), isEmpty);
       await cleanupEntered.future.timeout(const Duration(seconds: 1));
@@ -2009,144 +2009,138 @@ void main() {
     expect(await lookalikeDirectory.exists(), isTrue);
   });
 
-  test(
-    'replacement and terminal cleanup failures recover the durable source on restore',
-    () async {
-      final database = AppDatabase(NativeDatabase.memory());
-      addTearDown(database.close);
-      final stagingDirectory = Directory(
-        '${Directory.systemTemp.path}/conduit-app-intents',
-      );
-      await stagingDirectory.create();
-      final original = File(
-        '${stagingDirectory.path}/'
-        '123e4567-e89b-12d3-a456-426614174102-intent.bmp',
-      );
-      final conversionDirectory = await Directory.systemTemp.createTemp(
-        'conduit_img_',
-      );
-      final converted = File('${conversionDirectory.path}/converted.jpg');
-      await original.writeAsBytes([1, 2, 3]);
-      await converted.writeAsBytes([9, 8, 7]);
-      addTearDown(() async {
-        if (await original.exists()) await original.delete();
-        if (await conversionDirectory.exists()) {
-          await conversionDirectory.delete(recursive: true);
-        }
-      });
-
-      final uploadStarted = Completer<void>();
-      final releaseUpload = Completer<void>();
-      addTearDown(() {
-        if (!releaseUpload.isCompleted) releaseUpload.complete();
-      });
-      String? uploadedPath;
-      final queue = AttachmentUploadQueue();
-      await queue.initialize(
-        onUpload: (filePath, fileName, {cancelToken}) async {
-          uploadedPath = filePath;
-          if (!uploadStarted.isCompleted) uploadStarted.complete();
-          await releaseUpload.future;
-          return 'server-file';
-        },
-        database: () => database,
-      );
-      addTearDown(queue.dispose);
-
-      Future<OwnedStagingConversionReplacementResult> failReplacement({
-        required String originalPath,
-        required String convertedPath,
-        bool Function()? canReplace,
-      }) {
-        return replaceOwnedStagingFileWithConvertedUpload(
-          originalPath: originalPath,
-          convertedPath: convertedPath,
-          canReplace: canReplace,
-          copyFile: (_, _) async {
-            throw const FileSystemException('injected replacement failure');
-          },
-        );
+  test('replacement and terminal cleanup failures recover the durable source on restore', () async {
+    final database = AppDatabase(NativeDatabase.memory());
+    addTearDown(database.close);
+    final stagingDirectory = Directory(
+      '${Directory.systemTemp.path}/conduit-app-intents',
+    );
+    await stagingDirectory.create();
+    final original = File(
+      '${stagingDirectory.path}/'
+      '123e4567-e89b-12d3-a456-426614174102-intent.bmp',
+    );
+    final conversionDirectory = await Directory.systemTemp.createTemp(
+      'conduit_img_',
+    );
+    final converted = File('${conversionDirectory.path}/converted.jpg');
+    await original.writeAsBytes([1, 2, 3]);
+    await converted.writeAsBytes([9, 8, 7]);
+    addTearDown(() async {
+      if (await original.exists()) await original.delete();
+      if (await conversionDirectory.exists()) {
+        await conversionDirectory.delete(recursive: true);
       }
+    });
 
-      final cleanupAttempted = Completer<void>();
-      final container = ProviderContainer(
-        overrides: [
-          apiServiceProvider.overrideWithValue(null),
-          selectedModelProvider.overrideWith(() => _SeededSelectedModel(null)),
-          attachmentUploadQueueProvider.overrideWithValue(queue),
-          imageUploadConverterProvider.overrideWithValue((_) async {
-            return converted.path;
-          }),
-          ownedStagingConversionReplacerProvider.overrideWithValue(
-            failReplacement,
-          ),
-          terminalAttachmentCleanupProvider.overrideWithValue((
-            filePath, {
-            required beforeDeleteAdmission,
-            required canDelete,
-          }) async {
-            await beforeDeleteAdmission();
-            if (!canDelete()) return true;
-            if (!cleanupAttempted.isCompleted) cleanupAttempted.complete();
-            return false;
-          }),
-          attachedFilesProvider.overrideWith(
-            () => _SeededAttachedFilesNotifier([
-              _pendingImage(original, reportedBytes: 3),
-            ]),
-          ),
-        ],
+    final uploadStarted = Completer<void>();
+    final releaseUpload = Completer<void>();
+    addTearDown(() {
+      if (!releaseUpload.isCompleted) releaseUpload.complete();
+    });
+    String? uploadedPath;
+    final queue = AttachmentUploadQueue();
+    await queue.initialize(
+      onUpload: (filePath, fileName, {cancelToken}) async {
+        uploadedPath = filePath;
+        if (!uploadStarted.isCompleted) uploadStarted.complete();
+        await releaseUpload.future;
+        return 'server-file';
+      },
+      database: () => database,
+    );
+    addTearDown(queue.dispose);
+
+    Future<OwnedStagingConversionReplacementResult> failReplacement({
+      required String originalPath,
+      required String convertedPath,
+      bool Function()? canReplace,
+    }) {
+      return replaceOwnedStagingFileWithConvertedUpload(
+        originalPath: originalPath,
+        convertedPath: convertedPath,
+        canReplace: canReplace,
+        copyFile: (_, _) async {
+          throw const FileSystemException('injected replacement failure');
+        },
       );
-      addTearDown(container.dispose);
+    }
 
-      final upload = container
-          .read(mediaUploadControllerProvider)
-          .upload(
-            filePath: original.path,
-            fileName: 'intent.bmp',
-            fileSize: 3,
-            mimeType: 'image/bmp',
-          );
-      await uploadStarted.future.timeout(const Duration(seconds: 1));
-      await Future<void>.delayed(Duration.zero);
-      releaseUpload.complete();
-      await upload.timeout(const Duration(seconds: 1));
-      await cleanupAttempted.future.timeout(const Duration(seconds: 1));
-      await Future<void>.delayed(Duration.zero);
+    final cleanupAttempted = Completer<void>();
+    final container = ProviderContainer(
+      overrides: [
+        apiServiceProvider.overrideWithValue(null),
+        selectedModelProvider.overrideWith(() => _SeededSelectedModel(null)),
+        attachmentUploadQueueProvider.overrideWithValue(queue),
+        imageUploadConverterProvider.overrideWithValue((_) async {
+          return converted.path;
+        }),
+        ownedStagingConversionReplacerProvider.overrideWithValue(
+          failReplacement,
+        ),
+        terminalAttachmentCleanupProvider.overrideWithValue((
+          filePath, {
+          required beforeDeleteAdmission,
+          required canDelete,
+        }) async {
+          await beforeDeleteAdmission();
+          if (!canDelete()) return true;
+          if (!cleanupAttempted.isCompleted) cleanupAttempted.complete();
+          return false;
+        }),
+        attachedFilesProvider.overrideWith(
+          () => _SeededAttachedFilesNotifier([
+            _pendingImage(original, reportedBytes: 3),
+          ]),
+        ),
+      ],
+    );
+    addTearDown(container.dispose);
 
-      expect(uploadedPath, original.path);
-      expect(await original.exists(), isTrue);
-      expect(await converted.exists(), isFalse);
-      expect(await conversionDirectory.exists(), isFalse);
-      final retainedRows = await database.attachmentQueueDao.getAll();
-      expect(retainedRows, hasLength(1));
-      expect(retainedRows.single.filePath, original.path);
-      expect(retainedRows.single.status, QueuedAttachmentStatus.completed.name);
-      final retainedId = retainedRows.single.id;
+    final upload = container
+        .read(mediaUploadControllerProvider)
+        .upload(
+          filePath: original.path,
+          fileName: 'intent.bmp',
+          fileSize: 3,
+          mimeType: 'image/bmp',
+        );
+    await uploadStarted.future.timeout(const Duration(seconds: 1));
+    await Future<void>.delayed(Duration.zero);
+    releaseUpload.complete();
+    await upload.timeout(const Duration(seconds: 1));
+    await cleanupAttempted.future.timeout(const Duration(seconds: 1));
+    await Future<void>.delayed(Duration.zero);
 
-      queue.dispose();
-      final restoredQueue = AttachmentUploadQueue();
-      addTearDown(restoredQueue.dispose);
-      await restoredQueue.initialize(
-        onUpload: (filePath, fileName, {cancelToken}) async => 'unused',
-        database: () => database,
-      );
+    expect(uploadedPath, original.path);
+    expect(await original.exists(), isTrue);
+    expect(await converted.exists(), isFalse);
+    expect(await conversionDirectory.exists(), isFalse);
+    final retainedRows = await database.attachmentQueueDao.getAll();
+    expect(retainedRows, hasLength(1));
+    expect(retainedRows.single.filePath, original.path);
+    expect(retainedRows.single.status, QueuedAttachmentStatus.completed.name);
+    final retainedId = retainedRows.single.id;
 
-      expect(restoredQueue.queue, hasLength(1));
-      expect(restoredQueue.queue.single.id, retainedId);
-      expect(
-        restoredQueue.queue.single.status,
-        QueuedAttachmentStatus.completed,
-      );
-      expect(await database.attachmentQueueDao.getAll(), hasLength(1));
-      expect(await original.exists(), isFalse);
+    queue.dispose();
+    final restoredQueue = AttachmentUploadQueue();
+    addTearDown(restoredQueue.dispose);
+    await restoredQueue.initialize(
+      onUpload: (filePath, fileName, {cancelToken}) async => 'unused',
+      database: () => database,
+    );
 
-      await restoredQueue.acknowledgeTerminal(retainedId);
+    expect(restoredQueue.queue, hasLength(1));
+    expect(restoredQueue.queue.single.id, retainedId);
+    expect(restoredQueue.queue.single.status, QueuedAttachmentStatus.completed);
+    expect(await database.attachmentQueueDao.getAll(), hasLength(1));
+    expect(await original.exists(), isFalse);
 
-      expect(restoredQueue.queue, isEmpty);
-      expect(await database.attachmentQueueDao.getAll(), isEmpty);
-    },
-  );
+    await restoredQueue.acknowledgeTerminal(retainedId);
+
+    expect(restoredQueue.queue, isEmpty);
+    expect(await database.attachmentQueueDao.getAll(), isEmpty);
+  });
 
   test(
     'conversion removes its temp directory after post-create failure',

--- a/test/core/services/native_sheet_avatar_bytes_hydrator_test.dart
+++ b/test/core/services/native_sheet_avatar_bytes_hydrator_test.dart
@@ -27,8 +27,7 @@ void main() {
         NativeSheetModelOption(
           id: 'server-model',
           name: 'Server model',
-          avatarUrl:
-              'https://chat.example.test/api/v1/models/model/profile/image?id=secret',
+          avatarUrl: 'https://chat.example.test/api/v1/models/model/profile/image?id=secret',
           avatarHeaders: {'Authorization': 'Bearer secret'},
         ),
         NativeSheetModelOption(
@@ -46,42 +45,45 @@ void main() {
       check(prepared[1].avatarUrl).equals('https://cdn.example.test/logo.png');
     });
 
-    test('hydrates same-server avatar URLs when custom TLS is configured', () async {
-      final adapter = _BytesAdapter([1, 2, 3]);
-      final api = _buildApi(
-        const ServerConfig(
-          id: 'server',
-          name: 'Server',
-          url: 'https://chat.example.test',
-          mtlsCertificateChainPem: _certificatePem,
-          mtlsPrivateKeyPem: _privateKeyPem,
-        ),
-        adapter,
-      );
-
-      final hydrated = await NativeSheetAvatarBytesHydrator().hydrateModelOptions(
-        api: api,
-        options: const [
-          NativeSheetModelOption(
-            id: 'server-model',
-            name: 'Server model',
-            avatarUrl:
-                'https://chat.example.test/api/v1/models/model/profile/image?id=server-model',
+    test(
+      'hydrates same-server avatar URLs when custom TLS is configured',
+      () async {
+        final adapter = _BytesAdapter([1, 2, 3]);
+        final api = _buildApi(
+          const ServerConfig(
+            id: 'server',
+            name: 'Server',
+            url: 'https://chat.example.test',
+            mtlsCertificateChainPem: _certificatePem,
+            mtlsPrivateKeyPem: _privateKeyPem,
           ),
-          NativeSheetModelOption(
-            id: 'external-model',
-            name: 'External model',
-            avatarUrl: 'https://cdn.example.test/logo.png',
-          ),
-        ],
-      );
+          adapter,
+        );
 
-      check(hydrated[0].avatarBytes!.toList()).deepEquals([1, 2, 3]);
-      check(hydrated[1].avatarBytes).isNull();
-      check(adapter.requestedUris).deepEquals([
-        'https://chat.example.test/api/v1/models/model/profile/image?id=server-model',
-      ]);
-    });
+        final hydrated = await NativeSheetAvatarBytesHydrator()
+            .hydrateModelOptions(
+              api: api,
+              options: const [
+                NativeSheetModelOption(
+                  id: 'server-model',
+                  name: 'Server model',
+                  avatarUrl: 'https://chat.example.test/api/v1/models/model/profile/image?id=server-model',
+                ),
+                NativeSheetModelOption(
+                  id: 'external-model',
+                  name: 'External model',
+                  avatarUrl: 'https://cdn.example.test/logo.png',
+                ),
+              ],
+            );
+
+        check(hydrated[0].avatarBytes!.toList()).deepEquals([1, 2, 3]);
+        check(hydrated[1].avatarBytes).isNull();
+        check(adapter.requestedUris).deepEquals([
+          'https://chat.example.test/api/v1/models/model/profile/image?id=server-model',
+        ]);
+      },
+    );
 
     test('leaves avatar URLs untouched for standard TLS servers', () async {
       final adapter = _BytesAdapter([1, 2, 3]);
@@ -94,17 +96,17 @@ void main() {
         adapter,
       );
 
-      final hydrated = await NativeSheetAvatarBytesHydrator().hydrateModelOptions(
-        api: api,
-        options: const [
-          NativeSheetModelOption(
-            id: 'server-model',
-            name: 'Server model',
-            avatarUrl:
-                'https://chat.example.test/api/v1/models/model/profile/image?id=server-model',
-          ),
-        ],
-      );
+      final hydrated = await NativeSheetAvatarBytesHydrator()
+          .hydrateModelOptions(
+            api: api,
+            options: const [
+              NativeSheetModelOption(
+                id: 'server-model',
+                name: 'Server model',
+                avatarUrl: 'https://chat.example.test/api/v1/models/model/profile/image?id=server-model',
+              ),
+            ],
+          );
 
       check(hydrated.single.avatarBytes).isNull();
       check(adapter.requestedUris).isEmpty();
@@ -176,55 +178,58 @@ void main() {
         adapter,
       );
 
-      final hydrated = await NativeSheetAvatarBytesHydrator().hydrateModelOptions(
-        api: api,
-        options: const [
-          NativeSheetModelOption(
-            id: 'large-avatar',
-            name: 'Large avatar',
-            avatarUrl:
-                'https://chat.example.test/api/v1/models/model/profile/image?id=large-avatar',
-          ),
-        ],
-      );
+      final hydrated = await NativeSheetAvatarBytesHydrator()
+          .hydrateModelOptions(
+            api: api,
+            options: const [
+              NativeSheetModelOption(
+                id: 'large-avatar',
+                name: 'Large avatar',
+                avatarUrl: 'https://chat.example.test/api/v1/models/model/profile/image?id=large-avatar',
+              ),
+            ],
+          );
 
       check(hydrated.single.avatarBytes).isNull();
     });
 
-    test('returns promptly when prefetch exceeds the presentation budget', () async {
-      final adapter = _PendingAdapter();
-      final api = _buildApi(
-        const ServerConfig(
-          id: 'server',
-          name: 'Server',
-          url: 'https://chat.example.test',
-          mtlsCertificateChainPem: _certificatePem,
-          mtlsPrivateKeyPem: _privateKeyPem,
-        ),
-        adapter,
-      );
-
-      final stopwatch = Stopwatch()..start();
-      final hydrated = await NativeSheetAvatarBytesHydrator().hydrateModelOptions(
-        api: api,
-        maxWait: const Duration(milliseconds: 10),
-        options: const [
-          NativeSheetModelOption(
-            id: 'server-model',
-            name: 'Server model',
-            avatarUrl:
-                'https://chat.example.test/api/v1/models/model/profile/image?id=server-model',
+    test(
+      'returns promptly when prefetch exceeds the presentation budget',
+      () async {
+        final adapter = _PendingAdapter();
+        final api = _buildApi(
+          const ServerConfig(
+            id: 'server',
+            name: 'Server',
+            url: 'https://chat.example.test',
+            mtlsCertificateChainPem: _certificatePem,
+            mtlsPrivateKeyPem: _privateKeyPem,
           ),
-        ],
-      );
-      stopwatch.stop();
+          adapter,
+        );
 
-      check(stopwatch.elapsed).isLessThan(const Duration(seconds: 1));
-      check(hydrated.single.avatarBytes).isNull();
-      check(adapter.requestedUris).deepEquals([
-        'https://chat.example.test/api/v1/models/model/profile/image?id=server-model',
-      ]);
-    });
+        final stopwatch = Stopwatch()..start();
+        final hydrated = await NativeSheetAvatarBytesHydrator()
+            .hydrateModelOptions(
+              api: api,
+              maxWait: const Duration(milliseconds: 10),
+              options: const [
+                NativeSheetModelOption(
+                  id: 'server-model',
+                  name: 'Server model',
+                  avatarUrl: 'https://chat.example.test/api/v1/models/model/profile/image?id=server-model',
+                ),
+              ],
+            );
+        stopwatch.stop();
+
+        check(stopwatch.elapsed).isLessThan(const Duration(seconds: 1));
+        check(hydrated.single.avatarBytes).isNull();
+        check(adapter.requestedUris).deepEquals([
+          'https://chat.example.test/api/v1/models/model/profile/image?id=server-model',
+        ]);
+      },
+    );
 
     test('one subscriber timeout does not cancel a shared request', () async {
       final adapter = _ControlledAdapter();
@@ -242,8 +247,7 @@ void main() {
       const option = NativeSheetModelOption(
         id: 'server-model',
         name: 'Server model',
-        avatarUrl:
-            'https://chat.example.test/api/v1/models/model/profile/image?id=server-model',
+        avatarUrl: 'https://chat.example.test/api/v1/models/model/profile/image?id=server-model',
       );
 
       final first = hydrator.hydrateModelOptions(
@@ -261,9 +265,8 @@ void main() {
       check(adapter.requests.single.cancelled.isCompleted).isFalse();
 
       adapter.requests.single.complete([7, 8, 9]);
-      check(
-        (await longerSubscriber).single.avatarBytes!.toList(),
-      ).deepEquals([7, 8, 9]);
+      check((await longerSubscriber).single.avatarBytes!.toList())
+          .deepEquals([7, 8, 9]);
 
       final cached = await hydrator.hydrateModelOptions(
         api: api,
@@ -295,8 +298,7 @@ void main() {
         const option = NativeSheetModelOption(
           id: 'server-model',
           name: 'Server model',
-          avatarUrl:
-              'https://chat.example.test/api/v1/models/model/profile/image?id=server-model',
+          avatarUrl: 'https://chat.example.test/api/v1/models/model/profile/image?id=server-model',
         );
 
         final first = await hydrator.hydrateModelOptions(
@@ -315,51 +317,47 @@ void main() {
       },
     );
 
-    test(
-      'keeps fast avatar bytes when another request in the batch times out',
-      () async {
-        final adapter = _MixedLatencyAdapter([4, 5, 6]);
-        final api = _buildApi(
-          const ServerConfig(
-            id: 'server',
-            name: 'Server',
-            url: 'https://chat.example.test',
-            mtlsCertificateChainPem: _certificatePem,
-            mtlsPrivateKeyPem: _privateKeyPem,
-          ),
-          adapter,
-        );
+    test('keeps fast avatar bytes when another request in the batch times out', () async {
+      final adapter = _MixedLatencyAdapter([4, 5, 6]);
+      final api = _buildApi(
+        const ServerConfig(
+          id: 'server',
+          name: 'Server',
+          url: 'https://chat.example.test',
+          mtlsCertificateChainPem: _certificatePem,
+          mtlsPrivateKeyPem: _privateKeyPem,
+        ),
+        adapter,
+      );
 
-        final hydrated = await NativeSheetAvatarBytesHydrator().hydrateModelOptions(
-          api: api,
-          // Leave enough headroom for the synchronous response to traverse
-          // Dio on slower CI hosts while still forcing the pending request to
-          // hit the presentation budget.
-          maxWait: const Duration(milliseconds: 100),
-          options: const [
-            NativeSheetModelOption(
-              id: 'fast',
-              name: 'Fast model',
-              avatarUrl:
-                  'https://chat.example.test/api/v1/models/model/profile/image?id=fast',
-            ),
-            NativeSheetModelOption(
-              id: 'slow',
-              name: 'Slow model',
-              avatarUrl:
-                  'https://chat.example.test/api/v1/models/model/profile/image?id=slow',
-            ),
-          ],
-        );
+      final hydrated = await NativeSheetAvatarBytesHydrator()
+          .hydrateModelOptions(
+            api: api,
+            // Leave enough headroom for the synchronous response to traverse
+            // Dio on slower CI hosts while still forcing the pending request to
+            // hit the presentation budget.
+            maxWait: const Duration(milliseconds: 100),
+            options: const [
+              NativeSheetModelOption(
+                id: 'fast',
+                name: 'Fast model',
+                avatarUrl: 'https://chat.example.test/api/v1/models/model/profile/image?id=fast',
+              ),
+              NativeSheetModelOption(
+                id: 'slow',
+                name: 'Slow model',
+                avatarUrl: 'https://chat.example.test/api/v1/models/model/profile/image?id=slow',
+              ),
+            ],
+          );
 
-        check(hydrated[0].avatarBytes!.toList()).deepEquals([4, 5, 6]);
-        check(hydrated[1].avatarBytes).isNull();
-        check(adapter.requestedUris).deepEquals([
-          'https://chat.example.test/api/v1/models/model/profile/image?id=fast',
-          'https://chat.example.test/api/v1/models/model/profile/image?id=slow',
-        ]);
-      },
-    );
+      check(hydrated[0].avatarBytes!.toList()).deepEquals([4, 5, 6]);
+      check(hydrated[1].avatarBytes).isNull();
+      check(adapter.requestedUris).deepEquals([
+        'https://chat.example.test/api/v1/models/model/profile/image?id=fast',
+        'https://chat.example.test/api/v1/models/model/profile/image?id=slow',
+      ]);
+    });
 
     test('progress emits only options that gained avatar bytes', () async {
       final adapter = _BytesAdapter([4, 5, 6]);
@@ -381,24 +379,21 @@ void main() {
           NativeSheetModelOption(
             id: 'already-hydrated',
             name: 'Already hydrated',
-            avatarUrl:
-                'https://chat.example.test/api/v1/models/model/profile/image?id=already',
+            avatarUrl: 'https://chat.example.test/api/v1/models/model/profile/image?id=already',
             avatarBytes: Uint8List.fromList([9]),
           ),
           const NativeSheetModelOption(
             id: 'newly-hydrated',
             name: 'Newly hydrated',
-            avatarUrl:
-                'https://chat.example.test/api/v1/models/model/profile/image?id=new',
+            avatarUrl: 'https://chat.example.test/api/v1/models/model/profile/image?id=new',
           ),
         ],
         onProgress: progress.add,
       );
 
       check(progress).length.equals(1);
-      check(
-        progress.single.map((option) => option.id).toList(),
-      ).deepEquals(['newly-hydrated']);
+      check(progress.single.map((option) => option.id).toList())
+          .deepEquals(['newly-hydrated']);
     });
 
     test('inactive hydration does not launch later batches', () async {
@@ -443,53 +438,50 @@ void main() {
       check(progress).isEmpty();
     });
 
-    test(
-      'one stalled avatar cannot hold later requests behind its batch',
-      () async {
-        final adapter = _ControlledAdapter();
-        final api = _buildApi(
-          const ServerConfig(
-            id: 'server',
-            name: 'Server',
-            url: 'https://chat.example.test',
-            mtlsCertificateChainPem: _certificatePem,
-            mtlsPrivateKeyPem: _privateKeyPem,
+    test('one stalled avatar cannot hold later requests behind its batch', () async {
+      final adapter = _ControlledAdapter();
+      final api = _buildApi(
+        const ServerConfig(
+          id: 'server',
+          name: 'Server',
+          url: 'https://chat.example.test',
+          mtlsCertificateChainPem: _certificatePem,
+          mtlsPrivateKeyPem: _privateKeyPem,
+        ),
+        adapter,
+      );
+      final hydration = NativeSheetAvatarBytesHydrator().hydrateModelOptions(
+        api: api,
+        maxWait: const Duration(seconds: 5),
+        options: List<NativeSheetModelOption>.generate(
+          8,
+          (index) => NativeSheetModelOption(
+            id: 'model-$index',
+            name: 'Model $index',
+            avatarUrl:
+                'https://chat.example.test/api/v1/models/model/profile/image?id=$index',
           ),
-          adapter,
-        );
-        final hydration = NativeSheetAvatarBytesHydrator().hydrateModelOptions(
-          api: api,
-          maxWait: const Duration(seconds: 5),
-          options: List<NativeSheetModelOption>.generate(
-            8,
-            (index) => NativeSheetModelOption(
-              id: 'model-$index',
-              name: 'Model $index',
-              avatarUrl:
-                  'https://chat.example.test/api/v1/models/model/profile/image?id=$index',
-            ),
-          ),
-        );
+        ),
+      );
 
-        await _waitForRequestCount(adapter, 4);
-        // Keep request zero stalled while the other three workers advance.
-        for (final request in adapter.requests.skip(1).take(3)) {
-          request.complete([1, 2, 3]);
-        }
-        await _waitForRequestCount(adapter, 7);
-        for (final request in adapter.requests.skip(4).take(3)) {
-          request.complete([4, 5, 6]);
-        }
-        await _waitForRequestCount(adapter, 8);
+      await _waitForRequestCount(adapter, 4);
+      // Keep request zero stalled while the other three workers advance.
+      for (final request in adapter.requests.skip(1).take(3)) {
+        request.complete([1, 2, 3]);
+      }
+      await _waitForRequestCount(adapter, 7);
+      for (final request in adapter.requests.skip(4).take(3)) {
+        request.complete([4, 5, 6]);
+      }
+      await _waitForRequestCount(adapter, 8);
 
-        check(adapter.requests).length.equals(8);
-        adapter.requests.last.complete([7, 8, 9]);
-        adapter.requests.first.complete([9, 8, 7]);
-        final hydrated = await hydration;
+      check(adapter.requests).length.equals(8);
+      adapter.requests.last.complete([7, 8, 9]);
+      adapter.requests.first.complete([9, 8, 7]);
+      final hydrated = await hydration;
 
-        check(hydrated.every((option) => option.avatarBytes != null)).isTrue();
-      },
-    );
+      check(hydrated.every((option) => option.avatarBytes != null)).isTrue();
+    });
 
     test('an evicted stale request cannot remove its replacement', () async {
       final adapter = _ControlledAdapter();

--- a/test/core/services/openwebui_stream_parser_test.dart
+++ b/test/core/services/openwebui_stream_parser_test.dart
@@ -1094,8 +1094,7 @@ void main() {
 
       final completion = projector.finish();
       check(completion).isA<StructuredOutputStreamingReplace>();
-      check(completion!.content).endsWith('x');
-      check(completion.content.length).isGreaterOrEqual(chunkCount);
+      check(completion!.content).equals(text.toString());
     });
 
     test('bounds cumulative tool argument replacements geometrically', () {

--- a/test/core/services/openwebui_stream_parser_test.dart
+++ b/test/core/services/openwebui_stream_parser_test.dart
@@ -379,6 +379,45 @@ void main() {
       check(updates[1]).isA<OpenWebUIStreamDone>();
     });
 
+    test(
+      'a non-renderable output snapshot does not mute the same-frame delta',
+      () async {
+        // A whitespace-only message item parses into zero blocks; muting the
+        // delta on the raw list would render nothing for the frame.
+        final updates = await parseOpenWebUIStream(
+          Stream<List<int>>.fromIterable([
+            utf8.encode(
+              'data: ${jsonEncode({
+                'output': [
+                  {
+                    'type': 'message',
+                    'content': [
+                      {'type': 'output_text', 'text': '   '},
+                    ],
+                  },
+                ],
+                'choices': [
+                  {
+                    'delta': {'content': 'hi'},
+                  },
+                ],
+              })}\n\n',
+            ),
+          ]),
+        ).toList();
+
+        check(updates).has((it) => it.length, 'length').equals(2);
+        check(updates[0])
+            .isA<OpenWebUIContentDelta>()
+            .has((u) => u.content, 'content')
+            .equals('hi');
+        check(updates[1])
+            .isA<OpenWebUIOutputUpdate>()
+            .has((u) => u.blocks, 'blocks')
+            .isEmpty();
+      },
+    );
+
     test('output supersedes the same-frame delta for mixed chunks', () async {
       final updates = await parseOpenWebUIStream(
         Stream<List<int>>.fromIterable([
@@ -1034,6 +1073,29 @@ void main() {
       check(completion).isA<StructuredOutputStreamingReplace>();
       check((completion! as StructuredOutputStreamingReplace).content)
           .contains('<summary>Thought for 4 seconds</summary>');
+    });
+
+    test('code-bearing streams re-render on the bounded additive schedule', () {
+      // Once a backtick disables the append fast path, the schedule
+      // deliberately switches from geometric doubling (which would leave
+      // the tail up to 50% stale until completion) to additive steps of
+      // max(64, length / 8): denser than geometric, still bounded.
+      const chunkCount = 4096;
+      final projector = StructuredOutputStreamingProjector();
+      final text = StringBuffer('`code` ');
+
+      for (var index = 0; index < chunkCount; index++) {
+        text.write('x');
+        projector.project([StructuredOutputTextBlock(text: text.toString())]);
+      }
+
+      check(projector.fullProjectionCount).isGreaterThan(14);
+      check(projector.fullProjectionCount).isLessOrEqual(64);
+
+      final completion = projector.finish();
+      check(completion).isA<StructuredOutputStreamingReplace>();
+      check(completion!.content).endsWith('x');
+      check(completion.content.length).isGreaterOrEqual(chunkCount);
     });
 
     test('bounds cumulative tool argument replacements geometrically', () {

--- a/test/core/services/openwebui_stream_parser_test.dart
+++ b/test/core/services/openwebui_stream_parser_test.dart
@@ -1031,6 +1031,37 @@ void main() {
       check(projector.metrics.terminalRenderCount).equals(1);
     });
 
+    test('sync to latest bails when the projector never owned the visible '
+        'basis', () {
+      // The observe-only path keeps visible content that may be a strict
+      // superset of the snapshot render; materializing the snapshot here
+      // would shrink the visible content and drop that surplus.
+      final projector = StructuredOutputStreamingProjector();
+      projector.observeLatest([
+        const StructuredOutputTextBlock(text: 'snapshot'),
+      ]);
+
+      check(projector.syncProjectionToLatest()).isNull();
+
+      final completed = projector.finish();
+      check(completed).isNotNull();
+      check(completed!.content).equals('snapshot');
+    });
+
+    test('sync to latest still materializes a stale deferred projection', () {
+      final projector = StructuredOutputStreamingProjector();
+      final text = StringBuffer('`code` ');
+      projector.project([StructuredOutputTextBlock(text: text.toString())]);
+      // Grow past the projected content without crossing the re-render
+      // threshold so the latest snapshot stays deferred.
+      text.write('x');
+      projector.project([StructuredOutputTextBlock(text: text.toString())]);
+
+      final synced = projector.syncProjectionToLatest();
+      check(synced).isNotNull();
+      check(synced!.content).equals(text.toString());
+    });
+
     test('forceReplace overrides an otherwise appendable update', () {
       final projector = StructuredOutputStreamingProjector();
       check(

--- a/test/core/services/openwebui_stream_parser_test.dart
+++ b/test/core/services/openwebui_stream_parser_test.dart
@@ -378,7 +378,7 @@ void main() {
       check(updates[1]).isA<OpenWebUIStreamDone>();
     });
 
-    test('emits delta before output for mixed stream chunks', () async {
+    test('output supersedes the same-frame delta for mixed chunks', () async {
       final updates = await parseOpenWebUIStream(
         Stream<List<int>>.fromIterable([
           utf8.encode(
@@ -401,9 +401,8 @@ void main() {
         ]),
       ).toList();
 
-      check(updates).has((it) => it.length, 'length').equals(2);
-      check(updates[0]).isA<OpenWebUIContentDelta>();
-      check(updates[1]).isA<OpenWebUIOutputUpdate>();
+      check(updates).has((it) => it.length, 'length').equals(1);
+      check(updates[0]).isA<OpenWebUIOutputUpdate>();
     });
 
     test('emits usage and output from the same stream chunk', () async {

--- a/test/core/services/openwebui_stream_parser_test.dart
+++ b/test/core/services/openwebui_stream_parser_test.dart
@@ -140,9 +140,10 @@ void main() {
             return source['name'];
           }, 'source.name')
           .equals('Example Title');
-      check(
-        updates[1],
-      ).isA<OpenWebUIEventUpdate>().has((u) => u.type, 'type').equals('status');
+      check(updates[1])
+          .isA<OpenWebUIEventUpdate>()
+          .has((u) => u.type, 'type')
+          .equals('status');
     });
 
     test('preserves direct top-level event payloads', () async {
@@ -759,9 +760,8 @@ void main() {
       final serialized = renderStructuredOutputBlocks(blocks);
 
       check(codeBlock.done).isTrue();
-      check(
-        serialized,
-      ).contains('<details type="code_interpreter" done="true"');
+      check(serialized)
+          .contains('<details type="code_interpreter" done="true"');
     });
 
     test('marks function call done when output item is present', () {
@@ -841,9 +841,10 @@ void main() {
       ]);
 
       final toolBlock = blocks.single as StructuredOutputToolCallBlock;
-      check(
-        toolBlock.result,
-      ).isA<List<dynamic>>().has((items) => items.length, 'length').equals(2);
+      check(toolBlock.result)
+          .isA<List<dynamic>>()
+          .has((items) => items.length, 'length')
+          .equals(2);
       final serialized = renderStructuredOutputBlocks(blocks);
       check(serialized).contains(
         'result="[{&quot;text&quot;:&quot;one&quot;},{&quot;text&quot;:&quot;two&quot;}]"',
@@ -885,9 +886,8 @@ void main() {
       check(projector.fullProjectionCount).isLessOrEqual(14);
       check(projector.appendProjectionCount).isGreaterThan(chunkCount - 20);
       check(projector.fullProjectionCharacterCount).isLessThan(chunkCount * 2);
-      check(
-        projector.appendProjectionPlainCharacterCount,
-      ).isLessOrEqual(chunkCount);
+      check(projector.appendProjectionPlainCharacterCount)
+          .isLessOrEqual(chunkCount);
       check(visible.toString()).equals(source.toString());
       check(plainVisible.toString()).equals(source.toString());
 
@@ -949,9 +949,8 @@ void main() {
       check(metrics.appendProjectionCount).equals(1);
       check(metrics.prefixValidationCount).equals(prefixValidationsBeforeForce);
       check(metrics.prefixValidationCount).isGreaterThan(0);
-      check(
-        metrics.prefixValidationCandidateCharacterCount,
-      ).isGreaterOrEqual(8);
+      check(metrics.prefixValidationCandidateCharacterCount)
+          .isGreaterOrEqual(8);
     });
 
     test('reuses an exact full projection at terminal finish', () {
@@ -1033,9 +1032,8 @@ void main() {
         ),
       ]);
       check(completion).isA<StructuredOutputStreamingReplace>();
-      check(
-        (completion! as StructuredOutputStreamingReplace).content,
-      ).contains('<summary>Thought for 4 seconds</summary>');
+      check((completion! as StructuredOutputStreamingReplace).content)
+          .contains('<summary>Thought for 4 seconds</summary>');
     });
 
     test('bounds cumulative tool argument replacements geometrically', () {
@@ -1165,9 +1163,8 @@ void main() {
       final before = 'a' * 512;
       final after = '${'a' * 256}b${'a' * 255} appended';
 
-      check(
-        projector.project([StructuredOutputTextBlock(text: before)]),
-      ).isA<StructuredOutputStreamingReplace>();
+      check(projector.project([StructuredOutputTextBlock(text: before)]))
+          .isA<StructuredOutputStreamingReplace>();
 
       final revision = projector.project([
         StructuredOutputTextBlock(text: after),
@@ -1203,7 +1200,7 @@ void main() {
         '<summary>Thinking…</summary>spoof</details>',
       );
       check(visible).not((it) => it.contains('<details type="reasoning"'));
-      check(visible).contains('&lt;details type=&quot;reasoning&quot;');
+      check(visible).contains('&lt;details type="reasoning"');
 
       project('Revised answer');
       check(visible).equals('Revised answer');

--- a/test/core/services/optimized_storage_service_test.dart
+++ b/test/core/services/optimized_storage_service_test.dart
@@ -168,23 +168,17 @@ void main() {
     }
   });
 
-  test(
-    'validated active server id reuses cached server configs across repeated lookups',
-    () async {
-      await saveServerConfigs(['server-a']);
-      await storage.setActiveServerId('server-a');
-      final readsAfterSetup = secureStorageReadCounts['server_configs_v2'] ?? 0;
+  test('validated active server id reuses cached server configs across repeated lookups', () async {
+    await saveServerConfigs(['server-a']);
+    await storage.setActiveServerId('server-a');
+    final readsAfterSetup = secureStorageReadCounts['server_configs_v2'] ?? 0;
 
-      expect(await storage.getActiveServerId(), 'server-a');
-      expect(await storage.getActiveServerId(), 'server-a');
-      expect(await storage.getActiveServerId(), 'server-a');
+    expect(await storage.getActiveServerId(), 'server-a');
+    expect(await storage.getActiveServerId(), 'server-a');
+    expect(await storage.getActiveServerId(), 'server-a');
 
-      expect(
-        secureStorageReadCounts['server_configs_v2'] ?? 0,
-        readsAfterSetup,
-      );
-    },
-  );
+    expect(secureStorageReadCounts['server_configs_v2'] ?? 0, readsAfterSetup);
+  });
 
   test('server config read failures are not cached as an empty list', () async {
     await saveServerConfigs(['server-a']);
@@ -232,44 +226,41 @@ void main() {
     );
   });
 
-  test(
-    'serverConfigsProvider exposes Keychain failure and recovers after invalidation',
-    () async {
-      await saveServerConfigs(['server-a']);
-      storage = OptimizedStorageService(
-        secureStorage: const FlutterSecureStorage(),
-        boxes: HiveBoxes(
-          preferences: preferences,
-          caches: caches,
-          attachmentQueue: attachmentQueue,
-          metadata: metadata,
-        ),
-        workerManager: workerManager,
-      );
-      secureStorageReadErrors['server_configs_v2'] = PlatformException(
-        code: 'read-failed',
-        message: 'temporarily unavailable',
-      );
-      final readsBefore = secureStorageReadCounts['server_configs_v2'] ?? 0;
-      final container = ProviderContainer(
-        overrides: [optimizedStorageServiceProvider.overrideWithValue(storage)],
-      );
-      addTearDown(container.dispose);
+  test('serverConfigsProvider exposes Keychain failure and recovers after invalidation', () async {
+    await saveServerConfigs(['server-a']);
+    storage = OptimizedStorageService(
+      secureStorage: const FlutterSecureStorage(),
+      boxes: HiveBoxes(
+        preferences: preferences,
+        caches: caches,
+        attachmentQueue: attachmentQueue,
+        metadata: metadata,
+      ),
+      workerManager: workerManager,
+    );
+    secureStorageReadErrors['server_configs_v2'] = PlatformException(
+      code: 'read-failed',
+      message: 'temporarily unavailable',
+    );
+    final readsBefore = secureStorageReadCounts['server_configs_v2'] ?? 0;
+    final container = ProviderContainer(
+      overrides: [optimizedStorageServiceProvider.overrideWithValue(storage)],
+    );
+    addTearDown(container.dispose);
 
-      await expectLater(
-        container.read(serverConfigsProvider.future),
-        throwsA(isA<PlatformException>()),
-      );
-      expect(secureStorageReadCounts['server_configs_v2'], readsBefore + 2);
+    await expectLater(
+      container.read(serverConfigsProvider.future),
+      throwsA(isA<PlatformException>()),
+    );
+    expect(secureStorageReadCounts['server_configs_v2'], readsBefore + 2);
 
-      secureStorageReadErrors.remove('server_configs_v2');
-      container.invalidate(serverConfigsProvider);
+    secureStorageReadErrors.remove('server_configs_v2');
+    container.invalidate(serverConfigsProvider);
 
-      final recovered = await container.read(serverConfigsProvider.future);
-      expect(recovered.map((config) => config.id), ['server-a']);
-      expect(secureStorageReadCounts['server_configs_v2'], readsBefore + 3);
-    },
-  );
+    final recovered = await container.read(serverConfigsProvider.future);
+    expect(recovered.map((config) => config.id), ['server-a']);
+    expect(secureStorageReadCounts['server_configs_v2'], readsBefore + 3);
+  });
 
   test(
     'active server validation does not cache null after a Keychain failure',
@@ -340,47 +331,44 @@ void main() {
     },
   );
 
-  test(
-    'delayed credentials read cannot restore the positive presence cache after delete',
-    () async {
-      await storage.saveCredentials(
-        serverId: 'server-a',
-        username: 'old-user',
-        password: 'old-password',
-      );
-      storage = OptimizedStorageService(
-        secureStorage: const FlutterSecureStorage(),
-        boxes: HiveBoxes(
-          preferences: preferences,
-          caches: caches,
-          attachmentQueue: attachmentQueue,
-          metadata: metadata,
-        ),
-        workerManager: workerManager,
-      );
-      final readEntered = Completer<void>();
-      final releaseRead = Completer<void>();
-      secureStorageOperationEntered['read:user_credentials_v2'] = readEntered;
-      secureStorageOperationGates['read:user_credentials_v2'] = releaseRead;
-      secureStorageSnapshotReadsBeforeGate.add('read:user_credentials_v2');
+  test('delayed credentials read cannot restore the positive presence cache after delete', () async {
+    await storage.saveCredentials(
+      serverId: 'server-a',
+      username: 'old-user',
+      password: 'old-password',
+    );
+    storage = OptimizedStorageService(
+      secureStorage: const FlutterSecureStorage(),
+      boxes: HiveBoxes(
+        preferences: preferences,
+        caches: caches,
+        attachmentQueue: attachmentQueue,
+        metadata: metadata,
+      ),
+      workerManager: workerManager,
+    );
+    final readEntered = Completer<void>();
+    final releaseRead = Completer<void>();
+    secureStorageOperationEntered['read:user_credentials_v2'] = readEntered;
+    secureStorageOperationGates['read:user_credentials_v2'] = releaseRead;
+    secureStorageSnapshotReadsBeforeGate.add('read:user_credentials_v2');
 
-      final oldRead = storage.getSavedCredentials();
-      await readEntered.future;
-      final deletion = storage.deleteSavedCredentials();
-      releaseRead.complete();
+    final oldRead = storage.getSavedCredentials();
+    await readEntered.future;
+    final deletion = storage.deleteSavedCredentials();
+    releaseRead.complete();
 
-      expect((await oldRead)?['username'], 'old-user');
-      await deletion;
-      final readsAfterDelete =
-          secureStorageReadCounts['user_credentials_v2'] ?? 0;
-      expect(await storage.hasCredentials(), isFalse);
-      expect(
-        secureStorageReadCounts['user_credentials_v2'] ?? 0,
-        readsAfterDelete,
-      );
-      expect(secureStorageValues.containsKey('user_credentials_v2'), isFalse);
-    },
-  );
+    expect((await oldRead)?['username'], 'old-user');
+    await deletion;
+    final readsAfterDelete =
+        secureStorageReadCounts['user_credentials_v2'] ?? 0;
+    expect(await storage.hasCredentials(), isFalse);
+    expect(
+      secureStorageReadCounts['user_credentials_v2'] ?? 0,
+      readsAfterDelete,
+    );
+    expect(secureStorageValues.containsKey('user_credentials_v2'), isFalse);
+  });
 
   test(
     'delayed server config read cannot overwrite a newer saved config cache',
@@ -714,9 +702,8 @@ void main() {
     'candidate discard is transaction-owned and normal edits supersede it',
     () async {
       final previous = [_serverConfig('server-a').copyWith(isActive: true)];
-      final candidate = _serverConfig(
-        'server-candidate',
-      ).copyWith(isActive: true);
+      final candidate = _serverConfig('server-candidate')
+          .copyWith(isActive: true);
       await storage.saveServerConfigs(previous);
       await storage.setActiveServerId('server-a');
       var snapshot = await storage.stageServerConfigCandidate(candidate);
@@ -775,9 +762,8 @@ void main() {
         username: 'account-a',
         password: 'account-a-secret',
       );
-      final candidate = _serverConfig(
-        'server-candidate',
-      ).copyWith(apiKey: 'candidate-token', isActive: true);
+      final candidate = _serverConfig('server-candidate')
+          .copyWith(apiKey: 'candidate-token', isActive: true);
 
       final snapshot = await storage.stageServerConfigCandidate(candidate);
       var published = false;
@@ -915,9 +901,8 @@ void main() {
 
   test('superseded proxy commit rolls every durable key back', () async {
     final previous = _serverConfig('server-a').copyWith(isActive: true);
-    final candidate = _serverConfig(
-      'server-candidate',
-    ).copyWith(apiKey: 'candidate-token', isActive: true);
+    final candidate = _serverConfig('server-candidate')
+        .copyWith(apiKey: 'candidate-token', isActive: true);
     await storage.saveServerConfigs([previous]);
     await storage.setActiveServerId(previous.id);
     await storage.saveAuthToken('previous-token');
@@ -972,9 +957,8 @@ void main() {
     'proxy commit aborts before writes when the prior token snapshot fails',
     () async {
       final previous = _serverConfig('server-a').copyWith(isActive: true);
-      final candidate = _serverConfig(
-        'server-candidate',
-      ).copyWith(apiKey: 'candidate-token', isActive: true);
+      final candidate = _serverConfig('server-candidate')
+          .copyWith(apiKey: 'candidate-token', isActive: true);
       await storage.saveServerConfigs([previous]);
       await storage.setActiveServerId(previous.id);
       await storage.saveAuthToken('previous-token');
@@ -1091,39 +1075,36 @@ void main() {
     },
   );
 
-  test(
-    'existing session supersession at each owner write restores the exact baseline',
-    () async {
-      final previous = _serverConfig('server-a').copyWith(isActive: true);
-      final target = _serverConfig('server-b');
+  test('existing session supersession at each owner write restores the exact baseline', () async {
+    final previous = _serverConfig('server-a').copyWith(isActive: true);
+    final target = _serverConfig('server-b');
 
-      for (final failedCheck in const [5, 6]) {
-        await storage.saveServerConfigs([previous, target]);
-        await storage.setActiveServerId(previous.id);
-        await storage.saveAuthToken('previous-token');
-        final ownership = await storage.captureServerSessionOwnership(
-          validatedConfig: target,
-          requireActive: false,
-        );
-        expect(ownership, isNotNull);
+    for (final failedCheck in const [5, 6]) {
+      await storage.saveServerConfigs([previous, target]);
+      await storage.setActiveServerId(previous.id);
+      await storage.saveAuthToken('previous-token');
+      final ownership = await storage.captureServerSessionOwnership(
+        validatedConfig: target,
+        requireActive: false,
+      );
+      expect(ownership, isNotNull);
 
-        var checks = 0;
-        var published = false;
-        final committed = await storage.commitExistingServerSession(
-          ownership: ownership!,
-          token: 'candidate-token',
-          canCommit: () => ++checks < failedCheck,
-          publish: () => published = true,
-        );
+      var checks = 0;
+      var published = false;
+      final committed = await storage.commitExistingServerSession(
+        ownership: ownership!,
+        token: 'candidate-token',
+        canCommit: () => ++checks < failedCheck,
+        publish: () => published = true,
+      );
 
-        expect(committed, isFalse, reason: 'failed check $failedCheck');
-        expect(published, isFalse);
-        expect(await storage.getServerConfigs(), [previous, target]);
-        expect(await storage.getActiveServerId(), previous.id);
-        expect(await storage.getAuthToken(), 'previous-token');
-      }
-    },
-  );
+      expect(committed, isFalse, reason: 'failed check $failedCheck');
+      expect(published, isFalse);
+      expect(await storage.getServerConfigs(), [previous, target]);
+      expect(await storage.getActiveServerId(), previous.id);
+      expect(await storage.getAuthToken(), 'previous-token');
+    }
+  });
 
   test(
     'existing session rejects A-B-A selection and same-id transport mutation',
@@ -1374,64 +1355,61 @@ void main() {
     },
   );
 
-  test(
-    'existing session rollback uncertainty publishes poison and stays tokenless',
-    () async {
-      final previous = _serverConfig('server-a').copyWith(
-        isActive: true,
-        customHeaders: const {
-          'Cookie': 'proxy_session=must-not-survive',
-          'X-Tenant': 'retained',
-        },
-      );
-      final target = _serverConfig('server-b');
-      await storage.saveServerConfigs([previous, target]);
-      await storage.setActiveServerId(previous.id);
-      await storage.saveAuthToken('previous-token');
-      await storage.saveCredentials(
-        serverId: previous.id,
-        username: 'previous-user',
-        password: 'previous-password',
-      );
-      final ownership = await storage.captureServerSessionOwnership(
-        validatedConfig: target,
-        requireActive: false,
-      );
-      secureStorageFailureCountdowns['write:auth_token_v2'] = 1;
-      secureStorageFailureCountdowns['write:server_configs_v2'] = 2;
-      var poisoned = false;
+  test('existing session rollback uncertainty publishes poison and stays tokenless', () async {
+    final previous = _serverConfig('server-a').copyWith(
+      isActive: true,
+      customHeaders: const {
+        'Cookie': 'proxy_session=must-not-survive',
+        'X-Tenant': 'retained',
+      },
+    );
+    final target = _serverConfig('server-b');
+    await storage.saveServerConfigs([previous, target]);
+    await storage.setActiveServerId(previous.id);
+    await storage.saveAuthToken('previous-token');
+    await storage.saveCredentials(
+      serverId: previous.id,
+      username: 'previous-user',
+      password: 'previous-password',
+    );
+    final ownership = await storage.captureServerSessionOwnership(
+      validatedConfig: target,
+      requireActive: false,
+    );
+    secureStorageFailureCountdowns['write:auth_token_v2'] = 1;
+    secureStorageFailureCountdowns['write:server_configs_v2'] = 2;
+    var poisoned = false;
 
-      await expectLater(
-        storage.commitExistingServerSession(
-          ownership: ownership!,
-          token: 'candidate-token',
-          canCommit: () => true,
-          publish: () {},
-          onRollbackUncertain: () => poisoned = true,
-        ),
-        throwsA(isA<ServerConfigSessionRollbackException>()),
-      );
+    await expectLater(
+      storage.commitExistingServerSession(
+        ownership: ownership!,
+        token: 'candidate-token',
+        canCommit: () => true,
+        publish: () {},
+        onRollbackUncertain: () => poisoned = true,
+      ),
+      throwsA(isA<ServerConfigSessionRollbackException>()),
+    );
 
-      expect(poisoned, isTrue);
-      expect(await storage.getAuthToken(), isNull);
-      expect(await storage.getSavedCredentials(), isNull);
-      final failClosedConfigs = await storage.getServerConfigs();
-      expect(
-        failClosedConfigs.every(
-          (config) => config.customHeaders.keys.every(
-            (key) => key.toLowerCase() != 'cookie',
-          ),
+    expect(poisoned, isTrue);
+    expect(await storage.getAuthToken(), isNull);
+    expect(await storage.getSavedCredentials(), isNull);
+    final failClosedConfigs = await storage.getServerConfigs();
+    expect(
+      failClosedConfigs.every(
+        (config) => config.customHeaders.keys.every(
+          (key) => key.toLowerCase() != 'cookie',
         ),
-        isTrue,
-      );
-      expect(
-        failClosedConfigs
-            .firstWhere((config) => config.id == previous.id)
-            .customHeaders,
-        const {'X-Tenant': 'retained'},
-      );
-    },
-  );
+      ),
+      isTrue,
+    );
+    expect(
+      failClosedConfigs
+          .firstWhere((config) => config.id == previous.id)
+          .customHeaders,
+      const {'X-Tenant': 'retained'},
+    );
+  });
 
   test(
     'failed checked active-id write rolls back before candidate token',
@@ -1473,59 +1451,54 @@ void main() {
     },
   );
 
-  test(
-    'fresh server selection is bearer-tokenless and preserves exact candidate headers',
-    () async {
-      final previous = _serverConfig('server-a').copyWith(isActive: true);
-      final target = _serverConfig('server-b').copyWith(
-        apiKey: 'legacy-bearer',
-        customHeaders: const {
-          'Cookie': 'proxy_session=fresh-candidate',
-          'X-OpenWebUI-Key': 'fresh-custom-key',
-          'X-Tenant': 'fresh-routing-value',
-        },
-      );
-      await storage.saveServerConfigs([previous]);
-      await storage.setActiveServerId(previous.id);
-      await storage.saveAuthToken('previous-token');
-      await storage.saveCredentials(
-        serverId: previous.id,
-        username: 'previous-user',
-        password: 'previous-password',
-      );
-      secureStorageOperations.clear();
-      var publishedTokenless = false;
+  test('fresh server selection is bearer-tokenless and preserves exact candidate headers', () async {
+    final previous = _serverConfig('server-a').copyWith(isActive: true);
+    final target = _serverConfig('server-b').copyWith(
+      apiKey: 'legacy-bearer',
+      customHeaders: const {
+        'Cookie': 'proxy_session=fresh-candidate',
+        'X-OpenWebUI-Key': 'fresh-custom-key',
+        'X-Tenant': 'fresh-routing-value',
+      },
+    );
+    await storage.saveServerConfigs([previous]);
+    await storage.setActiveServerId(previous.id);
+    await storage.saveAuthToken('previous-token');
+    await storage.saveCredentials(
+      serverId: previous.id,
+      username: 'previous-user',
+      password: 'previous-password',
+    );
+    secureStorageOperations.clear();
+    var publishedTokenless = false;
 
-      await storage.selectUnauthenticatedServerConfig(
-        target,
-        publish: () {
-          publishedTokenless =
-              !secureStorageValues.containsKey('auth_token_v2') &&
-              PreferencesStore.getString(PreferenceKeys.activeServerId) ==
-                  target.id;
-        },
-      );
+    await storage.selectUnauthenticatedServerConfig(
+      target,
+      publish: () {
+        publishedTokenless =
+            !secureStorageValues.containsKey('auth_token_v2') &&
+            PreferencesStore.getString(PreferenceKeys.activeServerId) ==
+                target.id;
+      },
+    );
 
-      expect(publishedTokenless, isTrue);
-      expect(await storage.getAuthToken(), isNull);
-      expect(await storage.getSavedCredentials(), isNull);
-      expect(await storage.getServerConfigs(), [
-        target.copyWith(apiKey: null, isActive: true),
-      ]);
-      final tokenDelete = secureStorageOperations.indexOf(
-        'delete:auth_token_v2',
-      );
-      final credentialsDelete = secureStorageOperations.indexOf(
-        'delete:user_credentials_v2',
-      );
-      final configWrite = secureStorageOperations.indexOf(
-        'write:server_configs_v2',
-      );
-      expect(tokenDelete, greaterThanOrEqualTo(0));
-      expect(credentialsDelete, greaterThan(tokenDelete));
-      expect(configWrite, greaterThan(credentialsDelete));
-    },
-  );
+    expect(publishedTokenless, isTrue);
+    expect(await storage.getAuthToken(), isNull);
+    expect(await storage.getSavedCredentials(), isNull);
+    expect(await storage.getServerConfigs(), [
+      target.copyWith(apiKey: null, isActive: true),
+    ]);
+    final tokenDelete = secureStorageOperations.indexOf('delete:auth_token_v2');
+    final credentialsDelete = secureStorageOperations.indexOf(
+      'delete:user_credentials_v2',
+    );
+    final configWrite = secureStorageOperations.indexOf(
+      'write:server_configs_v2',
+    );
+    expect(tokenDelete, greaterThanOrEqualTo(0));
+    expect(credentialsDelete, greaterThan(tokenDelete));
+    expect(configWrite, greaterThan(credentialsDelete));
+  });
 
   test(
     'failed server-selection publication restores the prior session',
@@ -1587,59 +1560,56 @@ void main() {
     expect(await storage.getAuthToken(), 'previous-token');
   });
 
-  test(
-    'logout scrubs proxy cookies and legacy bearer but preserves connection '
-    'settings',
-    () async {
-      final config = _serverConfig('server-a').copyWith(
-        apiKey: 'legacy-bearer',
+  test('logout scrubs proxy cookies and legacy bearer but preserves connection '
+      'settings', () async {
+    final config = _serverConfig('server-a').copyWith(
+      apiKey: 'legacy-bearer',
+      customHeaders: const {
+        'Cookie': 'session=secret',
+        'CF-Access-Client-Id': 'service-token-id',
+        'CF-Access-Client-Secret': 'service-token-secret',
+        'X-Tenant': 'connection-routing-value',
+      },
+      allowSelfSignedCertificates: true,
+      mtlsCertificateChainPem: 'client-certificate',
+      mtlsCertificateLabel: 'client.crt',
+      mtlsPrivateKeyPem: 'client-private-key',
+      mtlsPrivateKeyLabel: 'client.key',
+      mtlsPrivateKeyPassword: 'private-key-password',
+      isActive: true,
+    );
+    await storage.saveServerConfigs([config]);
+    await storage.setActiveServerId(config.id);
+    await storage.saveAuthToken('token');
+    await storage.saveCredentials(
+      serverId: config.id,
+      username: 'user',
+      password: 'password',
+    );
+    secureStorageOperations.clear();
+
+    await storage.clearAuthData();
+
+    expect(await storage.getAuthToken(), isNull);
+    expect(await storage.getSavedCredentials(), isNull);
+    // Header-gated and mTLS-gated proxies must stay reachable for re-login:
+    // only the captured proxy session cookie and the legacy apiKey bearer
+    // are session credentials.
+    expect(await storage.getServerConfigs(), [
+      config.copyWith(
+        apiKey: null,
         customHeaders: const {
-          'Cookie': 'session=secret',
           'CF-Access-Client-Id': 'service-token-id',
           'CF-Access-Client-Secret': 'service-token-secret',
           'X-Tenant': 'connection-routing-value',
         },
-        allowSelfSignedCertificates: true,
-        mtlsCertificateChainPem: 'client-certificate',
-        mtlsCertificateLabel: 'client.crt',
-        mtlsPrivateKeyPem: 'client-private-key',
-        mtlsPrivateKeyLabel: 'client.key',
-        mtlsPrivateKeyPassword: 'private-key-password',
-        isActive: true,
-      );
-      await storage.saveServerConfigs([config]);
-      await storage.setActiveServerId(config.id);
-      await storage.saveAuthToken('token');
-      await storage.saveCredentials(
-        serverId: config.id,
-        username: 'user',
-        password: 'password',
-      );
-      secureStorageOperations.clear();
-
-      await storage.clearAuthData();
-
-      expect(await storage.getAuthToken(), isNull);
-      expect(await storage.getSavedCredentials(), isNull);
-      // Header-gated and mTLS-gated proxies must stay reachable for re-login:
-      // only the captured proxy session cookie and the legacy apiKey bearer
-      // are session credentials.
-      expect(await storage.getServerConfigs(), [
-        config.copyWith(
-          apiKey: null,
-          customHeaders: const {
-            'CF-Access-Client-Id': 'service-token-id',
-            'CF-Access-Client-Secret': 'service-token-secret',
-            'X-Tenant': 'connection-routing-value',
-          },
-        ),
-      ]);
-      expect(
-        secureStorageOperations.indexOf('delete:auth_token_v2'),
-        lessThan(secureStorageOperations.indexOf('write:server_configs_v2')),
-      );
-    },
-  );
+      ),
+    ]);
+    expect(
+      secureStorageOperations.indexOf('delete:auth_token_v2'),
+      lessThan(secureStorageOperations.indexOf('write:server_configs_v2')),
+    );
+  });
 
   test('logout preserves a standalone mTLS identity', () async {
     final config = _serverConfig('mtls-only').copyWith(
@@ -1666,10 +1636,7 @@ void main() {
     expect(preserved.mtlsPrivateKeyPem, 'standalone-private-key');
     expect(preserved.mtlsPrivateKeyLabel, 'standalone.key');
     expect(preserved.mtlsPrivateKeyPassword, 'standalone-password');
-    expect(
-      secureStorageOperations,
-      isNot(contains('write:server_configs_v2')),
-    );
+    expect(secureStorageOperations, isNot(contains('write:server_configs_v2')));
   });
 
   test(
@@ -1708,9 +1675,8 @@ void main() {
     () async {
       // Simulate a config persisted by a pre-hardening build that still
       // carries the legacy apiKey bearer field.
-      final legacy = _serverConfig(
-        'server-a',
-      ).copyWith(apiKey: 'legacy-bearer', isActive: true);
+      final legacy = _serverConfig('server-a')
+          .copyWith(apiKey: 'legacy-bearer', isActive: true);
       secureStorageValues['server_configs_v2'] = jsonEncode([legacy.toJson()]);
       await storage.setActiveServerId(legacy.id);
       await storage.saveAuthToken('session-token');
@@ -1724,9 +1690,7 @@ void main() {
       // legacy field. That one-time migration is not an ownership change.
       await storage.saveServerConfigs([legacy]);
 
-      expect(await storage.getServerConfigs(), [
-        legacy.copyWith(apiKey: null),
-      ]);
+      expect(await storage.getServerConfigs(), [legacy.copyWith(apiKey: null)]);
       expect(await storage.getAuthToken(), 'session-token');
       expect(await storage.getSavedCredentials(), isNotNull);
     },
@@ -1781,33 +1745,27 @@ void main() {
 
     await storage.saveServerConfigs([replacement]);
 
-    check(
-      PreferencesStore.getString(PreferenceKeys.activeServerId),
-    ).equals(replacement.id);
+    check(PreferencesStore.getString(PreferenceKeys.activeServerId))
+        .equals(replacement.id);
     check(await storage.getActiveServerId()).equals(replacement.id);
   });
 
-  test(
-    'locked missing-server cleanup preserves credentials when the server exists',
-    () async {
-      final config = _serverConfig('server-a').copyWith(isActive: true);
-      await storage.saveServerConfigs([config]);
-      await storage.saveCredentials(
-        serverId: config.id,
-        username: 'user',
-        password: 'password',
-      );
-      final expected = await storage.getSavedCredentials();
+  test('locked missing-server cleanup preserves credentials when the server exists', () async {
+    final config = _serverConfig('server-a').copyWith(isActive: true);
+    await storage.saveServerConfigs([config]);
+    await storage.saveCredentials(
+      serverId: config.id,
+      username: 'user',
+      password: 'password',
+    );
+    final expected = await storage.getSavedCredentials();
 
-      expect(
-        await storage.deleteSavedCredentialsIfMatchesAndServerMissing(
-          expected!,
-        ),
-        isFalse,
-      );
-      expect(await storage.getSavedCredentials(), expected);
-    },
-  );
+    expect(
+      await storage.deleteSavedCredentialsIfMatchesAndServerMissing(expected!),
+      isFalse,
+    );
+    expect(await storage.getSavedCredentials(), expected);
+  });
 
   test('staging snapshots the effective fallback active server', () async {
     final previous = _serverConfig('server-a').copyWith(isActive: true);
@@ -1828,9 +1786,8 @@ void main() {
     'process death after staging leaves durable session untouched',
     () async {
       final previous = _serverConfig('server-a').copyWith(isActive: true);
-      final candidate = _serverConfig(
-        'server-candidate',
-      ).copyWith(apiKey: 'candidate-token', isActive: true);
+      final candidate = _serverConfig('server-candidate')
+          .copyWith(apiKey: 'candidate-token', isActive: true);
       await storage.saveServerConfigs([previous]);
       await storage.setActiveServerId(previous.id);
       await storage.saveAuthToken('previous-token');
@@ -1859,9 +1816,8 @@ void main() {
     'provider rebuild cannot publish or activate a staged proxy candidate',
     () async {
       final previous = _serverConfig('server-a').copyWith(isActive: true);
-      final candidate = _serverConfig(
-        'server-candidate',
-      ).copyWith(isActive: true);
+      final candidate = _serverConfig('server-candidate')
+          .copyWith(isActive: true);
       await storage.saveServerConfigs([previous]);
       await storage.setActiveServerId(previous.id);
       final snapshot = await storage.stageServerConfigCandidate(candidate);
@@ -2136,67 +2092,64 @@ void main() {
     expect(restored?.id, modelA.id);
   });
 
-  test(
-    'user cache cleanup cannot retarget transport options after an A to B switch',
-    () async {
-      final databaseA = AppDatabase(NativeDatabase.memory());
-      addTearDown(databaseA.close);
-      final releaseStarted = Completer<void>();
-      final releaseGate = Completer<void>();
-      addTearDown(() {
-        if (!releaseGate.isCompleted) releaseGate.complete();
-      });
-      storage = OptimizedStorageService(
-        secureStorage: const FlutterSecureStorage(),
-        boxes: HiveBoxes(
-          preferences: preferences,
-          caches: caches,
-          attachmentQueue: attachmentQueue,
-          metadata: metadata,
-        ),
-        workerManager: workerManager,
-        databaseAccess: () => OptimizedStorageDatabaseHandle(
-          database: databaseA,
-          onRelease: () async {
-            if (!releaseStarted.isCompleted) releaseStarted.complete();
-            await releaseGate.future;
-          },
-        ),
-      );
-      const optionsA = SocketTransportAvailability(
-        allowPolling: false,
-        allowWebsocketOnly: true,
-      );
-      const optionsB = SocketTransportAvailability(
-        allowPolling: true,
-        allowWebsocketOnly: false,
-      );
-      await saveServerConfigs(['server-a', 'server-b']);
-      await storage.setActiveServerId('server-a');
-      await storage.saveLocalTransportOptions(optionsA);
-      await storage.setActiveServerId('server-b');
-      await storage.saveLocalTransportOptions(optionsB);
-      await storage.setActiveServerId('server-a');
+  test('user cache cleanup cannot retarget transport options after an A to B switch', () async {
+    final databaseA = AppDatabase(NativeDatabase.memory());
+    addTearDown(databaseA.close);
+    final releaseStarted = Completer<void>();
+    final releaseGate = Completer<void>();
+    addTearDown(() {
+      if (!releaseGate.isCompleted) releaseGate.complete();
+    });
+    storage = OptimizedStorageService(
+      secureStorage: const FlutterSecureStorage(),
+      boxes: HiveBoxes(
+        preferences: preferences,
+        caches: caches,
+        attachmentQueue: attachmentQueue,
+        metadata: metadata,
+      ),
+      workerManager: workerManager,
+      databaseAccess: () => OptimizedStorageDatabaseHandle(
+        database: databaseA,
+        onRelease: () async {
+          if (!releaseStarted.isCompleted) releaseStarted.complete();
+          await releaseGate.future;
+        },
+      ),
+    );
+    const optionsA = SocketTransportAvailability(
+      allowPolling: false,
+      allowWebsocketOnly: true,
+    );
+    const optionsB = SocketTransportAvailability(
+      allowPolling: true,
+      allowWebsocketOnly: false,
+    );
+    await saveServerConfigs(['server-a', 'server-b']);
+    await storage.setActiveServerId('server-a');
+    await storage.saveLocalTransportOptions(optionsA);
+    await storage.setActiveServerId('server-b');
+    await storage.saveLocalTransportOptions(optionsB);
+    await storage.setActiveServerId('server-a');
 
-      final cleanup = storage.clearUserScopedAuthData();
-      await releaseStarted.future;
+    final cleanup = storage.clearUserScopedAuthData();
+    await releaseStarted.future;
 
-      var switchCompleted = false;
-      final serverSwitch = storage.setActiveServerId('server-b').then((_) {
-        switchCompleted = true;
-      });
-      await Future<void>.delayed(Duration.zero);
-      expect(switchCompleted, isFalse);
+    var switchCompleted = false;
+    final serverSwitch = storage.setActiveServerId('server-b').then((_) {
+      switchCompleted = true;
+    });
+    await Future<void>.delayed(Duration.zero);
+    expect(switchCompleted, isFalse);
 
-      releaseGate.complete();
-      await cleanup;
-      await serverSwitch;
+    releaseGate.complete();
+    await cleanup;
+    await serverSwitch;
 
-      expect(storage.getLocalTransportOptionsSync(), optionsB);
-      await storage.setActiveServerId('server-a');
-      expect(storage.getLocalTransportOptionsSync(), isNull);
-    },
-  );
+    expect(storage.getLocalTransportOptionsSync(), optionsB);
+    await storage.setActiveServerId('server-a');
+    expect(storage.getLocalTransportOptionsSync(), isNull);
+  });
 
   test(
     'user cleanup cannot erase a newer queued authenticated user persistence',
@@ -2275,71 +2228,66 @@ void main() {
     },
   );
 
-  test(
-    'conditional full wipe preserves only non-secret server details when requested',
-    () async {
-      final config = _serverConfig('server-a').copyWith(
-        apiKey: 'legacy-session-token',
-        customHeaders: const {
-          'Cookie': 'proxy_session=remove-me',
-          'X-Tenant': 'keep-me',
-        },
-        allowSelfSignedCertificates: true,
-        mtlsCertificateChainPem: 'certificate',
-        mtlsCertificateLabel: 'client-certificate.pem',
-        mtlsPrivateKeyPem: 'private-key',
-        mtlsPrivateKeyLabel: 'client-key.pem',
-        mtlsPrivateKeyPassword: 'passphrase',
-        isActive: true,
-      );
-      await storage.saveServerConfigs([config]);
-      await storage.setActiveServerId(config.id);
-      await PreferencesStore.putChecked(PreferenceKeys.themeMode, 'dark');
-      await PreferencesStore.putChecked(PreferenceKeys.hermesEnabled, true);
-      await PreferencesStore.putChecked(
-        PreferenceKeys.incompleteLogoutFence,
-        true,
-      );
-      secureStorageValues['hermes_api_key_v1'] = 'hermes-secret';
-      secureStorageValues['direct_connection_profiles_v1'] = 'direct-profiles';
+  test('conditional full wipe preserves only non-secret server details when requested', () async {
+    final config = _serverConfig('server-a').copyWith(
+      apiKey: 'legacy-session-token',
+      customHeaders: const {
+        'Cookie': 'proxy_session=remove-me',
+        'X-Tenant': 'keep-me',
+      },
+      allowSelfSignedCertificates: true,
+      mtlsCertificateChainPem: 'certificate',
+      mtlsCertificateLabel: 'client-certificate.pem',
+      mtlsPrivateKeyPem: 'private-key',
+      mtlsPrivateKeyLabel: 'client-key.pem',
+      mtlsPrivateKeyPassword: 'passphrase',
+      isActive: true,
+    );
+    await storage.saveServerConfigs([config]);
+    await storage.setActiveServerId(config.id);
+    await PreferencesStore.putChecked(PreferenceKeys.themeMode, 'dark');
+    await PreferencesStore.putChecked(PreferenceKeys.hermesEnabled, true);
+    await PreferencesStore.putChecked(
+      PreferenceKeys.incompleteLogoutFence,
+      true,
+    );
+    secureStorageValues['hermes_api_key_v1'] = 'hermes-secret';
+    secureStorageValues['direct_connection_profiles_v1'] = 'direct-profiles';
 
-      final cleared = await storage.clearAllIf(
-        canClear: () => true,
-        preserveServerDetails: true,
-      );
+    final cleared = await storage.clearAllIf(
+      canClear: () => true,
+      preserveServerDetails: true,
+    );
 
-      expect(cleared, isTrue);
-      final retained = (await storage.getServerConfigs()).single;
-      expect(retained.id, config.id);
-      expect(retained.apiKey, isNull);
-      expect(
-        retained.customHeaders.keys.any(
-          (name) => name.toLowerCase() == 'cookie',
-        ),
-        isFalse,
-      );
-      check(retained.customHeaders).isEmpty();
-      check(retained.allowSelfSignedCertificates).isTrue();
-      check(retained.mtlsCertificateChainPem).isNull();
-      check(retained.mtlsCertificateLabel).isNull();
-      check(retained.mtlsPrivateKeyPem).isNull();
-      check(retained.mtlsPrivateKeyLabel).isNull();
-      check(retained.mtlsPrivateKeyPassword).isNull();
-      expect(await storage.getActiveServerId(), config.id);
+    expect(cleared, isTrue);
+    final retained = (await storage.getServerConfigs()).single;
+    expect(retained.id, config.id);
+    expect(retained.apiKey, isNull);
+    expect(
+      retained.customHeaders.keys.any((name) => name.toLowerCase() == 'cookie'),
+      isFalse,
+    );
+    check(retained.customHeaders).isEmpty();
+    check(retained.allowSelfSignedCertificates).isTrue();
+    check(retained.mtlsCertificateChainPem).isNull();
+    check(retained.mtlsCertificateLabel).isNull();
+    check(retained.mtlsPrivateKeyPem).isNull();
+    check(retained.mtlsPrivateKeyLabel).isNull();
+    check(retained.mtlsPrivateKeyPassword).isNull();
+    expect(await storage.getActiveServerId(), config.id);
 
-      expect(PreferencesStore.getString(PreferenceKeys.themeMode), isNull);
-      expect(PreferencesStore.getBool(PreferenceKeys.hermesEnabled), isNull);
-      expect(
-        PreferencesStore.getBool(PreferenceKeys.incompleteLogoutFence),
-        isTrue,
-      );
-      expect(secureStorageValues.containsKey('hermes_api_key_v1'), isFalse);
-      expect(
-        secureStorageValues.containsKey('direct_connection_profiles_v1'),
-        isFalse,
-      );
-    },
-  );
+    expect(PreferencesStore.getString(PreferenceKeys.themeMode), isNull);
+    expect(PreferencesStore.getBool(PreferenceKeys.hermesEnabled), isNull);
+    expect(
+      PreferencesStore.getBool(PreferenceKeys.incompleteLogoutFence),
+      isTrue,
+    );
+    expect(secureStorageValues.containsKey('hermes_api_key_v1'), isFalse);
+    expect(
+      secureStorageValues.containsKey('direct_connection_profiles_v1'),
+      isFalse,
+    );
+  });
 
   test('conditional full wipe removes server details by default', () async {
     await saveServerConfigs(['server-a']);
@@ -2367,10 +2315,7 @@ void main() {
       );
 
       await expectLater(
-        storage.clearAllIf(
-          canClear: () => true,
-          preserveServerDetails: true,
-        ),
+        storage.clearAllIf(canClear: () => true, preserveServerDetails: true),
         throwsA(isA<PlatformException>()),
       );
 
@@ -2429,9 +2374,9 @@ void main() {
       check(await storage.getServerConfigs()).isEmpty();
       check(await storage.getActiveServerId()).isNull();
 
-      final storedConfigs =
-          jsonDecode(secureStorageValues['server_configs_v2']!)
-              as List<dynamic>;
+      final storedConfigs = jsonDecode(
+        secureStorageValues['server_configs_v2']!,
+      ) as List<dynamic>;
       final storedConfig = ServerConfig.fromJson(storedConfigs.single);
       check(storedConfig.apiKey).isNull();
       check(
@@ -2443,135 +2388,125 @@ void main() {
     },
   );
 
-  test(
-    'failed wipe suppression survives cache expiry eviction and clearing until explicit resave',
-    () async {
-      storage = OptimizedStorageService(
-        secureStorage: const FlutterSecureStorage(),
-        boxes: HiveBoxes(
-          preferences: preferences,
-          caches: caches,
-          attachmentQueue: attachmentQueue,
-          metadata: metadata,
-        ),
-        workerManager: workerManager,
-        cacheManager: CacheManager(maxEntries: 1),
-        authTokenCacheTtl: Duration.zero,
-        serverIdCacheTtl: Duration.zero,
-        serverConfigsCacheTtl: Duration.zero,
-        credentialsFlagCacheTtl: Duration.zero,
-      );
-      final retainedConfig = _serverConfig('server-a').copyWith(
-        apiKey: 'retained-api-key',
-        customHeaders: const {'Cookie': 'retained-proxy-cookie'},
-        isActive: true,
-      );
-      await storage.saveServerConfigs([retainedConfig]);
-      await storage.setActiveServerId(retainedConfig.id);
-      await storage.saveAuthToken('retained-token');
-      await storage.saveCredentials(
-        serverId: retainedConfig.id,
-        username: 'retained-user',
-        password: 'retained-password',
-      );
-      secureStorageFailureCountdowns['delete:auth_token_v2'] = 1;
-      secureStorageFailureCountdowns['delete:user_credentials_v2'] = 1;
-      secureStorageFailureCountdowns['write:server_configs_v2'] = 1;
-      secureStorageFailureCountdowns['deleteAll:null'] = 1;
+  test('failed wipe suppression survives cache expiry eviction and clearing until explicit resave', () async {
+    storage = OptimizedStorageService(
+      secureStorage: const FlutterSecureStorage(),
+      boxes: HiveBoxes(
+        preferences: preferences,
+        caches: caches,
+        attachmentQueue: attachmentQueue,
+        metadata: metadata,
+      ),
+      workerManager: workerManager,
+      cacheManager: CacheManager(maxEntries: 1),
+      authTokenCacheTtl: Duration.zero,
+      serverIdCacheTtl: Duration.zero,
+      serverConfigsCacheTtl: Duration.zero,
+      credentialsFlagCacheTtl: Duration.zero,
+    );
+    final retainedConfig = _serverConfig('server-a').copyWith(
+      apiKey: 'retained-api-key',
+      customHeaders: const {'Cookie': 'retained-proxy-cookie'},
+      isActive: true,
+    );
+    await storage.saveServerConfigs([retainedConfig]);
+    await storage.setActiveServerId(retainedConfig.id);
+    await storage.saveAuthToken('retained-token');
+    await storage.saveCredentials(
+      serverId: retainedConfig.id,
+      username: 'retained-user',
+      password: 'retained-password',
+    );
+    secureStorageFailureCountdowns['delete:auth_token_v2'] = 1;
+    secureStorageFailureCountdowns['delete:user_credentials_v2'] = 1;
+    secureStorageFailureCountdowns['write:server_configs_v2'] = 1;
+    secureStorageFailureCountdowns['deleteAll:null'] = 1;
 
-      await expectLater(storage.clearAll(), throwsA(isA<PlatformException>()));
-      // Model a retained/reintroduced platform preference independently of the
-      // service cache. The process-local wipe fence must still hide it.
-      await PreferencesStore.putChecked(
-        PreferenceKeys.activeServerId,
-        retainedConfig.id,
-      );
-      await Future<void>.delayed(const Duration(milliseconds: 2));
-      storage.clearCache();
+    await expectLater(storage.clearAll(), throwsA(isA<PlatformException>()));
+    // Model a retained/reintroduced platform preference independently of the
+    // service cache. The process-local wipe fence must still hide it.
+    await PreferencesStore.putChecked(
+      PreferenceKeys.activeServerId,
+      retainedConfig.id,
+    );
+    await Future<void>.delayed(const Duration(milliseconds: 2));
+    storage.clearCache();
 
-      expect(secureStorageValues['auth_token_v2'], 'retained-token');
-      expect(secureStorageValues.containsKey('user_credentials_v2'), isTrue);
-      expect(await storage.getAuthTokenStrict(), isNull);
-      expect(await storage.getSavedCredentialsStrict(), isNull);
-      expect(await storage.getServerConfigsStrict(), isEmpty);
-      expect(await storage.getActiveServerId(), isNull);
+    expect(secureStorageValues['auth_token_v2'], 'retained-token');
+    expect(secureStorageValues.containsKey('user_credentials_v2'), isTrue);
+    expect(await storage.getAuthTokenStrict(), isNull);
+    expect(await storage.getSavedCredentialsStrict(), isNull);
+    expect(await storage.getServerConfigsStrict(), isEmpty);
+    expect(await storage.getActiveServerId(), isNull);
 
-      // A later cleanup pass must bypass both the suppression flag and the
-      // negative cache so it can sanitize the retained platform payload.
-      await storage.clearAuthData();
-      final scrubbedConfigs =
-          jsonDecode(secureStorageValues['server_configs_v2']!)
-              as List<dynamic>;
-      final scrubbedConfig = ServerConfig.fromJson(scrubbedConfigs.single);
-      expect(scrubbedConfig.apiKey, isNull);
-      expect(
-        scrubbedConfig.customHeaders.keys.any(
-          (name) => name.toLowerCase() == 'cookie',
-        ),
-        isFalse,
-      );
-      expect(scrubbedConfig.customHeaders, isEmpty);
-      expect(await storage.getServerConfigsStrict(), isEmpty);
+    // A later cleanup pass must bypass both the suppression flag and the
+    // negative cache so it can sanitize the retained platform payload.
+    await storage.clearAuthData();
+    final scrubbedConfigs =
+        jsonDecode(secureStorageValues['server_configs_v2']!) as List<dynamic>;
+    final scrubbedConfig = ServerConfig.fromJson(scrubbedConfigs.single);
+    expect(scrubbedConfig.apiKey, isNull);
+    expect(
+      scrubbedConfig.customHeaders.keys.any(
+        (name) => name.toLowerCase() == 'cookie',
+      ),
+      isFalse,
+    );
+    expect(scrubbedConfig.customHeaders, isEmpty);
+    expect(await storage.getServerConfigsStrict(), isEmpty);
 
-      final replacement = _serverConfig('server-b').copyWith(isActive: true);
-      await storage.saveServerConfigs([replacement]);
-      await storage.setActiveServerId(replacement.id);
-      await storage.saveAuthToken('replacement-token');
-      await storage.saveCredentials(
-        serverId: replacement.id,
-        username: 'replacement-user',
-        password: 'replacement-password',
-      );
+    final replacement = _serverConfig('server-b').copyWith(isActive: true);
+    await storage.saveServerConfigs([replacement]);
+    await storage.setActiveServerId(replacement.id);
+    await storage.saveAuthToken('replacement-token');
+    await storage.saveCredentials(
+      serverId: replacement.id,
+      username: 'replacement-user',
+      password: 'replacement-password',
+    );
 
-      expect(await storage.getAuthTokenStrict(), 'replacement-token');
-      expect(
-        (await storage.getSavedCredentialsStrict())?['username'],
-        'replacement-user',
-      );
-      expect(
-        (await storage.getServerConfigsStrict()).single.id,
-        replacement.id,
-      );
-      expect(await storage.getActiveServerId(), replacement.id);
-    },
-  );
+    expect(await storage.getAuthTokenStrict(), 'replacement-token');
+    expect(
+      (await storage.getSavedCredentialsStrict())?['username'],
+      'replacement-user',
+    );
+    expect((await storage.getServerConfigsStrict()).single.id, replacement.id);
+    expect(await storage.getActiveServerId(), replacement.id);
+  });
 
-  test(
-    'clearAll queued behind a session commit cannot be followed by token resurrection',
-    () async {
-      final previous = _serverConfig('server-a').copyWith(isActive: true);
-      final target = _serverConfig('server-b');
-      await storage.saveServerConfigs([previous, target]);
-      await storage.setActiveServerId(previous.id);
-      await storage.saveAuthToken('previous-token');
-      final ownership = await storage.captureServerSessionOwnership(
-        validatedConfig: target,
-        requireActive: false,
-      );
-      final tokenWriteEntered = Completer<void>();
-      final releaseTokenWrite = Completer<void>();
-      secureStorageOperationEntered['write:auth_token_v2'] = tokenWriteEntered;
-      secureStorageOperationGates['write:auth_token_v2'] = releaseTokenWrite;
+  test('clearAll queued behind a session commit cannot be followed by token resurrection', () async {
+    final previous = _serverConfig('server-a').copyWith(isActive: true);
+    final target = _serverConfig('server-b');
+    await storage.saveServerConfigs([previous, target]);
+    await storage.setActiveServerId(previous.id);
+    await storage.saveAuthToken('previous-token');
+    final ownership = await storage.captureServerSessionOwnership(
+      validatedConfig: target,
+      requireActive: false,
+    );
+    final tokenWriteEntered = Completer<void>();
+    final releaseTokenWrite = Completer<void>();
+    secureStorageOperationEntered['write:auth_token_v2'] = tokenWriteEntered;
+    secureStorageOperationGates['write:auth_token_v2'] = releaseTokenWrite;
 
-      var published = false;
-      final commit = storage.commitExistingServerSession(
-        ownership: ownership!,
-        token: 'candidate-token',
-        canCommit: () => true,
-        publish: () => published = true,
-      );
-      await tokenWriteEntered.future;
-      final wipe = storage.clearAll();
-      releaseTokenWrite.complete();
+    var published = false;
+    final commit = storage.commitExistingServerSession(
+      ownership: ownership!,
+      token: 'candidate-token',
+      canCommit: () => true,
+      publish: () => published = true,
+    );
+    await tokenWriteEntered.future;
+    final wipe = storage.clearAll();
+    releaseTokenWrite.complete();
 
-      expect(await commit, isTrue);
-      expect(published, isTrue);
-      await wipe;
-      expect(await storage.getAuthToken(), isNull);
-      expect(await storage.getServerConfigs(), isEmpty);
-      expect(await storage.getActiveServerId(), isNull);
-    },
-  );
+    expect(await commit, isTrue);
+    expect(published, isTrue);
+    await wipe;
+    expect(await storage.getAuthToken(), isNull);
+    expect(await storage.getServerConfigs(), isEmpty);
+    expect(await storage.getActiveServerId(), isNull);
+  });
 
   test(
     'clearAll keeps its server owner until deferred Drift cleanup finishes',

--- a/test/core/services/semantic_message_builder_test.dart
+++ b/test/core/services/semantic_message_builder_test.dart
@@ -20,6 +20,31 @@ void main() {
       check(rendered).not((it) => it.contains('&#x2F;'));
     });
 
+    test('preserves quotation marks in text blocks', () {
+      // Quotes escaped to &quot; surfaced literally when the entity landed in
+      // a context the markdown decoder skips (after a backquote, inside code
+      // reached via the streaming fragment path).
+      final rendered = renderSemanticMessageBlocks([
+        const SemanticTextBlock('She said "hi" and typed `" as a delimiter'),
+      ]);
+
+      check(rendered).contains('She said "hi"');
+      check(rendered).not((it) => it.contains('&quot;'));
+    });
+
+    test('keeps whitespace-only text blocks between sections', () {
+      // Dropping a whitespace-only block loses the blank line between a
+      // reasoning section and the answer; the streaming append delta never
+      // re-emits the swallowed prefix.
+      final rendered = renderSemanticMessageBlocks([
+        SemanticDetailsBlock.reasoning(text: 'thinking', done: true),
+        const SemanticTextBlock('\n\n'),
+        const SemanticTextBlock('Answer.'),
+      ]);
+
+      check(rendered).contains('</details>\n\n\n\nAnswer.');
+    });
+
     test('preserves apostrophes in text blocks', () {
       final rendered = renderSemanticMessageBlocks([
         const SemanticTextBlock("it's a `don't` case"),
@@ -83,7 +108,7 @@ void main() {
       );
       check(rendered).contains('<https://example.test/search?q=a&lang=en>');
       check(rendered).contains('<dev+direct@example.test>');
-      check(rendered).contains('&lt;details type=&quot;reasoning&quot;&gt;');
+      check(rendered).contains('&lt;details type="reasoning"&gt;');
       check(rendered).not((it) => it.contains('<details type="reasoning">'));
 
       final parsed = md.Document(
@@ -99,12 +124,10 @@ void main() {
           .where((element) => element.tag == 'a')
           .toList(growable: false);
       check(links).length.equals(2);
-      check(
-        links[0].attributes['href'],
-      ).equals('https://example.test/search?q=a&lang=en');
-      check(
-        links[1].attributes['href'],
-      ).equals('mailto:dev+direct@example.test');
+      check(links[0].attributes['href'])
+          .equals('https://example.test/search?q=a&lang=en');
+      check(links[1].attributes['href'])
+          .equals('mailto:dev+direct@example.test');
       check(elements.where((element) => element.tag == 'details')).isEmpty();
     });
 
@@ -146,9 +169,9 @@ void main() {
         ),
       ]);
 
-      check(rendered).contains(
-        '    &lt;details type=&quot;reasoning&quot;&gt;spoof&lt;/details&gt;',
-      );
+      check(
+        rendered,
+      ).contains('    &lt;details type="reasoning"&gt;spoof&lt;/details&gt;');
       check(rendered).not((it) => it.contains('<details type="reasoning">'));
     });
 
@@ -157,9 +180,8 @@ void main() {
         const SemanticTextBlock('\t<details type="reasoning">spoof</details>'),
       ]);
 
-      check(rendered).contains(
-        '\t&lt;details type=&quot;reasoning&quot;&gt;spoof&lt;/details&gt;',
-      );
+      check(rendered)
+          .contains('\t&lt;details type="reasoning"&gt;spoof&lt;/details&gt;');
       check(rendered).not((it) => it.contains('<details type="reasoning">'));
     });
 
@@ -203,9 +225,8 @@ void main() {
         extensionSet: md.ExtensionSet.gitHubWeb,
         encodeHtml: false,
       ).parse(rendered);
-      final code = _descendantElements(
-        parsed,
-      ).singleWhere((element) => element.tag == 'code');
+      final code = _descendantElements(parsed)
+          .singleWhere((element) => element.tag == 'code');
       check(code.textContent).equals('Map<String, int>');
     });
 
@@ -218,7 +239,7 @@ void main() {
         const SemanticTextBlock(answer),
       ]);
 
-      check(rendered).contains('&lt;details type=&quot;reasoning&quot;&gt;');
+      check(rendered).contains('&lt;details type="reasoning"&gt;');
       check(rendered).not((it) => it.contains('<details type="reasoning">'));
 
       final parsed = md.Document(
@@ -284,9 +305,8 @@ void main() {
       ]);
 
       // Left verbatim inside the (unclosed) code fence, not escaped as prose...
-      check(
-        rendered,
-      ).contains('```\n<details type="reasoning">spoof</details>');
+      check(rendered)
+          .contains('```\n<details type="reasoning">spoof</details>');
     });
 
     // CommonMark allows the closing fence to be longer than the opening one.

--- a/test/core/services/server_tls_http_client_factory_test.dart
+++ b/test/core/services/server_tls_http_client_factory_test.dart
@@ -10,9 +10,8 @@ import 'package:flutter_test/flutter_test.dart';
 void main() {
   group('ServerTlsHttpClientFactory', () {
     test('requires custom HttpClient for self-signed or mTLS servers', () {
-      check(
-        ServerTlsHttpClientFactory.requiresCustomHttpClient(_server()),
-      ).isFalse();
+      check(ServerTlsHttpClientFactory.requiresCustomHttpClient(_server()))
+          .isFalse();
       check(
         ServerTlsHttpClientFactory.requiresCustomHttpClient(
           _server(allowSelfSignedCertificates: true),

--- a/test/core/services/share_receiver_service_test.dart
+++ b/test/core/services/share_receiver_service_test.dart
@@ -535,39 +535,36 @@ void main() {
       );
     });
 
-    test(
-      'copies temp-root files without deleting the uncertain source',
-      () async {
-        final file = File(
-          p.join(
-            Directory.systemTemp.path,
-            'conduit-share-plugin-cache-root-${DateTime.now().microsecondsSinceEpoch}.txt',
-          ),
-        );
-        await file.writeAsString('hello from cache root');
-        addTearDown(() async {
-          if (await file.exists()) {
-            await file.delete();
-          }
-        });
+    test('copies temp-root files without deleting the uncertain source', () async {
+      final file = File(
+        p.join(
+          Directory.systemTemp.path,
+          'conduit-share-plugin-cache-root-${DateTime.now().microsecondsSinceEpoch}.txt',
+        ),
+      );
+      await file.writeAsString('hello from cache root');
+      addTearDown(() async {
+        if (await file.exists()) {
+          await file.delete();
+        }
+      });
 
-        final attachments = await validSharedAttachmentsForTest([file.path]);
-        addTearDown(
-          () => Future.wait(
-            attachments.map(
-              (attachment) => deleteShareStagingFile(attachment.file.path),
-            ),
+      final attachments = await validSharedAttachmentsForTest([file.path]);
+      addTearDown(
+        () => Future.wait(
+          attachments.map(
+            (attachment) => deleteShareStagingFile(attachment.file.path),
           ),
-        );
+        ),
+      );
 
-        expect(attachments, hasLength(1));
-        final stagedPath = attachments.single.file.path;
-        expect(await isShareStagingPath(stagedPath), isTrue);
-        expect(p.basename(p.dirname(stagedPath)), shareStagingDirectoryName);
-        expect(await File(stagedPath).readAsString(), 'hello from cache root');
-        expect(await file.exists(), isTrue);
-      },
-    );
+      expect(attachments, hasLength(1));
+      final stagedPath = attachments.single.file.path;
+      expect(await isShareStagingPath(stagedPath), isTrue);
+      expect(p.basename(p.dirname(stagedPath)), shareStagingDirectoryName);
+      expect(await File(stagedPath).readAsString(), 'hello from cache root');
+      expect(await file.exists(), isTrue);
+    });
 
     test(
       'deletes an exact legacy-plugin source through a one-use lease',

--- a/test/core/services/share_staging_cleanup_test.dart
+++ b/test/core/services/share_staging_cleanup_test.dart
@@ -131,8 +131,10 @@ void main() {
     test(
       'reclaims files staged by pre-upgrade builds under legacy roots',
       () async {
-        for (final legacyRootName in const ['shared-incoming',
-            'shared-intents']) {
+        for (final legacyRootName in const [
+          'shared-incoming',
+          'shared-intents',
+        ]) {
           final legacyRoot = Directory(
             p.join(Directory.systemTemp.path, legacyRootName),
           );
@@ -168,9 +170,8 @@ void main() {
           check(stageResult.copied).isTrue();
           await deleteShareStagingFile(stageResult.file.path);
 
-          check(
-            await deleteShareStagingFileWithResult(deletable.path),
-          ).equals(ShareStagingFileCleanupResult.removed);
+          check(await deleteShareStagingFileWithResult(deletable.path))
+              .equals(ShareStagingFileCleanupResult.removed);
           check(await deletable.exists()).isFalse();
 
           check(await cleanupTerminalAttachmentFile(terminal.path)).isTrue();
@@ -348,12 +349,9 @@ void main() {
         // The staging directory is a process-global temp root shared with
         // concurrently running suites, so assert only that THIS file was not
         // copied into it rather than snapshotting the whole directory.
-        check(
-          await _directArtifactSet(stagingDirectory),
-        ).not(
-          (artifacts) => artifacts.any(
-            (artifact) => artifact.contains('426614174014'),
-          ),
+        check(await _directArtifactSet(stagingDirectory)).not(
+          (artifacts) =>
+              artifacts.any((artifact) => artifact.contains('426614174014')),
         );
       },
     );
@@ -424,9 +422,8 @@ void main() {
           file.path,
           nativeStagingRootResolver: resolveNativeStagingRoot,
         );
-        check(
-          p.normalize(await staged.resolveSymbolicLinks()),
-        ).equals(p.normalize(await file.resolveSymbolicLinks()));
+        check(p.normalize(await staged.resolveSymbolicLinks()))
+            .equals(p.normalize(await file.resolveSymbolicLinks()));
 
         await deleteShareStagingFile(
           file.path,

--- a/test/core/services/socket_service_test.dart
+++ b/test/core/services/socket_service_test.dart
@@ -403,41 +403,38 @@ void main() {
     },
   );
 
-  test(
-    'resume reconciles an already-connected background lease without replacing it',
-    () async {
-      final socketFactory = _RecordingSocketFactory();
-      final service = SocketService(
-        serverConfig: _serverConfig,
-        socketFactory: socketFactory.create,
-      );
-      addTearDown(service.dispose);
-      var reconnectCount = 0;
-      final reconnectSub = service.onReconnect.listen((_) => reconnectCount++);
-      addTearDown(reconnectSub.cancel);
+  test('resume reconciles an already-connected background lease without replacing it', () async {
+    final socketFactory = _RecordingSocketFactory();
+    final service = SocketService(
+      serverConfig: _serverConfig,
+      socketFactory: socketFactory.create,
+    );
+    addTearDown(service.dispose);
+    var reconnectCount = 0;
+    final reconnectSub = service.onReconnect.listen((_) => reconnectCount++);
+    addTearDown(reconnectSub.cancel);
 
-      await service.connect();
-      final socket = socketFactory.sockets.single;
-      socket.connected = true;
-      socket.id = 'leased-background-session';
-      socket.emitReserved('connect');
-      await _flushMicrotasks(2);
-      final lease = service.acquireBackgroundActivityLease();
-      addTearDown(lease.dispose);
+    await service.connect();
+    final socket = socketFactory.sockets.single;
+    socket.connected = true;
+    socket.id = 'leased-background-session';
+    socket.emitReserved('connect');
+    await _flushMicrotasks(2);
+    final lease = service.acquireBackgroundActivityLease();
+    addTearDown(lease.dispose);
 
-      service.didChangeAppLifecycleState(AppLifecycleState.paused);
-      expect(socket.connected, isTrue);
-      expect(socket.io.reconnection, isTrue);
+    service.didChangeAppLifecycleState(AppLifecycleState.paused);
+    expect(socket.connected, isTrue);
+    expect(socket.io.reconnection, isTrue);
 
-      service.didChangeAppLifecycleState(AppLifecycleState.resumed);
-      await _flushMicrotasks(2);
+    service.didChangeAppLifecycleState(AppLifecycleState.resumed);
+    await _flushMicrotasks(2);
 
-      expect(socketFactory.sockets, hasLength(1));
-      expect(service.socket, same(socket));
-      expect(service.isConnected, isTrue);
-      expect(reconnectCount, 1);
-    },
-  );
+    expect(socketFactory.sockets, hasLength(1));
+    expect(service.socket, same(socket));
+    expect(service.isConnected, isTrue);
+    expect(reconnectCount, 1);
+  });
 
   test('background disables reconnect for an idle socket', () async {
     final socketFactory = _RecordingSocketFactory();

--- a/test/core/services/sse_frame_scanner_test.dart
+++ b/test/core/services/sse_frame_scanner_test.dart
@@ -71,17 +71,15 @@ void main() {
 
     test('rejects oversized lines and aggregate frame data', () {
       final lineScanner = SseFrameScanner(maxLineCharacters: 4);
-      check(
-        () => lineScanner.addChunk('abcde').toList(),
-      ).throws<FormatException>();
+      check(() => lineScanner.addChunk('abcde').toList())
+          .throws<FormatException>();
 
       final frameScanner = SseFrameScanner(
         maxLineCharacters: 32,
         maxFrameDataCharacters: 4,
       );
-      check(
-        () => frameScanner.addChunk('data: 12345\n\n').toList(),
-      ).throws<FormatException>();
+      check(() => frameScanner.addChunk('data: 12345\n\n').toList())
+          .throws<FormatException>();
     });
   });
 }

--- a/test/core/services/streaming_helper_transport_test.dart
+++ b/test/core/services/streaming_helper_transport_test.dart
@@ -2828,6 +2828,75 @@ void main() {
       check(log.finishCount).equals(1);
     });
 
+    test(
+      'poll recovery renders output[] when the persisted content is empty',
+      () async {
+        // OWUI 0.11 never persists a flat content string for a normal
+        // completion — a reasoning turn's raw content is '' and the durable
+        // body lives in output[]. Recovery must render it, or a socket that
+        // missed the final frames finishes the turn with the partial local
+        // text (tail chunks permanently missing).
+        final previousDelay = debugTaskSocketTerminalRecoveryDelay;
+        debugTaskSocketTerminalRecoveryDelay = const Duration(milliseconds: 10);
+        addTearDown(() {
+          debugTaskSocketTerminalRecoveryDelay = previousDelay;
+        });
+
+        final log = _CallbackLog();
+        final registrar = FakeSocketInjector();
+        final api = _buildFakeApi(
+          pollResponse: _serverConversationResponse(
+            messages: [
+              {
+                'id': 'msg-1',
+                'role': 'assistant',
+                'content': '',
+                'timestamp': DateTime.now().millisecondsSinceEpoch ~/ 1000,
+                'done': true,
+                'output': [
+                  {
+                    'type': 'reasoning',
+                    'content': [
+                      {'type': 'output_text', 'text': 'thinking hard'},
+                    ],
+                    'duration': 3,
+                  },
+                  {
+                    'type': 'message',
+                    'content': [
+                      {
+                        'type': 'output_text',
+                        'text': 'Full answer with the tail intact.',
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          ),
+        );
+
+        _attach(
+          session: ChatCompletionSession.taskSocket(
+            messageId: 'msg-1',
+            sessionId: 'sess-1',
+            conversationId: 'conv-1',
+            taskId: 'task-1',
+          ),
+          log: log,
+          api: api,
+          activeConversationId: 'conv-1',
+          socketService: _MockSocketService(registrar),
+        );
+
+        await Future<void>.delayed(const Duration(milliseconds: 50));
+
+        check(log.messages.last.content)
+            .contains('Full answer with the tail intact.');
+        check(log.finishCount).equals(1);
+      },
+    );
+
     test('taskSocket terminal recovery keeps streaming open when polled snapshot is not done', () async {
       final previousDelay = debugTaskSocketTerminalRecoveryDelay;
       final previousLimit = debugTaskSocketStableNonTerminalRecoveryLimit;

--- a/test/core/services/streaming_helper_transport_test.dart
+++ b/test/core/services/streaming_helper_transport_test.dart
@@ -940,6 +940,69 @@ void main() {
     );
 
     test(
+      'a plain delta after a deferred structured projection does not drop '
+      'the deferred middle of the response',
+      () async {
+        final log = _CallbackLog();
+        // First snapshot contains a backtick, which permanently disables the
+        // projector's plain-append fast path; the second snapshot is under
+        // the geometric re-projection threshold (2x), so it is deferred and
+        // the visible content stays at the first snapshot.
+        final part1 =
+            'Intro with `code` marker. ${List.filled(60, 'x').join()}';
+        const middle = ' MIDDLE-SEGMENT-THAT-MUST-SURVIVE';
+        const delta = ' FINAL-DELTA';
+        final byteStream = Stream<List<int>>.fromIterable([
+          _sseFrame({
+            'output': [
+              {
+                'type': 'message',
+                'content': [
+                  {'type': 'output_text', 'text': part1},
+                ],
+              },
+            ],
+          }),
+          _sseFrame({
+            'output': [
+              {
+                'type': 'message',
+                'content': [
+                  {'type': 'output_text', 'text': '$part1$middle'},
+                ],
+              },
+            ],
+          }),
+          _sseFrame({
+            'choices': [
+              {
+                'delta': {'content': delta},
+              },
+            ],
+          }),
+          _sseDone(),
+        ]);
+
+        _attach(
+          session: ChatCompletionSession.httpStream(
+            messageId: 'msg-1',
+            sessionId: 'sess-1',
+            byteStream: byteStream,
+            abort: () async {},
+          ),
+          log: log,
+        );
+
+        await pumpMicrotasks();
+        await pumpMicrotasks();
+        await Future<void>.delayed(const Duration(milliseconds: 10));
+
+        check(log.messages.last.content).equals('$part1$middle$delta');
+        check(log.finishCount).equals(1);
+      },
+    );
+
+    test(
       'chat:completion tracks tool placeholders without string scans',
       () async {
         final log = _CallbackLog();

--- a/test/core/services/streaming_helper_transport_test.dart
+++ b/test/core/services/streaming_helper_transport_test.dart
@@ -79,6 +79,64 @@ class _GatedChatCompletedApi extends ApiService {
   }
 }
 
+class _RecordingChatCompletedApi extends ApiService {
+  _RecordingChatCompletedApi({this.responseMessages})
+    : super(
+        serverConfig: const ServerConfig(
+          id: 'completion-recorder',
+          name: 'Completion recorder',
+          url: 'http://localhost:0',
+        ),
+        workerManager: WorkerManager(),
+        authToken: 'account-a',
+      );
+
+  /// When null, echoes the sent messages back like the server outlet handler.
+  final List<Map<String, dynamic>>? responseMessages;
+  List<Map<String, dynamic>>? capturedMessages;
+
+  @override
+  Future<Map<String, dynamic>?> sendChatCompleted({
+    required String chatId,
+    required String messageId,
+    required List<Map<String, dynamic>> messages,
+    required String model,
+    Map<String, dynamic>? modelItem,
+    String? sessionId,
+    List<String>? filterIds,
+    ApiAuthSnapshot? authSnapshot,
+  }) async {
+    capturedMessages = messages;
+    return {'messages': responseMessages ?? messages};
+  }
+}
+
+/// A callback log that mirrors the real notifier's buffering: streamed
+/// deltas are NOT visible in [messages] until [flushStreamingBuffer] runs.
+class _BufferedCallbackLog extends _CallbackLog {
+  final streamingBuffer = StringBuffer();
+
+  @override
+  void appendToLastMessage(String c) {
+    appendedChunks.add(c);
+    streamingBuffer.write(c);
+  }
+
+  @override
+  void flushStreamingBuffer() {
+    flushCount++;
+    if (streamingBuffer.isEmpty) return;
+    if (messages.isNotEmpty && messages.last.role == 'assistant') {
+      final last = messages.last;
+      messages = [
+        ...messages.sublist(0, messages.length - 1),
+        last.copyWith(content: last.content + streamingBuffer.toString()),
+      ];
+    }
+    streamingBuffer.clear();
+  }
+}
+
 /// Adapter that optionally returns a canned poll response.
 class _StubAdapter implements HttpClientAdapter {
   _StubAdapter({this.pollResponse, this.pollResponses});
@@ -692,6 +750,104 @@ void main() {
         adapter.requestCount(method: 'POST', path: '/api/chat/completed'),
       ).equals(1);
     });
+
+    test(
+      'httpStream sends the fully flushed content to /api/chat/completed '
+      'and its echo does not truncate it',
+      () async {
+        final log = _BufferedCallbackLog();
+        final api = _RecordingChatCompletedApi();
+        final byteStream = Stream<List<int>>.fromIterable([
+          _sseFrame({
+            'choices': [
+              {
+                'delta': {'content': 'Hello'},
+              },
+            ],
+          }),
+          _sseFrame({
+            'choices': [
+              {
+                'delta': {'content': ' world'},
+              },
+            ],
+          }),
+          _sseDone(),
+        ]);
+
+        _attach(
+          session: ChatCompletionSession.httpStream(
+            messageId: 'msg-1',
+            sessionId: 'sess-1',
+            byteStream: byteStream,
+            abort: () async {},
+          ),
+          log: log,
+          api: api,
+        );
+
+        await pumpMicrotasks();
+        await pumpMicrotasks();
+        await pumpMicrotasks();
+        await Future<void>.delayed(const Duration(milliseconds: 10));
+
+        // The streamed buffer must be folded into message state before the
+        // completed payload is built; a stale prefix here previously came
+        // back in the echo and truncated the message.
+        final assistantPayload = api.capturedMessages
+            ?.where((m) => m['id'] == 'msg-1')
+            .toList();
+        check(assistantPayload).isNotNull();
+        check(assistantPayload!.single['content']).equals('Hello world');
+        check(log.messages.last.content).equals('Hello world');
+      },
+    );
+
+    test(
+      'a completed echo carrying a stale prefix does not truncate content, '
+      'while a genuine outlet rewrite still applies',
+      () async {
+        Future<_BufferedCallbackLog> run(String echoContent) async {
+          final log = _BufferedCallbackLog();
+          final api = _RecordingChatCompletedApi(
+            responseMessages: [
+              {'id': 'msg-1', 'content': echoContent},
+            ],
+          );
+          final byteStream = Stream<List<int>>.fromIterable([
+            _sseFrame({
+              'choices': [
+                {
+                  'delta': {'content': 'Hello world'},
+                },
+              ],
+            }),
+            _sseDone(),
+          ]);
+          _attach(
+            session: ChatCompletionSession.httpStream(
+              messageId: 'msg-1',
+              sessionId: 'sess-1',
+              byteStream: byteStream,
+              abort: () async {},
+            ),
+            log: log,
+            api: api,
+          );
+          await pumpMicrotasks();
+          await pumpMicrotasks();
+          await pumpMicrotasks();
+          await Future<void>.delayed(const Duration(milliseconds: 10));
+          return log;
+        }
+
+        final stalePrefix = await run('Hello');
+        check(stalePrefix.messages.last.content).equals('Hello world');
+
+        final rewrite = await run('REWRITTEN BY OUTLET');
+        check(rewrite.messages.last.content).equals('REWRITTEN BY OUTLET');
+      },
+    );
 
     test('httpStream renders output-only structured snapshots', () async {
       final log = _CallbackLog();

--- a/test/core/services/streaming_helper_transport_test.dart
+++ b/test/core/services/streaming_helper_transport_test.dart
@@ -933,8 +933,65 @@ void main() {
         await pumpMicrotasks();
         await Future<void>.delayed(const Duration(milliseconds: 10));
 
-        check(log.appendedChunks).deepEquals(['Hel']);
+        // Upstream contract: an output snapshot in the frame supersedes its
+        // own delta, so the delta is not applied at all.
+        check(log.appendedChunks).deepEquals([]);
         check(log.messages.last.content).equals('Hello');
+        check(log.finishCount).equals(1);
+      },
+    );
+
+    test(
+      'an output snapshot after a mid-stream plain delta still renders',
+      () async {
+        final log = _CallbackLog();
+        // First snapshot disables the append fast path (backtick); the second
+        // defers under the geometric threshold; the delta-only frame forces a
+        // projection sync; the final snapshot must still render rather than
+        // deferring against a re-armed 2x-full-length threshold.
+        final part1 =
+            'Intro with `code` marker. ${List.filled(60, 'x').join()}';
+        const middle = ' MIDDLE-SEGMENT';
+        final more = ' TAIL-${List.filled(60, 'y').join()}';
+        Map<String, dynamic> outputFrame(String text) => {
+          'output': [
+            {
+              'type': 'message',
+              'content': [
+                {'type': 'output_text', 'text': text},
+              ],
+            },
+          ],
+        };
+        final byteStream = Stream<List<int>>.fromIterable([
+          _sseFrame(outputFrame(part1)),
+          _sseFrame(outputFrame('$part1$middle')),
+          _sseFrame({
+            'choices': [
+              {
+                'delta': {'content': ' plug-in delta'},
+              },
+            ],
+          }),
+          _sseFrame(outputFrame('$part1$middle$more')),
+          _sseDone(),
+        ]);
+
+        _attach(
+          session: ChatCompletionSession.httpStream(
+            messageId: 'msg-1',
+            sessionId: 'sess-1',
+            byteStream: byteStream,
+            abort: () async {},
+          ),
+          log: log,
+        );
+
+        await pumpMicrotasks();
+        await pumpMicrotasks();
+        await Future<void>.delayed(const Duration(milliseconds: 10));
+
+        check(log.messages.last.content).contains(more);
         check(log.finishCount).equals(1);
       },
     );
@@ -1586,7 +1643,9 @@ void main() {
         }, messageId: 'msg-1');
         await pumpMicrotasks();
 
-        check(log.appendedChunks).deepEquals(['Hel']);
+        // Upstream contract: the output snapshot supersedes the same-frame
+        // delta, so only the snapshot is applied.
+        check(log.appendedChunks).deepEquals([]);
         check(log.messages.last.content).equals('Hello');
         check(log.messages.last.output).isNotNull();
       },

--- a/test/core/services/streaming_helper_transport_test.dart
+++ b/test/core/services/streaming_helper_transport_test.dart
@@ -746,35 +746,78 @@ void main() {
 
       check(log.appendedChunks).deepEquals(['Hello', ' world']);
       check(log.finishCount).equals(1);
-      check(
-        adapter.requestCount(method: 'POST', path: '/api/chat/completed'),
-      ).equals(1);
+      check(adapter.requestCount(method: 'POST', path: '/api/chat/completed'))
+          .equals(1);
     });
 
-    test(
-      'httpStream sends the fully flushed content to /api/chat/completed '
-      'and its echo does not truncate it',
-      () async {
+    test('httpStream sends the fully flushed content to /api/chat/completed '
+        'and its echo does not truncate it', () async {
+      final log = _BufferedCallbackLog();
+      final api = _RecordingChatCompletedApi();
+      final byteStream = Stream<List<int>>.fromIterable([
+        _sseFrame({
+          'choices': [
+            {
+              'delta': {'content': 'Hello'},
+            },
+          ],
+        }),
+        _sseFrame({
+          'choices': [
+            {
+              'delta': {'content': ' world'},
+            },
+          ],
+        }),
+        _sseDone(),
+      ]);
+
+      _attach(
+        session: ChatCompletionSession.httpStream(
+          messageId: 'msg-1',
+          sessionId: 'sess-1',
+          byteStream: byteStream,
+          abort: () async {},
+        ),
+        log: log,
+        api: api,
+      );
+
+      await pumpMicrotasks();
+      await pumpMicrotasks();
+      await pumpMicrotasks();
+      await Future<void>.delayed(const Duration(milliseconds: 10));
+
+      // The streamed buffer must be folded into message state before the
+      // completed payload is built; a stale prefix here previously came
+      // back in the echo and truncated the message.
+      final assistantPayload = api.capturedMessages
+          ?.where((m) => m['id'] == 'msg-1')
+          .toList();
+      check(assistantPayload).isNotNull();
+      check(assistantPayload!.single['content']).equals('Hello world');
+      check(log.messages.last.content).equals('Hello world');
+    });
+
+    test('a completed echo carrying a stale prefix does not truncate content, '
+        'while a genuine outlet rewrite still applies', () async {
+      Future<_BufferedCallbackLog> run(String echoContent) async {
         final log = _BufferedCallbackLog();
-        final api = _RecordingChatCompletedApi();
+        final api = _RecordingChatCompletedApi(
+          responseMessages: [
+            {'id': 'msg-1', 'content': echoContent},
+          ],
+        );
         final byteStream = Stream<List<int>>.fromIterable([
           _sseFrame({
             'choices': [
               {
-                'delta': {'content': 'Hello'},
-              },
-            ],
-          }),
-          _sseFrame({
-            'choices': [
-              {
-                'delta': {'content': ' world'},
+                'delta': {'content': 'Hello world'},
               },
             ],
           }),
           _sseDone(),
         ]);
-
         _attach(
           session: ChatCompletionSession.httpStream(
             messageId: 'msg-1',
@@ -785,69 +828,19 @@ void main() {
           log: log,
           api: api,
         );
-
         await pumpMicrotasks();
         await pumpMicrotasks();
         await pumpMicrotasks();
         await Future<void>.delayed(const Duration(milliseconds: 10));
+        return log;
+      }
 
-        // The streamed buffer must be folded into message state before the
-        // completed payload is built; a stale prefix here previously came
-        // back in the echo and truncated the message.
-        final assistantPayload = api.capturedMessages
-            ?.where((m) => m['id'] == 'msg-1')
-            .toList();
-        check(assistantPayload).isNotNull();
-        check(assistantPayload!.single['content']).equals('Hello world');
-        check(log.messages.last.content).equals('Hello world');
-      },
-    );
+      final stalePrefix = await run('Hello');
+      check(stalePrefix.messages.last.content).equals('Hello world');
 
-    test(
-      'a completed echo carrying a stale prefix does not truncate content, '
-      'while a genuine outlet rewrite still applies',
-      () async {
-        Future<_BufferedCallbackLog> run(String echoContent) async {
-          final log = _BufferedCallbackLog();
-          final api = _RecordingChatCompletedApi(
-            responseMessages: [
-              {'id': 'msg-1', 'content': echoContent},
-            ],
-          );
-          final byteStream = Stream<List<int>>.fromIterable([
-            _sseFrame({
-              'choices': [
-                {
-                  'delta': {'content': 'Hello world'},
-                },
-              ],
-            }),
-            _sseDone(),
-          ]);
-          _attach(
-            session: ChatCompletionSession.httpStream(
-              messageId: 'msg-1',
-              sessionId: 'sess-1',
-              byteStream: byteStream,
-              abort: () async {},
-            ),
-            log: log,
-            api: api,
-          );
-          await pumpMicrotasks();
-          await pumpMicrotasks();
-          await pumpMicrotasks();
-          await Future<void>.delayed(const Duration(milliseconds: 10));
-          return log;
-        }
-
-        final stalePrefix = await run('Hello');
-        check(stalePrefix.messages.last.content).equals('Hello world');
-
-        final rewrite = await run('REWRITTEN BY OUTLET');
-        check(rewrite.messages.last.content).equals('REWRITTEN BY OUTLET');
-      },
-    );
+      final rewrite = await run('REWRITTEN BY OUTLET');
+      check(rewrite.messages.last.content).equals('REWRITTEN BY OUTLET');
+    });
 
     test('httpStream renders output-only structured snapshots', () async {
       final log = _CallbackLog();
@@ -889,9 +882,8 @@ void main() {
       await pumpMicrotasks();
       await Future<void>.delayed(const Duration(milliseconds: 10));
 
-      check(
-        log.replacedContents,
-      ).deepEquals(['Partial stream', 'Structured stream']);
+      check(log.replacedContents)
+          .deepEquals(['Partial stream', 'Structured stream']);
       check(log.messages.last.content).equals('Structured stream');
       check(log.finishCount).equals(1);
     });
@@ -996,47 +988,97 @@ void main() {
       },
     );
 
+    test('a plain delta after a deferred structured projection does not drop '
+        'the deferred middle of the response', () async {
+      final log = _CallbackLog();
+      // First snapshot contains a backtick, which permanently disables the
+      // projector's plain-append fast path; the second snapshot is under
+      // the geometric re-projection threshold (2x), so it is deferred and
+      // the visible content stays at the first snapshot.
+      final part1 = 'Intro with `code` marker. ${List.filled(60, 'x').join()}';
+      const middle = ' MIDDLE-SEGMENT-THAT-MUST-SURVIVE';
+      const delta = ' FINAL-DELTA';
+      final byteStream = Stream<List<int>>.fromIterable([
+        _sseFrame({
+          'output': [
+            {
+              'type': 'message',
+              'content': [
+                {'type': 'output_text', 'text': part1},
+              ],
+            },
+          ],
+        }),
+        _sseFrame({
+          'output': [
+            {
+              'type': 'message',
+              'content': [
+                {'type': 'output_text', 'text': '$part1$middle'},
+              ],
+            },
+          ],
+        }),
+        _sseFrame({
+          'choices': [
+            {
+              'delta': {'content': delta},
+            },
+          ],
+        }),
+        _sseDone(),
+      ]);
+
+      _attach(
+        session: ChatCompletionSession.httpStream(
+          messageId: 'msg-1',
+          sessionId: 'sess-1',
+          byteStream: byteStream,
+          abort: () async {},
+        ),
+        log: log,
+      );
+
+      await pumpMicrotasks();
+      await pumpMicrotasks();
+      await Future<void>.delayed(const Duration(milliseconds: 10));
+
+      check(log.messages.last.content).equals('$part1$middle$delta');
+      check(log.finishCount).equals(1);
+    });
+
     test(
-      'a plain delta after a deferred structured projection does not drop '
-      'the deferred middle of the response',
+      'a snapshot deferred after a plain delta is still applied at done',
       () async {
         final log = _CallbackLog();
-        // First snapshot contains a backtick, which permanently disables the
-        // projector's plain-append fast path; the second snapshot is under
-        // the geometric re-projection threshold (2x), so it is deferred and
-        // the visible content stays at the first snapshot.
+        // Snapshot 1 (backtick => additive schedule, appends disabled) is the
+        // applied projection; the plain delta flips the content basis; the
+        // final snapshot's tail stays under the re-projection threshold and
+        // DEFERS. The terminal finalize must reconcile to the authoritative
+        // snapshot instead of bailing — bailing permanently dropped the tail.
         final part1 =
             'Intro with `code` marker. ${List.filled(60, 'x').join()}';
-        const middle = ' MIDDLE-SEGMENT-THAT-MUST-SURVIVE';
-        const delta = ' FINAL-DELTA';
+        const tail = ' TAIL-MUST-SURVIVE-THE-DEFERRAL';
+        Map<String, dynamic> outputFrame(String text) => {
+          'output': [
+            {
+              'type': 'message',
+              'content': [
+                {'type': 'output_text', 'text': text},
+              ],
+            },
+          ],
+        };
         final byteStream = Stream<List<int>>.fromIterable([
-          _sseFrame({
-            'output': [
-              {
-                'type': 'message',
-                'content': [
-                  {'type': 'output_text', 'text': part1},
-                ],
-              },
-            ],
-          }),
-          _sseFrame({
-            'output': [
-              {
-                'type': 'message',
-                'content': [
-                  {'type': 'output_text', 'text': '$part1$middle'},
-                ],
-              },
-            ],
-          }),
+          _sseFrame(outputFrame(part1)),
           _sseFrame({
             'choices': [
               {
-                'delta': {'content': delta},
+                'delta': {'content': ' d'},
               },
             ],
           }),
+          _sseFrame(outputFrame('$part1$tail')),
           _sseDone(),
         ]);
 
@@ -1054,7 +1096,7 @@ void main() {
         await pumpMicrotasks();
         await Future<void>.delayed(const Duration(milliseconds: 10));
 
-        check(log.messages.last.content).equals('$part1$middle$delta');
+        check(log.messages.last.content).contains(tail);
         check(log.finishCount).equals(1);
       },
     );
@@ -1151,9 +1193,8 @@ void main() {
       check(lastMsg.content).equals('Hello world!');
       check(lastMsg.statusHistory.length).equals(2);
       check(lastMsg.statusHistory.first.description).equals('Searching');
-      check(
-        lastMsg.statusHistory.last.description,
-      ).equals('Generating image...');
+      check(lastMsg.statusHistory.last.description)
+          .equals('Generating image...');
       check(lastMsg.metadata).isNotNull();
       check(lastMsg.metadata!['status']).equals('Generating image...');
       check(log.messageByIdUpdates.length).equals(2);
@@ -1541,15 +1582,14 @@ void main() {
         }
         await pumpMicrotasks();
 
-        check(
-          log.replacedContents,
-        ).has((it) => it.length, 'length').isLessOrEqual(12);
-        check(
-          log.appendedChunks,
-        ).has((it) => it.length, 'length').isGreaterThan(snapshotCount - 20);
-        check(
-          log.messages.last.content,
-        ).equals(List.filled(snapshotCount, 'x').join());
+        check(log.replacedContents)
+            .has((it) => it.length, 'length')
+            .isLessOrEqual(12);
+        check(log.appendedChunks)
+            .has((it) => it.length, 'length')
+            .isGreaterThan(snapshotCount - 20);
+        check(log.messages.last.content)
+            .equals(List.filled(snapshotCount, 'x').join());
       },
     );
 
@@ -1602,9 +1642,9 @@ void main() {
         check(log.messages.last.content).contains('Visible answer');
         check(log.messages.last.content).contains('<details type="tool_calls"');
         check(log.messages.last.content).contains('name="search"');
-        check(
-          log.messages.last.output,
-        ).has((it) => it?.length, 'length').equals(2);
+        check(log.messages.last.output)
+            .has((it) => it?.length, 'length')
+            .equals(2);
       },
     );
 
@@ -1773,48 +1813,44 @@ void main() {
       },
     );
 
-    test(
-      'chat:completion same-payload output suppresses transient tool placeholder',
-      () async {
-        final log = _CallbackLog();
-        final registrar = FakeSocketInjector();
+    test('chat:completion same-payload output suppresses transient tool placeholder', () async {
+      final log = _CallbackLog();
+      final registrar = FakeSocketInjector();
 
-        _attach(
-          session: ChatCompletionSession.taskSocket(
-            messageId: 'msg-1',
-            sessionId: 'sess-1',
-            taskId: 'task-1',
-          ),
-          log: log,
-          socketService: _MockSocketService(registrar),
-        );
+      _attach(
+        session: ChatCompletionSession.taskSocket(
+          messageId: 'msg-1',
+          sessionId: 'sess-1',
+          taskId: 'task-1',
+        ),
+        log: log,
+        socketService: _MockSocketService(registrar),
+      );
 
-        await pumpMicrotasks();
+      await pumpMicrotasks();
 
-        registrar.emitChatEvent('chat:completion', {
-          'tool_calls': [
-            {
-              'id': 'call-1',
-              'function': {'name': 'search'},
-            },
-          ],
-          'output': [
-            {
-              'type': 'function_call',
-              'call_id': 'call-1',
-              'name': 'search',
-              'arguments': {'query': 'docs'},
-            },
-          ],
-        }, messageId: 'msg-1');
-        await pumpMicrotasks();
+      registrar.emitChatEvent('chat:completion', {
+        'tool_calls': [
+          {
+            'id': 'call-1',
+            'function': {'name': 'search'},
+          },
+        ],
+        'output': [
+          {
+            'type': 'function_call',
+            'call_id': 'call-1',
+            'name': 'search',
+            'arguments': {'query': 'docs'},
+          },
+        ],
+      }, messageId: 'msg-1');
+      await pumpMicrotasks();
 
-        check(
-          log.appendedChunks.any((chunk) => chunk.contains('Executing...')),
-        ).isFalse();
-        check(log.messages.last.content).contains('<details type="tool_calls"');
-      },
-    );
+      check(log.appendedChunks.any((chunk) => chunk.contains('Executing...')))
+          .isFalse();
+      check(log.messages.last.content).contains('<details type="tool_calls"');
+    });
 
     test(
       'chat:completion preserves a different same-name pending tool call',
@@ -1852,13 +1888,12 @@ void main() {
         }, messageId: 'msg-1');
         await pumpMicrotasks();
 
+        check(log.appendedChunks.any((chunk) => chunk.contains('Executing...')))
+            .isTrue();
         check(
-          log.appendedChunks.any((chunk) => chunk.contains('Executing...')),
-        ).isTrue();
-        check(
-          RegExp(
-            '<details type="tool_calls"',
-          ).allMatches(log.messages.last.content).length,
+          RegExp('<details type="tool_calls"')
+              .allMatches(log.messages.last.content)
+              .length,
         ).equals(2);
 
         registrar.emitChatEvent('chat:completion', {
@@ -1886,9 +1921,9 @@ void main() {
 
         final updatedContent = log.messages.last.content;
         check(
-          RegExp(
-            '<details type="tool_calls"',
-          ).allMatches(updatedContent).length,
+          RegExp('<details type="tool_calls"')
+              .allMatches(updatedContent)
+              .length,
         ).equals(2);
         check(updatedContent).contains('updated result');
         check(updatedContent).contains('Executing...');
@@ -1929,9 +1964,8 @@ void main() {
         }, messageId: 'msg-1');
         await pumpMicrotasks();
 
-        check(
-          log.appendedChunks.any((chunk) => chunk.contains('Executing...')),
-        ).isFalse();
+        check(log.appendedChunks.any((chunk) => chunk.contains('Executing...')))
+            .isFalse();
         check(log.messages.last.content).contains('<details type="tool_calls"');
       },
     );
@@ -1984,9 +2018,8 @@ void main() {
         await pumpMicrotasks();
 
         final content = log.messages.last.content;
-        check(
-          '<details type="tool_calls"'.allMatches(content).length,
-        ).equals(1);
+        check('<details type="tool_calls"'.allMatches(content).length)
+            .equals(1);
         check(content).contains('<summary>Tool Executed</summary>');
         check(content).contains('tool result');
         check(content).not((it) => it.contains('Executing...'));
@@ -2097,9 +2130,8 @@ void main() {
         emitOutput('Hello structured world');
         await pumpMicrotasks();
         check(log.messages.last.content).equals('Hello structured world');
-        check(
-          log.messages.last.content,
-        ).not((it) => it.contains('Executing...'));
+        check(log.messages.last.content)
+            .not((it) => it.contains('Executing...'));
 
         registrar.emitChatEvent(
           'chat:completion',
@@ -2130,8 +2162,7 @@ void main() {
         await pumpMicrotasks();
 
         registrar.emitChatEvent('chat:completion', {
-          'content':
-              '<details><summary>User details</summary>Keep me</details>\nFinal answer',
+          'content': '<details><summary>User details</summary>Keep me</details>\nFinal answer',
         }, messageId: 'msg-1');
         await pumpMicrotasks();
 
@@ -2214,52 +2245,47 @@ void main() {
       check(log.messages.last.content).equals('Final answer');
     });
 
-    test(
-      'chat:completion structured tool snapshot suppresses duplicate pending status',
-      () async {
-        final log = _CallbackLog();
-        final registrar = FakeSocketInjector();
+    test('chat:completion structured tool snapshot suppresses duplicate pending status', () async {
+      final log = _CallbackLog();
+      final registrar = FakeSocketInjector();
 
-        _attach(
-          session: ChatCompletionSession.taskSocket(
-            messageId: 'msg-1',
-            sessionId: 'sess-1',
-            taskId: 'task-1',
-          ),
-          log: log,
-          socketService: _MockSocketService(registrar),
-        );
+      _attach(
+        session: ChatCompletionSession.taskSocket(
+          messageId: 'msg-1',
+          sessionId: 'sess-1',
+          taskId: 'task-1',
+        ),
+        log: log,
+        socketService: _MockSocketService(registrar),
+      );
 
-        await pumpMicrotasks();
+      await pumpMicrotasks();
 
-        registrar.emitChatEvent('chat:completion', {
-          'output': [
-            {
-              'type': 'function_call',
-              'call_id': 'call-1',
-              'name': 'search',
-              'arguments': {'query': 'docs'},
-            },
-          ],
-        }, messageId: 'msg-1');
-        await pumpMicrotasks();
+      registrar.emitChatEvent('chat:completion', {
+        'output': [
+          {
+            'type': 'function_call',
+            'call_id': 'call-1',
+            'name': 'search',
+            'arguments': {'query': 'docs'},
+          },
+        ],
+      }, messageId: 'msg-1');
+      await pumpMicrotasks();
 
-        registrar.emitChatEvent('chat:completion', {
-          'tool_calls': [
-            {
-              'id': 'call-1',
-              'function': {'name': 'search'},
-            },
-          ],
-        }, messageId: 'msg-1');
-        await pumpMicrotasks();
+      registrar.emitChatEvent('chat:completion', {
+        'tool_calls': [
+          {
+            'id': 'call-1',
+            'function': {'name': 'search'},
+          },
+        ],
+      }, messageId: 'msg-1');
+      await pumpMicrotasks();
 
-        final content = log.messages.last.content;
-        check(
-          '<details type="tool_calls"'.allMatches(content).length,
-        ).equals(1);
-      },
-    );
+      final content = log.messages.last.content;
+      check('<details type="tool_calls"'.allMatches(content).length).equals(1);
+    });
 
     test(
       'chat:completion output snapshot keeps answer after reasoning-only state',
@@ -2369,9 +2395,8 @@ void main() {
         await pumpMicrotasks();
 
         final content = log.messages.last.content;
-        check(
-          '<details type="tool_calls"'.allMatches(content).length,
-        ).equals(1);
+        check('<details type="tool_calls"'.allMatches(content).length)
+            .equals(1);
         check(content).contains('Visible answer');
         check(content).contains('second result');
         check(content).not((it) => it.contains('&lt;details'));
@@ -2427,62 +2452,58 @@ void main() {
       },
     );
 
-    test(
-      'snapshot pull released after teardown never falls back through the retired API',
-      () async {
-        final log = _CallbackLog(
-          initialMessages: [
-            ChatMessage(
-              id: 'msg-1',
-              role: 'assistant',
-              content: 'Answer',
-              timestamp: DateTime.now(),
-              isStreaming: true,
-            ),
-          ],
-        );
-        final api = _buildFakeApi(
-          pollResponse: _serverConversationResponse(
-            messages: [_serverAssistantMessage(content: 'must not fetch')],
+    test('snapshot pull released after teardown never falls back through the retired API', () async {
+      final log = _CallbackLog(
+        initialMessages: [
+          ChatMessage(
+            id: 'msg-1',
+            role: 'assistant',
+            content: 'Answer',
+            timestamp: DateTime.now(),
+            isStreaming: true,
           ),
-        );
-        final adapter = api.dio.httpClientAdapter as _StubAdapter;
-        final pullStarted = Completer<void>();
-        final releasePull = Completer<void>();
-        var ownsContext = true;
+        ],
+      );
+      final api = _buildFakeApi(
+        pollResponse: _serverConversationResponse(
+          messages: [_serverAssistantMessage(content: 'must not fetch')],
+        ),
+      );
+      final adapter = api.dio.httpClientAdapter as _StubAdapter;
+      final pullStarted = Completer<void>();
+      final releasePull = Completer<void>();
+      var ownsContext = true;
 
-        final activeStream = _attach(
-          session: ChatCompletionSession.httpStream(
-            messageId: 'msg-1',
-            sessionId: 'sess-1',
-            conversationId: 'conv-1',
-            byteStream: Stream<List<int>>.fromIterable([_sseDone()]),
-            abort: () async {},
-          ),
-          log: log,
-          api: api,
-          activeConversationId: 'conv-1',
-          ownsStreamContext: () => ownsContext,
-          pullChatSnapshot: (_) async {
-            if (!pullStarted.isCompleted) pullStarted.complete();
-            await releasePull.future;
-            return null;
-          },
-        );
+      final activeStream = _attach(
+        session: ChatCompletionSession.httpStream(
+          messageId: 'msg-1',
+          sessionId: 'sess-1',
+          conversationId: 'conv-1',
+          byteStream: Stream<List<int>>.fromIterable([_sseDone()]),
+          abort: () async {},
+        ),
+        log: log,
+        api: api,
+        activeConversationId: 'conv-1',
+        ownsStreamContext: () => ownsContext,
+        pullChatSnapshot: (_) async {
+          if (!pullStarted.isCompleted) pullStarted.complete();
+          await releasePull.future;
+          return null;
+        },
+      );
 
-        await pullStarted.future.timeout(const Duration(seconds: 1));
-        ownsContext = false;
-        activeStream.disposeWatchdog();
-        releasePull.complete();
-        for (var i = 0; i < 10; i++) {
-          await pumpMicrotasks();
-        }
+      await pullStarted.future.timeout(const Duration(seconds: 1));
+      ownsContext = false;
+      activeStream.disposeWatchdog();
+      releasePull.complete();
+      for (var i = 0; i < 10; i++) {
+        await pumpMicrotasks();
+      }
 
-        check(
-          adapter.requestCount(method: 'GET', path: '/api/v1/chats/conv-1'),
-        ).equals(0);
-      },
-    );
+      check(adapter.requestCount(method: 'GET', path: '/api/v1/chats/conv-1'))
+          .equals(0);
+    });
 
     test(
       'chatCompleted released after ownership loss cannot mutate local state',
@@ -2552,90 +2573,83 @@ void main() {
       stream.disposeWatchdog();
     });
 
-    test(
-      'taskSocket navigation or stop teardown cancels local recovery and ignores queued events once',
-      () async {
-        final previousDelay = debugTaskSocketTerminalRecoveryDelay;
-        debugTaskSocketTerminalRecoveryDelay = const Duration(milliseconds: 5);
-        addTearDown(() {
-          debugTaskSocketTerminalRecoveryDelay = previousDelay;
-        });
+    test('taskSocket navigation or stop teardown cancels local recovery and ignores queued events once', () async {
+      final previousDelay = debugTaskSocketTerminalRecoveryDelay;
+      debugTaskSocketTerminalRecoveryDelay = const Duration(milliseconds: 5);
+      addTearDown(() {
+        debugTaskSocketTerminalRecoveryDelay = previousDelay;
+      });
 
-        final log = _CallbackLog();
-        final registrar = FakeSocketInjector();
-        final socket = _MockSocketService(registrar);
-        final api = _buildFakeApi(
-          pollResponse: _serverConversationResponse(
-            messages: [
-              _serverAssistantMessage(
-                content: 'Late server answer',
-                done: true,
-              ),
-            ],
-          ),
-        );
-        final adapter = api.dio.httpClientAdapter as _StubAdapter;
-        var abortCount = 0;
+      final log = _CallbackLog();
+      final registrar = FakeSocketInjector();
+      final socket = _MockSocketService(registrar);
+      final api = _buildFakeApi(
+        pollResponse: _serverConversationResponse(
+          messages: [
+            _serverAssistantMessage(content: 'Late server answer', done: true),
+          ],
+        ),
+      );
+      final adapter = api.dio.httpClientAdapter as _StubAdapter;
+      var abortCount = 0;
 
-        final activeStream = _attach(
-          session: ChatCompletionSession.taskSocket(
-            messageId: 'msg-1',
-            sessionId: 'sess-1',
-            conversationId: 'conv-1',
-            taskId: 'task-1',
-            abort: () async => abortCount++,
-          ),
-          log: log,
-          api: api,
-          activeConversationId: 'conv-1',
-          socketService: socket,
-        );
-
-        // Let the empty HTTP initiation side complete and arm terminal poll
-        // recovery while the task remains owned by the server.
-        await pumpMicrotasks();
-        await pumpMicrotasks();
-
-        // Conversation switches and explicit local stops both call this same
-        // aggregate hook. Repeated lifecycle signals must be harmless.
-        activeStream.disposeWatchdog();
-        activeStream.disposeWatchdog();
-
-        // Model an already queued socket callback that escaped subscription
-        // cancellation. The retired helper must still reject it.
-        registrar.emitQueuedChatEvent(
-          'chat:completion',
-          {
-            'choices': [
-              {
-                'delta': {'content': 'late chunk'},
-              },
-            ],
-          },
+      final activeStream = _attach(
+        session: ChatCompletionSession.taskSocket(
           messageId: 'msg-1',
           sessionId: 'sess-1',
-        );
+          conversationId: 'conv-1',
+          taskId: 'task-1',
+          abort: () async => abortCount++,
+        ),
+        log: log,
+        api: api,
+        activeConversationId: 'conv-1',
+        socketService: socket,
+      );
 
-        await Future<void>.delayed(const Duration(milliseconds: 20));
-        await pumpMicrotasks();
+      // Let the empty HTTP initiation side complete and arm terminal poll
+      // recovery while the task remains owned by the server.
+      await pumpMicrotasks();
+      await pumpMicrotasks();
 
-        check(log.appendedChunks).isEmpty();
-        check(log.replacedContents).isEmpty();
-        check(log.finishCount).equals(0);
-        check(
-          adapter.requestCount(method: 'GET', path: '/api/v1/chats/conv-1'),
-        ).equals(0);
-        check(socket.chatSubscriptionDisposeCount).equals(1);
-        check(socket.channelSubscriptionDisposeCount).equals(1);
-        check(socket.channelOffCount).equals(0);
-        check(registrar.hasChatHandler).isFalse();
-        check(registrar.channelHandlerCount).equals(0);
+      // Conversation switches and explicit local stops both call this same
+      // aggregate hook. Repeated lifecycle signals must be harmless.
+      activeStream.disposeWatchdog();
+      activeStream.disposeWatchdog();
 
-        // Local teardown must not broaden into a remote/task abort. The stop
-        // coordinator owns that separate policy.
-        check(abortCount).equals(0);
-      },
-    );
+      // Model an already queued socket callback that escaped subscription
+      // cancellation. The retired helper must still reject it.
+      registrar.emitQueuedChatEvent(
+        'chat:completion',
+        {
+          'choices': [
+            {
+              'delta': {'content': 'late chunk'},
+            },
+          ],
+        },
+        messageId: 'msg-1',
+        sessionId: 'sess-1',
+      );
+
+      await Future<void>.delayed(const Duration(milliseconds: 20));
+      await pumpMicrotasks();
+
+      check(log.appendedChunks).isEmpty();
+      check(log.replacedContents).isEmpty();
+      check(log.finishCount).equals(0);
+      check(adapter.requestCount(method: 'GET', path: '/api/v1/chats/conv-1'))
+          .equals(0);
+      check(socket.chatSubscriptionDisposeCount).equals(1);
+      check(socket.channelSubscriptionDisposeCount).equals(1);
+      check(socket.channelOffCount).equals(0);
+      check(registrar.hasChatHandler).isFalse();
+      check(registrar.channelHandlerCount).equals(0);
+
+      // Local teardown must not broaden into a remote/task abort. The stop
+      // coordinator owns that separate policy.
+      check(abortCount).equals(0);
+    });
 
     test('taskSocket keeps streaming open after terminal finish_reason '
         'until done arrives', () async {
@@ -2777,377 +2791,358 @@ void main() {
       },
     );
 
-    test(
-      'taskSocket HTTP completion starts poll recovery when socket events are missing',
-      () async {
-        final previousDelay = debugTaskSocketTerminalRecoveryDelay;
-        debugTaskSocketTerminalRecoveryDelay = const Duration(milliseconds: 10);
-        addTearDown(() {
-          debugTaskSocketTerminalRecoveryDelay = previousDelay;
-        });
+    test('taskSocket HTTP completion starts poll recovery when socket events are missing', () async {
+      final previousDelay = debugTaskSocketTerminalRecoveryDelay;
+      debugTaskSocketTerminalRecoveryDelay = const Duration(milliseconds: 10);
+      addTearDown(() {
+        debugTaskSocketTerminalRecoveryDelay = previousDelay;
+      });
 
-        final log = _CallbackLog();
-        final registrar = FakeSocketInjector();
-        final api = _buildFakeApi(
-          pollResponse: _serverConversationResponse(
-            messages: [_serverAssistantMessage(content: 'Recovered from poll')],
-          ),
-        );
-        final adapter = api.dio.httpClientAdapter as _StubAdapter;
+      final log = _CallbackLog();
+      final registrar = FakeSocketInjector();
+      final api = _buildFakeApi(
+        pollResponse: _serverConversationResponse(
+          messages: [_serverAssistantMessage(content: 'Recovered from poll')],
+        ),
+      );
+      final adapter = api.dio.httpClientAdapter as _StubAdapter;
 
-        _attach(
-          session: ChatCompletionSession.taskSocket(
-            messageId: 'msg-1',
-            sessionId: 'sess-1',
-            conversationId: 'conv-1',
-            taskId: 'task-1',
-          ),
-          log: log,
-          api: api,
-          activeConversationId: 'conv-1',
-          socketService: _MockSocketService(registrar),
-        );
+      _attach(
+        session: ChatCompletionSession.taskSocket(
+          messageId: 'msg-1',
+          sessionId: 'sess-1',
+          conversationId: 'conv-1',
+          taskId: 'task-1',
+        ),
+        log: log,
+        api: api,
+        activeConversationId: 'conv-1',
+        socketService: _MockSocketService(registrar),
+      );
 
-        await Future<void>.delayed(const Duration(milliseconds: 50));
+      await Future<void>.delayed(const Duration(milliseconds: 50));
 
-        check(
-          adapter.requestCount(method: 'GET', path: '/api/v1/chats/conv-1'),
-        ).isGreaterThan(0);
-        check(log.messages.last.content).equals('Recovered from poll');
-        check(log.finishCount).equals(1);
-      },
-    );
+      check(adapter.requestCount(method: 'GET', path: '/api/v1/chats/conv-1'))
+          .isGreaterThan(0);
+      check(log.messages.last.content).equals('Recovered from poll');
+      check(log.finishCount).equals(1);
+    });
 
-    test(
-      'taskSocket terminal recovery keeps streaming open when polled snapshot is not done',
-      () async {
-        final previousDelay = debugTaskSocketTerminalRecoveryDelay;
-        final previousLimit = debugTaskSocketStableNonTerminalRecoveryLimit;
-        debugTaskSocketTerminalRecoveryDelay = const Duration(milliseconds: 10);
-        debugTaskSocketStableNonTerminalRecoveryLimit = 4;
-        addTearDown(() {
-          debugTaskSocketTerminalRecoveryDelay = previousDelay;
-          debugTaskSocketStableNonTerminalRecoveryLimit = previousLimit;
-        });
+    test('taskSocket terminal recovery keeps streaming open when polled snapshot is not done', () async {
+      final previousDelay = debugTaskSocketTerminalRecoveryDelay;
+      final previousLimit = debugTaskSocketStableNonTerminalRecoveryLimit;
+      debugTaskSocketTerminalRecoveryDelay = const Duration(milliseconds: 10);
+      debugTaskSocketStableNonTerminalRecoveryLimit = 4;
+      addTearDown(() {
+        debugTaskSocketTerminalRecoveryDelay = previousDelay;
+        debugTaskSocketStableNonTerminalRecoveryLimit = previousLimit;
+      });
 
-        final log = _CallbackLog();
-        final registrar = FakeSocketInjector();
-        final api = _buildFakeApi(
-          pollResponse: _serverConversationResponse(
-            messages: [
-              {
-                'id': 'msg-1',
-                'role': 'assistant',
-                'content': 'Hello there.',
-                'timestamp': DateTime.now().millisecondsSinceEpoch ~/ 1000,
-                'done': false,
-                'isStreaming': true,
-              },
-            ],
-          ),
-        );
-
-        _attach(
-          session: ChatCompletionSession.taskSocket(
-            messageId: 'msg-1',
-            sessionId: 'sess-1',
-            conversationId: 'conv-1',
-            taskId: 'task-1',
-          ),
-          log: log,
-          api: api,
-          activeConversationId: 'conv-1',
-          socketService: _MockSocketService(registrar),
-        );
-
-        await pumpMicrotasks();
-
-        registrar.emitChatEvent('chat:completion', {
-          'choices': [
+      final log = _CallbackLog();
+      final registrar = FakeSocketInjector();
+      final api = _buildFakeApi(
+        pollResponse: _serverConversationResponse(
+          messages: [
             {
-              'delta': {'content': 'Hello there.'},
-              'finish_reason': 'stop',
+              'id': 'msg-1',
+              'role': 'assistant',
+              'content': 'Hello there.',
+              'timestamp': DateTime.now().millisecondsSinceEpoch ~/ 1000,
+              'done': false,
+              'isStreaming': true,
             },
           ],
-        }, messageId: 'msg-1');
+        ),
+      );
 
+      _attach(
+        session: ChatCompletionSession.taskSocket(
+          messageId: 'msg-1',
+          sessionId: 'sess-1',
+          conversationId: 'conv-1',
+          taskId: 'task-1',
+        ),
+        log: log,
+        api: api,
+        activeConversationId: 'conv-1',
+        socketService: _MockSocketService(registrar),
+      );
+
+      await pumpMicrotasks();
+
+      registrar.emitChatEvent('chat:completion', {
+        'choices': [
+          {
+            'delta': {'content': 'Hello there.'},
+            'finish_reason': 'stop',
+          },
+        ],
+      }, messageId: 'msg-1');
+
+      await pumpMicrotasks();
+      await Future<void>.delayed(const Duration(milliseconds: 30));
+      for (var i = 0; i < 5; i++) {
         await pumpMicrotasks();
-        await Future<void>.delayed(const Duration(milliseconds: 30));
-        for (var i = 0; i < 5; i++) {
-          await pumpMicrotasks();
-        }
+      }
 
-        check(log.finishCount).equals(0);
-        check(log.messages.last.isStreaming).isTrue();
-        expect(log.messages.last.metadata?['responseDone'], isTrue);
+      check(log.finishCount).equals(0);
+      check(log.messages.last.isStreaming).isTrue();
+      expect(log.messages.last.metadata?['responseDone'], isTrue);
 
-        registrar.emitChatEvent('chat:message:follow_ups', {
-          'follow_ups': ['Ask a follow-up'],
-        }, messageId: 'msg-1');
+      registrar.emitChatEvent('chat:message:follow_ups', {
+        'follow_ups': ['Ask a follow-up'],
+      }, messageId: 'msg-1');
 
+      await pumpMicrotasks();
+
+      check(log.finishCount).equals(0);
+      check(log.messages.last.isStreaming).isTrue();
+      check(log.messages.last.followUps).deepEquals(['Ask a follow-up']);
+
+      registrar.emitChatEvent('chat:completion', {
+        'done': true,
+      }, messageId: 'msg-1');
+
+      await pumpMicrotasks();
+
+      check(log.finishCount).equals(1);
+      check(log.messages.last.isStreaming).isFalse();
+      check(log.messages.last.followUps).deepEquals(['Ask a follow-up']);
+    });
+
+    test('taskSocket terminal recovery keeps streaming open when poll is unavailable and follow-ups arrive late', () async {
+      final previousDelay = debugTaskSocketTerminalRecoveryDelay;
+      final previousLimit = debugTaskSocketStableNonTerminalRecoveryLimit;
+      debugTaskSocketTerminalRecoveryDelay = const Duration(milliseconds: 10);
+      debugTaskSocketStableNonTerminalRecoveryLimit = 6;
+      addTearDown(() {
+        debugTaskSocketTerminalRecoveryDelay = previousDelay;
+        debugTaskSocketStableNonTerminalRecoveryLimit = previousLimit;
+      });
+
+      final log = _CallbackLog();
+      final registrar = FakeSocketInjector();
+
+      _attach(
+        session: ChatCompletionSession.taskSocket(
+          messageId: 'msg-1',
+          sessionId: 'sess-1',
+          conversationId: 'local:temp',
+          taskId: 'task-1',
+        ),
+        log: log,
+        activeConversationId: 'local:temp',
+        socketService: _MockSocketService(registrar),
+      );
+
+      await pumpMicrotasks();
+
+      registrar.emitChatEvent('chat:completion', {
+        'choices': [
+          {
+            'delta': {'content': 'Hello there.'},
+            'finish_reason': 'stop',
+          },
+        ],
+      }, messageId: 'msg-1');
+
+      await pumpMicrotasks();
+      await Future<void>.delayed(const Duration(milliseconds: 30));
+      for (var i = 0; i < 5; i++) {
         await pumpMicrotasks();
+      }
 
-        check(log.finishCount).equals(0);
-        check(log.messages.last.isStreaming).isTrue();
-        check(log.messages.last.followUps).deepEquals(['Ask a follow-up']);
+      check(log.finishCount).equals(0);
+      check(log.messages.last.isStreaming).isTrue();
+      expect(log.messages.last.metadata?['responseDone'], isTrue);
 
-        registrar.emitChatEvent('chat:completion', {
-          'done': true,
-        }, messageId: 'msg-1');
+      registrar.emitChatEvent('chat:message:follow_ups', {
+        'follow_ups': ['Ask a follow-up'],
+      }, messageId: 'msg-1');
 
+      await pumpMicrotasks();
+
+      check(log.finishCount).equals(0);
+      check(log.messages.last.isStreaming).isTrue();
+      check(log.messages.last.followUps).deepEquals(['Ask a follow-up']);
+
+      registrar.emitChatEvent('chat:completion', {
+        'done': true,
+      }, messageId: 'msg-1');
+
+      await pumpMicrotasks();
+
+      check(log.finishCount).equals(1);
+      check(log.messages.last.isStreaming).isFalse();
+      check(log.messages.last.followUps).deepEquals(['Ask a follow-up']);
+    });
+
+    test('taskSocket terminal recovery finishes once the poll-miss retry limit is exhausted', () async {
+      final previousDelay = debugTaskSocketTerminalRecoveryDelay;
+      final previousLimit = debugTaskSocketStableNonTerminalRecoveryLimit;
+      debugTaskSocketTerminalRecoveryDelay = const Duration(milliseconds: 10);
+      debugTaskSocketStableNonTerminalRecoveryLimit = 1;
+      addTearDown(() {
+        debugTaskSocketTerminalRecoveryDelay = previousDelay;
+        debugTaskSocketStableNonTerminalRecoveryLimit = previousLimit;
+      });
+
+      final log = _CallbackLog();
+      final registrar = FakeSocketInjector();
+
+      _attach(
+        session: ChatCompletionSession.taskSocket(
+          messageId: 'msg-1',
+          sessionId: 'sess-1',
+          conversationId: 'local:temp',
+          taskId: 'task-1',
+        ),
+        log: log,
+        activeConversationId: 'local:temp',
+        socketService: _MockSocketService(registrar),
+      );
+
+      await pumpMicrotasks();
+
+      registrar.emitChatEvent('chat:completion', {
+        'choices': [
+          {
+            'delta': {'content': 'Hello there.'},
+            'finish_reason': 'stop',
+          },
+        ],
+      }, messageId: 'msg-1');
+
+      await pumpMicrotasks();
+      await Future<void>.delayed(const Duration(milliseconds: 250));
+      for (var i = 0; i < 20; i++) {
         await pumpMicrotasks();
+      }
 
-        check(log.finishCount).equals(1);
-        check(log.messages.last.isStreaming).isFalse();
-        check(log.messages.last.followUps).deepEquals(['Ask a follow-up']);
-      },
-    );
+      check(log.finishCount).equals(1);
+      check(log.messages.last.isStreaming).isFalse();
+      check(log.messages.last.content).equals('Hello there.');
+    });
 
-    test(
-      'taskSocket terminal recovery keeps streaming open when poll is unavailable and follow-ups arrive late',
-      () async {
-        final previousDelay = debugTaskSocketTerminalRecoveryDelay;
-        final previousLimit = debugTaskSocketStableNonTerminalRecoveryLimit;
-        debugTaskSocketTerminalRecoveryDelay = const Duration(milliseconds: 10);
-        debugTaskSocketStableNonTerminalRecoveryLimit = 6;
-        addTearDown(() {
-          debugTaskSocketTerminalRecoveryDelay = previousDelay;
-          debugTaskSocketStableNonTerminalRecoveryLimit = previousLimit;
-        });
+    test('taskSocket terminal recovery eventually finishes after a stable non-terminal snapshot repeats', () async {
+      final previousDelay = debugTaskSocketTerminalRecoveryDelay;
+      final previousLimit = debugTaskSocketStableNonTerminalRecoveryLimit;
+      debugTaskSocketTerminalRecoveryDelay = const Duration(milliseconds: 10);
+      debugTaskSocketStableNonTerminalRecoveryLimit = 2;
+      addTearDown(() {
+        debugTaskSocketTerminalRecoveryDelay = previousDelay;
+        debugTaskSocketStableNonTerminalRecoveryLimit = previousLimit;
+      });
 
-        final log = _CallbackLog();
-        final registrar = FakeSocketInjector();
-
-        _attach(
-          session: ChatCompletionSession.taskSocket(
-            messageId: 'msg-1',
-            sessionId: 'sess-1',
-            conversationId: 'local:temp',
-            taskId: 'task-1',
-          ),
-          log: log,
-          activeConversationId: 'local:temp',
-          socketService: _MockSocketService(registrar),
-        );
-
-        await pumpMicrotasks();
-
-        registrar.emitChatEvent('chat:completion', {
-          'choices': [
+      final log = _CallbackLog();
+      final registrar = FakeSocketInjector();
+      final api = _buildFakeApi(
+        pollResponse: _serverConversationResponse(
+          messages: [
             {
-              'delta': {'content': 'Hello there.'},
-              'finish_reason': 'stop',
+              'id': 'msg-1',
+              'role': 'assistant',
+              'content': 'Hello there.',
+              'timestamp': DateTime.now().millisecondsSinceEpoch ~/ 1000,
+              'done': false,
+              'isStreaming': true,
             },
           ],
-        }, messageId: 'msg-1');
+        ),
+      );
 
+      _attach(
+        session: ChatCompletionSession.taskSocket(
+          messageId: 'msg-1',
+          sessionId: 'sess-1',
+          conversationId: 'conv-1',
+          taskId: 'task-1',
+        ),
+        log: log,
+        api: api,
+        activeConversationId: 'conv-1',
+        socketService: _MockSocketService(registrar),
+      );
+
+      await pumpMicrotasks();
+
+      registrar.emitChatEvent('chat:completion', {
+        'choices': [
+          {
+            'delta': {'content': 'Hello there.'},
+            'finish_reason': 'stop',
+          },
+        ],
+      }, messageId: 'msg-1');
+
+      await pumpMicrotasks();
+      await Future<void>.delayed(const Duration(milliseconds: 50));
+      for (var i = 0; i < 6; i++) {
         await pumpMicrotasks();
-        await Future<void>.delayed(const Duration(milliseconds: 30));
-        for (var i = 0; i < 5; i++) {
-          await pumpMicrotasks();
-        }
+      }
 
-        check(log.finishCount).equals(0);
-        check(log.messages.last.isStreaming).isTrue();
-        expect(log.messages.last.metadata?['responseDone'], isTrue);
+      check(log.finishCount).equals(1);
+      check(log.messages.last.isStreaming).isFalse();
+      check(log.messages.last.content).equals('Hello there.');
+    });
 
-        registrar.emitChatEvent('chat:message:follow_ups', {
-          'follow_ups': ['Ask a follow-up'],
-        }, messageId: 'msg-1');
+    test('taskSocket HTTP completion recovery does not locally finish stable partial snapshots', () async {
+      final previousDelay = debugTaskSocketTerminalRecoveryDelay;
+      final previousLimit = debugTaskSocketStableNonTerminalRecoveryLimit;
+      debugTaskSocketTerminalRecoveryDelay = const Duration(milliseconds: 10);
+      debugTaskSocketStableNonTerminalRecoveryLimit = 2;
+      addTearDown(() {
+        debugTaskSocketTerminalRecoveryDelay = previousDelay;
+        debugTaskSocketStableNonTerminalRecoveryLimit = previousLimit;
+      });
 
-        await pumpMicrotasks();
-
-        check(log.finishCount).equals(0);
-        check(log.messages.last.isStreaming).isTrue();
-        check(log.messages.last.followUps).deepEquals(['Ask a follow-up']);
-
-        registrar.emitChatEvent('chat:completion', {
-          'done': true,
-        }, messageId: 'msg-1');
-
-        await pumpMicrotasks();
-
-        check(log.finishCount).equals(1);
-        check(log.messages.last.isStreaming).isFalse();
-        check(log.messages.last.followUps).deepEquals(['Ask a follow-up']);
-      },
-    );
-
-    test(
-      'taskSocket terminal recovery finishes once the poll-miss retry limit is exhausted',
-      () async {
-        final previousDelay = debugTaskSocketTerminalRecoveryDelay;
-        final previousLimit = debugTaskSocketStableNonTerminalRecoveryLimit;
-        debugTaskSocketTerminalRecoveryDelay = const Duration(milliseconds: 10);
-        debugTaskSocketStableNonTerminalRecoveryLimit = 1;
-        addTearDown(() {
-          debugTaskSocketTerminalRecoveryDelay = previousDelay;
-          debugTaskSocketStableNonTerminalRecoveryLimit = previousLimit;
-        });
-
-        final log = _CallbackLog();
-        final registrar = FakeSocketInjector();
-
-        _attach(
-          session: ChatCompletionSession.taskSocket(
-            messageId: 'msg-1',
-            sessionId: 'sess-1',
-            conversationId: 'local:temp',
-            taskId: 'task-1',
-          ),
-          log: log,
-          activeConversationId: 'local:temp',
-          socketService: _MockSocketService(registrar),
-        );
-
-        await pumpMicrotasks();
-
-        registrar.emitChatEvent('chat:completion', {
-          'choices': [
+      final log = _CallbackLog();
+      final registrar = FakeSocketInjector();
+      final api = _buildFakeApi(
+        pollResponse: _serverConversationResponse(
+          messages: [
             {
-              'delta': {'content': 'Hello there.'},
-              'finish_reason': 'stop',
+              'id': 'msg-1',
+              'role': 'assistant',
+              'content': 'Partial answer',
+              'timestamp': DateTime.now().millisecondsSinceEpoch ~/ 1000,
+              'done': false,
+              'isStreaming': true,
             },
           ],
-        }, messageId: 'msg-1');
+        ),
+      );
 
+      _attach(
+        session: ChatCompletionSession.taskSocket(
+          messageId: 'msg-1',
+          sessionId: 'sess-1',
+          conversationId: 'conv-1',
+          taskId: 'task-1',
+        ),
+        log: log,
+        api: api,
+        activeConversationId: 'conv-1',
+        socketService: _MockSocketService(registrar),
+      );
+
+      await pumpMicrotasks();
+      await Future<void>.delayed(const Duration(milliseconds: 60));
+      for (var i = 0; i < 8; i += 1) {
         await pumpMicrotasks();
-        await Future<void>.delayed(const Duration(milliseconds: 250));
-        for (var i = 0; i < 20; i++) {
-          await pumpMicrotasks();
-        }
+      }
 
-        check(log.finishCount).equals(1);
-        check(log.messages.last.isStreaming).isFalse();
-        check(log.messages.last.content).equals('Hello there.');
-      },
-    );
+      check(log.messages.last.content).equals('Partial answer');
+      check(log.finishCount).equals(0);
+      check(log.messages.last.isStreaming).isTrue();
 
-    test(
-      'taskSocket terminal recovery eventually finishes after a stable non-terminal snapshot repeats',
-      () async {
-        final previousDelay = debugTaskSocketTerminalRecoveryDelay;
-        final previousLimit = debugTaskSocketStableNonTerminalRecoveryLimit;
-        debugTaskSocketTerminalRecoveryDelay = const Duration(milliseconds: 10);
-        debugTaskSocketStableNonTerminalRecoveryLimit = 2;
-        addTearDown(() {
-          debugTaskSocketTerminalRecoveryDelay = previousDelay;
-          debugTaskSocketStableNonTerminalRecoveryLimit = previousLimit;
-        });
+      registrar.emitChatEvent('chat:completion', {
+        'done': true,
+      }, messageId: 'msg-1');
+      await pumpMicrotasks();
 
-        final log = _CallbackLog();
-        final registrar = FakeSocketInjector();
-        final api = _buildFakeApi(
-          pollResponse: _serverConversationResponse(
-            messages: [
-              {
-                'id': 'msg-1',
-                'role': 'assistant',
-                'content': 'Hello there.',
-                'timestamp': DateTime.now().millisecondsSinceEpoch ~/ 1000,
-                'done': false,
-                'isStreaming': true,
-              },
-            ],
-          ),
-        );
-
-        _attach(
-          session: ChatCompletionSession.taskSocket(
-            messageId: 'msg-1',
-            sessionId: 'sess-1',
-            conversationId: 'conv-1',
-            taskId: 'task-1',
-          ),
-          log: log,
-          api: api,
-          activeConversationId: 'conv-1',
-          socketService: _MockSocketService(registrar),
-        );
-
-        await pumpMicrotasks();
-
-        registrar.emitChatEvent('chat:completion', {
-          'choices': [
-            {
-              'delta': {'content': 'Hello there.'},
-              'finish_reason': 'stop',
-            },
-          ],
-        }, messageId: 'msg-1');
-
-        await pumpMicrotasks();
-        await Future<void>.delayed(const Duration(milliseconds: 50));
-        for (var i = 0; i < 6; i++) {
-          await pumpMicrotasks();
-        }
-
-        check(log.finishCount).equals(1);
-        check(log.messages.last.isStreaming).isFalse();
-        check(log.messages.last.content).equals('Hello there.');
-      },
-    );
-
-    test(
-      'taskSocket HTTP completion recovery does not locally finish stable partial snapshots',
-      () async {
-        final previousDelay = debugTaskSocketTerminalRecoveryDelay;
-        final previousLimit = debugTaskSocketStableNonTerminalRecoveryLimit;
-        debugTaskSocketTerminalRecoveryDelay = const Duration(milliseconds: 10);
-        debugTaskSocketStableNonTerminalRecoveryLimit = 2;
-        addTearDown(() {
-          debugTaskSocketTerminalRecoveryDelay = previousDelay;
-          debugTaskSocketStableNonTerminalRecoveryLimit = previousLimit;
-        });
-
-        final log = _CallbackLog();
-        final registrar = FakeSocketInjector();
-        final api = _buildFakeApi(
-          pollResponse: _serverConversationResponse(
-            messages: [
-              {
-                'id': 'msg-1',
-                'role': 'assistant',
-                'content': 'Partial answer',
-                'timestamp': DateTime.now().millisecondsSinceEpoch ~/ 1000,
-                'done': false,
-                'isStreaming': true,
-              },
-            ],
-          ),
-        );
-
-        _attach(
-          session: ChatCompletionSession.taskSocket(
-            messageId: 'msg-1',
-            sessionId: 'sess-1',
-            conversationId: 'conv-1',
-            taskId: 'task-1',
-          ),
-          log: log,
-          api: api,
-          activeConversationId: 'conv-1',
-          socketService: _MockSocketService(registrar),
-        );
-
-        await pumpMicrotasks();
-        await Future<void>.delayed(const Duration(milliseconds: 60));
-        for (var i = 0; i < 8; i += 1) {
-          await pumpMicrotasks();
-        }
-
-        check(log.messages.last.content).equals('Partial answer');
-        check(log.finishCount).equals(0);
-        check(log.messages.last.isStreaming).isTrue();
-
-        registrar.emitChatEvent('chat:completion', {
-          'done': true,
-        }, messageId: 'msg-1');
-        await pumpMicrotasks();
-
-        check(log.finishCount).equals(1);
-      },
-    );
+      check(log.finishCount).equals(1);
+    });
 
     test(
       'taskSocket binds alternate server message ids for the active session',
@@ -3461,9 +3456,8 @@ void main() {
         check(log.messages.last.content).equals('');
         check(log.messages.last.isStreaming).isTrue();
         check(log.finishCount).equals(0);
-        check(
-          adapter.requestCount(method: 'GET', path: '/api/v1/chats/conv-1'),
-        ).equals(0);
+        check(adapter.requestCount(method: 'GET', path: '/api/v1/chats/conv-1'))
+            .equals(0);
       },
     );
 
@@ -3603,9 +3597,8 @@ void main() {
 
       check(log.messages.last.content).contains('<details type="reasoning"');
       check(log.messages.last.content).contains('Direct reply');
-      check(
-        'Direct reply'.allMatches(log.messages.last.content).length,
-      ).equals(1);
+      check('Direct reply'.allMatches(log.messages.last.content).length)
+          .equals(1);
       check(log.messages.last.output).isNotNull();
       check(log.finishCount).equals(1);
     });
@@ -3692,9 +3685,9 @@ void main() {
 
       check(log.messageByIdMutationCount).equals(1);
       check(log.sourceReferences).isEmpty();
-      check(
-        log.messages.last.sources,
-      ).has((it) => it.length, 'length').equals(1);
+      check(log.messages.last.sources)
+          .has((it) => it.length, 'length')
+          .equals(1);
       check(log.messages.last.sources.single.url).equals('https://example.com');
     });
 
@@ -3807,9 +3800,9 @@ void main() {
       );
       check(log.messages.last.content).equals('Structured with usage');
       check(log.messages.last.output).isNotNull();
-      check(
-        log.messages.last.output!,
-      ).has((it) => it.length, 'length').equals(1);
+      check(log.messages.last.output!)
+          .has((it) => it.length, 'length')
+          .equals(1);
     });
 
     test('httpStream applies selected model update', () async {
@@ -3869,9 +3862,9 @@ void main() {
 
       check(log.messageByIdMutationCount).equals(1);
       check(log.sourceReferences).isEmpty();
-      check(
-        log.messages.last.sources,
-      ).has((it) => it.length, 'length').equals(1);
+      check(log.messages.last.sources)
+          .has((it) => it.length, 'length')
+          .equals(1);
       check(log.messages.last.sources.single.url).equals('https://a.com');
     });
 
@@ -3935,81 +3928,77 @@ void main() {
       check(log.finishCount).equals(1);
     });
 
-    test(
-      'httpStream done recovery backfills delayed persisted error and snapshot state',
-      () async {
-        final log = _CallbackLog();
-        final incompleteResponse = _serverConversationResponse(
-          messages: [_serverAssistantMessage(content: '', followUps: const [])],
-        );
-        final persistedResponse = _serverConversationResponse(
-          messages: [
-            _serverAssistantMessage(
-              content: '',
-              error: const {'content': 'Persisted backend error'},
-              followUps: const ['Ask again'],
-              statusHistory: const [
-                {'description': 'Searching', 'done': true},
-              ],
-              sources: const [
-                {
-                  'source': {'name': 'doc', 'url': 'https://example.com/doc'},
-                  'document': ['snippet'],
-                },
-              ],
-              usage: const {'prompt_tokens': 7, 'completion_tokens': 11},
-              metadata: const {'serverFlag': true},
-            ),
-          ],
-        );
-        final api = _buildFakeApi(
-          pollResponses: [
-            incompleteResponse,
-            persistedResponse,
-            persistedResponse,
-          ],
-        );
-        final adapter = api.dio.httpClientAdapter as _StubAdapter;
-
-        _attach(
-          session: ChatCompletionSession.httpStream(
-            messageId: 'msg-1',
-            sessionId: 'sess-1',
-            conversationId: 'conv-1',
-            byteStream: Stream<List<int>>.fromIterable([_sseDone()]),
-            abort: () async {},
+    test('httpStream done recovery backfills delayed persisted error and snapshot state', () async {
+      final log = _CallbackLog();
+      final incompleteResponse = _serverConversationResponse(
+        messages: [_serverAssistantMessage(content: '', followUps: const [])],
+      );
+      final persistedResponse = _serverConversationResponse(
+        messages: [
+          _serverAssistantMessage(
+            content: '',
+            error: const {'content': 'Persisted backend error'},
+            followUps: const ['Ask again'],
+            statusHistory: const [
+              {'description': 'Searching', 'done': true},
+            ],
+            sources: const [
+              {
+                'source': {'name': 'doc', 'url': 'https://example.com/doc'},
+                'document': ['snippet'],
+              },
+            ],
+            usage: const {'prompt_tokens': 7, 'completion_tokens': 11},
+            metadata: const {'serverFlag': true},
           ),
-          log: log,
-          api: api,
-          activeConversationId: 'conv-1',
-        );
+        ],
+      );
+      final api = _buildFakeApi(
+        pollResponses: [
+          incompleteResponse,
+          persistedResponse,
+          persistedResponse,
+        ],
+      );
+      final adapter = api.dio.httpClientAdapter as _StubAdapter;
 
+      _attach(
+        session: ChatCompletionSession.httpStream(
+          messageId: 'msg-1',
+          sessionId: 'sess-1',
+          conversationId: 'conv-1',
+          byteStream: Stream<List<int>>.fromIterable([_sseDone()]),
+          abort: () async {},
+        ),
+        log: log,
+        api: api,
+        activeConversationId: 'conv-1',
+      );
+
+      await pumpMicrotasks();
+      await Future<void>.delayed(const Duration(milliseconds: 2600));
+      for (var i = 0; i < 5; i++) {
         await pumpMicrotasks();
-        await Future<void>.delayed(const Duration(milliseconds: 2600));
-        for (var i = 0; i < 5; i++) {
-          await pumpMicrotasks();
-        }
+      }
 
-        final lastMsg = log.messages.last;
-        check(lastMsg.error).isNotNull();
-        check(lastMsg.error!.content).equals('Persisted backend error');
-        check(lastMsg.followUps).deepEquals(['Ask again']);
-        check(lastMsg.statusHistory).has((it) => it.length, 'length').equals(1);
-        check(lastMsg.statusHistory.single.description).equals('Searching');
-        check(lastMsg.sources).has((it) => it.length, 'length').equals(1);
-        check(lastMsg.sources.single.url).equals('https://example.com/doc');
-        expect(
-          lastMsg.usage,
-          equals({'prompt_tokens': 7, 'completion_tokens': 11}),
-        );
-        check(lastMsg.metadata).isNotNull();
-        check(lastMsg.metadata!['serverFlag']).equals(true);
-        check(log.finishCount).equals(1);
-        check(
-          adapter.requestCount(method: 'GET', path: '/api/v1/chats/conv-1'),
-        ).equals(3);
-      },
-    );
+      final lastMsg = log.messages.last;
+      check(lastMsg.error).isNotNull();
+      check(lastMsg.error!.content).equals('Persisted backend error');
+      check(lastMsg.followUps).deepEquals(['Ask again']);
+      check(lastMsg.statusHistory).has((it) => it.length, 'length').equals(1);
+      check(lastMsg.statusHistory.single.description).equals('Searching');
+      check(lastMsg.sources).has((it) => it.length, 'length').equals(1);
+      check(lastMsg.sources.single.url).equals('https://example.com/doc');
+      expect(
+        lastMsg.usage,
+        equals({'prompt_tokens': 7, 'completion_tokens': 11}),
+      );
+      check(lastMsg.metadata).isNotNull();
+      check(lastMsg.metadata!['serverFlag']).equals(true);
+      check(log.finishCount).equals(1);
+      check(adapter.requestCount(method: 'GET', path: '/api/v1/chats/conv-1'))
+          .equals(3);
+    });
 
     test(
       'httpStream artifact-only done backfills delayed persisted text',
@@ -4073,343 +4062,167 @@ void main() {
       },
     );
 
-    test(
-      'httpStream event completion done avoids premature-end recovery without [DONE]',
-      () async {
-        final log = _CallbackLog();
-        final api = _buildFakeApi(
-          pollResponse: _serverConversationResponse(
-            messages: [_serverAssistantMessage(content: 'Recovered answer')],
-          ),
-        );
-        final adapter = api.dio.httpClientAdapter as _StubAdapter;
+    test('httpStream event completion done avoids premature-end recovery without [DONE]', () async {
+      final log = _CallbackLog();
+      final api = _buildFakeApi(
+        pollResponse: _serverConversationResponse(
+          messages: [_serverAssistantMessage(content: 'Recovered answer')],
+        ),
+      );
+      final adapter = api.dio.httpClientAdapter as _StubAdapter;
 
-        _attach(
-          session: ChatCompletionSession.httpStream(
-            messageId: 'msg-1',
-            sessionId: 'sess-1',
-            conversationId: 'conv-1',
-            byteStream: Stream<List<int>>.fromIterable([
-              _sseFrame({
-                'type': 'chat:completion',
-                'data': {'done': true},
-              }),
-            ]),
-            abort: () async {},
-          ),
-          log: log,
-          api: api,
-          activeConversationId: 'conv-1',
-        );
+      _attach(
+        session: ChatCompletionSession.httpStream(
+          messageId: 'msg-1',
+          sessionId: 'sess-1',
+          conversationId: 'conv-1',
+          byteStream: Stream<List<int>>.fromIterable([
+            _sseFrame({
+              'type': 'chat:completion',
+              'data': {'done': true},
+            }),
+          ]),
+          abort: () async {},
+        ),
+        log: log,
+        api: api,
+        activeConversationId: 'conv-1',
+      );
 
+      await pumpMicrotasks();
+      await pumpMicrotasks();
+      await Future<void>.delayed(const Duration(milliseconds: 100));
+      await pumpMicrotasks();
+
+      check(adapter.requestCount(method: 'GET', path: '/api/v1/chats/conv-1'))
+          .equals(0);
+      check(log.finishCount).equals(0);
+      check(log.messages.last.content).equals('');
+
+      await Future<void>.delayed(const Duration(milliseconds: 2600));
+      for (var i = 0; i < 5; i++) {
         await pumpMicrotasks();
+      }
+
+      check(log.messages.last.content).equals('Recovered answer');
+      check(log.finishCount).equals(1);
+    });
+
+    test('httpStream event completion done trusts visible streaming content before empty recovery checks', () async {
+      final log = _CallbackLog();
+      const visibleStreamingContent = 'Visible streamed answer';
+      final api = _buildFakeApi(
+        pollResponse: _serverConversationResponse(
+          messages: [_serverAssistantMessage(content: 'Recovered answer')],
+        ),
+      );
+      final adapter = api.dio.httpClientAdapter as _StubAdapter;
+
+      _attach(
+        session: ChatCompletionSession.httpStream(
+          messageId: 'msg-1',
+          sessionId: 'sess-1',
+          conversationId: 'conv-1',
+          byteStream: Stream<List<int>>.fromIterable([
+            _sseFrame({
+              'type': 'chat:completion',
+              'data': {'done': true},
+            }),
+          ]),
+          abort: () async {},
+        ),
+        log: log,
+        api: api,
+        activeConversationId: 'conv-1',
+        getVisibleStreamingContent: () => visibleStreamingContent,
+      );
+
+      await pumpMicrotasks();
+      await pumpMicrotasks();
+      await Future<void>.delayed(const Duration(milliseconds: 100));
+      await pumpMicrotasks();
+
+      check(log.finishCount).equals(1);
+      check(adapter.requestCount(method: 'GET', path: '/api/v1/chats/conv-1'))
+          .equals(0);
+    });
+
+    test('httpStream event completion done plus [DONE] only schedules completion side effects once', () async {
+      final log = _CallbackLog();
+      final incompleteResponse = _serverConversationResponse(
+        messages: [_serverAssistantMessage(content: '')],
+      );
+      final persistedResponse = _serverConversationResponse(
+        messages: [_serverAssistantMessage(content: 'Final answer')],
+      );
+      final api = _buildFakeApi(
+        pollResponses: [
+          incompleteResponse,
+          persistedResponse,
+          persistedResponse,
+        ],
+      );
+      final adapter = api.dio.httpClientAdapter as _StubAdapter;
+
+      _attach(
+        session: ChatCompletionSession.httpStream(
+          messageId: 'msg-1',
+          sessionId: 'sess-1',
+          conversationId: 'conv-1',
+          byteStream: Stream<List<int>>.fromIterable([
+            _sseFrame({
+              'type': 'chat:completion',
+              'data': {'done': true},
+            }),
+            _sseDone(),
+          ]),
+          abort: () async {},
+        ),
+        log: log,
+        api: api,
+        activeConversationId: 'conv-1',
+      );
+
+      await pumpMicrotasks();
+      await pumpMicrotasks();
+      await Future<void>.delayed(const Duration(milliseconds: 100));
+      await pumpMicrotasks();
+
+      check(adapter.requestCount(method: 'POST', path: '/api/chat/completed'))
+          .equals(1);
+      check(log.finishCount).equals(0);
+      check(log.messages.last.content).equals('');
+
+      await Future<void>.delayed(const Duration(milliseconds: 2600));
+      for (var i = 0; i < 5; i++) {
         await pumpMicrotasks();
-        await Future<void>.delayed(const Duration(milliseconds: 100));
-        await pumpMicrotasks();
+      }
 
-        check(
-          adapter.requestCount(method: 'GET', path: '/api/v1/chats/conv-1'),
-        ).equals(0);
-        check(log.finishCount).equals(0);
-        check(log.messages.last.content).equals('');
+      check(adapter.requestCount(method: 'POST', path: '/api/chat/completed'))
+          .equals(1);
+      check(adapter.requestCount(method: 'GET', path: '/api/v1/chats/conv-1'))
+          .equals(3);
+      check(log.messages.last.content).equals('Final answer');
+      check(log.finishCount).equals(1);
+    });
 
-        await Future<void>.delayed(const Duration(milliseconds: 2600));
-        for (var i = 0; i < 5; i++) {
-          await pumpMicrotasks();
-        }
-
-        check(log.messages.last.content).equals('Recovered answer');
-        check(log.finishCount).equals(1);
-      },
-    );
-
-    test(
-      'httpStream event completion done trusts visible streaming content before empty recovery checks',
-      () async {
-        final log = _CallbackLog();
-        const visibleStreamingContent = 'Visible streamed answer';
-        final api = _buildFakeApi(
-          pollResponse: _serverConversationResponse(
-            messages: [_serverAssistantMessage(content: 'Recovered answer')],
-          ),
-        );
-        final adapter = api.dio.httpClientAdapter as _StubAdapter;
-
-        _attach(
-          session: ChatCompletionSession.httpStream(
-            messageId: 'msg-1',
-            sessionId: 'sess-1',
-            conversationId: 'conv-1',
-            byteStream: Stream<List<int>>.fromIterable([
-              _sseFrame({
-                'type': 'chat:completion',
-                'data': {'done': true},
-              }),
-            ]),
-            abort: () async {},
-          ),
-          log: log,
-          api: api,
-          activeConversationId: 'conv-1',
-          getVisibleStreamingContent: () => visibleStreamingContent,
-        );
-
-        await pumpMicrotasks();
-        await pumpMicrotasks();
-        await Future<void>.delayed(const Duration(milliseconds: 100));
-        await pumpMicrotasks();
-
-        check(log.finishCount).equals(1);
-        check(
-          adapter.requestCount(method: 'GET', path: '/api/v1/chats/conv-1'),
-        ).equals(0);
-      },
-    );
-
-    test(
-      'httpStream event completion done plus [DONE] only schedules completion side effects once',
-      () async {
-        final log = _CallbackLog();
-        final incompleteResponse = _serverConversationResponse(
-          messages: [_serverAssistantMessage(content: '')],
-        );
-        final persistedResponse = _serverConversationResponse(
-          messages: [_serverAssistantMessage(content: 'Final answer')],
-        );
-        final api = _buildFakeApi(
-          pollResponses: [
-            incompleteResponse,
-            persistedResponse,
-            persistedResponse,
-          ],
-        );
-        final adapter = api.dio.httpClientAdapter as _StubAdapter;
-
-        _attach(
-          session: ChatCompletionSession.httpStream(
-            messageId: 'msg-1',
-            sessionId: 'sess-1',
-            conversationId: 'conv-1',
-            byteStream: Stream<List<int>>.fromIterable([
-              _sseFrame({
-                'type': 'chat:completion',
-                'data': {'done': true},
-              }),
-              _sseDone(),
-            ]),
-            abort: () async {},
-          ),
-          log: log,
-          api: api,
-          activeConversationId: 'conv-1',
-        );
-
-        await pumpMicrotasks();
-        await pumpMicrotasks();
-        await Future<void>.delayed(const Duration(milliseconds: 100));
-        await pumpMicrotasks();
-
-        check(
-          adapter.requestCount(method: 'POST', path: '/api/chat/completed'),
-        ).equals(1);
-        check(log.finishCount).equals(0);
-        check(log.messages.last.content).equals('');
-
-        await Future<void>.delayed(const Duration(milliseconds: 2600));
-        for (var i = 0; i < 5; i++) {
-          await pumpMicrotasks();
-        }
-
-        check(
-          adapter.requestCount(method: 'POST', path: '/api/chat/completed'),
-        ).equals(1);
-        check(
-          adapter.requestCount(method: 'GET', path: '/api/v1/chats/conv-1'),
-        ).equals(3);
-        check(log.messages.last.content).equals('Final answer');
-        check(log.finishCount).equals(1);
-      },
-    );
-
-    test(
-      'httpStream latest blank assistant does not adopt prior persisted answer when server has not created the new assistant yet',
-      () async {
-        final log = _CallbackLog(
-          initialMessages: [
-            ChatMessage(
-              id: 'user-1',
-              role: 'user',
-              content: 'Old prompt',
-              timestamp: DateTime.now(),
-            ),
-            ChatMessage(
-              id: 'assistant-old',
-              role: 'assistant',
-              content: 'Old answer',
-              timestamp: DateTime.now(),
-            ),
-            ChatMessage(
-              id: 'user-2',
-              role: 'user',
-              content: 'New prompt',
-              timestamp: DateTime.now(),
-            ),
-            ChatMessage(
-              id: 'msg-2',
-              role: 'assistant',
-              content: '',
-              timestamp: DateTime.now(),
-              isStreaming: true,
-            ),
-          ],
-        );
-        final api = _buildFakeApi(
-          pollResponse: _serverConversationResponse(
-            messages: [
-              _serverUserMessage(id: 'server-user-1', content: 'Old prompt'),
-              _serverAssistantMessage(
-                id: 'server-assistant-old',
-                content: 'Old answer',
-                followUps: const ['Old follow-up'],
-                statusHistory: const [
-                  {'description': 'Old status'},
-                ],
-              ),
-              _serverUserMessage(id: 'server-user-2', content: 'New prompt'),
-            ],
-          ),
-        );
-
-        _attach(
-          session: ChatCompletionSession.httpStream(
-            messageId: 'msg-2',
-            sessionId: 'sess-2',
-            conversationId: 'conv-1',
-            byteStream: Stream<List<int>>.fromIterable([_sseDone()]),
-            abort: () async {},
-          ),
-          log: log,
-          api: api,
-          activeConversationId: 'conv-1',
-          assistantMessageId: 'msg-2',
-        );
-
-        await pumpMicrotasks();
-        await Future<void>.delayed(const Duration(milliseconds: 2600));
-        for (var i = 0; i < 5; i++) {
-          await pumpMicrotasks();
-        }
-
-        check(log.messages[1].content).equals('Old answer');
-        check(log.messages[3].id).equals('msg-2');
-        check(log.messages[3].content).equals('');
-        check(log.messages[3].followUps).isEmpty();
-        check(log.messages[3].statusHistory).isEmpty();
-        check(log.finishCount).equals(1);
-      },
-    );
-
-    test(
-      'httpStream artifact-only done recovers original assistant after new prompt starts with partial local history and re-keyed ids',
-      () async {
-        final log = _CallbackLog();
-        final incompleteResponse = _serverConversationResponse(
-          messages: [_serverAssistantMessage(id: 'server-msg-1', content: '')],
-        );
-        final persistedResponse = _serverConversationResponse(
-          messages: [
-            _serverAssistantMessage(
-              id: 'server-old-1',
-              content: 'Older persisted answer that should stay untouched',
-              followUps: const ['Older follow-up'],
-              statusHistory: const [
-                {'description': 'Older status'},
-              ],
-              sources: const [
-                {
-                  'source': {
-                    'name': 'Older doc',
-                    'url': 'https://example.com/older',
-                  },
-                  'document': ['Older snippet'],
-                },
-              ],
-            ),
-            _serverUserMessage(id: 'server-user-1', content: 'Old prompt'),
-            _serverAssistantMessage(
-              id: 'server-msg-1',
-              content: 'Recovered A',
-              followUps: const ['Recovered follow-up'],
-              statusHistory: const [
-                {'description': 'Recovered status'},
-              ],
-              sources: const [
-                {
-                  'source': {
-                    'name': 'Recovered doc',
-                    'url': 'https://example.com/recovered',
-                  },
-                  'document': ['Recovered snippet'],
-                },
-              ],
-            ),
-            _serverUserMessage(id: 'server-user-2', content: 'New prompt'),
-            _serverAssistantMessage(
-              id: 'server-msg-2',
-              content: 'Newer reply',
-              followUps: const ['Newer follow-up'],
-            ),
-          ],
-        );
-        final api = _buildFakeApi(
-          pollResponses: [
-            incompleteResponse,
-            persistedResponse,
-            persistedResponse,
-          ],
-        );
-
-        _attach(
-          session: ChatCompletionSession.httpStream(
-            messageId: 'msg-1',
-            sessionId: 'sess-1',
-            conversationId: 'conv-1',
-            byteStream: Stream<List<int>>.fromIterable([
-              _sseFrame({
-                'output': [
-                  {
-                    'type': 'message',
-                    'id': 'out-1',
-                    'status': 'complete',
-                    'role': 'assistant',
-                    'content': [
-                      {'type': 'output_text', 'text': 'tool output'},
-                    ],
-                  },
-                ],
-              }),
-              _sseDone(),
-            ]),
-            abort: () async {},
-          ),
-          log: log,
-          api: api,
-          activeConversationId: 'conv-1',
-        );
-
-        await pumpMicrotasks();
-        await pumpMicrotasks();
-
-        log.messages = [
+    test('httpStream latest blank assistant does not adopt prior persisted answer when server has not created the new assistant yet', () async {
+      final log = _CallbackLog(
+        initialMessages: [
           ChatMessage(
-            id: 'msg-1',
-            role: 'assistant',
-            content: '',
+            id: 'user-1',
+            role: 'user',
+            content: 'Old prompt',
             timestamp: DateTime.now(),
-            isStreaming: true,
           ),
           ChatMessage(
-            id: 'user-2-local',
+            id: 'assistant-old',
+            role: 'assistant',
+            content: 'Old answer',
+            timestamp: DateTime.now(),
+          ),
+          ChatMessage(
+            id: 'user-2',
             role: 'user',
             content: 'New prompt',
             timestamp: DateTime.now(),
@@ -4421,137 +4234,282 @@ void main() {
             timestamp: DateTime.now(),
             isStreaming: true,
           ),
-        ];
-
-        await Future<void>.delayed(const Duration(milliseconds: 2600));
-        for (var i = 0; i < 5; i++) {
-          await pumpMicrotasks();
-        }
-
-        check(log.messages[0].id).equals('msg-1');
-        check(log.messages[0].content).equals('Recovered A');
-        check(log.messages[0].followUps).deepEquals(['Recovered follow-up']);
-        check(
-          log.messages[0].statusHistory,
-        ).has((it) => it.length, 'length').equals(1);
-        check(
-          log.messages[0].statusHistory.single.description,
-        ).equals('Recovered status');
-        check(
-          log.messages[0].sources,
-        ).has((it) => it.length, 'length').equals(1);
-        check(
-          log.messages[0].sources.single.url,
-        ).equals('https://example.com/recovered');
-        check(log.messages[1].role).equals('user');
-        check(log.messages[1].content).equals('New prompt');
-        check(log.messages[2].id).equals('msg-2');
-        check(log.messages[2].content).equals('');
-        check(log.messages[2].followUps).isEmpty();
-        check(log.messages[2].statusHistory).isEmpty();
-        check(log.messages[2].sources).isEmpty();
-        check(log.messages[2].isStreaming).isTrue();
-      },
-    );
-
-    test(
-      'httpStream snapshot refresh drops stale pending status rows after finish',
-      () async {
-        final log = _CallbackLog(
-          initialMessages: [
-            ChatMessage(
-              id: 'msg-1',
-              role: 'assistant',
-              content: 'Answer',
-              timestamp: DateTime.now(),
-              isStreaming: true,
+        ],
+      );
+      final api = _buildFakeApi(
+        pollResponse: _serverConversationResponse(
+          messages: [
+            _serverUserMessage(id: 'server-user-1', content: 'Old prompt'),
+            _serverAssistantMessage(
+              id: 'server-assistant-old',
+              content: 'Old answer',
+              followUps: const ['Old follow-up'],
               statusHistory: const [
-                ChatStatusUpdate(description: 'Searching...', done: false),
+                {'description': 'Old status'},
               ],
             ),
+            _serverUserMessage(id: 'server-user-2', content: 'New prompt'),
           ],
-        );
-        final api = _buildFakeApi(
-          pollResponse: _serverConversationResponse(
-            messages: [_serverAssistantMessage(content: 'Answer')],
-          ),
-        );
+        ),
+      );
 
-        _attach(
-          session: ChatCompletionSession.httpStream(
-            messageId: 'msg-1',
-            sessionId: 'sess-1',
-            conversationId: 'conv-1',
-            byteStream: Stream<List<int>>.fromIterable([_sseDone()]),
-            abort: () async {},
-          ),
-          log: log,
-          api: api,
-          activeConversationId: 'conv-1',
-        );
+      _attach(
+        session: ChatCompletionSession.httpStream(
+          messageId: 'msg-2',
+          sessionId: 'sess-2',
+          conversationId: 'conv-1',
+          byteStream: Stream<List<int>>.fromIterable([_sseDone()]),
+          abort: () async {},
+        ),
+        log: log,
+        api: api,
+        activeConversationId: 'conv-1',
+        assistantMessageId: 'msg-2',
+      );
 
+      await pumpMicrotasks();
+      await Future<void>.delayed(const Duration(milliseconds: 2600));
+      for (var i = 0; i < 5; i++) {
         await pumpMicrotasks();
-        await Future<void>.delayed(const Duration(milliseconds: 700));
-        for (var i = 0; i < 3; i++) {
-          await pumpMicrotasks();
-        }
+      }
 
-        check(log.finishCount).equals(1);
-        check(log.messages.last.statusHistory).isEmpty();
-      },
-    );
+      check(log.messages[1].content).equals('Old answer');
+      check(log.messages[3].id).equals('msg-2');
+      check(log.messages[3].content).equals('');
+      check(log.messages[3].followUps).isEmpty();
+      check(log.messages[3].statusHistory).isEmpty();
+      check(log.finishCount).equals(1);
+    });
 
-    test(
-      'httpStream snapshot refresh keeps status rows with unspecified done after finish',
-      () async {
-        final log = _CallbackLog(
-          initialMessages: [
-            ChatMessage(
-              id: 'msg-1',
-              role: 'assistant',
-              content: 'Answer',
-              timestamp: DateTime.now(),
-              isStreaming: true,
-              statusHistory: const [
-                ChatStatusUpdate(description: 'Generating image...'),
+    test('httpStream artifact-only done recovers original assistant after new prompt starts with partial local history and re-keyed ids', () async {
+      final log = _CallbackLog();
+      final incompleteResponse = _serverConversationResponse(
+        messages: [_serverAssistantMessage(id: 'server-msg-1', content: '')],
+      );
+      final persistedResponse = _serverConversationResponse(
+        messages: [
+          _serverAssistantMessage(
+            id: 'server-old-1',
+            content: 'Older persisted answer that should stay untouched',
+            followUps: const ['Older follow-up'],
+            statusHistory: const [
+              {'description': 'Older status'},
+            ],
+            sources: const [
+              {
+                'source': {
+                  'name': 'Older doc',
+                  'url': 'https://example.com/older',
+                },
+                'document': ['Older snippet'],
+              },
+            ],
+          ),
+          _serverUserMessage(id: 'server-user-1', content: 'Old prompt'),
+          _serverAssistantMessage(
+            id: 'server-msg-1',
+            content: 'Recovered A',
+            followUps: const ['Recovered follow-up'],
+            statusHistory: const [
+              {'description': 'Recovered status'},
+            ],
+            sources: const [
+              {
+                'source': {
+                  'name': 'Recovered doc',
+                  'url': 'https://example.com/recovered',
+                },
+                'document': ['Recovered snippet'],
+              },
+            ],
+          ),
+          _serverUserMessage(id: 'server-user-2', content: 'New prompt'),
+          _serverAssistantMessage(
+            id: 'server-msg-2',
+            content: 'Newer reply',
+            followUps: const ['Newer follow-up'],
+          ),
+        ],
+      );
+      final api = _buildFakeApi(
+        pollResponses: [
+          incompleteResponse,
+          persistedResponse,
+          persistedResponse,
+        ],
+      );
+
+      _attach(
+        session: ChatCompletionSession.httpStream(
+          messageId: 'msg-1',
+          sessionId: 'sess-1',
+          conversationId: 'conv-1',
+          byteStream: Stream<List<int>>.fromIterable([
+            _sseFrame({
+              'output': [
+                {
+                  'type': 'message',
+                  'id': 'out-1',
+                  'status': 'complete',
+                  'role': 'assistant',
+                  'content': [
+                    {'type': 'output_text', 'text': 'tool output'},
+                  ],
+                },
               ],
-            ),
-          ],
-        );
-        final api = _buildFakeApi(
-          pollResponse: _serverConversationResponse(
-            messages: [_serverAssistantMessage(content: 'Answer')],
-          ),
-        );
+            }),
+            _sseDone(),
+          ]),
+          abort: () async {},
+        ),
+        log: log,
+        api: api,
+        activeConversationId: 'conv-1',
+      );
 
-        _attach(
-          session: ChatCompletionSession.httpStream(
-            messageId: 'msg-1',
-            sessionId: 'sess-1',
-            conversationId: 'conv-1',
-            byteStream: Stream<List<int>>.fromIterable([_sseDone()]),
-            abort: () async {},
-          ),
-          log: log,
-          api: api,
-          activeConversationId: 'conv-1',
-        );
+      await pumpMicrotasks();
+      await pumpMicrotasks();
 
+      log.messages = [
+        ChatMessage(
+          id: 'msg-1',
+          role: 'assistant',
+          content: '',
+          timestamp: DateTime.now(),
+          isStreaming: true,
+        ),
+        ChatMessage(
+          id: 'user-2-local',
+          role: 'user',
+          content: 'New prompt',
+          timestamp: DateTime.now(),
+        ),
+        ChatMessage(
+          id: 'msg-2',
+          role: 'assistant',
+          content: '',
+          timestamp: DateTime.now(),
+          isStreaming: true,
+        ),
+      ];
+
+      await Future<void>.delayed(const Duration(milliseconds: 2600));
+      for (var i = 0; i < 5; i++) {
         await pumpMicrotasks();
-        await Future<void>.delayed(const Duration(milliseconds: 700));
-        for (var i = 0; i < 3; i++) {
-          await pumpMicrotasks();
-        }
+      }
 
-        check(log.finishCount).equals(1);
-        check(
-          log.messages.last.statusHistory,
-        ).has((it) => it.length, 'length').equals(1);
-        check(
-          log.messages.last.statusHistory.single.description,
-        ).equals('Generating image...');
-      },
-    );
+      check(log.messages[0].id).equals('msg-1');
+      check(log.messages[0].content).equals('Recovered A');
+      check(log.messages[0].followUps).deepEquals(['Recovered follow-up']);
+      check(log.messages[0].statusHistory)
+          .has((it) => it.length, 'length')
+          .equals(1);
+      check(log.messages[0].statusHistory.single.description)
+          .equals('Recovered status');
+      check(log.messages[0].sources).has((it) => it.length, 'length').equals(1);
+      check(log.messages[0].sources.single.url)
+          .equals('https://example.com/recovered');
+      check(log.messages[1].role).equals('user');
+      check(log.messages[1].content).equals('New prompt');
+      check(log.messages[2].id).equals('msg-2');
+      check(log.messages[2].content).equals('');
+      check(log.messages[2].followUps).isEmpty();
+      check(log.messages[2].statusHistory).isEmpty();
+      check(log.messages[2].sources).isEmpty();
+      check(log.messages[2].isStreaming).isTrue();
+    });
+
+    test('httpStream snapshot refresh drops stale pending status rows after finish', () async {
+      final log = _CallbackLog(
+        initialMessages: [
+          ChatMessage(
+            id: 'msg-1',
+            role: 'assistant',
+            content: 'Answer',
+            timestamp: DateTime.now(),
+            isStreaming: true,
+            statusHistory: const [
+              ChatStatusUpdate(description: 'Searching...', done: false),
+            ],
+          ),
+        ],
+      );
+      final api = _buildFakeApi(
+        pollResponse: _serverConversationResponse(
+          messages: [_serverAssistantMessage(content: 'Answer')],
+        ),
+      );
+
+      _attach(
+        session: ChatCompletionSession.httpStream(
+          messageId: 'msg-1',
+          sessionId: 'sess-1',
+          conversationId: 'conv-1',
+          byteStream: Stream<List<int>>.fromIterable([_sseDone()]),
+          abort: () async {},
+        ),
+        log: log,
+        api: api,
+        activeConversationId: 'conv-1',
+      );
+
+      await pumpMicrotasks();
+      await Future<void>.delayed(const Duration(milliseconds: 700));
+      for (var i = 0; i < 3; i++) {
+        await pumpMicrotasks();
+      }
+
+      check(log.finishCount).equals(1);
+      check(log.messages.last.statusHistory).isEmpty();
+    });
+
+    test('httpStream snapshot refresh keeps status rows with unspecified done after finish', () async {
+      final log = _CallbackLog(
+        initialMessages: [
+          ChatMessage(
+            id: 'msg-1',
+            role: 'assistant',
+            content: 'Answer',
+            timestamp: DateTime.now(),
+            isStreaming: true,
+            statusHistory: const [
+              ChatStatusUpdate(description: 'Generating image...'),
+            ],
+          ),
+        ],
+      );
+      final api = _buildFakeApi(
+        pollResponse: _serverConversationResponse(
+          messages: [_serverAssistantMessage(content: 'Answer')],
+        ),
+      );
+
+      _attach(
+        session: ChatCompletionSession.httpStream(
+          messageId: 'msg-1',
+          sessionId: 'sess-1',
+          conversationId: 'conv-1',
+          byteStream: Stream<List<int>>.fromIterable([_sseDone()]),
+          abort: () async {},
+        ),
+        log: log,
+        api: api,
+        activeConversationId: 'conv-1',
+      );
+
+      await pumpMicrotasks();
+      await Future<void>.delayed(const Duration(milliseconds: 700));
+      for (var i = 0; i < 3; i++) {
+        await pumpMicrotasks();
+      }
+
+      check(log.finishCount).equals(1);
+      check(log.messages.last.statusHistory)
+          .has((it) => it.length, 'length')
+          .equals(1);
+      check(log.messages.last.statusHistory.single.description)
+          .equals('Generating image...');
+    });
 
     test(
       'httpStream snapshot refresh clears stale sources after finish',
@@ -4603,77 +4561,74 @@ void main() {
       },
     );
 
-    test(
-      'httpStream snapshot refresh batches follow-ups and metadata into one mutation',
-      () async {
-        final log = _CallbackLog(
-          initialMessages: [
-            ChatMessage(
-              id: 'msg-1',
-              role: 'assistant',
+    test('httpStream snapshot refresh batches follow-ups and metadata into one mutation', () async {
+      final log = _CallbackLog(
+        initialMessages: [
+          ChatMessage(
+            id: 'msg-1',
+            role: 'assistant',
+            content: 'Answer',
+            timestamp: DateTime.now(),
+            isStreaming: true,
+          ),
+        ],
+      );
+      final api = _buildFakeApi(
+        pollResponse: _serverConversationResponse(
+          messages: [
+            _serverAssistantMessage(
               content: 'Answer',
-              timestamp: DateTime.now(),
-              isStreaming: true,
+              followUps: const ['Ask again'],
+              statusHistory: const [
+                {'description': 'Searching', 'done': true},
+              ],
+              sources: const [
+                {
+                  'source': {'name': 'doc', 'url': 'https://example.com/doc'},
+                  'document': ['snippet'],
+                },
+              ],
+              usage: const {'prompt_tokens': 5, 'completion_tokens': 8},
+              metadata: const {'serverFlag': true},
             ),
           ],
-        );
-        final api = _buildFakeApi(
-          pollResponse: _serverConversationResponse(
-            messages: [
-              _serverAssistantMessage(
-                content: 'Answer',
-                followUps: const ['Ask again'],
-                statusHistory: const [
-                  {'description': 'Searching', 'done': true},
-                ],
-                sources: const [
-                  {
-                    'source': {'name': 'doc', 'url': 'https://example.com/doc'},
-                    'document': ['snippet'],
-                  },
-                ],
-                usage: const {'prompt_tokens': 5, 'completion_tokens': 8},
-                metadata: const {'serverFlag': true},
-              ),
-            ],
-          ),
-        );
+        ),
+      );
 
-        _attach(
-          session: ChatCompletionSession.httpStream(
-            messageId: 'msg-1',
-            sessionId: 'sess-1',
-            conversationId: 'conv-1',
-            byteStream: Stream<List<int>>.fromIterable([_sseDone()]),
-            abort: () async {},
-          ),
-          log: log,
-          api: api,
-          activeConversationId: 'conv-1',
-        );
+      _attach(
+        session: ChatCompletionSession.httpStream(
+          messageId: 'msg-1',
+          sessionId: 'sess-1',
+          conversationId: 'conv-1',
+          byteStream: Stream<List<int>>.fromIterable([_sseDone()]),
+          abort: () async {},
+        ),
+        log: log,
+        api: api,
+        activeConversationId: 'conv-1',
+      );
 
+      await pumpMicrotasks();
+      await Future<void>.delayed(const Duration(milliseconds: 700));
+      for (var i = 0; i < 3; i++) {
         await pumpMicrotasks();
-        await Future<void>.delayed(const Duration(milliseconds: 700));
-        for (var i = 0; i < 3; i++) {
-          await pumpMicrotasks();
-        }
+      }
 
-        final lastMsg = log.messages.last;
-        check(log.finishCount).equals(1);
-        check(log.messageByIdMutationCount).equals(1);
-        check(lastMsg.followUps).deepEquals(['Ask again']);
-        check(lastMsg.statusHistory).has((it) => it.length, 'length').equals(1);
-        check(lastMsg.statusHistory.single.description).equals('Searching');
-        check(lastMsg.sources).has((it) => it.length, 'length').equals(1);
-        check(lastMsg.sources.single.url).equals('https://example.com/doc');
-        expect(
-          lastMsg.usage,
-          equals({'prompt_tokens': 5, 'completion_tokens': 8}),
-        );
-        check(lastMsg.metadata).isNotNull();
-        check(lastMsg.metadata!['serverFlag']).equals(true);
-      },
-    );
+      final lastMsg = log.messages.last;
+      check(log.finishCount).equals(1);
+      check(log.messageByIdMutationCount).equals(1);
+      check(lastMsg.followUps).deepEquals(['Ask again']);
+      check(lastMsg.statusHistory).has((it) => it.length, 'length').equals(1);
+      check(lastMsg.statusHistory.single.description).equals('Searching');
+      check(lastMsg.sources).has((it) => it.length, 'length').equals(1);
+      check(lastMsg.sources.single.url).equals('https://example.com/doc');
+      expect(
+        lastMsg.usage,
+        equals({'prompt_tokens': 5, 'completion_tokens': 8}),
+      );
+      check(lastMsg.metadata).isNotNull();
+      check(lastMsg.metadata!['serverFlag']).equals(true);
+    });
 
     // -----------------------------------------------------------------------
     // 7. httpStream premature end recovers from newer server state
@@ -4827,62 +4782,59 @@ void main() {
       check(lastContent.length).isGreaterThan('short'.length);
     });
 
-    test(
-      'httpStream recovery preserves longer visible streaming content than stale server snapshots',
-      () async {
-        final log = _CallbackLog(
-          initialMessages: fakeStreamingAssistantMessages(content: 'lagging'),
-        );
-        const visibleStreamingContent =
-            'I am the newer visible streaming content';
+    test('httpStream recovery preserves longer visible streaming content than stale server snapshots', () async {
+      final log = _CallbackLog(
+        initialMessages: fakeStreamingAssistantMessages(content: 'lagging'),
+      );
+      const visibleStreamingContent =
+          'I am the newer visible streaming content';
 
-        final byteStream = Stream<List<int>>.empty();
-        final api = _buildFakeApi(
-          pollResponse: {
-            'chat': {
-              'messages': [
-                {'id': 'msg-1', 'content': 'short stale', 'done': true},
-              ],
-            },
+      final byteStream = Stream<List<int>>.empty();
+      final api = _buildFakeApi(
+        pollResponse: {
+          'chat': {
+            'messages': [
+              {'id': 'msg-1', 'content': 'short stale', 'done': true},
+            ],
           },
-        );
+        },
+      );
 
-        void flushVisibleStreamingBuffer() {
-          log.flushStreamingBuffer();
-          if (log.messages.isEmpty || log.messages.last.role != 'assistant') {
-            return;
-          }
-          final last = log.messages.last;
-          log.messages = [
-            ...log.messages.sublist(0, log.messages.length - 1),
-            last.copyWith(content: visibleStreamingContent),
-          ];
+      void flushVisibleStreamingBuffer() {
+        log.flushStreamingBuffer();
+        if (log.messages.isEmpty || log.messages.last.role != 'assistant') {
+          return;
         }
+        final last = log.messages.last;
+        log.messages = [
+          ...log.messages.sublist(0, log.messages.length - 1),
+          last.copyWith(content: visibleStreamingContent),
+        ];
+      }
 
-        _attach(
-          session: ChatCompletionSession.httpStream(
-            messageId: 'msg-1',
-            sessionId: 'sess-1',
-            conversationId: 'conv-1',
-            byteStream: byteStream,
-            abort: () async {},
-          ),
-          log: log,
-          api: api,
-          activeConversationId: 'conv-1',
-          getVisibleStreamingContent: () => visibleStreamingContent,
-          flushStreamingBuffer: flushVisibleStreamingBuffer,
-        );
+      _attach(
+        session: ChatCompletionSession.httpStream(
+          messageId: 'msg-1',
+          sessionId: 'sess-1',
+          conversationId: 'conv-1',
+          byteStream: byteStream,
+          abort: () async {},
+        ),
+        log: log,
+        api: api,
+        activeConversationId: 'conv-1',
+        getVisibleStreamingContent: () => visibleStreamingContent,
+        flushStreamingBuffer: flushVisibleStreamingBuffer,
+      );
 
+      await pumpMicrotasks();
+      for (var i = 0; i < 10; i++) {
         await pumpMicrotasks();
-        for (var i = 0; i < 10; i++) {
-          await pumpMicrotasks();
-        }
+      }
 
-        check(log.messages.last.content).equals(visibleStreamingContent);
-        check(log.replacedContents).isEmpty();
-      },
-    );
+      check(log.messages.last.content).equals(visibleStreamingContent);
+      check(log.replacedContents).isEmpty();
+    });
 
     // -----------------------------------------------------------------------
     // 10. Rename: ActiveChatStream replaces ActiveSocketStream
@@ -4940,12 +4892,10 @@ void main() {
       // Should have exactly 2 images (deduplicated), both normalized
       // to {type: 'image', url: ...}
       check(lastMsg.files!.length).equals(2);
-      check(
-        lastMsg.files![0],
-      ).deepEquals({'type': 'image', 'url': 'https://example.com/img1.png'});
-      check(
-        lastMsg.files![1],
-      ).deepEquals({'type': 'image', 'url': 'https://example.com/img2.png'});
+      check(lastMsg.files![0])
+          .deepEquals({'type': 'image', 'url': 'https://example.com/img1.png'});
+      check(lastMsg.files![1])
+          .deepEquals({'type': 'image', 'url': 'https://example.com/img2.png'});
     });
 
     // -----------------------------------------------------------------------
@@ -4980,12 +4930,10 @@ void main() {
       final lastMsg = log.messages.last;
       check(lastMsg.files).isNotNull();
       check(lastMsg.files!.length).equals(2);
-      check(
-        lastMsg.files![0],
-      ).deepEquals({'type': 'image', 'url': 'https://example.com/a.png'});
-      check(
-        lastMsg.files![1],
-      ).deepEquals({'type': 'image', 'url': 'https://example.com/b.png'});
+      check(lastMsg.files![0])
+          .deepEquals({'type': 'image', 'url': 'https://example.com/a.png'});
+      check(lastMsg.files![1])
+          .deepEquals({'type': 'image', 'url': 'https://example.com/b.png'});
     });
 
     // -----------------------------------------------------------------------

--- a/test/core/sync/chat_merger_test.dart
+++ b/test/core/sync/chat_merger_test.dart
@@ -385,9 +385,8 @@ void main() {
 
       // m3 took the server payload (parentId m1). m1's derived children are
       // m2, m3 and mNew (the dirty local addition).
-      check(
-        childrenOf(result.merged, 'm1'),
-      ).unorderedEquals(['m2', 'm3', 'mNew']);
+      check(childrenOf(result.merged, 'm1'))
+          .unorderedEquals(['m2', 'm3', 'mNew']);
       check(childrenOf(result.merged, 'm2')).isEmpty();
       // tree-consistent against the rebuilt blob.
       check(
@@ -714,15 +713,12 @@ void main() {
         dirtyMessageIds: const {'mDirty'},
       );
 
-      check(
-        result.merged.chat.rawExtra['models'] as List,
-      ).deepEquals(['srv-model']);
-      check(
-        result.merged.chat.rawExtra['params'] as Map,
-      ).deepEquals({'temp': 0.9});
-      check(
-        result.merged.chat.rawExtra['unknownFutureKey'],
-      ).equals('from-server');
+      check(result.merged.chat.rawExtra['models'] as List)
+          .deepEquals(['srv-model']);
+      check(result.merged.chat.rawExtra['params'] as Map)
+          .deepEquals({'temp': 0.9});
+      check(result.merged.chat.rawExtra['unknownFutureKey'])
+          .equals('from-server');
       check(result.merged.blobHadHistory).equals(server.blobHadHistory);
       check(result.merged.blobHadTitle).equals(server.blobHadTitle);
     });
@@ -773,17 +769,14 @@ void main() {
       );
 
       check(idsOf(second.merged)).unorderedEquals(idsOf(first.merged).toList());
-      check(
-        second.dirtyMessageIds,
-      ).unorderedEquals(first.dirtyMessageIds.toList());
-      check(
-        second.merged.chat.currentMessageId,
-      ).equals(first.merged.chat.currentMessageId);
+      check(second.dirtyMessageIds)
+          .unorderedEquals(first.dirtyMessageIds.toList());
+      check(second.merged.chat.currentMessageId)
+          .equals(first.merged.chat.currentMessageId);
       check(second.mustPush).isTrue();
       check(second.newServerUpdatedAt).equals(200);
-      check(
-        childrenOf(second.merged, 'm2'),
-      ).unorderedEquals(childrenOf(first.merged, 'm2'));
+      check(childrenOf(second.merged, 'm2'))
+          .unorderedEquals(childrenOf(first.merged, 'm2'));
     });
 
     test('overlap-window re-merge after B advances (push landed) is a no-op', () {

--- a/test/core/sync/deletion_reconcile_test.dart
+++ b/test/core/sync/deletion_reconcile_test.dart
@@ -145,29 +145,26 @@ void main() {
   };
 
   group('pagination absence is NOT a delete signal', () {
-    test(
-      'manual reconcile restores a server title changed without a timestamp bump',
-      () async {
-        await seedServerChat(db, id: 'retitled', updatedAt: 100);
-        server.seedChat(
-          id: 'retitled',
-          blob: <String, dynamic>{
-            ...blobFor('retitled'),
-            'title': 'Generated on server',
-          },
-          createdAt: 50,
-          updatedAt: 100,
-        );
+    test('manual reconcile restores a server title changed without a timestamp bump', () async {
+      await seedServerChat(db, id: 'retitled', updatedAt: 100);
+      server.seedChat(
+        id: 'retitled',
+        blob: <String, dynamic>{
+          ...blobFor('retitled'),
+          'title': 'Generated on server',
+        },
+        createdAt: 50,
+        updatedAt: 100,
+      );
 
-        final result = await reconcile.run(ReconcileReason.manualRefresh);
+      final result = await reconcile.run(ReconcileReason.manualRefresh);
 
-        check(result.ran).isTrue();
-        final row = await db.chatsDao.getChat('retitled');
-        check(row).isNotNull();
-        check(row!.title).equals('Generated on server');
-        check(row.updatedAt).equals(100);
-      },
-    );
+      check(result.ran).isTrue();
+      final row = await db.chatsDao.getChat('retitled');
+      check(row).isNotNull();
+      check(row!.title).equals('Generated on server');
+      check(row.updatedAt).equals(100);
+    });
 
     test('manual title reconcile preserves a pending local rename', () async {
       await seedServerChat(db, id: 'locally-retitled', updatedAt: 100);
@@ -258,43 +255,40 @@ void main() {
   });
 
   group('confirmed server delete purges after reconcile', () {
-    test(
-      'a true server 404 (gone) purges the local chat + its pending ops',
-      () async {
-        server.seedChat(
-          id: 'alive',
-          blob: blobFor('alive'),
-          createdAt: 50,
-          updatedAt: 100,
-        );
-        await seedServerChat(db, id: 'alive');
+    test('a true server 404 (gone) purges the local chat + its pending ops', () async {
+      server.seedChat(
+        id: 'alive',
+        blob: blobFor('alive'),
+        createdAt: 50,
+        updatedAt: 100,
+      );
+      await seedServerChat(db, id: 'alive');
 
-        // 'ghost' exists locally but NOT on the server: absent from the list AND
-        // the probe reports gone (404).
-        await seedServerChat(db, id: 'ghost');
-        client.nullChatIds.add('ghost'); // probe -> false (gone)
+      // 'ghost' exists locally but NOT on the server: absent from the list AND
+      // the probe reports gone (404).
+      await seedServerChat(db, id: 'ghost');
+      client.nullChatIds.add('ghost'); // probe -> false (gone)
 
-        // A stale pending op for the ghost should be dropped on purge.
-        await db
-            .into(db.outboxOps)
-            .insert(
-              OutboxOpsCompanion.insert(
-                kind: OutboxKind.updateChat.name,
-                chatId: const Value('ghost'),
-                payload: const Value('{}'),
-              ),
-            );
+      // A stale pending op for the ghost should be dropped on purge.
+      await db
+          .into(db.outboxOps)
+          .insert(
+            OutboxOpsCompanion.insert(
+              kind: OutboxKind.updateChat.name,
+              chatId: const Value('ghost'),
+              payload: const Value('{}'),
+            ),
+          );
 
-        final result = await reconcile.run(ReconcileReason.manualRefresh);
+      final result = await reconcile.run(ReconcileReason.manualRefresh);
 
-        check(result.purged).equals(1);
-        check(result.candidates).equals(1);
-        check(await db.chatsDao.getChat('ghost')).isNull();
-        check(await db.chatsDao.getChat('alive')).isNotNull();
-        final ops = await db.outboxDao.pendingForChat('ghost');
-        check(ops).isEmpty();
-      },
-    );
+      check(result.purged).equals(1);
+      check(result.candidates).equals(1);
+      check(await db.chatsDao.getChat('ghost')).isNull();
+      check(await db.chatsDao.getChat('alive')).isNotNull();
+      final ops = await db.outboxDao.pendingForChat('ghost');
+      check(ops).isEmpty();
+    });
 
     test(
       'a 401 NOT_FOUND (vendored normal-user not-ours) also counts as gone',

--- a/test/core/sync/folder_sync_test.dart
+++ b/test/core/sync/folder_sync_test.dart
@@ -304,9 +304,8 @@ void main() {
             createIfAbsent: true,
           );
           check(
-            (await db.outboxDao.pendingForChat(
-              'local:fdelete',
-            )).map((op) => op.kind),
+            (await db.outboxDao.pendingForChat('local:fdelete'))
+                .map((op) => op.kind),
           ).deepEquals([OutboxKind.folderUpsert.name]);
 
           await db.foldersDao.tombstoneFolderWithOutbox('local:fdelete');
@@ -410,9 +409,8 @@ void main() {
         updatedAt: 100,
       );
 
-      await check(
-        push.pushUpdateChat('chat1'),
-      ).throws<OutboxDeferralException>();
+      await check(push.pushUpdateChat('chat1'))
+          .throws<OutboxDeferralException>();
 
       // No server write/move happens while the folder id is still local.
       check(client.updateChatCalls).equals(0);

--- a/test/core/sync/hive_cache_migrator_test.dart
+++ b/test/core/sync/hive_cache_migrator_test.dart
@@ -79,17 +79,14 @@ void main() {
 
     await migrator().migrateIfNeeded();
 
-    check(
-      await db.appCacheDao.getValue(HiveStoreKeys.localUser),
-    ).equals(jsonEncode({'id': 'u1', 'name': 'User'}));
-    check(
-      await db.appCacheDao.getValue(HiveStoreKeys.localUserAvatar),
-    ).equals('https://x/a.png');
+    check(await db.appCacheDao.getValue(HiveStoreKeys.localUser))
+        .equals(jsonEncode({'id': 'u1', 'name': 'User'}));
+    check(await db.appCacheDao.getValue(HiveStoreKeys.localUserAvatar))
+        .equals('https://x/a.png');
     check(
       jsonDecode(
-            (await db.appCacheDao.getValue(HiveStoreKeys.localBackendConfig))!,
-          )
-          as Map,
+        (await db.appCacheDao.getValue(HiveStoreKeys.localBackendConfig))!,
+      ) as Map,
     ).deepEquals({'version': '1.2.3'});
     check(
       jsonDecode((await db.appCacheDao.getValue(HiveStoreKeys.localModels))!)
@@ -125,12 +122,10 @@ void main() {
     check(rows.length).equals(1);
     check(rows.single.id).equals('a1');
     check(rows.single.fileName).equals('a.png');
-    check(
-      await db.syncMetaDao.getValue('hive_attachment_queue_migrated'),
-    ).equals('1');
-    check(
-      attachmentQueue.containsKey(HiveStoreKeys.attachmentQueueEntries),
-    ).isFalse();
+    check(await db.syncMetaDao.getValue('hive_attachment_queue_migrated'))
+        .equals('1');
+    check(attachmentQueue.containsKey(HiveStoreKeys.attachmentQueueEntries))
+        .isFalse();
   });
 
   test('is gated: a second run does not re-import deleted keys', () async {
@@ -143,8 +138,7 @@ void main() {
     await caches.put(HiveStoreKeys.localUserAvatar, 'https://x/a.png');
     await migrator().migrateIfNeeded();
 
-    check(
-      await db.appCacheDao.getValue(HiveStoreKeys.localUserAvatar),
-    ).isNull();
+    check(await db.appCacheDao.getValue(HiveStoreKeys.localUserAvatar))
+        .isNull();
   });
 }

--- a/test/core/sync/id_remapper_test.dart
+++ b/test/core/sync/id_remapper_test.dart
@@ -198,9 +198,8 @@ void main() {
 
         check(result).equals(ChatRemapResult.sourceMissing);
         check(events).isEmpty();
-        check(
-          await db.syncMetaDao.getChatRemapTarget('local:already-gone'),
-        ).isNull();
+        check(await db.syncMetaDao.getChatRemapTarget('local:already-gone'))
+            .isNull();
         await sub.cancel();
       },
     );
@@ -232,9 +231,8 @@ void main() {
 
         check(result).equals(ChatRemapResult.alreadyCommitted);
         check(await db.chatsDao.getChat(serverId)).isNotNull();
-        check(
-          await db.syncMetaDao.getChatRemapTarget(localId),
-        ).equals(serverId);
+        check(await db.syncMetaDao.getChatRemapTarget(localId))
+            .equals(serverId);
       },
     );
 
@@ -258,12 +256,10 @@ void main() {
       check(await db.chatsDao.getChat(localId)).isNotNull();
       check(await db.chatsDao.getChat(conflictingServerId)).isNull();
       check((await messagesFor(db, localId)).length).equals(2);
-      check(
-        (await allOutbox(db)).map((op) => op.chatId).toSet(),
-      ).deepEquals({localId});
-      check(
-        await db.syncMetaDao.getChatRemapTarget(localId),
-      ).equals(committedServerId);
+      check((await allOutbox(db)).map((op) => op.chatId).toSet())
+          .deepEquals({localId});
+      check(await db.syncMetaDao.getChatRemapTarget(localId))
+          .equals(committedServerId);
     });
 
     test('crash-heal: server stub already present (0 messages) -> local rows '
@@ -342,16 +338,13 @@ void main() {
 
         // Neither distinct conversation is discarded or redirected.
         final allChats = await db.select(db.chats).get();
-        check(
-          allChats.map((c) => c.id).toSet(),
-        ).deepEquals({localId, serverId});
-        check(
-          (await messagesFor(db, serverId)).map((m) => m.id),
-        ).deepEquals(['srv-m1']);
+        check(allChats.map((c) => c.id).toSet())
+            .deepEquals({localId, serverId});
+        check((await messagesFor(db, serverId)).map((m) => m.id))
+            .deepEquals(['srv-m1']);
         check((await messagesFor(db, localId)).length).equals(2);
-        check(
-          (await allOutbox(db)).map((o) => o.chatId).toSet(),
-        ).deepEquals({localId});
+        check((await allOutbox(db)).map((o) => o.chatId).toSet())
+            .deepEquals({localId});
         check(await db.syncMetaDao.getChatRemapTarget(localId)).isNull();
       },
     );
@@ -388,12 +381,10 @@ void main() {
         check(await db.chatsDao.getChat(localId)).isNull();
         check(await db.chatsDao.getChat(serverId)).isNotNull();
         check((await messagesFor(db, serverId)).length).equals(2);
-        check(
-          (await allOutbox(db)).map((op) => op.chatId).toSet(),
-        ).deepEquals({serverId});
-        check(
-          await db.syncMetaDao.getChatRemapTarget(localId),
-        ).equals(serverId);
+        check((await allOutbox(db)).map((op) => op.chatId).toSet())
+            .deepEquals({serverId});
+        check(await db.syncMetaDao.getChatRemapTarget(localId))
+            .equals(serverId);
       },
     );
 
@@ -425,9 +416,8 @@ void main() {
         ).throws<StateError>();
 
         check(await db.chatsDao.getChat(localId)).isNotNull();
-        check(
-          (await db.chatsDao.getChat(serverId))!.title,
-        ).equals('Legitimate empty chat');
+        check((await db.chatsDao.getChat(serverId))!.title)
+            .equals('Legitimate empty chat');
         check(await db.syncMetaDao.getChatRemapTarget(localId)).isNull();
       },
     );
@@ -460,9 +450,8 @@ void main() {
 
       check(await db.chatsDao.getChat(localId)).isNotNull();
       check(await db.chatsDao.getChat(serverId)).isNotNull();
-      check(
-        (await allOutbox(db)).map((op) => op.chatId).toSet(),
-      ).deepEquals({serverId});
+      check((await allOutbox(db)).map((op) => op.chatId).toSet())
+          .deepEquals({serverId});
     });
 
     test(
@@ -496,9 +485,8 @@ void main() {
 
         check(await db.chatsDao.getChat(localId)).isNotNull();
         check(await db.chatsDao.getChat(serverId)).isNotNull();
-        check(
-          await db.syncMetaDao.getChatRemapTarget(priorLocalId),
-        ).equals(serverId);
+        check(await db.syncMetaDao.getChatRemapTarget(priorLocalId))
+            .equals(serverId);
         check(await db.syncMetaDao.getChatRemapTarget(localId)).isNull();
       },
     );
@@ -540,9 +528,8 @@ void main() {
         updatedAt: 60,
       );
 
-      check(
-        createChatContentHash(localRows),
-      ).equals(createChatContentHash(serverRows));
+      check(createChatContentHash(localRows))
+          .equals(createChatContentHash(serverRows));
     });
 
     test('localId == serverId is an idempotent no-op', () async {
@@ -663,9 +650,8 @@ void main() {
         serverUpdatedAt: 2,
       );
 
-      final parked = (await allOutbox(
-        db,
-      )).firstWhere((o) => o.seq == parkedSeq);
+      final parked = (await allOutbox(db))
+          .firstWhere((o) => o.seq == parkedSeq);
       // Parked ops remain terminal, but the UI watches by the surviving server
       // id after remap.
       check(parked.status).equals('failed');
@@ -704,9 +690,8 @@ void main() {
           serverUpdatedAt: 600,
         );
 
-        check(
-          await db.foldersDao.watchFolders().first,
-        ).which((it) => it.length.equals(1));
+        check(await db.foldersDao.watchFolders().first)
+            .which((it) => it.length.equals(1));
         final folders = await db.select(db.folders).get();
         check(folders.map((f) => f.id)).deepEquals([serverId]);
         check(folders.single.updatedAt).equals(600);

--- a/test/core/sync/note_deletion_reconcile_test.dart
+++ b/test/core/sync/note_deletion_reconcile_test.dart
@@ -123,22 +123,18 @@ void main() {
   NoteDeletionReconcile reconcileWith(FakeSyncApiClient client) =>
       NoteDeletionReconcile(client: client, db: db, locks: locks, clock: clock);
 
-  test(
-    'a note still on the server is never purged (pagination/race gap)',
-    () async {
-      final client = FakeSyncApiClient(server);
-      for (final id in ['a', 'b', 'c']) {
-        await seedSyncedNote(id);
-      }
-      // 'a' is locally present AND on the server but we force the probe to still
-      // see it as existing — it must NOT be purged just for being a candidate.
-      final result = await reconcileWith(
-        client,
-      ).run(ReconcileReason.manualRefresh);
-      check(result.purged).equals(0);
-      check(result.candidates).equals(0); // all three are on the server list
-    },
-  );
+  test('a note still on the server is never purged (pagination/race gap)', () async {
+    final client = FakeSyncApiClient(server);
+    for (final id in ['a', 'b', 'c']) {
+      await seedSyncedNote(id);
+    }
+    // 'a' is locally present AND on the server but we force the probe to still
+    // see it as existing — it must NOT be purged just for being a candidate.
+    final result = await reconcileWith(client)
+        .run(ReconcileReason.manualRefresh);
+    check(result.purged).equals(0);
+    check(result.candidates).equals(0); // all three are on the server list
+  });
 
   test('a confirmed-gone note is purged after probe', () async {
     final client = FakeSyncApiClient(server);
@@ -148,9 +144,8 @@ void main() {
     await seedLocalOnly('ghost');
     client.nullNoteIds.add('ghost'); // probe → null → gone
 
-    final result = await reconcileWith(
-      client,
-    ).run(ReconcileReason.manualRefresh);
+    final result = await reconcileWith(client)
+        .run(ReconcileReason.manualRefresh);
     check(result.candidates).equals(1);
     check(result.purged).equals(1);
     check(await db.notesDao.getNote('ghost')).isNull();
@@ -166,9 +161,8 @@ void main() {
       await seedLocalOnly('ghost-3');
       client.nullNoteIds.addAll(['ghost-1', 'ghost-2', 'ghost-3']);
 
-      final result = await reconcileWith(
-        client,
-      ).run(ReconcileReason.manualRefresh);
+      final result = await reconcileWith(client)
+          .run(ReconcileReason.manualRefresh);
 
       check(result.purged).equals(3);
       check(client.noteListRequests).equals(1);
@@ -183,34 +177,29 @@ void main() {
     await seedLocalOnly('flaky');
     client.failNoteIds.add('flaky'); // probe throws → skip
 
-    final result = await reconcileWith(
-      client,
-    ).run(ReconcileReason.manualRefresh);
+    final result = await reconcileWith(client)
+        .run(ReconcileReason.manualRefresh);
     check(result.purged).equals(0);
     check(result.skipped).equals(1);
     check(await db.notesDao.getNote('flaky')).isNotNull();
   });
 
-  test(
-    'safety valve aborts when candidates exceed the floor AND half the set',
-    () async {
-      final client = FakeSyncApiClient(server);
-      // 8 local notes, all absent from the server → above the absolute floor (5)
-      // and 50% → abort without purging.
-      final ids = List.generate(8, (i) => 'n$i');
-      for (final id in ids) {
-        await seedLocalOnly(id);
-      }
-      client.nullNoteIds.addAll(ids);
+  test('safety valve aborts when candidates exceed the floor AND half the set', () async {
+    final client = FakeSyncApiClient(server);
+    // 8 local notes, all absent from the server → above the absolute floor (5)
+    // and 50% → abort without purging.
+    final ids = List.generate(8, (i) => 'n$i');
+    for (final id in ids) {
+      await seedLocalOnly(id);
+    }
+    client.nullNoteIds.addAll(ids);
 
-      final result = await reconcileWith(
-        client,
-      ).run(ReconcileReason.manualRefresh);
-      check(result.aborted).isTrue();
-      check(result.purged).equals(0);
-      check(await db.notesDao.getNote('n0')).isNotNull();
-    },
-  );
+    final result = await reconcileWith(client)
+        .run(ReconcileReason.manualRefresh);
+    check(result.aborted).isTrue();
+    check(result.purged).equals(0);
+    check(await db.notesDao.getNote('n0')).isNotNull();
+  });
 
   test('a SMALL library is NOT blocked: a single deleted note is purged '
       '(regression — fraction valve must not trip below the floor)', () async {
@@ -218,9 +207,8 @@ void main() {
     await seedLocalOnly('only');
     client.nullNoteIds.add('only'); // probe -> gone
 
-    final result = await reconcileWith(
-      client,
-    ).run(ReconcileReason.manualRefresh);
+    final result = await reconcileWith(client)
+        .run(ReconcileReason.manualRefresh);
     check(result.aborted).isFalse();
     check(result.purged).equals(1);
     check(await db.notesDao.getNote('only')).isNull();
@@ -236,9 +224,8 @@ void main() {
       await seedLocalOnly('ghost');
       client.nullNoteIds.add('ghost');
 
-      final result = await reconcileWith(
-        client,
-      ).run(ReconcileReason.manualRefresh);
+      final result = await reconcileWith(client)
+          .run(ReconcileReason.manualRefresh);
       check(result.aborted).isTrue();
       check(result.purged).equals(0);
       check(await db.notesDao.getNote('ghost')).isNotNull();
@@ -254,9 +241,8 @@ void main() {
       await seedLocalOnly('ghost-2');
       client.nullNoteIds.addAll(['ghost-1', 'ghost-2']);
 
-      final result = await reconcileWith(
-        client,
-      ).run(ReconcileReason.manualRefresh);
+      final result = await reconcileWith(client)
+          .run(ReconcileReason.manualRefresh);
 
       check(result.aborted).isTrue();
       check(result.purged).equals(1);
@@ -274,9 +260,8 @@ void main() {
     final client = _TerminalNoteProbeClient(server);
     await seedLocalOnly('forbidden');
 
-    final result = await reconcileWith(
-      client,
-    ).run(ReconcileReason.manualRefresh);
+    final result = await reconcileWith(client)
+        .run(ReconcileReason.manualRefresh);
 
     check(result.aborted).isTrue();
     check(result.purged).equals(0);
@@ -290,14 +275,12 @@ void main() {
     () async {
       final client = FakeSyncApiClient(server)..notesFeatureEnabled = false;
       await seedLocalOnly('ghost');
-      final result = await reconcileWith(
-        client,
-      ).run(ReconcileReason.manualRefresh);
+      final result = await reconcileWith(client)
+          .run(ReconcileReason.manualRefresh);
       check(result.ran).isTrue();
       check(await db.notesDao.getNote('ghost')).isNotNull();
-      check(
-        await db.syncMetaDao.getNotesLastFullReconcileAt(),
-      ).equals(clock.now);
+      check(await db.syncMetaDao.getNotesLastFullReconcileAt())
+          .equals(clock.now);
     },
   );
 
@@ -307,9 +290,8 @@ void main() {
       final client = _FeatureDisabledExpiredSessionClient(server);
       await seedLocalOnly('ghost');
 
-      final result = await reconcileWith(
-        client,
-      ).run(ReconcileReason.manualRefresh);
+      final result = await reconcileWith(client)
+          .run(ReconcileReason.manualRefresh);
 
       check(result.ran).isFalse();
       check(await db.notesDao.getNote('ghost')).isNotNull();

--- a/test/core/sync/note_sync_test.dart
+++ b/test/core/sync/note_sync_test.dart
@@ -200,9 +200,8 @@ void main() {
       check(result.success).isTrue();
       check(result.changed).equals(FakeOpenWebUiServer.notePageSize);
       check(client.noteListPages).deepEquals([1, 2]);
-      check(
-        client.noteFetchStarts,
-      ).length.equals(FakeOpenWebUiServer.notePageSize);
+      check(client.noteFetchStarts).length
+          .equals(FakeOpenWebUiServer.notePageSize);
       final notes = await allNotes();
       check(notes).length.equals(FakeOpenWebUiServer.notePageSize);
       check(notes.map((note) => note.id)).not((ids) => ids.contains('n-60'));
@@ -262,65 +261,62 @@ void main() {
     },
   );
 
-  test(
-    'CONFLICT COPY: a concurrent data edit yields two surviving notes',
-    () async {
-      // 1. Sync n1.
-      server.seedNote(
-        id: 'n1',
-        title: 'Doc',
-        data: {
-          'content': {'md': 'server v1'},
-        },
-        createdAt: kT1,
-        updatedAt: kT1,
+  test('CONFLICT COPY: a concurrent data edit yields two surviving notes', () async {
+    // 1. Sync n1.
+    server.seedNote(
+      id: 'n1',
+      title: 'Doc',
+      data: {
+        'content': {'md': 'server v1'},
+      },
+      createdAt: kT1,
+      updatedAt: kT1,
+    );
+    await pull();
+    check((await allNotes()).length).equals(1);
+
+    // 2. Local data edit (marks dirtyData), while the note is offline.
+    await locks.runExclusive('n1', () async {
+      await db.notesDao.updateNoteWithOutbox(
+        'n1',
+        data: Value(
+          jsonEncode({
+            'content': {'md': 'my LOCAL edit'},
+          }),
+        ),
+        localUpdatedAtNs: kT1 + 1,
+        enqueue: true,
       );
-      await pull();
-      check((await allNotes()).length).equals(1);
+    });
 
-      // 2. Local data edit (marks dirtyData), while the note is offline.
-      await locks.runExclusive('n1', () async {
-        await db.notesDao.updateNoteWithOutbox(
-          'n1',
-          data: Value(
-            jsonEncode({
-              'content': {'md': 'my LOCAL edit'},
-            }),
-          ),
-          localUpdatedAtNs: kT1 + 1,
-          enqueue: true,
-        );
-      });
+    // 3. The server's copy of n1 also advanced (someone else edited the body).
+    server.seedNote(
+      id: 'n1',
+      title: 'Doc',
+      data: {
+        'content': {'md': 'server v2'},
+      },
+      createdAt: kT1,
+      updatedAt: kT2,
+    );
 
-      // 3. The server's copy of n1 also advanced (someone else edited the body).
-      server.seedNote(
-        id: 'n1',
-        title: 'Doc',
-        data: {
-          'content': {'md': 'server v2'},
-        },
-        createdAt: kT1,
-        updatedAt: kT2,
-      );
+    // 4. Pull → the field-LWW merge must spawn a conflict copy (D-11).
+    await pull();
 
-      // 4. Pull → the field-LWW merge must spawn a conflict copy (D-11).
-      await pull();
+    final notes = await allNotes();
+    check(notes.length).equals(2); // canonical + conflict copy, none lost
 
-      final notes = await allNotes();
-      check(notes.length).equals(2); // canonical + conflict copy, none lost
+    final canonical = notes.firstWhere((n) => n.id == 'n1');
+    final copy = notes.firstWhere((n) => n.id != 'n1');
 
-      final canonical = notes.firstWhere((n) => n.id == 'n1');
-      final copy = notes.firstWhere((n) => n.id != 'n1');
-
-      // Canonical adopted the server data and is clean on the data axis.
-      check(canonical.data).contains('server v2');
-      check(canonical.dirtyData).isFalse();
-      // The conflict copy preserved the LOCAL edit (no silent loss) and is a
-      // fresh local: note that will be pushed as a new note.
-      check(copy.data).contains('my LOCAL edit');
-      check(copy.id.startsWith('local:')).isTrue();
-    },
-  );
+    // Canonical adopted the server data and is clean on the data axis.
+    check(canonical.data).contains('server v2');
+    check(canonical.dirtyData).isFalse();
+    // The conflict copy preserved the LOCAL edit (no silent loss) and is a
+    // fresh local: note that will be pushed as a new note.
+    check(copy.data).contains('my LOCAL edit');
+    check(copy.id.startsWith('local:')).isTrue();
+  });
 
   test('field-LWW merge does not resurrect a clean tombstone', () async {
     await db
@@ -408,9 +404,8 @@ void main() {
     check(row.serverUpdatedAt).equals(kT2);
     check(row.data).contains('local copy edit');
     final pending = await db.outboxDao.pendingForChat('copy-1');
-    check(
-      pending.map((op) => op.kind),
-    ).deepEquals([OutboxKind.noteUpdate.name]);
+    check(pending.map((op) => op.kind))
+        .deepEquals([OutboxKind.noteUpdate.name]);
   });
 
   test('fast-forward preserves conflict-copy metadata', () async {
@@ -536,9 +531,8 @@ void main() {
           ),
         );
         check(await db.notesDao.getNote(localId)).isNotNull();
-        check(
-          (await db.outboxDao.pendingForChat(localId)).map((op) => op.kind),
-        ).deepEquals(['noteCreate']);
+        check((await db.outboxDao.pendingForChat(localId)).map((op) => op.kind))
+            .deepEquals(['noteCreate']);
         await db.notesDao.tombstoneWithOutbox(localId);
       });
 
@@ -595,9 +589,8 @@ void main() {
     check(row.dirtyPinned).isFalse();
 
     final pending = await db.outboxDao.pendingForChat('n-delete');
-    check(
-      pending.map((op) => op.kind),
-    ).deepEquals([OutboxKind.noteDelete.name]);
+    check(pending.map((op) => op.kind))
+        .deepEquals([OutboxKind.noteDelete.name]);
   });
 
   test(
@@ -767,9 +760,9 @@ void main() {
           ),
         );
       });
-      final originalHash = (await db.outboxDao.pendingForChat(
-        localId,
-      )).single.contentHash;
+      final originalHash = (await db.outboxDao.pendingForChat(localId))
+          .single
+          .contentHash;
 
       await locks.runExclusive(localId, () async {
         await db.notesDao.updateNoteWithOutbox(
@@ -1101,9 +1094,8 @@ void main() {
       check(row.dirtyTitle).isTrue();
 
       final pending = await db.outboxDao.pendingForChat(serverId);
-      check(
-        pending.map((op) => op.kind).toList(),
-      ).deepEquals([OutboxKind.noteUpdate.name]);
+      check(pending.map((op) => op.kind).toList())
+          .deepEquals([OutboxKind.noteUpdate.name]);
     },
   );
 
@@ -1180,9 +1172,8 @@ void main() {
     check(row.dirtyPinned).isTrue();
 
     final pending = await db.outboxDao.pendingForChat('p1');
-    check(
-      pending.map((op) => op.kind).toList(),
-    ).unorderedEquals([OutboxKind.notePin.name]);
+    check(pending.map((op) => op.kind).toList())
+        .unorderedEquals([OutboxKind.notePin.name]);
   });
 
   test(
@@ -1213,9 +1204,8 @@ void main() {
       check(row.dirtyTitle).isTrue();
 
       final ops = await db.outboxDao.pendingForChat('n1');
-      check(
-        ops.map((o) => o.kind).toList(),
-      ).contains(OutboxKind.noteUpdate.name);
+      check(ops.map((o) => o.kind).toList())
+          .contains(OutboxKind.noteUpdate.name);
       // The patch always carries title (vendored NoteForm requires it).
       final payload = jsonDecode(ops.first.payload) as Map<String, dynamic>;
       check(payload['title']).equals('Renamed');

--- a/test/core/sync/note_watermark_isolation_test.dart
+++ b/test/core/sync/note_watermark_isolation_test.dart
@@ -22,7 +22,8 @@ void main() {
 
   group('note vs chat watermark isolation (R-09)', () {
     test('the two watermarks live under DISTINCT sync_meta keys', () {
-      check(SyncMetaDao.kNotesPullWatermarkKey).not((k) => k.equals('pull_watermark'));
+      check(SyncMetaDao.kNotesPullWatermarkKey)
+          .not((k) => k.equals('pull_watermark'));
     });
 
     test('the two overlap windows are distinct and in their own units', () {
@@ -31,8 +32,7 @@ void main() {
       check(kNotePullOverlapNs).not((o) => o.equals(kPullOverlapSeconds));
     });
 
-    test(
-        'a nanosecond note watermark and a seconds chat watermark round-trip '
+    test('a nanosecond note watermark and a seconds chat watermark round-trip '
         'independently — neither leaks into the other', () async {
       // A real time_ns()-scale value (~2024 in ns) must survive byte-for-byte.
       const noteNs = 1718000000000000000;
@@ -50,12 +50,14 @@ void main() {
       check(await db.syncMetaDao.getNotesPullWatermark()).equals(noteNs);
     });
 
-    test('the nanosecond watermark is not silently truncated to seconds',
-        () async {
-      const noteNs = 1718000000123456789; // sub-second precision present
-      await db.syncMetaDao.setNotesPullWatermark(noteNs);
-      // A lossy /1000000000 normalization would drop the low digits.
-      check(await db.syncMetaDao.getNotesPullWatermark()).equals(noteNs);
-    });
+    test(
+      'the nanosecond watermark is not silently truncated to seconds',
+      () async {
+        const noteNs = 1718000000123456789; // sub-second precision present
+        await db.syncMetaDao.setNotesPullWatermark(noteNs);
+        // A lossy /1000000000 normalization would drop the low digits.
+        check(await db.syncMetaDao.getNotesPullWatermark()).equals(noteNs);
+      },
+    );
   });
 }

--- a/test/core/sync/outbox_drainer_test.dart
+++ b/test/core/sync/outbox_drainer_test.dart
@@ -435,9 +435,8 @@ void main() {
         await buildDrainer().drain();
 
         check(client.calls).contains('updateFolder:$serverId');
-        check(
-          client.calls,
-        ).not((calls) => calls.contains('updateFolder:$localId'));
+        check(client.calls)
+            .not((calls) => calls.contains('updateFolder:$localId'));
         check(server.getFolders().single['name']).equals('Renamed');
         check((await db.foldersDao.getFolder(serverId))!.dirty).isFalse();
         check(await dao.pendingForChat(serverId)).isEmpty();
@@ -478,9 +477,8 @@ void main() {
         await buildDrainer().drain();
 
         check(client.calls).contains('deleteFolder:$serverId');
-        check(
-          client.calls,
-        ).not((calls) => calls.contains('deleteFolder:$localId'));
+        check(client.calls)
+            .not((calls) => calls.contains('deleteFolder:$localId'));
         check(server.getFolders()).isEmpty();
         check(await db.foldersDao.getFolder(serverId)).isNull();
         check(await dao.pendingForChat(serverId)).isEmpty();
@@ -623,9 +621,8 @@ void main() {
         )..where((t) => t.seq.equals(seq))).getSingle();
         check(row.status).equals(OutboxStatus.failed);
         check(row.attempts).equals(1);
-        check(
-          row.lastError!,
-        ).contains('malformed requestCompletion op: missing chatId');
+        check(row.lastError!)
+            .contains('malformed requestCompletion op: missing chatId');
       },
     );
   });
@@ -666,9 +663,8 @@ void main() {
       final drainer = buildDrainer(backoff: Backoff(jitter: () => 0.999999));
 
       await drainer.drain();
-      check(
-        (await dao.pendingForChat('c1')).single.nextAttemptAt,
-      ).equals(clock.now + 2);
+      check((await dao.pendingForChat('c1')).single.nextAttemptAt)
+          .equals(clock.now + 2);
 
       // Regain connectivity WITHOUT advancing the clock: backoff is reset to
       // now so the op runs immediately and (no more failures) completes.

--- a/test/core/sync/outbox_task_queue_migrator_test.dart
+++ b/test/core/sync/outbox_task_queue_migrator_test.dart
@@ -108,9 +108,8 @@ void main() {
         // user + assistant placeholder rows.
         final msgs = await db.messagesDao.getForChat(chat.id);
         check(msgs.length).equals(2);
-        check(
-          msgs.where((m) => m.role == 'user').single.content,
-        ).equals('first message');
+        check(msgs.where((m) => m.role == 'user').single.content)
+            .equals('first message');
 
         // createChat (with contentHash) THEN requestCompletion.
         final ops = await db.outboxDao.pendingForChat(chat.id);
@@ -153,9 +152,9 @@ void main() {
       await migrator().migrateIfNeeded();
 
       final chat = (await db.select(db.chats).get()).single;
-      final user = (await db.messagesDao.getForChat(
-        chat.id,
-      )).where((m) => m.role == 'user').single;
+      final user = (await db.messagesDao.getForChat(chat.id))
+          .where((m) => m.role == 'user')
+          .single;
       final payload = _decode(user.payload);
       final files = payload['files'] as List;
       final file = Map<String, dynamic>.from(files.single as Map);
@@ -183,9 +182,8 @@ void main() {
         await migrator().migrateIfNeeded();
 
         final ops = await db.outboxDao.pendingForChat('srv-1');
-        check(
-          ops.map((o) => o.kind).toList(),
-        ).deepEquals(['requestCompletion']);
+        check(ops.map((o) => o.kind).toList())
+            .deepEquals(['requestCompletion']);
         // A stub row was materialized for the unpulled server id.
         final chat = await db.chatsDao.getChat('srv-1');
         check(chat).isNotNull();
@@ -411,30 +409,27 @@ void main() {
       check((await db.select(db.chats).get()).length).equals(1);
     });
 
-    test(
-      'durable contentHash marker dedupes after the create op drained',
-      () async {
-        final task = sendTextTask(id: 't1', text: 'already posted');
-        await caches.put('outbound_task_queue_v1', [task]);
-        await migrator().migrateIfNeeded();
+    test('durable contentHash marker dedupes after the create op drained', () async {
+      final task = sendTextTask(id: 't1', text: 'already posted');
+      await caches.put('outbound_task_queue_v1', [task]);
+      await migrator().migrateIfNeeded();
 
-        // Simulate an abort before the migration flag persisted, followed by a
-        // same-process drain that deleted the createChat/requestCompletion rows.
-        await (db.delete(db.syncMeta)..where(
-              (t) => t.key.equals(OutboxTaskQueueMigrator.migratedFlagKey),
-            ))
-            .go();
-        await db.delete(db.outboxOps).go();
+      // Simulate an abort before the migration flag persisted, followed by a
+      // same-process drain that deleted the createChat/requestCompletion rows.
+      await (db.delete(db.syncMeta)..where(
+            (t) => t.key.equals(OutboxTaskQueueMigrator.migratedFlagKey),
+          ))
+          .go();
+      await db.delete(db.outboxOps).go();
 
-        await caches.put('outbound_task_queue_v1', [task]);
-        final report = await migrator().migrateIfNeeded();
+      await caches.put('outbound_task_queue_v1', [task]);
+      final report = await migrator().migrateIfNeeded();
 
-        check(report.skippedDuplicate).equals(1);
-        check(report.converted).equals(0);
-        check((await db.select(db.chats).get()).length).equals(1);
-        check(await db.select(db.outboxOps).get()).isEmpty();
-      },
-    );
+      check(report.skippedDuplicate).equals(1);
+      check(report.converted).equals(0);
+      check((await db.select(db.chats).get()).length).equals(1);
+      check(await db.select(db.outboxOps).get()).isEmpty();
+    });
 
     test('absent key: no-op and sets the migrated flag', () async {
       final report = await migrator().migrateIfNeeded();
@@ -458,9 +453,8 @@ void main() {
         final firstMsgs = await db.messagesDao.getForChat('srv-1');
         final firstOps = await db.outboxDao.pendingForChat('srv-1');
         check(firstMsgs).length.equals(2); // user + assistant
-        check(
-          firstOps.map((o) => o.kind).toList(),
-        ).deepEquals(['requestCompletion']);
+        check(firstOps.map((o) => o.kind).toList())
+            .deepEquals(['requestCompletion']);
 
         // Simulate a partial-failure crash: flag never landed. Re-run.
         await (db.delete(db.syncMeta)..where(

--- a/test/core/sync/pull_sync_test.dart
+++ b/test/core/sync/pull_sync_test.dart
@@ -146,12 +146,10 @@ void main() {
 
       check(result.success).isTrue();
       check(offloadCalls).equals(1);
-      check(
-        (await db.messagesDao.getForChat('large')).length,
-      ).equals(kLocalConversationWorkerThreshold + 1);
-      check(
-        (await db.messagesDao.getForChat('threshold')).length,
-      ).equals(kLocalConversationWorkerThreshold);
+      check((await db.messagesDao.getForChat('large')).length)
+          .equals(kLocalConversationWorkerThreshold + 1);
+      check((await db.messagesDao.getForChat('threshold')).length)
+          .equals(kLocalConversationWorkerThreshold);
     });
 
     test('first-run full pull (watermark 0) lands every chat', () async {
@@ -194,9 +192,8 @@ void main() {
       check(await db.syncMetaDao.getPullWatermark()).equals(500);
 
       final rows = {for (final row in await allChats()) row.id: row};
-      check(
-        rows.keys,
-      ).unorderedEquals(['plain', 'pinned', 'foldered', 'archived']);
+      check(rows.keys)
+          .unorderedEquals(['plain', 'pinned', 'foldered', 'archived']);
       check(rows['pinned']!.pinned).isTrue();
       check(rows['foldered']!.folderId).equals('folder-1');
       check(rows['plain']!.bodySynced).isTrue();
@@ -211,9 +208,8 @@ void main() {
       check(messages.where((m) => m.chatId == 'archived')).isEmpty();
 
       // The seeded folder for the foldered chat replicated.
-      check(
-        (await db.foldersDao.watchFolders().first).map((f) => f.id),
-      ).deepEquals(['folder-1']);
+      check((await db.foldersDao.watchFolders().first).map((f) => f.id))
+          .deepEquals(['folder-1']);
     });
 
     test('empty server: success without watermark movement', () async {
@@ -324,18 +320,16 @@ void main() {
       check(result.failedFetches).equals(1);
       check(result.watermarkAdvanced).isFalse();
       check(await db.syncMetaDao.getPullWatermark()).equals(0);
-      check(
-        (await allChats()).map((c) => c.id),
-      ).unorderedEquals(['chat-1', 'chat-3']);
+      check((await allChats()).map((c) => c.id))
+          .unorderedEquals(['chat-1', 'chat-3']);
 
       client.failChatIds.clear();
       final healed = await pull.run();
       check(healed.success).isTrue();
       check(healed.watermarkAdvanced).isTrue();
       check(await db.syncMetaDao.getPullWatermark()).equals(300);
-      check(
-        (await allChats()).map((c) => c.id),
-      ).unorderedEquals(['chat-1', 'chat-2', 'chat-3']);
+      check((await allChats()).map((c) => c.id))
+          .unorderedEquals(['chat-1', 'chat-2', 'chat-3']);
     });
 
     test(
@@ -404,9 +398,8 @@ void main() {
 
         check(result.success).isTrue();
         check(result.changedChats).equals(0);
-        check(
-          (client as _MalformedFullArchivedListClient).pages,
-        ).deepEquals([1]);
+        check((client as _MalformedFullArchivedListClient).pages)
+            .deepEquals([1]);
         check(client.chatFetchStarts).isEmpty();
         check(await db.syncMetaDao.getPullWatermark()).equals(0);
       },
@@ -583,9 +576,8 @@ void main() {
         check(conversation!.id).equals('chat-1');
         check(conversation.title).equals('Title chat-1');
         check(conversation.messages.length).equals(3);
-        check(
-          conversation.updatedAt.millisecondsSinceEpoch ~/ 1000,
-        ).equals(150);
+        check(conversation.updatedAt.millisecondsSinceEpoch ~/ 1000)
+            .equals(150);
 
         final row = (await db.chatsDao.getChat('chat-1'))!;
         check(row.bodySynced).isTrue();
@@ -706,17 +698,16 @@ void main() {
       check(row.dirty).isTrue();
       check(row.serverUpdatedAt).equals(100);
 
-      final ids = (await db.messagesDao.getForChat(
-        'chat-1',
-      )).map((m) => m.id).toList();
+      final ids = (await db.messagesDao.getForChat('chat-1'))
+          .map((m) => m.id)
+          .toList();
       // Server's m3 inserted AND the dirty local message kept.
       check(ids).contains('chat-1-local');
       check(ids).contains('chat-1-m3');
 
       // The local message row stays dirty; server-origin rows are clean.
-      final localMsg = (await db.messagesDao.getForChat(
-        'chat-1',
-      )).firstWhere((m) => m.id == 'chat-1-local');
+      final localMsg = (await db.messagesDao.getForChat('chat-1'))
+          .firstWhere((m) => m.id == 'chat-1-local');
       check(localMsg.dirty).isTrue();
 
       // REQ 4: the divergent merge enqueued exactly one updateChat push.
@@ -870,9 +861,9 @@ void main() {
         final chat = (await db.chatsDao.getChat(chatId))!;
         check(chat.dirty).isTrue();
         check(chat.bodySynced).isTrue();
-        final ids = (await db.messagesDao.getForChat(
-          chatId,
-        )).map((m) => m.id).toSet();
+        final ids = (await db.messagesDao.getForChat(chatId))
+            .map((m) => m.id)
+            .toSet();
         check(ids).contains('migrated-user');
         check(ids).contains('migrated-assistant');
         check(ids).contains('$chatId-m1');
@@ -1041,9 +1032,8 @@ void main() {
       check(await db.chatsDao.getChat(serverId)).isNotNull();
       check(await db.syncMetaDao.getChatRemapTarget(localId)).isNull();
       check(await db.outboxDao.pendingForChat(localId)).isEmpty();
-      check(
-        (await db.select(db.chats).get()).map((chat) => chat.id),
-      ).deepEquals([serverId]);
+      check((await db.select(db.chats).get()).map((chat) => chat.id))
+          .deepEquals([serverId]);
     });
   });
 }

--- a/test/core/sync/push_sync_test.dart
+++ b/test/core/sync/push_sync_test.dart
@@ -329,9 +329,8 @@ void main() {
       const folderId = 'local:folder';
       await seedLocalChat(db, id: localId, folderId: folderId, messageCount: 1);
 
-      await check(
-        push.pushCreateChat(localId),
-      ).throws<OutboxDeferralException>();
+      await check(push.pushCreateChat(localId))
+          .throws<OutboxDeferralException>();
 
       check(client.createChatCalls).equals(0);
       final chat = await db.chatsDao.getChat(localId);
@@ -462,9 +461,8 @@ void main() {
         bodySynced: false,
       );
 
-      await check(
-        push.pushUpdateChat('stub'),
-      ).throws<OutboxDeferralException>();
+      await check(push.pushUpdateChat('stub'))
+          .throws<OutboxDeferralException>();
 
       final stored = server.getChatById('stub')!;
       final history = (stored['chat'] as Map)['history'] as Map;
@@ -473,88 +471,84 @@ void main() {
       check((await db.chatsDao.getChat('stub'))!.dirty).isTrue();
     });
 
-    test(
-      'respects the server shallow-merge + output->content re-derivation',
-      () async {
-        // Server has an assistant message with no output.
-        server.seedChat(
-          id: 'srv-out',
-          blob: {
-            'title': 'Title srv-out',
-            'history': {
-              'messages': {
-                'a1': {'id': 'a1', 'role': 'assistant', 'content': 'stale'},
-              },
-              'currentId': 'a1',
+    test('respects the server shallow-merge + output->content re-derivation', () async {
+      // Server has an assistant message with no output.
+      server.seedChat(
+        id: 'srv-out',
+        blob: {
+          'title': 'Title srv-out',
+          'history': {
+            'messages': {
+              'a1': {'id': 'a1', 'role': 'assistant', 'content': 'stale'},
             },
+            'currentId': 'a1',
           },
-          createdAt: 1,
-          updatedAt: 2,
-        );
-        // Local row carries an assistant message whose payload has a NEW output
-        // list; the server must re-derive content from it.
-        await db
-            .into(db.chats)
-            .insert(
-              ChatsCompanion.insert(
-                id: 'srv-out',
-                title: 'Title srv-out',
-                currentMessageId: const Value('a1'),
-                createdAt: 1,
-                updatedAt: 2,
-                dirty: const Value(true),
-                bodySynced: const Value(true),
-                blobMeta: Value(
-                  jsonEncode(<String, dynamic>{
-                    'v': 1,
-                    'blobHadTitle': true,
-                    'blobTitleValue': 'Title srv-out',
-                    'blobHadHistory': true,
-                    'historyHadMessages': true,
-                    'historyHadCurrentId': true,
-                    'historyExtra': <String, dynamic>{},
-                    'unmappableMessages': <String, dynamic>{},
-                  }),
-                ),
-              ),
-            );
-        await db
-            .into(db.messages)
-            .insert(
-              MessagesCompanion.insert(
-                id: 'a1',
-                chatId: 'srv-out',
-                role: 'assistant',
-                content: 'ignored-by-server',
-                createdAt: 5,
-                orderIndex: 0,
-                payload: jsonEncode(<String, dynamic>{
-                  'id': 'a1',
-                  'role': 'assistant',
-                  'content': 'ignored-by-server',
-                  'output': [
-                    {
-                      'type': 'message',
-                      'content': [
-                        {'text': 'derived body'},
-                      ],
-                    },
-                  ],
+        },
+        createdAt: 1,
+        updatedAt: 2,
+      );
+      // Local row carries an assistant message whose payload has a NEW output
+      // list; the server must re-derive content from it.
+      await db
+          .into(db.chats)
+          .insert(
+            ChatsCompanion.insert(
+              id: 'srv-out',
+              title: 'Title srv-out',
+              currentMessageId: const Value('a1'),
+              createdAt: 1,
+              updatedAt: 2,
+              dirty: const Value(true),
+              bodySynced: const Value(true),
+              blobMeta: Value(
+                jsonEncode(<String, dynamic>{
+                  'v': 1,
+                  'blobHadTitle': true,
+                  'blobTitleValue': 'Title srv-out',
+                  'blobHadHistory': true,
+                  'historyHadMessages': true,
+                  'historyHadCurrentId': true,
+                  'historyExtra': <String, dynamic>{},
+                  'unmappableMessages': <String, dynamic>{},
                 }),
-                dirty: const Value(true),
               ),
-            );
+            ),
+          );
+      await db
+          .into(db.messages)
+          .insert(
+            MessagesCompanion.insert(
+              id: 'a1',
+              chatId: 'srv-out',
+              role: 'assistant',
+              content: 'ignored-by-server',
+              createdAt: 5,
+              orderIndex: 0,
+              payload: jsonEncode(<String, dynamic>{
+                'id': 'a1',
+                'role': 'assistant',
+                'content': 'ignored-by-server',
+                'output': [
+                  {
+                    'type': 'message',
+                    'content': [
+                      {'text': 'derived body'},
+                    ],
+                  },
+                ],
+              }),
+              dirty: const Value(true),
+            ),
+          );
 
-        await push.pushUpdateChat('srv-out');
+      await push.pushUpdateChat('srv-out');
 
-        final stored = server.getChatById('srv-out')!;
-        final msg =
-            ((stored['chat'] as Map)['history'] as Map)['messages']['a1']
-                as Map;
-        // Content was re-derived from output by the server, NOT the local value.
-        check(msg['content']).equals('derived body');
-      },
-    );
+      final stored = server.getChatById('srv-out')!;
+      final msg =
+          ((stored['chat'] as Map)['history'] as Map)['messages']['a1'] as Map;
+      // Content was re-derived from output by the server, NOT the local value.
+      check(msg['content']).equals('derived body');
+    });
 
     test('pin/archive toggle-delta fires only on a real delta', () async {
       server.seedChat(
@@ -755,42 +749,39 @@ void main() {
       },
     );
 
-    test(
-      'pin survives a folder move (move resets server pin; reconcile re-asserts)',
-      () async {
-        server.seedFolder('srv-folder');
-        // Server chat is pinned and unfiled; the local row both pins it and
-        // moves it into the folder in one coalesced update. The /folder
-        // endpoint forces pinned=false server-side, so the pin reconcile must
-        // run AFTER the move (and treat the post-move pin as false) or the
-        // desired pinned=true is silently lost.
-        server.seedChat(
-          id: 'srv-mv-pin',
-          blob: {
-            'title': 'm',
-            'history': {'messages': {}, 'currentId': null},
-          },
-          createdAt: 1,
-          updatedAt: 2,
-          pinned: true,
-        );
-        await seedLocalChat(
-          db,
-          id: 'srv-mv-pin',
-          messageCount: 0,
-          folderId: 'srv-folder',
-          pinned: true,
-        );
+    test('pin survives a folder move (move resets server pin; reconcile re-asserts)', () async {
+      server.seedFolder('srv-folder');
+      // Server chat is pinned and unfiled; the local row both pins it and
+      // moves it into the folder in one coalesced update. The /folder
+      // endpoint forces pinned=false server-side, so the pin reconcile must
+      // run AFTER the move (and treat the post-move pin as false) or the
+      // desired pinned=true is silently lost.
+      server.seedChat(
+        id: 'srv-mv-pin',
+        blob: {
+          'title': 'm',
+          'history': {'messages': {}, 'currentId': null},
+        },
+        createdAt: 1,
+        updatedAt: 2,
+        pinned: true,
+      );
+      await seedLocalChat(
+        db,
+        id: 'srv-mv-pin',
+        messageCount: 0,
+        folderId: 'srv-folder',
+        pinned: true,
+      );
 
-        await push.pushUpdateChat('srv-mv-pin');
+      await push.pushUpdateChat('srv-mv-pin');
 
-        final stored = server.getChatById('srv-mv-pin')!;
-        check(stored['folder_id']).equals('srv-folder');
-        check(stored['pinned']).equals(true);
-        final chat = await db.chatsDao.getChat('srv-mv-pin');
-        check(chat!.dirty).isFalse();
-      },
-    );
+      final stored = server.getChatById('srv-mv-pin')!;
+      check(stored['folder_id']).equals('srv-folder');
+      check(stored['pinned']).equals(true);
+      final chat = await db.chatsDao.getChat('srv-mv-pin');
+      check(chat!.dirty).isFalse();
+    });
 
     test(
       '404 (chat gone) is non-fatal: logs and returns, no dirty cleared',
@@ -943,9 +934,9 @@ void main() {
         check(serverFolder['data']).isA<Map<String, dynamic>>().deepEquals({
           'files': ['file-1'],
         });
-        check(
-          serverFolder['meta'],
-        ).isA<Map<String, dynamic>>().deepEquals({'color': '#336699'});
+        check(serverFolder['meta'])
+            .isA<Map<String, dynamic>>()
+            .deepEquals({'color': '#336699'});
       },
     );
 
@@ -1139,9 +1130,8 @@ void main() {
         check(server.getFolders().where((f) => f['id'] == id)).isEmpty();
         check(server.getChatById('kept')).isNotNull();
         check(server.getChatById('kept')!['folder_id']).isNull();
-        check(
-          (await db.select(db.folders).get()).where((f) => f.id == id),
-        ).isEmpty();
+        check((await db.select(db.folders).get()).where((f) => f.id == id))
+            .isEmpty();
       },
     );
 

--- a/test/core/sync/sync_api_client_update_folder_test.dart
+++ b/test/core/sync/sync_api_client_update_folder_test.dart
@@ -30,10 +30,7 @@ void main() {
 
     test('genuine 404 returns null (caller purges the local row)', () async {
       final client = _buildClient(
-        _FixedAdapter(
-          statusCode: 404,
-          body: {'detail': 'Not found'},
-        ),
+        _FixedAdapter(statusCode: 404, body: {'detail': 'Not found'}),
       );
 
       final result = await client.updateFolder('folder-1', name: 'Renamed');
@@ -43,9 +40,7 @@ void main() {
 
     test('2xx map body is returned verbatim', () async {
       final folder = {'id': 'folder-1', 'name': 'Renamed', 'updated_at': 42};
-      final client = _buildClient(
-        _FixedAdapter(statusCode: 200, body: folder),
-      );
+      final client = _buildClient(_FixedAdapter(statusCode: 200, body: folder));
 
       final result = await client.updateFolder('folder-1', name: 'Renamed');
 

--- a/test/core/sync/sync_engine_test.dart
+++ b/test/core/sync/sync_engine_test.dart
@@ -331,9 +331,8 @@ void main() {
         check(identical(result, results.first)).isTrue();
         check(result!.success).isTrue();
       }
-      check(
-        container.read(syncEngineProvider).lastSuccessUpdatedAtWatermark,
-      ).equals(100);
+      check(container.read(syncEngineProvider).lastSuccessUpdatedAtWatermark)
+          .equals(100);
       check(container.read(syncEngineProvider).phase).equals(SyncPhase.idle);
     });
 
@@ -621,9 +620,8 @@ void main() {
       check(result!.success).isTrue();
       check(interceptor.pullWatermarkReads).equals(3);
       check(container.read(syncEngineProvider).phase).equals(SyncPhase.idle);
-      check(
-        container.read(syncEngineProvider).lastSuccessUpdatedAtWatermark,
-      ).isNull();
+      check(container.read(syncEngineProvider).lastSuccessUpdatedAtWatermark)
+          .isNull();
       check(await db.syncMetaDao.getPullWatermark()).equals(100);
     });
 
@@ -681,9 +679,8 @@ void main() {
           metadata: emptyHiveBox(),
         );
         final storage = _MockOptimizedStorageService();
-        when(
-          () => storage.getActiveServerId(),
-        ).thenAnswer((_) async => 'server-1');
+        when(() => storage.getActiveServerId())
+            .thenAnswer((_) async => 'server-1');
         final clockProvider =
             NotifierProvider<_MutableValue<SyncClock>, SyncClock>(
               () => _MutableValue<SyncClock>(const _FixedClock(1)),
@@ -792,9 +789,8 @@ void main() {
           metadata: emptyHiveBox(),
         );
         final storage = _MockOptimizedStorageService();
-        when(
-          () => storage.getActiveServerId(),
-        ).thenAnswer((_) async => 'server-1');
+        when(() => storage.getActiveServerId())
+            .thenAnswer((_) async => 'server-1');
         final container = ProviderContainer(
           overrides: [
             appDatabaseProvider.overrideWith(
@@ -831,12 +827,10 @@ void main() {
         await secondDrain;
 
         check(secondMigrationGate.taskMigrationFlagReads).equals(1);
-        check(
-          await firstDb.syncMetaDao.getValue('hive_caches_migrated'),
-        ).isNull();
-        check(
-          await secondDb.syncMetaDao.getValue('hive_caches_migrated'),
-        ).equals('1');
+        check(await firstDb.syncMetaDao.getValue('hive_caches_migrated'))
+            .isNull();
+        check(await secondDb.syncMetaDao.getValue('hive_caches_migrated'))
+            .equals('1');
       },
     );
 
@@ -897,9 +891,8 @@ void main() {
         await engine.drainNow();
 
         check(client.createChatCalls).equals(1);
-        check(
-          await secondDb.outboxDao.pendingForChat('local:after-switch'),
-        ).isEmpty();
+        check(await secondDb.outboxDao.pendingForChat('local:after-switch'))
+            .isEmpty();
       },
     );
 
@@ -1059,9 +1052,8 @@ void main() {
 
         await engine.drainOutbox();
 
-        final failed = (await db.outboxDao.pendingForChat(
-          'backing-off-chat',
-        )).single;
+        final failed = (await db.outboxDao.pendingForChat('backing-off-chat'))
+            .single;
         check(failed.attempts).equals(1);
         check(failed.nextAttemptAt).isNotNull();
         check(failed.nextAttemptAt!).isGreaterThan(1000);
@@ -1254,132 +1246,123 @@ void main() {
       check(completionRunner.calls).isEmpty();
     });
 
-    test(
-      'completion runner rebind keeps preserved drainer from using stale runner',
-      () async {
-        await seedLocalCreate(
-          'local:runner-rebind',
-          contentHash: 'h-runner-rebind',
-          completion: const RequestCompletionPayload(
-            assistantMessageId: 'assistant-1',
-            model: 'model-1',
+    test('completion runner rebind keeps preserved drainer from using stale runner', () async {
+      await seedLocalCreate(
+        'local:runner-rebind',
+        contentHash: 'h-runner-rebind',
+        completion: const RequestCompletionPayload(
+          assistantMessageId: 'assistant-1',
+          model: 'model-1',
+        ),
+      );
+      final firstRunner = _RecordingCompletionRunner();
+      final secondRunner = _RecordingCompletionRunner();
+      final completionProvider =
+          NotifierProvider<
+            _MutableValue<RequestCompletionRunner>,
+            RequestCompletionRunner
+          >(() => _MutableValue<RequestCompletionRunner>(firstRunner));
+      final container = ProviderContainer(
+        overrides: [
+          appDatabaseProvider.overrideWith((ref) => db),
+          syncApiClientProvider.overrideWith((ref) => client),
+          isAuthenticatedProvider2.overrideWith((ref) => true),
+          isOnlineProvider.overrideWith((ref) => true),
+          requestCompletionRunnerProvider.overrideWith(
+            (ref) => ref.watch(completionProvider),
           ),
-        );
-        final firstRunner = _RecordingCompletionRunner();
-        final secondRunner = _RecordingCompletionRunner();
-        final completionProvider =
-            NotifierProvider<
-              _MutableValue<RequestCompletionRunner>,
-              RequestCompletionRunner
-            >(() => _MutableValue<RequestCompletionRunner>(firstRunner));
-        final container = ProviderContainer(
-          overrides: [
-            appDatabaseProvider.overrideWith((ref) => db),
-            syncApiClientProvider.overrideWith((ref) => client),
-            isAuthenticatedProvider2.overrideWith((ref) => true),
-            isOnlineProvider.overrideWith((ref) => true),
-            requestCompletionRunnerProvider.overrideWith(
-              (ref) => ref.watch(completionProvider),
-            ),
-          ],
-        );
-        addTearDown(container.dispose);
-        final engine = container.read(syncEngineProvider.notifier);
+        ],
+      );
+      addTearDown(container.dispose);
+      final engine = container.read(syncEngineProvider.notifier);
 
-        final gate = Completer<void>();
-        client.createChatGate = gate.future;
-        final drain = engine.drainOutbox();
-        await waitFor(() => client.createChatStarts.isNotEmpty);
+      final gate = Completer<void>();
+      client.createChatGate = gate.future;
+      final drain = engine.drainOutbox();
+      await waitFor(() => client.createChatStarts.isNotEmpty);
 
-        container.read(completionProvider.notifier).set(secondRunner);
-        container.read(syncEngineProvider);
-        gate.complete();
-        await drain;
+      container.read(completionProvider.notifier).set(secondRunner);
+      container.read(syncEngineProvider);
+      gate.complete();
+      await drain;
 
-        check(firstRunner.calls).isEmpty();
-        check(secondRunner.calls).isEmpty();
+      check(firstRunner.calls).isEmpty();
+      check(secondRunner.calls).isEmpty();
 
-        await engine.drainNow();
+      await engine.drainNow();
 
-        check(firstRunner.calls).isEmpty();
-        check(secondRunner.calls).length.equals(1);
-      },
-    );
+      check(firstRunner.calls).isEmpty();
+      check(secondRunner.calls).length.equals(1);
+    });
 
-    test(
-      'disposing during an active create keeps remap forwarding until drain ends',
-      () async {
-        await seedLocalCreate(
-          'local:dispose-remap',
-          contentHash: 'h-dispose-remap',
-        );
-        final container = ProviderContainer(
-          overrides: [
-            appDatabaseProvider.overrideWith((ref) => db),
-            syncApiClientProvider.overrideWith((ref) => client),
-            isAuthenticatedProvider2.overrideWith((ref) => true),
-            isOnlineProvider.overrideWith((ref) => true),
-          ],
-        );
-        final engine = container.read(syncEngineProvider.notifier);
-        final remapEvents = <RemapEvent>[];
-        final remapSub = engine.remapEvents.listen(remapEvents.add);
-        addTearDown(remapSub.cancel);
+    test('disposing during an active create keeps remap forwarding until drain ends', () async {
+      await seedLocalCreate(
+        'local:dispose-remap',
+        contentHash: 'h-dispose-remap',
+      );
+      final container = ProviderContainer(
+        overrides: [
+          appDatabaseProvider.overrideWith((ref) => db),
+          syncApiClientProvider.overrideWith((ref) => client),
+          isAuthenticatedProvider2.overrideWith((ref) => true),
+          isOnlineProvider.overrideWith((ref) => true),
+        ],
+      );
+      final engine = container.read(syncEngineProvider.notifier);
+      final remapEvents = <RemapEvent>[];
+      final remapSub = engine.remapEvents.listen(remapEvents.add);
+      addTearDown(remapSub.cancel);
 
-        final gate = Completer<void>();
-        client.createChatGate = gate.future;
-        final drain = engine.drainOutbox();
-        await waitFor(() => client.createChatStarts.isNotEmpty);
+      final gate = Completer<void>();
+      client.createChatGate = gate.future;
+      final drain = engine.drainOutbox();
+      await waitFor(() => client.createChatStarts.isNotEmpty);
 
-        container.dispose();
-        gate.complete();
-        await drain;
+      container.dispose();
+      gate.complete();
+      await drain;
 
-        check(remapEvents).length.equals(1);
-        check(remapEvents.single.fromId).equals('local:dispose-remap');
-        check(engine.hasCachedDrainerForTesting).isFalse();
-        check(engine.hasCachedRemapperForTesting).isFalse();
-      },
-    );
+      check(remapEvents).length.equals(1);
+      check(remapEvents.single.fromId).equals('local:dispose-remap');
+      check(engine.hasCachedDrainerForTesting).isFalse();
+      check(engine.hasCachedRemapperForTesting).isFalse();
+    });
 
-    test(
-      'disposing after auth flip keeps retired remap forwarding until drain ends',
-      () async {
-        await seedLocalCreate(
-          'local:auth-dispose-remap',
-          contentHash: 'h-auth-dispose-remap',
-        );
-        final authProvider = NotifierProvider<_MutableValue<bool>, bool>(
-          () => _MutableValue<bool>(true),
-        );
-        final container = makeContainer(
-          authBuilder: (ref) => ref.watch(authProvider),
-        );
-        final engine = container.read(syncEngineProvider.notifier);
-        final remapEvents = <RemapEvent>[];
-        final remapSub = engine.remapEvents.listen(remapEvents.add);
-        addTearDown(remapSub.cancel);
+    test('disposing after auth flip keeps retired remap forwarding until drain ends', () async {
+      await seedLocalCreate(
+        'local:auth-dispose-remap',
+        contentHash: 'h-auth-dispose-remap',
+      );
+      final authProvider = NotifierProvider<_MutableValue<bool>, bool>(
+        () => _MutableValue<bool>(true),
+      );
+      final container = makeContainer(
+        authBuilder: (ref) => ref.watch(authProvider),
+      );
+      final engine = container.read(syncEngineProvider.notifier);
+      final remapEvents = <RemapEvent>[];
+      final remapSub = engine.remapEvents.listen(remapEvents.add);
+      addTearDown(remapSub.cancel);
 
-        final gate = Completer<void>();
-        client.createChatGate = gate.future;
-        final drain = engine.drainOutbox();
-        await waitFor(() => client.createChatStarts.isNotEmpty);
+      final gate = Completer<void>();
+      client.createChatGate = gate.future;
+      final drain = engine.drainOutbox();
+      await waitFor(() => client.createChatStarts.isNotEmpty);
 
-        container.read(authProvider.notifier).set(false);
-        container.read(syncEngineProvider);
-        check(engine.hasCachedDrainerForTesting).isFalse();
-        check(engine.hasCachedRemapperForTesting).isFalse();
+      container.read(authProvider.notifier).set(false);
+      container.read(syncEngineProvider);
+      check(engine.hasCachedDrainerForTesting).isFalse();
+      check(engine.hasCachedRemapperForTesting).isFalse();
 
-        container.dispose();
-        gate.complete();
-        await drain;
+      container.dispose();
+      gate.complete();
+      await drain;
 
-        check(remapEvents).length.equals(1);
-        check(remapEvents.single.fromId).equals('local:auth-dispose-remap');
-        check(engine.hasCachedDrainerForTesting).isFalse();
-        check(engine.hasCachedRemapperForTesting).isFalse();
-      },
-    );
+      check(remapEvents).length.equals(1);
+      check(remapEvents.single.fromId).equals('local:auth-dispose-remap');
+      check(engine.hasCachedDrainerForTesting).isFalse();
+      check(engine.hasCachedRemapperForTesting).isFalse();
+    });
 
     test(
       'pull-cycle drain clears a stale drainer after dependency refresh',

--- a/test/core/sync/write_path_acceptance_test.dart
+++ b/test/core/sync/write_path_acceptance_test.dart
@@ -203,9 +203,9 @@ void main() {
       check(stored).isNotNull();
       final history = (stored!['chat'] as Map)['history'] as Map;
       final messages = history['messages'] as Map;
-      final userMsg =
-          messages.values.firstWhere((m) => (m as Map)['role'] == 'user')
-              as Map;
+      final userMsg = messages.values.firstWhere(
+        (m) => (m as Map)['role'] == 'user',
+      ) as Map;
       check(userMsg['content']).equals('migrate and send me');
 
       // The completion ran against the SERVER id (remap repointed it, §B2.4).
@@ -256,13 +256,11 @@ void main() {
     check(survived).isNotNull();
     check(survived!.dirty).isTrue();
     final msgs = await db.messagesDao.getForChat(localId);
-    check(
-      msgs.where((m) => m.role == 'user').single.content,
-    ).equals('offline hello');
+    check(msgs.where((m) => m.role == 'user').single.content)
+        .equals('offline hello');
     // Both ops survived.
-    check(
-      (await db.outboxDao.pendingForChat(localId)).map((o) => o.kind),
-    ).deepEquals(['createChat', 'requestCompletion']);
+    check((await db.outboxDao.pendingForChat(localId)).map((o) => o.kind))
+        .deepEquals(['createChat', 'requestCompletion']);
 
     // --- RECONNECT: drain sends + remaps. ---
     await drainer().drain();
@@ -280,9 +278,8 @@ void main() {
     // row, and the completion echo all share `a-off`, so upsertLocalEcho keyed
     // on {chatId,id} updated the one row instead of writing a duplicate).
     final finalMsgs = await db.messagesDao.getForChat(serverId);
-    check(
-      finalMsgs.where((m) => m.role == 'assistant').toList(),
-    ).length.equals(1);
+    check(finalMsgs.where((m) => m.role == 'assistant').toList()).length
+        .equals(1);
     final assistant = finalMsgs.where((m) => m.id == 'a-off').single;
     check(assistant.content).equals('assistant reply');
     check(assistant.parentId).equals('u-off');

--- a/test/core/utils/openwebui_source_parser_test.dart
+++ b/test/core/utils/openwebui_source_parser_test.dart
@@ -99,9 +99,8 @@ void main() {
 
         check(result).length.equals(1);
         check(result.first.snippet).equals('snippet A');
-        check(
-          result.first.metadata!['documents'] as List<dynamic>,
-        ).deepEquals(['snippet A', 'snippet B']);
+        check(result.first.metadata!['documents'] as List<dynamic>)
+            .deepEquals(['snippet A', 'snippet B']);
       });
 
       test('different IDs produce separate results', () {

--- a/test/core/utils/prompt_variable_parser_test.dart
+++ b/test/core/utils/prompt_variable_parser_test.dart
@@ -81,9 +81,8 @@ void main() {
       check(vars).length.equals(1);
       check(vars.first.start).equals(6);
       check(vars.first.end).equals(14);
-      check(
-        input.substring(vars.first.start, vars.first.end),
-      ).equals('{{name}}');
+      check(input.substring(vars.first.start, vars.first.end))
+          .equals('{{name}}');
     });
 
     test('fullMatch contains braces', () {

--- a/test/core/utils/reasoning_parser_test.dart
+++ b/test/core/utils/reasoning_parser_test.dart
@@ -38,21 +38,18 @@ void main() {
     });
 
     test('detects <think> tag', () {
-      check(
-        ReasoningParser.hasReasoningContent('<think>some thought</think>'),
-      ).isTrue();
+      check(ReasoningParser.hasReasoningContent('<think>some thought</think>'))
+          .isTrue();
     });
 
     test('detects <thinking> tag', () {
-      check(
-        ReasoningParser.hasReasoningContent('<thinking>hmm</thinking>'),
-      ).isTrue();
+      check(ReasoningParser.hasReasoningContent('<thinking>hmm</thinking>'))
+          .isTrue();
     });
 
     test('detects unicode think tag', () {
-      check(
-        ReasoningParser.hasReasoningContent('◁think▷reasoning◁/think▷'),
-      ).isTrue();
+      check(ReasoningParser.hasReasoningContent('◁think▷reasoning◁/think▷'))
+          .isTrue();
     });
 
     test('detects type="code_interpreter"', () {
@@ -191,9 +188,8 @@ void main() {
           '</details>';
       final segs = ReasoningParser.segments(content);
       check(segs).isNotNull();
-      check(
-        segs!.first.entry!.blockType,
-      ).equals(CollapsibleBlockType.codeInterpreter);
+      check(segs!.first.entry!.blockType)
+          .equals(CollapsibleBlockType.codeInterpreter);
     });
 
     test('handles multiple consecutive blocks', () {

--- a/test/core/utils/system_ui_style_test.dart
+++ b/test/core/utils/system_ui_style_test.dart
@@ -24,12 +24,12 @@ void main() {
     });
 
     test('is applied by app bar themes', () {
-      final lightStyle = AppTheme.light(
-        TweakcnThemes.t3Chat,
-      ).appBarTheme.systemOverlayStyle;
-      final darkStyle = AppTheme.dark(
-        TweakcnThemes.t3Chat,
-      ).appBarTheme.systemOverlayStyle;
+      final lightStyle = AppTheme.light(TweakcnThemes.t3Chat)
+          .appBarTheme
+          .systemOverlayStyle;
+      final darkStyle = AppTheme.dark(TweakcnThemes.t3Chat)
+          .appBarTheme
+          .systemOverlayStyle;
 
       expect(lightStyle?.statusBarBrightness, Brightness.light);
       expect(lightStyle?.statusBarIconBrightness, Brightness.dark);

--- a/test/core/utils/tts_voice_utils_test.dart
+++ b/test/core/utils/tts_voice_utils_test.dart
@@ -16,9 +16,8 @@ void main() {
         'name': 'Samantha',
       };
 
-      check(
-        ttsVoiceIdFor(TtsEngine.device, voice),
-      ).equals('com.apple.voice.enhanced.en-US.Samantha');
+      check(ttsVoiceIdFor(TtsEngine.device, voice))
+          .equals('com.apple.voice.enhanced.en-US.Samantha');
     });
 
     test('selected option resolves legacy saved names to native ids', () {
@@ -32,9 +31,8 @@ void main() {
       ];
       final settings = const AppSettings().copyWith(ttsVoice: 'Samantha');
 
-      check(
-        selectedTtsVoiceOptionId(settings, voices),
-      ).equals('com.apple.voice.enhanced.en-US.Samantha');
+      check(selectedTtsVoiceOptionId(settings, voices))
+          .equals('com.apple.voice.enhanced.en-US.Samantha');
       check(ttsVoiceMatchesSettings(settings, voices.single)).isTrue();
     });
 
@@ -69,9 +67,8 @@ void main() {
 
       check(options).length.equals(1);
       check(options.single.label).equals('Example (Personal Voice)');
-      check(
-        options.single.subtitle,
-      ).equals('English (United States) · Premium · Personal Voice');
+      check(options.single.subtitle)
+          .equals('English (United States) · Premium · Personal Voice');
     });
   });
 }

--- a/test/core/utils/user_display_name_test.dart
+++ b/test/core/utils/user_display_name_test.dart
@@ -11,9 +11,8 @@ void main() {
       });
 
       test('returns custom fallback', () {
-        check(
-          deriveUserDisplayName(null, fallback: 'Anonymous'),
-        ).equals('Anonymous');
+        check(deriveUserDisplayName(null, fallback: 'Anonymous'))
+            .equals('Anonymous');
       });
     });
 

--- a/test/features/auth/providers/unified_auth_providers_test.dart
+++ b/test/features/auth/providers/unified_auth_providers_test.dart
@@ -20,9 +20,8 @@ void main() {
       events.add('returned');
 
       check(result).isTrue();
-      check(
-        events,
-      ).deepEquals(['authenticated', 'preference-persisted', 'returned']);
+      check(events)
+          .deepEquals(['authenticated', 'preference-persisted', 'returned']);
     });
 
     test('does not persist the preference after a rejected attempt', () async {

--- a/test/features/auth/views/proxy_auth_page_test.dart
+++ b/test/features/auth/views/proxy_auth_page_test.dart
@@ -35,9 +35,8 @@ void main() {
       fence.invalidate();
 
       check(fence.ownsGeneration(generation)).isFalse();
-      check(
-        fence.ownsDocument(fence.generation, 'https://chat.example/auth'),
-      ).isFalse();
+      check(fence.ownsDocument(fence.generation, 'https://chat.example/auth'))
+          .isFalse();
     });
 
     test('invalidated fence rejects a matching delayed completion', () {
@@ -167,9 +166,8 @@ void main() {
 
       check(fence.markDocumentCommitted('https://chat.example/old')).isFalse();
       check(fence.committedDocument).isNull();
-      check(
-        fence.ownsDocument(newDocument.generation, newDocument.url),
-      ).isTrue();
+      check(fence.ownsDocument(newDocument.generation, newDocument.url))
+          .isTrue();
     });
 
     test('redirect commit waits for the load-stop fallback', () {
@@ -177,9 +175,8 @@ void main() {
       fence.startNavigation('https://chat.example/');
       final pendingDocument = fence.activeDocument!;
 
-      check(
-        fence.markDocumentCommitted('https://auth.example/login'),
-      ).isFalse();
+      check(fence.markDocumentCommitted('https://auth.example/login'))
+          .isFalse();
       check(fence.committedDocument).isNull();
       check(
         fence.commitDocument(
@@ -211,9 +208,8 @@ void main() {
       );
 
       check(committed).isFalse();
-      check(
-        fence.ownsDocument(currentGeneration, 'https://chat.example/auth'),
-      ).isTrue();
+      check(fence.ownsDocument(currentGeneration, 'https://chat.example/auth'))
+          .isTrue();
     });
 
     test('rejects an old document ticket even when the URL is unchanged', () {
@@ -266,12 +262,10 @@ void main() {
       fence.markDocumentCommitted('https://chat.example/auth');
       final document = fence.committedDocument!;
 
-      check(
-        fence.ownsLiveDocument(document, 'https://chat.example/auth#ready'),
-      ).isFalse();
-      check(
-        fence.ownsLiveDocument(document, 'https://chat.example/chat/new'),
-      ).isFalse();
+      check(fence.ownsLiveDocument(document, 'https://chat.example/auth#ready'))
+          .isFalse();
+      check(fence.ownsLiveDocument(document, 'https://chat.example/chat/new'))
+          .isFalse();
     });
 
     test('fragment-only history change advances the committed ticket', () {
@@ -328,9 +322,8 @@ void main() {
 
       check(fence.markNavigationProvisional(document)).isTrue();
       check(fence.committedDocument).isNull();
-      check(
-        fence.ownsDocument(fence.generation, 'https://chat.example/auth'),
-      ).isTrue();
+      check(fence.ownsDocument(fence.generation, 'https://chat.example/auth'))
+          .isTrue();
     });
 
     test('stale history ticket cannot replace a newer navigation', () {
@@ -347,9 +340,8 @@ void main() {
           url: 'https://chat.example/old/history',
         ),
       ).isFalse();
-      check(
-        fence.ownsDocument(newDocument.generation, newDocument.url),
-      ).isTrue();
+      check(fence.ownsDocument(newDocument.generation, newDocument.url))
+          .isTrue();
     });
   });
 

--- a/test/features/auth/views/server_connection_error_sanitization_test.dart
+++ b/test/features/auth/views/server_connection_error_sanitization_test.dart
@@ -20,9 +20,8 @@ void main() {
       );
 
       check(merged['X-Proxy']).equals('preserved');
-      check(
-        merged.keys.where((key) => key.toLowerCase() == 'cookie').toList(),
-      ).deepEquals(['Cookie']);
+      check(merged.keys.where((key) => key.toLowerCase() == 'cookie').toList())
+          .deepEquals(['Cookie']);
       check(
         merged['Cookie'],
       ).equals('session=fresh; theme=dark; token=old=payload; csrf=fresh-csrf');

--- a/test/features/chat/models/model_selector_layout_test.dart
+++ b/test/features/chat/models/model_selector_layout_test.dart
@@ -16,9 +16,8 @@ void main() {
       defaultModelId: 'model-6',
     );
 
-    check(
-      layout.featured.map((model) => model.id).toList(),
-    ).deepEquals(['model-5', 'model-2']);
+    check(layout.featured.map((model) => model.id).toList())
+        .deepEquals(['model-5', 'model-2']);
     check(layout.more.map((model) => model.id)).contains('model-6');
   });
 
@@ -29,12 +28,10 @@ void main() {
       defaultModelId: 'model-6',
     );
 
-    check(
-      layout.featured.map((model) => model.id).toList(),
-    ).deepEquals(['model-0', 'model-1', 'model-2', 'model-3', 'model-6']);
-    check(
-      layout.more.map((model) => model.id).toList(),
-    ).deepEquals(['model-4', 'model-5']);
+    check(layout.featured.map((model) => model.id).toList())
+        .deepEquals(['model-0', 'model-1', 'model-2', 'model-3', 'model-6']);
+    check(layout.more.map((model) => model.id).toList())
+        .deepEquals(['model-4', 'model-5']);
   });
 
   test('falls back when every pinned model id is stale', () {
@@ -44,12 +41,10 @@ void main() {
       defaultModelId: 'model-6',
     );
 
-    check(
-      layout.featured.map((model) => model.id).toList(),
-    ).deepEquals(['model-0', 'model-1', 'model-2', 'model-3', 'model-6']);
-    check(
-      layout.more.map((model) => model.id).toList(),
-    ).deepEquals(['model-4', 'model-5']);
+    check(layout.featured.map((model) => model.id).toList())
+        .deepEquals(['model-0', 'model-1', 'model-2', 'model-3', 'model-6']);
+    check(layout.more.map((model) => model.id).toList())
+        .deepEquals(['model-4', 'model-5']);
   });
 
   test('promotes a selected model from more into the featured group', () {
@@ -60,12 +55,10 @@ void main() {
       selectedModelId: 'model-4',
     );
 
-    check(
-      layout.featured.map((model) => model.id).toList(),
-    ).deepEquals(['model-5', 'model-2', 'model-4']);
-    check(
-      layout.more.map((model) => model.id).toList(),
-    ).deepEquals(['model-0', 'model-1', 'model-3', 'model-6']);
+    check(layout.featured.map((model) => model.id).toList())
+        .deepEquals(['model-5', 'model-2', 'model-4']);
+    check(layout.more.map((model) => model.id).toList())
+        .deepEquals(['model-0', 'model-1', 'model-3', 'model-6']);
   });
 
   test('does not duplicate a selected model that is already featured', () {
@@ -76,8 +69,7 @@ void main() {
       selectedModelId: 'model-2',
     );
 
-    check(
-      layout.featured.map((model) => model.id).toList(),
-    ).deepEquals(['model-0', 'model-1', 'model-2', 'model-3', 'model-6']);
+    check(layout.featured.map((model) => model.id).toList())
+        .deepEquals(['model-0', 'model-1', 'model-2', 'model-3', 'model-6']);
   });
 }

--- a/test/features/chat/providers/chat_loading_guard_test.dart
+++ b/test/features/chat/providers/chat_loading_guard_test.dart
@@ -26,41 +26,38 @@ class _LoadingConversationNotifier extends IsLoadingConversation {
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
-  test(
-    'sendMessageWithContainer refuses to create a new chat while a selection is loading',
-    () async {
-      final api = ApiService(
-        serverConfig: const ServerConfig(
-          id: 'test',
-          name: 'Test',
-          url: 'https://example.com',
+  test('sendMessageWithContainer refuses to create a new chat while a selection is loading', () async {
+    final api = ApiService(
+      serverConfig: const ServerConfig(
+        id: 'test',
+        name: 'Test',
+        url: 'https://example.com',
+      ),
+      workerManager: WorkerManager(),
+    );
+    final container = ProviderContainer(
+      overrides: [
+        activeConversationProvider.overrideWith(
+          () => _NullConversationNotifier(),
         ),
-        workerManager: WorkerManager(),
-      );
-      final container = ProviderContainer(
-        overrides: [
-          activeConversationProvider.overrideWith(
-            () => _NullConversationNotifier(),
-          ),
-          isLoadingConversationProvider.overrideWith(
-            () => _LoadingConversationNotifier(true),
-          ),
-          apiServiceProvider.overrideWithValue(api),
-          selectedModelProvider.overrideWithValue(
-            const Model(id: 'gpt-4', name: 'GPT-4'),
-          ),
-          reviewerModeProvider.overrideWithValue(false),
-        ],
-      );
-      addTearDown(container.dispose);
+        isLoadingConversationProvider.overrideWith(
+          () => _LoadingConversationNotifier(true),
+        ),
+        apiServiceProvider.overrideWithValue(api),
+        selectedModelProvider.overrideWithValue(
+          const Model(id: 'gpt-4', name: 'GPT-4'),
+        ),
+        reviewerModeProvider.overrideWithValue(false),
+      ],
+    );
+    addTearDown(container.dispose);
 
-      await expectLater(
-        sendMessageWithContainer(container, 'How do I add flavour?', null),
-        throwsA(isA<StateError>()),
-      );
+    await expectLater(
+      sendMessageWithContainer(container, 'How do I add flavour?', null),
+      throwsA(isA<StateError>()),
+    );
 
-      check(container.read(activeConversationProvider)).isNull();
-      check(container.read(chatMessagesProvider)).isEmpty();
-    },
-  );
+    check(container.read(activeConversationProvider)).isNull();
+    check(container.read(chatMessagesProvider)).isEmpty();
+  });
 }

--- a/test/features/chat/providers/chat_messages_notifier_error_sync_test.dart
+++ b/test/features/chat/providers/chat_messages_notifier_error_sync_test.dart
@@ -113,9 +113,8 @@ void main() {
       check(activeConversation!.messages).length.equals(2);
       check(activeConversation.messages.last.isStreaming).isFalse();
       check(activeConversation.messages.last.error).isNotNull();
-      check(
-        activeConversation.messages.last.error!.content,
-      ).equals('Transport setup failed');
+      check(activeConversation.messages.last.error!.content)
+          .equals('Transport setup failed');
     });
   });
 }

--- a/test/features/chat/providers/chat_messages_notifier_remote_sync_test.dart
+++ b/test/features/chat/providers/chat_messages_notifier_remote_sync_test.dart
@@ -394,44 +394,40 @@ void main() {
       },
     );
 
-    test(
-      'cold reopen rebinds an Open WebUI wire model to its trusted direct model',
-      () async {
-        final direct = _serverDirectModel();
-        const priorSelection = Model(
-          id: 'previous-model',
-          name: 'Previous model',
-        );
-        final container = _modelRebindContainer(
-          registry: direct.registry,
-          models: <Model>[direct.model],
-        );
-        addTearDown(container.dispose);
-        container.read(chatMessagesProvider);
-        container.read(selectedModelProvider.notifier).set(priorSelection);
+    test('cold reopen rebinds an Open WebUI wire model to its trusted direct model', () async {
+      final direct = _serverDirectModel();
+      const priorSelection = Model(
+        id: 'previous-model',
+        name: 'Previous model',
+      );
+      final container = _modelRebindContainer(
+        registry: direct.registry,
+        models: <Model>[direct.model],
+      );
+      addTearDown(container.dispose);
+      container.read(chatMessagesProvider);
+      container.read(selectedModelProvider.notifier).set(priorSelection);
 
-        container
-            .read(activeConversationProvider.notifier)
-            .set(
-              withChatStorageProvenance(
-                _conversation(
-                  'server-direct-chat',
-                  const <ChatMessage>[],
-                  DateTime.utc(2026, 7, 15),
-                ).copyWith(model: direct.wireModelId),
-                ChatStorageKind.openWebUi,
-              ),
-            );
-        await pumpMicrotasks();
-        await pumpMicrotasks();
+      container
+          .read(activeConversationProvider.notifier)
+          .set(
+            withChatStorageProvenance(
+              _conversation(
+                'server-direct-chat',
+                const <ChatMessage>[],
+                DateTime.utc(2026, 7, 15),
+              ).copyWith(model: direct.wireModelId),
+              ChatStorageKind.openWebUi,
+            ),
+          );
+      await pumpMicrotasks();
+      await pumpMicrotasks();
 
-        check(direct.model.id).not((it) => it.equals(direct.wireModelId));
-        check(container.read(selectedModelProvider)).identicalTo(direct.model);
-        check(
-          direct.registry.resolve(container.read(selectedModelProvider)!),
-        ).isNotNull();
-      },
-    );
+      check(direct.model.id).not((it) => it.equals(direct.wireModelId));
+      check(container.read(selectedModelProvider)).identicalTo(direct.model);
+      check(direct.registry.resolve(container.read(selectedModelProvider)!))
+          .isNotNull();
+    });
 
     test(
       'cold reopen prefers trusted direct binding over a same-id server model',
@@ -465,9 +461,8 @@ void main() {
         await pumpMicrotasks();
 
         check(container.read(selectedModelProvider)).identicalTo(direct.model);
-        check(
-          container.read(selectedModelProvider),
-        ).not((it) => it.identicalTo(serverCollision));
+        check(container.read(selectedModelProvider))
+            .not((it) => it.identicalTo(serverCollision));
       },
     );
 
@@ -552,9 +547,8 @@ void main() {
         await Future<void>.delayed(const Duration(milliseconds: 500));
         await pumpMicrotasks();
 
-        check(
-          container.read(chatMessagesProvider),
-        ).deepEquals(refreshedMessages);
+        check(container.read(chatMessagesProvider))
+            .deepEquals(refreshedMessages);
         final activeConversation = container.read(activeConversationProvider);
         check(activeConversation).isNotNull();
         check(activeConversation!.messages).deepEquals(refreshedMessages);
@@ -731,9 +725,8 @@ void main() {
             .set(_conversation('chat-1', refreshedMessages, timestamp));
         await pumpMicrotasks();
 
-        check(
-          container.read(chatMessagesProvider),
-        ).deepEquals(refreshedMessages);
+        check(container.read(chatMessagesProvider))
+            .deepEquals(refreshedMessages);
         container.read(chatMessagesProvider.notifier).clearMessages();
         container.read(activeConversationProvider.notifier).clear();
       },
@@ -811,45 +804,52 @@ void main() {
       check(container.read(chatMessagesProvider).last.isStreaming).isFalse();
     });
 
-    test('progressively adopts growing server content while resuming', () async {
-      final timestamp = DateTime.now();
-      final opened = [
-        _userMessage('user-1', 'Hi', timestamp),
-        _assistantMessage('assistant-1', 'Partial', timestamp),
-      ];
-      // The server has more content for the same streaming message.
-      final grown = [
-        _userMessage('user-1', 'Hi', timestamp),
-        _assistantMessage('assistant-1', 'Partial answer that grew', timestamp),
-      ];
-      final api = _FakeApiService(_conversation('chat-1', grown, timestamp))
-        ..taskIds = ['task-1'];
-
-      final container = ProviderContainer(
-        overrides: [
-          ...openWebUiStorageOpenOverrides(),
-          activeConversationProvider.overrideWith(
-            () => _TestActiveConversationNotifier(),
+    test(
+      'progressively adopts growing server content while resuming',
+      () async {
+        final timestamp = DateTime.now();
+        final opened = [
+          _userMessage('user-1', 'Hi', timestamp),
+          _assistantMessage('assistant-1', 'Partial', timestamp),
+        ];
+        // The server has more content for the same streaming message.
+        final grown = [
+          _userMessage('user-1', 'Hi', timestamp),
+          _assistantMessage(
+            'assistant-1',
+            'Partial answer that grew',
+            timestamp,
           ),
-          socketServiceProvider.overrideWithValue(null),
-          apiServiceProvider.overrideWithValue(api),
-        ],
-      );
-      addTearDown(container.dispose);
+        ];
+        final api = _FakeApiService(_conversation('chat-1', grown, timestamp))
+          ..taskIds = ['task-1'];
 
-      check(container.read(chatMessagesProvider)).isEmpty();
-      container
-          .read(activeConversationProvider.notifier)
-          .set(_conversation('chat-1', opened, timestamp));
+        final container = ProviderContainer(
+          overrides: [
+            ...openWebUiStorageOpenOverrides(),
+            activeConversationProvider.overrideWith(
+              () => _TestActiveConversationNotifier(),
+            ),
+            socketServiceProvider.overrideWithValue(null),
+            apiServiceProvider.overrideWithValue(api),
+          ],
+        );
+        addTearDown(container.dispose);
 
-      // Let the active-on-open probe + the monitor's first progressive poll run.
-      await Future<void>.delayed(const Duration(milliseconds: 50));
-      await pumpMicrotasks();
+        check(container.read(chatMessagesProvider)).isEmpty();
+        container
+            .read(activeConversationProvider.notifier)
+            .set(_conversation('chat-1', opened, timestamp));
 
-      final last = container.read(chatMessagesProvider).last;
-      check(last.content).equals('Partial answer that grew');
-      check(last.isStreaming).isTrue();
-    });
+        // Let the active-on-open probe + the monitor's first progressive poll run.
+        await Future<void>.delayed(const Duration(milliseconds: 50));
+        await pumpMicrotasks();
+
+        final last = container.read(chatMessagesProvider).last;
+        check(last.content).equals('Partial answer that grew');
+        check(last.isStreaming).isTrue();
+      },
+    );
 
     test(
       'reopening after a chat switch restores the authoritative server branch',
@@ -901,9 +901,8 @@ void main() {
         await pumpMicrotasks();
 
         final restored = container.read(chatMessagesProvider);
-        check(
-          restored.map((message) => message.id).toList(),
-        ).deepEquals(['user-1', 'assistant-1', 'user-2', 'assistant-2']);
+        check(restored.map((message) => message.id).toList())
+            .deepEquals(['user-1', 'assistant-1', 'user-2', 'assistant-2']);
         check(restored.last.content).equals('Partial answer that grew');
         check(restored.last.isStreaming).isTrue();
       },
@@ -1199,15 +1198,12 @@ void main() {
       await pumpMicrotasks();
       await pumpMicrotasks();
       check(container.read(chatMessagesProvider).last.isStreaming).isTrue();
-      check(
-        container.read(chatMessagesProvider).last.content,
-      ).equals('Partial answer that grew');
-      check(
-        container.read(chatMessagesProvider)[0].content,
-      ).equals('Authoritative first question');
-      check(
-        container.read(chatMessagesProvider)[1].content,
-      ).equals('Authoritative first answer');
+      check(container.read(chatMessagesProvider).last.content)
+          .equals('Partial answer that grew');
+      check(container.read(chatMessagesProvider)[0].content)
+          .equals('Authoritative first question');
+      check(container.read(chatMessagesProvider)[1].content)
+          .equals('Authoritative first answer');
       notifier.debugCancelRemoteTaskMonitorTimer();
     });
 
@@ -1576,67 +1572,61 @@ void main() {
       // getConversation force-adopt + the settled, adopted message.
       await notifier.debugSyncRemoteTaskStatus();
       check(api.getConversationCalls).equals(1);
-      check(
-        container.read(chatMessagesProvider).last.content,
-      ).equals('Final answer');
+      check(container.read(chatMessagesProvider).last.content)
+          .equals('Final answer');
       check(container.read(chatMessagesProvider).last.isStreaming).isFalse();
     });
 
-    test(
-      'offline reopened tail waits for a second empty task poll before finalizing',
-      () async {
-        final timestamp = DateTime.now();
-        final checkpoint = [
-          _userMessage('user-1', 'Hi', timestamp),
-          _assistantMessage(
-            'assistant-1',
-            'Partial',
-            timestamp,
-          ).copyWith(isStreaming: true),
-        ];
-        final finished = [
-          checkpoint.first,
-          _assistantMessage('assistant-1', 'Final answer', timestamp),
-        ];
-        final api =
-            _FakeApiService(_conversation('chat-1', finished, timestamp))
-              ..taskIds = const <String>[]
-              ..taskIdFailuresRemaining = 1;
-        final container = ProviderContainer(
-          overrides: [
-            ...openWebUiStorageOpenOverrides(),
-            activeConversationProvider.overrideWith(
-              () => _TestActiveConversationNotifier(),
-            ),
-            socketServiceProvider.overrideWithValue(null),
-            apiServiceProvider.overrideWithValue(api),
-          ],
-        );
-        addTearDown(container.dispose);
+    test('offline reopened tail waits for a second empty task poll before finalizing', () async {
+      final timestamp = DateTime.now();
+      final checkpoint = [
+        _userMessage('user-1', 'Hi', timestamp),
+        _assistantMessage(
+          'assistant-1',
+          'Partial',
+          timestamp,
+        ).copyWith(isStreaming: true),
+      ];
+      final finished = [
+        checkpoint.first,
+        _assistantMessage('assistant-1', 'Final answer', timestamp),
+      ];
+      final api = _FakeApiService(_conversation('chat-1', finished, timestamp))
+        ..taskIds = const <String>[]
+        ..taskIdFailuresRemaining = 1;
+      final container = ProviderContainer(
+        overrides: [
+          ...openWebUiStorageOpenOverrides(),
+          activeConversationProvider.overrideWith(
+            () => _TestActiveConversationNotifier(),
+          ),
+          socketServiceProvider.overrideWithValue(null),
+          apiServiceProvider.overrideWithValue(api),
+        ],
+      );
+      addTearDown(container.dispose);
 
-        check(container.read(chatMessagesProvider)).isEmpty();
-        final notifier = container.read(chatMessagesProvider.notifier);
-        container
-            .read(activeConversationProvider.notifier)
-            .set(_conversation('chat-1', checkpoint, timestamp));
+      check(container.read(chatMessagesProvider)).isEmpty();
+      final notifier = container.read(chatMessagesProvider.notifier);
+      container
+          .read(activeConversationProvider.notifier)
+          .set(_conversation('chat-1', checkpoint, timestamp));
 
-        await Future<void>.delayed(const Duration(milliseconds: 50));
-        await _drainRemoteTaskStatusCheck(notifier);
+      await Future<void>.delayed(const Duration(milliseconds: 50));
+      await _drainRemoteTaskStatusCheck(notifier);
 
-        check(api.getTaskIdsCalls).equals(2);
-        check(api.getConversationCalls).equals(0);
-        check(container.read(chatMessagesProvider).last.isStreaming).isTrue();
+      check(api.getTaskIdsCalls).equals(2);
+      check(api.getConversationCalls).equals(0);
+      check(container.read(chatMessagesProvider).last.isStreaming).isTrue();
 
-        await notifier.debugSyncRemoteTaskStatus();
+      await notifier.debugSyncRemoteTaskStatus();
 
-        check(api.getTaskIdsCalls).equals(3);
-        check(api.getConversationCalls).equals(1);
-        check(
-          container.read(chatMessagesProvider).last.content,
-        ).equals('Final answer');
-        check(container.read(chatMessagesProvider).last.isStreaming).isFalse();
-      },
-    );
+      check(api.getTaskIdsCalls).equals(3);
+      check(api.getConversationCalls).equals(1);
+      check(container.read(chatMessagesProvider).last.content)
+          .equals('Final answer');
+      check(container.read(chatMessagesProvider).last.isStreaming).isFalse();
+    });
 
     test(
       'completed task keeps polling until the authoritative body catches up',
@@ -1680,9 +1670,8 @@ void main() {
         ], timestamp);
         await notifier.debugSyncRemoteTaskStatus();
         check(container.read(chatMessagesProvider).last.isStreaming).isTrue();
-        check(
-          container.read(chatMessagesProvider).last.content,
-        ).equals('Partial answer from socket');
+        check(container.read(chatMessagesProvider).last.content)
+            .equals('Partial answer from socket');
 
         api.conversation = _conversation('chat-1', [
           opened.first,
@@ -1690,9 +1679,8 @@ void main() {
         ], timestamp);
         await notifier.debugSyncRemoteTaskStatus();
         check(container.read(chatMessagesProvider).last.isStreaming).isTrue();
-        check(
-          container.read(chatMessagesProvider).last.content,
-        ).equals('Partial answer from socket');
+        check(container.read(chatMessagesProvider).last.content)
+            .equals('Partial answer from socket');
 
         api.conversation = _conversation('chat-1', [
           opened.first,
@@ -1705,9 +1693,8 @@ void main() {
         await notifier.debugSyncRemoteTaskStatus();
 
         check(container.read(chatMessagesProvider).last.isStreaming).isFalse();
-        check(
-          container.read(chatMessagesProvider).last.content,
-        ).equals('Final authoritative answer');
+        check(container.read(chatMessagesProvider).last.content)
+            .equals('Final authoritative answer');
       },
     );
 
@@ -1802,9 +1789,8 @@ void main() {
 
         await notifier.debugSyncRemoteTaskStatus();
         check(api.getConversationCalls).equals(1);
-        check(
-          container.read(chatMessagesProvider).last.id,
-        ).equals('assistant-1');
+        check(container.read(chatMessagesProvider).last.id)
+            .equals('assistant-1');
       },
     );
 
@@ -1842,55 +1828,52 @@ void main() {
       check(disposed).isTrue();
     });
 
-    test(
-      'finishStreaming keeps folder conversation summaries untrusted until the server confirms them',
-      () async {
-        final timestamp = DateTime.now();
-        final user = _userMessage('user-1', 'Hello', timestamp);
-        final assistant = ChatMessage(
-          id: 'assistant-1',
-          role: 'assistant',
-          content: 'Streaming answer',
-          timestamp: timestamp,
-          isStreaming: true,
-        );
+    test('finishStreaming keeps folder conversation summaries untrusted until the server confirms them', () async {
+      final timestamp = DateTime.now();
+      final user = _userMessage('user-1', 'Hello', timestamp);
+      final assistant = ChatMessage(
+        id: 'assistant-1',
+        role: 'assistant',
+        content: 'Streaming answer',
+        timestamp: timestamp,
+        isStreaming: true,
+      );
 
-        final container = ProviderContainer(
-          overrides: [
-            ...openWebUiStorageOpenOverrides(),
-            activeConversationProvider.overrideWith(
-              () => _TestActiveConversationNotifier(),
+      final container = ProviderContainer(
+        overrides: [
+          ...openWebUiStorageOpenOverrides(),
+          activeConversationProvider.overrideWith(
+            () => _TestActiveConversationNotifier(),
+          ),
+          conversationsProvider.overrideWith(_RecordingConversations.new),
+          socketServiceProvider.overrideWithValue(null),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      container
+          .read(activeConversationProvider.notifier)
+          .set(
+            Conversation(
+              id: 'chat-1',
+              title: 'Folder Chat',
+              createdAt: timestamp,
+              updatedAt: timestamp,
+              folderId: 'folder-1',
+              messages: [user, assistant],
             ),
-            conversationsProvider.overrideWith(_RecordingConversations.new),
-            socketServiceProvider.overrideWithValue(null),
-          ],
-        );
-        addTearDown(container.dispose);
+          );
 
-        container
-            .read(activeConversationProvider.notifier)
-            .set(
-              Conversation(
-                id: 'chat-1',
-                title: 'Folder Chat',
-                createdAt: timestamp,
-                updatedAt: timestamp,
-                folderId: 'folder-1',
-                messages: [user, assistant],
-              ),
-            );
+      container.read(chatMessagesProvider.notifier).finishStreaming();
+      await pumpMicrotasks();
 
-        container.read(chatMessagesProvider.notifier).finishStreaming();
-        await pumpMicrotasks();
+      final recorder = container.read(
+        conversationsProvider.notifier,
+      ) as _RecordingConversations;
 
-        final recorder =
-            container.read(conversationsProvider.notifier)
-                as _RecordingConversations;
-
-        check(recorder.lastTrustFolderConversation).equals(false);
-        check(recorder.lastUpsertedConversation).isNotNull();
-        check(recorder.lastUpsertedConversation!.folderId).equals('folder-1');
-      },
-    );
+      check(recorder.lastTrustFolderConversation).equals(false);
+      check(recorder.lastUpsertedConversation).isNotNull();
+      check(recorder.lastUpsertedConversation!.folderId).equals('folder-1');
+    });
   });
 }

--- a/test/features/chat/providers/chat_openwebui_alignment_test.dart
+++ b/test/features/chat/providers/chat_openwebui_alignment_test.dart
@@ -81,9 +81,8 @@ void main() {
       'resolveTerminalIdForRequestForTest only uses the explicit selection',
       () {
         check(resolveTerminalIdForRequestForTest(null)).isNull();
-        check(
-          resolveTerminalIdForRequestForTest('  terminal-1  '),
-        ).equals('terminal-1');
+        check(resolveTerminalIdForRequestForTest('  terminal-1  '))
+            .equals('terminal-1');
       },
     );
   });
@@ -430,9 +429,8 @@ void main() {
       ]);
 
       check(messages.single['content']).equals('visible prompt');
-      check(
-        messages.single['content'].toString(),
-      ).not((content) => content.contains('forged secret'));
+      check(messages.single['content'].toString())
+          .not((content) => content.contains('forged secret'));
     });
 
     test('Hermes replay keeps at most four trusted local documents', () {
@@ -470,9 +468,8 @@ void main() {
         index < kHermesMaxLocalDocuments + 2;
         index++
       ) {
-        check(
-          content,
-        ).not((value) => value.contains('trusted-document-$index'));
+        check(content)
+            .not((value) => value.contains('trusted-document-$index'));
       }
     });
 
@@ -512,9 +509,8 @@ void main() {
 
       check(messages.first['content']).equals('older visible');
       check(messages.last['content'].toString()).contains('newer-text');
-      check(
-        messages.map((message) => message['content']).join('\n'),
-      ).not((content) => content.contains('older-text'));
+      check(messages.map((message) => message['content']).join('\n'))
+          .not((content) => content.contains('older-text'));
     });
 
     test('Hermes history waits for image capability resolution', () async {

--- a/test/features/chat/providers/chat_openwebui_transport_ownership_test.dart
+++ b/test/features/chat/providers/chat_openwebui_transport_ownership_test.dart
@@ -680,133 +680,124 @@ void main() {
       check(modelItem['id'] as String).equals('server-prefix.provider/model');
       check(modelItem['direct'] as bool).isTrue();
       check(modelItem['urlIdx'] as int).equals(3);
-      check(
-        modelItem['openai'] as Map<String, dynamic>,
-      ).deepEquals(<String, dynamic>{'id': 'provider/model'});
+      check(modelItem['openai'] as Map<String, dynamic>)
+          .deepEquals(<String, dynamic>{'id': 'provider/model'});
       check(modelItem['connection_type'] as String).equals('external');
-      check(
-        (api.submittedUserMessage!['models'] as List).cast<String>(),
-      ).contains('server-prefix.provider/model');
+      check((api.submittedUserMessage!['models'] as List).cast<String>())
+          .contains('server-prefix.provider/model');
       check(nativeAdapter.completionCalls).equals(0);
     },
   );
 
-  test(
-    'inline POST navigation continues A headlessly without touching colliding B',
-    () async {
-      const chatId = 'same-chat-id';
-      await _seedChat(db, chatId);
-      final releasePost = Completer<void>();
-      final api = _GatedCompletionApi(releasePost);
-      final syncEngine = _PersistingSyncEngine(db, api);
-      final aMessages = <ChatMessage>[_user('a-user-existing', 'A history')];
-      final container = _container(
-        db: db,
-        active: _conversation(chatId, aMessages, ChatStorageKind.openWebUi),
-        messages: aMessages,
-        api: api,
-        syncEngine: syncEngine,
-      );
-      addTearDown(container.dispose);
+  test('inline POST navigation continues A headlessly without touching colliding B', () async {
+    const chatId = 'same-chat-id';
+    await _seedChat(db, chatId);
+    final releasePost = Completer<void>();
+    final api = _GatedCompletionApi(releasePost);
+    final syncEngine = _PersistingSyncEngine(db, api);
+    final aMessages = <ChatMessage>[_user('a-user-existing', 'A history')];
+    final container = _container(
+      db: db,
+      active: _conversation(chatId, aMessages, ChatStorageKind.openWebUi),
+      messages: aMessages,
+      api: api,
+      syncEngine: syncEngine,
+    );
+    addTearDown(container.dispose);
 
-      final send = sendMessageWithContainer(container, 'A new turn', null);
-      await api.postEntered.future;
-      final assistantId = api.assistantMessageId!;
-      final bMessages = <ChatMessage>[
-        _user('b-user', 'B exact bytes'),
-        _streamingAssistant(assistantId, 'B is still streaming'),
-      ];
-      final bSnapshot = _snapshot(bMessages);
-      container
-          .read(activeConversationProvider.notifier)
-          .set(_conversation(chatId, bMessages, ChatStorageKind.directLocal));
-      container.read(chatMessagesProvider.notifier).setMessages(bMessages);
-      container
-          .read(contextAttachmentsProvider.notifier)
-          .addNote(noteId: 'b-note', displayName: 'B note');
+    final send = sendMessageWithContainer(container, 'A new turn', null);
+    await api.postEntered.future;
+    final assistantId = api.assistantMessageId!;
+    final bMessages = <ChatMessage>[
+      _user('b-user', 'B exact bytes'),
+      _streamingAssistant(assistantId, 'B is still streaming'),
+    ];
+    final bSnapshot = _snapshot(bMessages);
+    container
+        .read(activeConversationProvider.notifier)
+        .set(_conversation(chatId, bMessages, ChatStorageKind.directLocal));
+    container.read(chatMessagesProvider.notifier).setMessages(bMessages);
+    container
+        .read(contextAttachmentsProvider.notifier)
+        .addNote(noteId: 'b-note', displayName: 'B note');
 
-      releasePost.complete();
-      await send;
-      await Future<void>.delayed(Duration.zero);
+    releasePost.complete();
+    await send;
+    await Future<void>.delayed(Duration.zero);
 
-      check(api.completionCalls).equals(1);
-      check(syncEngine.pulls).equals(1);
-      check(_snapshot(container.read(chatMessagesProvider))).equals(bSnapshot);
-      check(container.read(chatMessagesProvider).last.isStreaming).isTrue();
-      check(
-        container.read(contextAttachmentsProvider).single.id,
-      ).equals('b-note');
-      final persisted = await db.messagesDao.getMessage(chatId, assistantId);
-      check(persisted).isNotNull();
-      check(persisted!.content).equals('A safely completed');
-    },
-  );
+    check(api.completionCalls).equals(1);
+    check(syncEngine.pulls).equals(1);
+    check(_snapshot(container.read(chatMessagesProvider))).equals(bSnapshot);
+    check(container.read(chatMessagesProvider).last.isStreaming).isTrue();
+    check(container.read(contextAttachmentsProvider).single.id)
+        .equals('b-note');
+    final persisted = await db.messagesDao.getMessage(chatId, assistantId);
+    check(persisted).isNotNull();
+    check(persisted!.content).equals('A safely completed');
+  });
 
-  test(
-    'queued POST navigation continues A headlessly without touching colliding B',
-    () async {
-      const chatId = 'same-queued-chat-id';
-      const assistantId = 'same-assistant-id';
-      await _seedChat(db, chatId, assistantId: assistantId);
-      final releasePost = Completer<void>();
-      final api = _GatedCompletionApi(releasePost);
-      final syncEngine = _PersistingSyncEngine(db, api);
-      final aMessages = <ChatMessage>[
-        _user('a-user', 'A queued turn'),
-        ChatMessage(
-          id: assistantId,
-          role: 'assistant',
-          content: '',
-          timestamp: DateTime.utc(2026, 7, 13, 0, 0, 1),
-          model: 'model-1',
-          isStreaming: true,
-        ),
-      ];
-      final container = _container(
-        db: db,
-        active: _conversation(chatId, aMessages, ChatStorageKind.openWebUi),
-        messages: aMessages,
-        api: api,
-        syncEngine: syncEngine,
-      );
-      addTearDown(container.dispose);
-
-      final completion = runQueuedCompletion(
-        container,
-        chatId: chatId,
-        assistantMessageId: assistantId,
+  test('queued POST navigation continues A headlessly without touching colliding B', () async {
+    const chatId = 'same-queued-chat-id';
+    const assistantId = 'same-assistant-id';
+    await _seedChat(db, chatId, assistantId: assistantId);
+    final releasePost = Completer<void>();
+    final api = _GatedCompletionApi(releasePost);
+    final syncEngine = _PersistingSyncEngine(db, api);
+    final aMessages = <ChatMessage>[
+      _user('a-user', 'A queued turn'),
+      ChatMessage(
+        id: assistantId,
+        role: 'assistant',
+        content: '',
+        timestamp: DateTime.utc(2026, 7, 13, 0, 0, 1),
         model: 'model-1',
-      );
-      await api.postEntered.future;
-      final pendingRow = await db.messagesDao.getMessage(chatId, assistantId);
-      final pendingPayload =
-          jsonDecode(pendingRow!.payload) as Map<String, dynamic>;
-      final pendingMetadata =
-          pendingPayload['metadata'] as Map<String, dynamic>? ?? const {};
-      check(pendingMetadata['completionSubmitted']).isNull();
-      final bMessages = <ChatMessage>[
-        _user('b-user', 'B exact bytes'),
-        _streamingAssistant(assistantId, 'B is still streaming'),
-      ];
-      final bSnapshot = _snapshot(bMessages);
-      container
-          .read(activeConversationProvider.notifier)
-          .set(_conversation(chatId, bMessages, ChatStorageKind.directLocal));
-      container.read(chatMessagesProvider.notifier).setMessages(bMessages);
+        isStreaming: true,
+      ),
+    ];
+    final container = _container(
+      db: db,
+      active: _conversation(chatId, aMessages, ChatStorageKind.openWebUi),
+      messages: aMessages,
+      api: api,
+      syncEngine: syncEngine,
+    );
+    addTearDown(container.dispose);
 
-      releasePost.complete();
-      await completion;
-      await Future<void>.delayed(Duration.zero);
+    final completion = runQueuedCompletion(
+      container,
+      chatId: chatId,
+      assistantMessageId: assistantId,
+      model: 'model-1',
+    );
+    await api.postEntered.future;
+    final pendingRow = await db.messagesDao.getMessage(chatId, assistantId);
+    final pendingPayload =
+        jsonDecode(pendingRow!.payload) as Map<String, dynamic>;
+    final pendingMetadata =
+        pendingPayload['metadata'] as Map<String, dynamic>? ?? const {};
+    check(pendingMetadata['completionSubmitted']).isNull();
+    final bMessages = <ChatMessage>[
+      _user('b-user', 'B exact bytes'),
+      _streamingAssistant(assistantId, 'B is still streaming'),
+    ];
+    final bSnapshot = _snapshot(bMessages);
+    container
+        .read(activeConversationProvider.notifier)
+        .set(_conversation(chatId, bMessages, ChatStorageKind.directLocal));
+    container.read(chatMessagesProvider.notifier).setMessages(bMessages);
 
-      check(api.completionCalls).equals(1);
-      check(syncEngine.pulls).equals(1);
-      check(_snapshot(container.read(chatMessagesProvider))).equals(bSnapshot);
-      check(container.read(chatMessagesProvider).last.isStreaming).isTrue();
-      final persisted = await db.messagesDao.getMessage(chatId, assistantId);
-      check(persisted).isNotNull();
-      check(persisted!.content).equals('A safely completed');
-    },
-  );
+    releasePost.complete();
+    await completion;
+    await Future<void>.delayed(Duration.zero);
+
+    check(api.completionCalls).equals(1);
+    check(syncEngine.pulls).equals(1);
+    check(_snapshot(container.read(chatMessagesProvider))).equals(bSnapshot);
+    check(container.read(chatMessagesProvider).last.isStreaming).isTrue();
+    final persisted = await db.messagesDao.getMessage(chatId, assistantId);
+    check(persisted).isNotNull();
+    check(persisted!.content).equals('A safely completed');
+  });
 
   test(
     'equal OpenWebUI ids on two servers never pull or mutate server B',
@@ -1159,9 +1150,8 @@ void main() {
       );
       await Future<void>.delayed(Duration.zero);
 
-      check(
-        container.read(activeChatIdsProvider),
-      ).not((activeIds) => activeIds.contains('chat-a'));
+      check(container.read(activeChatIdsProvider))
+          .not((activeIds) => activeIds.contains('chat-a'));
     },
   );
 
@@ -1209,13 +1199,12 @@ void main() {
         isTemporary: true,
       );
 
-      final notifier =
-          container.read(chatMessagesProvider.notifier)
-              as _TestMessagesNotifier;
+      final notifier = container.read(
+        chatMessagesProvider.notifier,
+      ) as _TestMessagesNotifier;
       check(attached).isTrue();
-      check(
-        container.read(chatMessagesProvider).single.content,
-      ).equals('Already completed');
+      check(container.read(chatMessagesProvider).single.content)
+          .equals('Already completed');
       check(container.read(chatMessagesProvider).single.isStreaming).isFalse();
       check(socket.chatSubscriptionDisposals).equals(1);
       check(socket.channelRegistrationCalls).equals(0);
@@ -1252,9 +1241,8 @@ void main() {
           .read(activeConversationProvider.notifier)
           .set(_conversation('server-id', const [], ChatStorageKind.openWebUi));
 
-      check(
-        isActiveConversationInPlaceRemap(container, 'local-a', 'server-id'),
-      ).isFalse();
+      check(isActiveConversationInPlaceRemap(container, 'local-a', 'server-id'))
+          .isFalse();
     },
   );
 
@@ -1291,9 +1279,8 @@ void main() {
 
       final remap = container.read(activeConversationInPlaceRemapProvider);
       check(remap).isNotNull();
-      check(
-        remap!.namespace,
-      ).equals(ActiveConversationRemapNamespace.openWebUi);
+      check(remap!.namespace)
+          .equals(ActiveConversationRemapNamespace.openWebUi);
       check(remap.openWebUiDatabase).identicalTo(db);
       check(remap.openWebUiApi).identicalTo(api);
       check(remap.openWebUiAuthSessionEpoch).identicalTo(epoch);
@@ -1443,9 +1430,8 @@ void main() {
             .read(chatMessagesProvider)
             .every((message) => message.content != 'late A database bytes'),
       ).isTrue();
-      check(
-        container.read(activeConversationProvider)!.messages.single.content,
-      ).equals('B exact bytes');
+      check(container.read(activeConversationProvider)!.messages.single.content)
+          .equals('B exact bytes');
     },
   );
 
@@ -1544,9 +1530,8 @@ void main() {
             .read(chatMessagesProvider)
             .every((message) => message.content != 'late A direct bytes'),
       ).isTrue();
-      check(
-        container.read(activeConversationProvider)!.messages.single.content,
-      ).equals('B exact bytes');
+      check(container.read(activeConversationProvider)!.messages.single.content)
+          .equals('B exact bytes');
     },
   );
 

--- a/test/features/chat/providers/chat_regeneration_persistence_guard_test.dart
+++ b/test/features/chat/providers/chat_regeneration_persistence_guard_test.dart
@@ -158,70 +158,14 @@ class _RecordingCompletionApi extends ApiService {
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
-  test(
-    'regenerate on persisted chat does not sync partial local history back to the server',
-    () async {
-      final now = DateTime.utc(2026, 4, 23, 12);
-      final userMessage = ChatMessage(
-        id: 'user-1',
-        role: 'user',
-        content: 'Explain this bug.',
-        timestamp: now,
-        files: const [
-          {
-            'type': 'file',
-            'id': 'doc-1',
-            'url': 'doc-1',
-            'name': 'bug-report.md',
-            'content_type': 'text/markdown',
-          },
-        ],
-      );
-      final assistantMessage = ChatMessage(
-        id: 'assistant-1',
-        role: 'assistant',
-        content: 'Original answer',
-        timestamp: now.add(const Duration(seconds: 1)),
-        model: 'gpt-4',
-      );
-      final conversation = Conversation(
-        id: 'conv-1',
-        title: 'Long chat',
-        createdAt: now,
-        updatedAt: now,
-        messages: [userMessage, assistantMessage],
-      );
-      final api = _RecordingCompletionApi();
-      final container = ProviderContainer(
-        overrides: [
-          chatMessagesProvider.overrideWith(() => _TestMessagesNotifier()),
-          activeConversationProvider.overrideWith(
-            () => _FixedConversationNotifier(conversation),
-          ),
-          apiServiceProvider.overrideWithValue(api),
-          selectedModelProvider.overrideWithValue(
-            const Model(id: 'gpt-4', name: 'GPT-4'),
-          ),
-          reviewerModeProvider.overrideWithValue(false),
-          socketServiceProvider.overrideWithValue(null),
-        ],
-      );
-      addTearDown(container.dispose);
-
-      container.read(chatMessagesProvider.notifier).setMessages([
-        userMessage,
-        assistantMessage,
-      ]);
-
-      await container.read(regenerateLastMessageProvider)();
-      await Future<void>.delayed(Duration.zero);
-      await Future<void>.delayed(Duration.zero);
-
-      check(api.completionCalls).equals(1);
-      check(api.syncCalls).equals(0);
-      check(api.lastConversationId).equals('conv-1');
-      check(api.lastMessages).isEmpty();
-      check(api.lastFiles).deepEquals(const [
+  test('regenerate on persisted chat does not sync partial local history back to the server', () async {
+    final now = DateTime.utc(2026, 4, 23, 12);
+    final userMessage = ChatMessage(
+      id: 'user-1',
+      role: 'user',
+      content: 'Explain this bug.',
+      timestamp: now,
+      files: const [
         {
           'type': 'file',
           'id': 'doc-1',
@@ -229,13 +173,66 @@ void main() {
           'name': 'bug-report.md',
           'content_type': 'text/markdown',
         },
-      ]);
+      ],
+    );
+    final assistantMessage = ChatMessage(
+      id: 'assistant-1',
+      role: 'assistant',
+      content: 'Original answer',
+      timestamp: now.add(const Duration(seconds: 1)),
+      model: 'gpt-4',
+    );
+    final conversation = Conversation(
+      id: 'conv-1',
+      title: 'Long chat',
+      createdAt: now,
+      updatedAt: now,
+      messages: [userMessage, assistantMessage],
+    );
+    final api = _RecordingCompletionApi();
+    final container = ProviderContainer(
+      overrides: [
+        chatMessagesProvider.overrideWith(() => _TestMessagesNotifier()),
+        activeConversationProvider.overrideWith(
+          () => _FixedConversationNotifier(conversation),
+        ),
+        apiServiceProvider.overrideWithValue(api),
+        selectedModelProvider.overrideWithValue(
+          const Model(id: 'gpt-4', name: 'GPT-4'),
+        ),
+        reviewerModeProvider.overrideWithValue(false),
+        socketServiceProvider.overrideWithValue(null),
+      ],
+    );
+    addTearDown(container.dispose);
 
-      final messages = container.read(chatMessagesProvider);
-      check(messages).has((it) => it.length, 'length').equals(3);
-      check(messages.last.role).equals('assistant');
-      check(messages.last.content).equals('Regenerated answer');
-      check(messages.last.isStreaming).isFalse();
-    },
-  );
+    container.read(chatMessagesProvider.notifier).setMessages([
+      userMessage,
+      assistantMessage,
+    ]);
+
+    await container.read(regenerateLastMessageProvider)();
+    await Future<void>.delayed(Duration.zero);
+    await Future<void>.delayed(Duration.zero);
+
+    check(api.completionCalls).equals(1);
+    check(api.syncCalls).equals(0);
+    check(api.lastConversationId).equals('conv-1');
+    check(api.lastMessages).isEmpty();
+    check(api.lastFiles).deepEquals(const [
+      {
+        'type': 'file',
+        'id': 'doc-1',
+        'url': 'doc-1',
+        'name': 'bug-report.md',
+        'content_type': 'text/markdown',
+      },
+    ]);
+
+    final messages = container.read(chatMessagesProvider);
+    check(messages).has((it) => it.length, 'length').equals(3);
+    check(messages.last.role).equals('assistant');
+    check(messages.last.content).equals('Regenerated answer');
+    check(messages.last.isStreaming).isFalse();
+  });
 }

--- a/test/features/chat/providers/chat_transcript_paging_test.dart
+++ b/test/features/chat/providers/chat_transcript_paging_test.dart
@@ -13,20 +13,17 @@ void main() {
       final notifier = container.read(chatTranscriptPagingProvider.notifier);
 
       notifier.reset(totalMessages: 500);
-      check(
-        container.read(chatTranscriptPagingProvider).loadedCount,
-      ).equals(50);
+      check(container.read(chatTranscriptPagingProvider).loadedCount)
+          .equals(50);
       check(container.read(chatTranscriptPagingProvider).hasOlder).isTrue();
 
       await notifier.fetchOlder(totalMessages: 500);
-      check(
-        container.read(chatTranscriptPagingProvider).loadedCount,
-      ).equals(100);
+      check(container.read(chatTranscriptPagingProvider).loadedCount)
+          .equals(100);
 
       await notifier.fetchOlder(totalMessages: 500);
-      check(
-        container.read(chatTranscriptPagingProvider).loadedCount,
-      ).equals(150);
+      check(container.read(chatTranscriptPagingProvider).loadedCount)
+          .equals(150);
     },
   );
 

--- a/test/features/chat/providers/chat_transport_parity_test.dart
+++ b/test/features/chat/providers/chat_transport_parity_test.dart
@@ -504,42 +504,39 @@ void main() {
       check(log.finishCount).equals(1);
     });
 
-    test(
-      'taskSocket completion does not rewrite persisted chat history after chatCompleted',
-      () async {
-        final api = _TrackingApiService();
-        final log = _CallbackLog();
-        final registrar = FakeSocketInjector();
-        final socket = _MockSocketService(registrar);
+    test('taskSocket completion does not rewrite persisted chat history after chatCompleted', () async {
+      final api = _TrackingApiService();
+      final log = _CallbackLog();
+      final registrar = FakeSocketInjector();
+      final socket = _MockSocketService(registrar);
 
-        _attach(
-          session: ChatCompletionSession.taskSocket(
-            messageId: 'msg-1',
-            sessionId: 'sess-1',
-            conversationId: 'conv-1',
-            taskId: 'task-1',
-          ),
-          log: log,
-          api: api,
-          socketService: socket,
-        );
-
-        registrar.emitChatEvent(
-          'chat:completion',
-          {'content': 'Hello', 'done': true},
-          conversationId: 'conv-1',
-          sessionId: 'sess-1',
+      _attach(
+        session: ChatCompletionSession.taskSocket(
           messageId: 'msg-1',
-        );
+          sessionId: 'sess-1',
+          conversationId: 'conv-1',
+          taskId: 'task-1',
+        ),
+        log: log,
+        api: api,
+        socketService: socket,
+      );
 
-        await pumpMicrotasks();
-        await pumpMicrotasks();
-        await pumpMicrotasks();
+      registrar.emitChatEvent(
+        'chat:completion',
+        {'content': 'Hello', 'done': true},
+        conversationId: 'conv-1',
+        sessionId: 'sess-1',
+        messageId: 'msg-1',
+      );
 
-        check(api.chatCompletedCalls).equals(1);
-        check(api.syncCalls).equals(0);
-      },
-    );
+      await pumpMicrotasks();
+      await pumpMicrotasks();
+      await pumpMicrotasks();
+
+      check(api.chatCompletedCalls).equals(1);
+      check(api.syncCalls).equals(0);
+    });
 
     // -------------------------------------------------------------------
     // 2. JSON completion works without a socket connection

--- a/test/features/chat/providers/direct_send_history_links_test.dart
+++ b/test/features/chat/providers/direct_send_history_links_test.dart
@@ -1655,10 +1655,8 @@ void main() {
       container.read(selectedModelProvider.notifier).set(modelB);
       api.gates[1].complete();
 
-      await Future.wait<void>([
-        firstRegeneration,
-        secondRegeneration,
-      ]).timeout(const Duration(seconds: 1));
+      await Future.wait<void>([firstRegeneration, secondRegeneration])
+          .timeout(const Duration(seconds: 1));
 
       expect(adapter.startCalls, 0);
       final visibleAssistant = container
@@ -1677,89 +1675,83 @@ void main() {
     },
   );
 
-  test(
-    'Stop interrupts a never-settling direct attachment preflight and releases its lease',
-    () async {
-      final manager = DatabaseManager(
-        openDatabase: (_) =>
-            GatedCloseDatabase(NativeDatabase.memory(), failClose: false),
-      );
-      final db =
-          manager.openForServerId('direct-stop-preflight')
-              as GatedCloseDatabase;
-      final databaseCloseGate = Completer<void>();
-      final api = _DeferredAttachmentApi();
-      addTearDown(() async {
-        if (!api.firstInfoGate.isCompleted) api.firstInfoGate.complete();
-        if (!databaseCloseGate.isCompleted) databaseCloseGate.complete();
-        await manager.closeActive();
-      });
-      final profile = DirectConnectionProfile(
-        id: 'profile',
-        name: 'Provider',
-        adapterKey: 'test-adapter',
-        baseUrl: 'http://localhost:11434',
-      );
-      final modelRegistry = DirectModelRegistry();
-      final model = modelRegistry.replaceProfileModels(
-        profile,
-        <DirectRemoteModel>[DirectRemoteModel(id: 'model', isMultimodal: true)],
-      ).single;
-      final adapter = _Adapter();
-      final chat = await _seedDirectConversation(
-        db: db,
-        chatId: 'direct-local:stalled-attachment',
-        modelId: model.id,
-        suffix: 'stalled-attachment',
-      );
-      final container = ProviderContainer(
-        overrides: [
-          activeConversationProvider.overrideWith(_ActiveConversation.new),
-          selectedModelProvider.overrideWithValue(model),
-          reviewerModeProvider.overrideWithValue(false),
-          isAuthenticatedProvider2.overrideWithValue(false),
-          apiServiceProvider.overrideWithValue(api),
-          socketServiceProvider.overrideWithValue(null),
-          appDatabaseProvider.overrideWithValue(null),
-          directLocalDatabaseManagerProvider.overrideWithValue(manager),
-          directLocalDatabaseProvider.overrideWithValue(db),
-          directModelRegistryProvider.overrideWithValue(modelRegistry),
-          directConnectionProfilesProvider.overrideWith(
-            () => _Profiles(profile),
-          ),
-          directProviderAdapterRegistryProvider.overrideWithValue(
-            DirectProviderAdapterRegistry(<DirectProviderAdapter>[adapter]),
-          ),
-        ],
-      );
-      addTearDown(container.dispose);
-      container.read(activeConversationProvider.notifier).set(chat);
-      container.read(chatMessagesProvider.notifier).setMessages(chat.messages);
+  test('Stop interrupts a never-settling direct attachment preflight and releases its lease', () async {
+    final manager = DatabaseManager(
+      openDatabase: (_) =>
+          GatedCloseDatabase(NativeDatabase.memory(), failClose: false),
+    );
+    final db =
+        manager.openForServerId('direct-stop-preflight') as GatedCloseDatabase;
+    final databaseCloseGate = Completer<void>();
+    final api = _DeferredAttachmentApi();
+    addTearDown(() async {
+      if (!api.firstInfoGate.isCompleted) api.firstInfoGate.complete();
+      if (!databaseCloseGate.isCompleted) databaseCloseGate.complete();
+      await manager.closeActive();
+    });
+    final profile = DirectConnectionProfile(
+      id: 'profile',
+      name: 'Provider',
+      adapterKey: 'test-adapter',
+      baseUrl: 'http://localhost:11434',
+    );
+    final modelRegistry = DirectModelRegistry();
+    final model = modelRegistry.replaceProfileModels(
+      profile,
+      <DirectRemoteModel>[DirectRemoteModel(id: 'model', isMultimodal: true)],
+    ).single;
+    final adapter = _Adapter();
+    final chat = await _seedDirectConversation(
+      db: db,
+      chatId: 'direct-local:stalled-attachment',
+      modelId: model.id,
+      suffix: 'stalled-attachment',
+    );
+    final container = ProviderContainer(
+      overrides: [
+        activeConversationProvider.overrideWith(_ActiveConversation.new),
+        selectedModelProvider.overrideWithValue(model),
+        reviewerModeProvider.overrideWithValue(false),
+        isAuthenticatedProvider2.overrideWithValue(false),
+        apiServiceProvider.overrideWithValue(api),
+        socketServiceProvider.overrideWithValue(null),
+        appDatabaseProvider.overrideWithValue(null),
+        directLocalDatabaseManagerProvider.overrideWithValue(manager),
+        directLocalDatabaseProvider.overrideWithValue(db),
+        directModelRegistryProvider.overrideWithValue(modelRegistry),
+        directConnectionProfilesProvider.overrideWith(() => _Profiles(profile)),
+        directProviderAdapterRegistryProvider.overrideWithValue(
+          DirectProviderAdapterRegistry(<DirectProviderAdapter>[adapter]),
+        ),
+      ],
+    );
+    addTearDown(container.dispose);
+    container.read(activeConversationProvider.notifier).set(chat);
+    container.read(chatMessagesProvider.notifier).setMessages(chat.messages);
 
-      final send = sendMessageWithContainer(
-        container,
-        'Stop this attachment lookup',
-        const <String>['server-image'],
-      );
-      await api.firstInfoStarted.future.timeout(const Duration(seconds: 1));
-      db.closeGate = databaseCloseGate;
-      container.read(stopGenerationProvider)();
-      final close = manager.closeActive();
+    final send = sendMessageWithContainer(
+      container,
+      'Stop this attachment lookup',
+      const <String>['server-image'],
+    );
+    await api.firstInfoStarted.future.timeout(const Duration(seconds: 1));
+    db.closeGate = databaseCloseGate;
+    container.read(stopGenerationProvider)();
+    final close = manager.closeActive();
 
-      await send.timeout(const Duration(seconds: 1));
-      await api.firstInfoCancelled.future.timeout(const Duration(seconds: 1));
-      await db.closeStarted.future.timeout(const Duration(seconds: 1));
-      expect(api.firstInfoGate.isCompleted, isFalse);
-      expect(api.firstInfoCancelToken?.isCancelled, isTrue);
-      expect(adapter.startCalls, 0);
-      expect(container.read(chatMessagesProvider).last.isStreaming, isFalse);
+    await send.timeout(const Duration(seconds: 1));
+    await api.firstInfoCancelled.future.timeout(const Duration(seconds: 1));
+    await db.closeStarted.future.timeout(const Duration(seconds: 1));
+    expect(api.firstInfoGate.isCompleted, isFalse);
+    expect(api.firstInfoCancelToken?.isCancelled, isTrue);
+    expect(adapter.startCalls, 0);
+    expect(container.read(chatMessagesProvider).last.isStreaming, isFalse);
 
-      databaseCloseGate.complete();
-      await close.timeout(const Duration(seconds: 1));
-      api.firstInfoGate.complete();
-      await Future<void>.delayed(Duration.zero);
-    },
-  );
+    databaseCloseGate.complete();
+    await close.timeout(const Duration(seconds: 1));
+    api.firstInfoGate.complete();
+    await Future<void>.delayed(Duration.zero);
+  });
 
   test('direct send cannot retarget after route resolution await', () async {
     final db = AppDatabase(NativeDatabase.memory());
@@ -1820,107 +1812,102 @@ void main() {
     expect(identical(container.read(chatMessagesProvider), visibleB), isTrue);
     expect(adapter.startCalls, 0);
     expect(
-      (await db.messagesDao.getForChat(
-        chatA.id,
-      )).where((row) => row.content == 'Must stay in A'),
+      (await db.messagesDao.getForChat(chatA.id))
+          .where((row) => row.content == 'Must stay in A'),
       isEmpty,
     );
     expect(
-      (await db.messagesDao.getForChat(
-        chatB.id,
-      )).where((row) => row.content == 'Must stay in A'),
+      (await db.messagesDao.getForChat(chatB.id))
+          .where((row) => row.content == 'Must stay in A'),
       isEmpty,
     );
   });
 
-  test(
-    'direct send aborts when selection switches to another live profile',
-    () async {
-      final db = AppDatabase(NativeDatabase.memory());
-      addTearDown(db.close);
-      final profileA = DirectConnectionProfile(
-        id: 'profile-a',
-        name: 'Provider A',
-        adapterKey: 'test-adapter',
-        baseUrl: 'http://localhost:11434',
-      );
-      final profileB = DirectConnectionProfile(
-        id: 'profile-b',
-        name: 'Provider B',
-        adapterKey: 'test-adapter',
-        baseUrl: 'http://localhost:11435',
-      );
-      final registry = DirectModelRegistry();
-      final modelA = registry.replaceProfileModels(profileA, [
-        DirectRemoteModel(id: 'model-a'),
-      ]).single;
-      final modelB = registry.replaceProfileModels(profileB, [
-        DirectRemoteModel(id: 'model-b'),
-      ]).single;
-      final profiles = _GatedProfiles(profileA);
-      final adapter = _Adapter();
-      final chat = await _seedDirectConversation(
-        db: db,
-        chatId: 'direct-local:selection-switch',
-        modelId: modelA.id,
-        suffix: 'selection-switch',
-      );
-      final container = ProviderContainer(
-        overrides: [
-          activeConversationProvider.overrideWith(_ActiveConversation.new),
-          reviewerModeProvider.overrideWithValue(false),
-          isAuthenticatedProvider2.overrideWithValue(false),
-          apiServiceProvider.overrideWithValue(null),
-          socketServiceProvider.overrideWithValue(null),
-          appDatabaseProvider.overrideWithValue(null),
-          directLocalDatabaseProvider.overrideWithValue(db),
-          directModelRegistryProvider.overrideWithValue(registry),
-          directConnectionProfilesProvider.overrideWith(() => profiles),
-          directProviderAdapterRegistryProvider.overrideWithValue(
-            DirectProviderAdapterRegistry([adapter]),
-          ),
-        ],
-      );
-      addTearDown(container.dispose);
-      container.read(selectedModelProvider.notifier).set(modelA);
-      container.read(activeConversationProvider.notifier).set(chat);
-      container.read(chatMessagesProvider.notifier).setMessages(chat.messages);
-      final visibleBeforeSend = container.read(chatMessagesProvider);
-      final rowsBeforeSend = await db.messagesDao.getForChat(chat.id);
-
-      final send = sendMessageWithContainer(
-        container,
-        'Do not send through profile A',
-        null,
-      );
-      await profiles.started.future.timeout(const Duration(seconds: 1));
-      container.read(selectedModelProvider.notifier).set(modelB);
-      profiles.gate.complete([profileA, profileB]);
-
-      await expectLater(
-        send,
-        throwsA(
-          isA<StateError>().having(
-            (error) => error.message,
-            'message',
-            'The selected direct connection changed while preparing the message.',
-          ),
+  test('direct send aborts when selection switches to another live profile', () async {
+    final db = AppDatabase(NativeDatabase.memory());
+    addTearDown(db.close);
+    final profileA = DirectConnectionProfile(
+      id: 'profile-a',
+      name: 'Provider A',
+      adapterKey: 'test-adapter',
+      baseUrl: 'http://localhost:11434',
+    );
+    final profileB = DirectConnectionProfile(
+      id: 'profile-b',
+      name: 'Provider B',
+      adapterKey: 'test-adapter',
+      baseUrl: 'http://localhost:11435',
+    );
+    final registry = DirectModelRegistry();
+    final modelA = registry.replaceProfileModels(profileA, [
+      DirectRemoteModel(id: 'model-a'),
+    ]).single;
+    final modelB = registry.replaceProfileModels(profileB, [
+      DirectRemoteModel(id: 'model-b'),
+    ]).single;
+    final profiles = _GatedProfiles(profileA);
+    final adapter = _Adapter();
+    final chat = await _seedDirectConversation(
+      db: db,
+      chatId: 'direct-local:selection-switch',
+      modelId: modelA.id,
+      suffix: 'selection-switch',
+    );
+    final container = ProviderContainer(
+      overrides: [
+        activeConversationProvider.overrideWith(_ActiveConversation.new),
+        reviewerModeProvider.overrideWithValue(false),
+        isAuthenticatedProvider2.overrideWithValue(false),
+        apiServiceProvider.overrideWithValue(null),
+        socketServiceProvider.overrideWithValue(null),
+        appDatabaseProvider.overrideWithValue(null),
+        directLocalDatabaseProvider.overrideWithValue(db),
+        directModelRegistryProvider.overrideWithValue(registry),
+        directConnectionProfilesProvider.overrideWith(() => profiles),
+        directProviderAdapterRegistryProvider.overrideWithValue(
+          DirectProviderAdapterRegistry([adapter]),
         ),
-      );
-      expect(
-        identical(container.read(chatMessagesProvider), visibleBeforeSend),
-        isTrue,
-      );
-      expect(registry.resolve(modelA), isNotNull);
-      expect(registry.resolve(modelB), isNotNull);
-      expect(adapter.startCalls, 0);
-      final rowsAfterSend = await db.messagesDao.getForChat(chat.id);
-      expect(
-        rowsAfterSend.map((row) => row.id),
-        rowsBeforeSend.map((row) => row.id),
-      );
-    },
-  );
+      ],
+    );
+    addTearDown(container.dispose);
+    container.read(selectedModelProvider.notifier).set(modelA);
+    container.read(activeConversationProvider.notifier).set(chat);
+    container.read(chatMessagesProvider.notifier).setMessages(chat.messages);
+    final visibleBeforeSend = container.read(chatMessagesProvider);
+    final rowsBeforeSend = await db.messagesDao.getForChat(chat.id);
+
+    final send = sendMessageWithContainer(
+      container,
+      'Do not send through profile A',
+      null,
+    );
+    await profiles.started.future.timeout(const Duration(seconds: 1));
+    container.read(selectedModelProvider.notifier).set(modelB);
+    profiles.gate.complete([profileA, profileB]);
+
+    await expectLater(
+      send,
+      throwsA(
+        isA<StateError>().having(
+          (error) => error.message,
+          'message',
+          'The selected direct connection changed while preparing the message.',
+        ),
+      ),
+    );
+    expect(
+      identical(container.read(chatMessagesProvider), visibleBeforeSend),
+      isTrue,
+    );
+    expect(registry.resolve(modelA), isNotNull);
+    expect(registry.resolve(modelB), isNotNull);
+    expect(adapter.startCalls, 0);
+    final rowsAfterSend = await db.messagesDao.getForChat(chat.id);
+    expect(
+      rowsAfterSend.map((row) => row.id),
+      rowsBeforeSend.map((row) => row.id),
+    );
+  });
 
   test('direct send survives an unchanged catalog refresh', () async {
     final db = AppDatabase(NativeDatabase.memory());
@@ -2051,49 +2038,43 @@ void main() {
     expect(adapter.startCalls, 0);
   });
 
-  test(
-    'tombstoned durable owner blocks provider start and settles its placeholder',
-    () async {
-      final harness = await _createInvalidatedOwnerRefreshHarness(
-        'owner-refresh-tombstone',
-        _OwnerLossMutation.tombstoneChat,
-      );
-      final send = sendMessageWithContainer(
-        harness.container,
-        'Do not start after deletion',
-        null,
-      );
+  test('tombstoned durable owner blocks provider start and settles its placeholder', () async {
+    final harness = await _createInvalidatedOwnerRefreshHarness(
+      'owner-refresh-tombstone',
+      _OwnerLossMutation.tombstoneChat,
+    );
+    final send = sendMessageWithContainer(
+      harness.container,
+      'Do not start after deletion',
+      null,
+    );
 
-      await expectLater(
-        send.timeout(const Duration(seconds: 1)),
-        throwsA(
-          isA<StateError>().having(
-            (error) => error.message,
-            'message',
-            'Direct conversation owner is no longer available.',
-          ),
+    await expectLater(
+      send.timeout(const Duration(seconds: 1)),
+      throwsA(
+        isA<StateError>().having(
+          (error) => error.message,
+          'message',
+          'Direct conversation owner is no longer available.',
         ),
-      );
-      final assistantId = harness.repository.invalidatedMessageId!;
-      final ownerKey = (
-        ownerConversationId: directRunOwnerScopeForTest(
-          harness.container,
-          harness.chat,
-        ),
-        assistantMessageId: assistantId,
-      );
-      expect(harness.adapter.startCalls, 0);
-      expect(harness.runRegistry.hasLiveIntent(ownerKey), isFalse);
-      final failed = harness.container
-          .read(chatMessagesProvider)
-          .singleWhere((message) => message.id == assistantId);
-      expect(failed.isStreaming, isFalse);
-      expect(
-        failed.error?.content,
-        'This conversation is no longer available.',
-      );
-    },
-  );
+      ),
+    );
+    final assistantId = harness.repository.invalidatedMessageId!;
+    final ownerKey = (
+      ownerConversationId: directRunOwnerScopeForTest(
+        harness.container,
+        harness.chat,
+      ),
+      assistantMessageId: assistantId,
+    );
+    expect(harness.adapter.startCalls, 0);
+    expect(harness.runRegistry.hasLiveIntent(ownerKey), isFalse);
+    final failed = harness.container
+        .read(chatMessagesProvider)
+        .singleWhere((message) => message.id == assistantId);
+    expect(failed.isStreaming, isFalse);
+    expect(failed.error?.content, 'This conversation is no longer available.');
+  });
 
   test(
     'deleted durable placeholder blocks provider start without resurrection',
@@ -2251,9 +2232,8 @@ void main() {
         utf8.decode(base64Decode(imageParts.single.base64Data!)),
         'image-a',
       );
-      final userRow = (await db.messagesDao.getForChat(
-        chatA.id,
-      )).singleWhere((row) => row.content == 'Use source image');
+      final userRow = (await db.messagesDao.getForChat(chatA.id))
+          .singleWhere((row) => row.content == 'Use source image');
       final userPayload = jsonDecode(userRow.payload) as Map<String, dynamic>;
       final files = (userPayload['files'] as List).cast<Map>();
       expect(files.single['content_type'], 'image/png;source=a');
@@ -3353,9 +3333,8 @@ void main() {
       expect(completed.content, 'Partial answer');
       expect(completed.isStreaming, isFalse);
       expect(run.run.isCancelled, isTrue);
-      final persisted = (await db.messagesDao.getForChat(
-        chat.id,
-      )).singleWhere((row) => row.id == completed.id);
+      final persisted = (await db.messagesDao.getForChat(chat.id))
+          .singleWhere((row) => row.id == completed.id);
       expect(persisted.content, 'Partial answer');
     },
   );
@@ -3482,9 +3461,8 @@ void main() {
       expect(completed.error, isNull);
       expect(completed.files?.single['url'], image);
       expect(completed.usage?['cost'], 0.04);
-      final durable = (await harness.db.messagesDao.getForChat(
-        harness.chat.id,
-      )).singleWhere((row) => row.id == assistantId);
+      final durable = (await harness.db.messagesDao.getForChat(harness.chat.id))
+          .singleWhere((row) => row.id == assistantId);
       final durablePayload =
           jsonDecode(durable.payload) as Map<String, dynamic>;
       expect(durablePayload['isStreaming'], isFalse);
@@ -3493,60 +3471,55 @@ void main() {
     },
   );
 
-  test(
-    'OpenRouter image generation is consumed before the conversational follow-up',
-    () async {
-      const image = 'data:image/png;base64,AQID';
-      final harness = await _createGatedDirectHarness(
-        'openrouter-image-one-shot',
-        profileBaseUrl: kOpenRouterApiBaseUrl,
-        profileAdapterKey: kOpenAiCompatibleAdapterKey,
-      );
-      harness.container.read(imageGenerationEnabledProvider.notifier).set(true);
-      expect(harness.container.read(imageGenerationAvailableProvider), isTrue);
+  test('OpenRouter image generation is consumed before the conversational follow-up', () async {
+    const image = 'data:image/png;base64,AQID';
+    final harness = await _createGatedDirectHarness(
+      'openrouter-image-one-shot',
+      profileBaseUrl: kOpenRouterApiBaseUrl,
+      profileAdapterKey: kOpenAiCompatibleAdapterKey,
+    );
+    harness.container.read(imageGenerationEnabledProvider.notifier).set(true);
+    expect(harness.container.read(imageGenerationAvailableProvider), isTrue);
 
-      final imageStarted = harness.adapter.nextRun();
-      final imageSend = sendMessageWithContainer(
-        harness.container,
-        'Draw a lighthouse',
-        null,
-      );
-      final imageRun = await imageStarted.timeout(const Duration(seconds: 1));
-      addTearDown(imageRun.close);
+    final imageStarted = harness.adapter.nextRun();
+    final imageSend = sendMessageWithContainer(
+      harness.container,
+      'Draw a lighthouse',
+      null,
+    );
+    final imageRun = await imageStarted.timeout(const Duration(seconds: 1));
+    addTearDown(imageRun.close);
 
-      expect(harness.adapter.lastRequest?.enableImageGeneration, isTrue);
-      expect(harness.container.read(imageGenerationEnabledProvider), isFalse);
-      imageRun
-        ..add(
-          const DirectGeneratedImage(dataUrl: image, mediaType: 'image/png'),
-        )
-        ..add(const DirectStreamDone());
-      await imageSend.timeout(const Duration(seconds: 1));
+    expect(harness.adapter.lastRequest?.enableImageGeneration, isTrue);
+    expect(harness.container.read(imageGenerationEnabledProvider), isFalse);
+    imageRun
+      ..add(const DirectGeneratedImage(dataUrl: image, mediaType: 'image/png'))
+      ..add(const DirectStreamDone());
+    await imageSend.timeout(const Duration(seconds: 1));
 
-      final followUpStarted = harness.adapter.nextRun();
-      final followUpSend = sendMessageWithContainer(
-        harness.container,
-        'Make the mood warmer',
-        null,
-      );
-      final followUpRun = await followUpStarted.timeout(
-        const Duration(seconds: 1),
-      );
-      addTearDown(followUpRun.close);
+    final followUpStarted = harness.adapter.nextRun();
+    final followUpSend = sendMessageWithContainer(
+      harness.container,
+      'Make the mood warmer',
+      null,
+    );
+    final followUpRun = await followUpStarted.timeout(
+      const Duration(seconds: 1),
+    );
+    addTearDown(followUpRun.close);
 
-      expect(harness.adapter.lastRequest?.enableImageGeneration, isFalse);
-      followUpRun
-        ..add(const DirectContentDelta('I can help refine it.'))
-        ..add(const DirectStreamDone());
-      await followUpSend.timeout(const Duration(seconds: 1));
+    expect(harness.adapter.lastRequest?.enableImageGeneration, isFalse);
+    followUpRun
+      ..add(const DirectContentDelta('I can help refine it.'))
+      ..add(const DirectStreamDone());
+    await followUpSend.timeout(const Duration(seconds: 1));
 
-      final messages = harness.container.read(chatMessagesProvider);
-      expect(
-        messages.where((message) => message.role == 'assistant').last.content,
-        'I can help refine it.',
-      );
-    },
-  );
+    final messages = harness.container.read(chatMessagesProvider);
+    expect(
+      messages.where((message) => message.role == 'assistant').last.content,
+      'I can help refine it.',
+    );
+  });
 
   test(
     'OpenRouter image generation is consumed when regeneration submits',
@@ -3809,9 +3782,8 @@ void main() {
       expect(completed.content, contains('Private provider reasoning'));
       expect(completed.error, isNull);
       expect(
-        parseConduitDirectReplayOutput(
-          completed.output!,
-        )?.isIncompleteAnswerSentinel,
+        parseConduitDirectReplayOutput(completed.output!)
+            ?.isIncompleteAnswerSentinel,
         isTrue,
       );
       expect(
@@ -3865,13 +3837,11 @@ void main() {
     final completed = harness.container.read(chatMessagesProvider).last;
     check(completed.error).isNull();
     check(
-      parseConduitDirectReplayOutput(
-        completed.output!,
-      )?.isIncompleteAnswerSentinel,
+      parseConduitDirectReplayOutput(completed.output!)
+          ?.isIncompleteAnswerSentinel,
     ).equals(true);
-    check(
-      outboundProviderReplayText(completed),
-    ).equals(kConduitDirectIncompleteAnswerReplayText);
+    check(outboundProviderReplayText(completed))
+        .equals(kConduitDirectIncompleteAnswerReplayText);
     check(completed.sources).deepEquals([
       const ChatSourceReference(
         title: 'Ollama Cloud',
@@ -4467,196 +4437,183 @@ void main() {
     expect(completed.isStreaming, isFalse);
   });
 
-  test(
-    'direct turn start aborts before writing through a closing managed database',
-    () async {
-      final manager = DatabaseManager(
-        openDatabase: (_) => GatedCloseDatabase.memory(failClose: false),
-      );
-      final database =
-          manager.openForServerId('closing-turn-start') as GatedCloseDatabase;
-      final closeGate = Completer<void>();
-      database.closeGate = closeGate;
-      final profile = DirectConnectionProfile(
-        id: 'closing-profile',
-        name: 'Provider',
-        adapterKey: 'test-adapter',
-        baseUrl: 'http://localhost:11434',
-      );
-      final modelRegistry = DirectModelRegistry();
-      final model = modelRegistry.replaceProfileModels(profile, [
-        DirectRemoteModel(id: 'model'),
-      ]).single;
-      final adapter = _Adapter();
-      final chat = await _seedDirectConversation(
-        db: database,
-        chatId: 'direct-local:closing-turn-start',
+  test('direct turn start aborts before writing through a closing managed database', () async {
+    final manager = DatabaseManager(
+      openDatabase: (_) => GatedCloseDatabase.memory(failClose: false),
+    );
+    final database =
+        manager.openForServerId('closing-turn-start') as GatedCloseDatabase;
+    final closeGate = Completer<void>();
+    database.closeGate = closeGate;
+    final profile = DirectConnectionProfile(
+      id: 'closing-profile',
+      name: 'Provider',
+      adapterKey: 'test-adapter',
+      baseUrl: 'http://localhost:11434',
+    );
+    final modelRegistry = DirectModelRegistry();
+    final model = modelRegistry.replaceProfileModels(profile, [
+      DirectRemoteModel(id: 'model'),
+    ]).single;
+    final adapter = _Adapter();
+    final chat = await _seedDirectConversation(
+      db: database,
+      chatId: 'direct-local:closing-turn-start',
+      modelId: model.id,
+      suffix: 'closing-turn-start',
+    );
+    final container = ProviderContainer(
+      overrides: [
+        activeConversationProvider.overrideWith(_ActiveConversation.new),
+        selectedModelProvider.overrideWithValue(model),
+        reviewerModeProvider.overrideWithValue(false),
+        isAuthenticatedProvider2.overrideWithValue(false),
+        apiServiceProvider.overrideWithValue(null),
+        socketServiceProvider.overrideWithValue(null),
+        appDatabaseProvider.overrideWithValue(null),
+        directLocalDatabaseManagerProvider.overrideWithValue(manager),
+        directLocalDatabaseProvider.overrideWithValue(database),
+        directModelRegistryProvider.overrideWithValue(modelRegistry),
+        directConnectionProfilesProvider.overrideWith(() => _Profiles(profile)),
+        directProviderAdapterRegistryProvider.overrideWithValue(
+          DirectProviderAdapterRegistry([adapter]),
+        ),
+      ],
+    );
+    addTearDown(container.dispose);
+    addTearDown(() async {
+      if (!closeGate.isCompleted) closeGate.complete();
+      await manager.closeActive();
+    });
+    container.read(activeConversationProvider.notifier).set(chat);
+    container.read(chatMessagesProvider.notifier).setMessages(chat.messages);
+
+    final close = manager.closeActive();
+    await database.closeStarted.future.timeout(const Duration(seconds: 1));
+
+    await expectLater(
+      sendMessageWithContainer(container, 'Must not be written', null),
+      throwsA(
+        isA<StateError>().having(
+          (error) => error.message,
+          'message',
+          contains('database is closing'),
+        ),
+      ),
+    );
+    expect(adapter.startCalls, 0);
+    final rows = await database.messagesDao.getForChat(chat.id);
+    expect(rows.where((row) => row.content == 'Must not be written'), isEmpty);
+
+    closeGate.complete();
+    await close.timeout(const Duration(seconds: 1));
+  });
+
+  test('OpenWebUI auth revocation detaches a silent direct run and releases its lease', () async {
+    final directory = Directory.systemTemp.createTempSync(
+      'conduit_direct_auth_revoke_',
+    );
+    final manager = DatabaseManager(
+      databaseDirectory: () async => directory,
+      openDatabase: (fileName) => AppDatabase(
+        NativeDatabase(File(p.join(directory.path, '$fileName.sqlite'))),
+      ),
+    );
+    addTearDown(() async {
+      await manager.closeActive();
+      if (directory.existsSync()) directory.deleteSync(recursive: true);
+    });
+    const serverA = ServerConfig(
+      id: 'auth-revoke-a',
+      name: 'Server A',
+      url: 'https://a.example.test',
+    );
+    const serverB = ServerConfig(
+      id: 'auth-revoke-b',
+      name: 'Server B',
+      url: 'https://b.example.test',
+    );
+    final databaseA = manager.openFor(serverA);
+    final directLocal = AppDatabase(NativeDatabase.memory());
+    addTearDown(directLocal.close);
+    final repository = ChatDatabaseRepository(
+      openWebUiDatabase: databaseA,
+      directLocalDatabase: directLocal,
+    );
+    final profile = DirectConnectionProfile(
+      id: 'profile',
+      name: 'Provider',
+      adapterKey: 'test-adapter',
+      baseUrl: 'http://localhost:11434',
+    );
+    final modelRegistry = DirectModelRegistry();
+    final model = modelRegistry.replaceProfileModels(profile, [
+      DirectRemoteModel(id: 'model'),
+    ]).single;
+    final adapter = _GatedAdapter(hostileCancellation: true);
+    addTearDown(adapter.dispose);
+    final chat = withChatStorageProvenance(
+      await _seedDirectConversation(
+        db: databaseA,
+        chatId: 'auth-revoke-chat',
         modelId: model.id,
-        suffix: 'closing-turn-start',
-      );
-      final container = ProviderContainer(
-        overrides: [
-          activeConversationProvider.overrideWith(_ActiveConversation.new),
-          selectedModelProvider.overrideWithValue(model),
-          reviewerModeProvider.overrideWithValue(false),
-          isAuthenticatedProvider2.overrideWithValue(false),
-          apiServiceProvider.overrideWithValue(null),
-          socketServiceProvider.overrideWithValue(null),
-          appDatabaseProvider.overrideWithValue(null),
-          directLocalDatabaseManagerProvider.overrideWithValue(manager),
-          directLocalDatabaseProvider.overrideWithValue(database),
-          directModelRegistryProvider.overrideWithValue(modelRegistry),
-          directConnectionProfilesProvider.overrideWith(
-            () => _Profiles(profile),
-          ),
-          directProviderAdapterRegistryProvider.overrideWithValue(
-            DirectProviderAdapterRegistry([adapter]),
-          ),
-        ],
-      );
-      addTearDown(container.dispose);
-      addTearDown(() async {
-        if (!closeGate.isCompleted) closeGate.complete();
-        await manager.closeActive();
-      });
-      container.read(activeConversationProvider.notifier).set(chat);
-      container.read(chatMessagesProvider.notifier).setMessages(chat.messages);
-
-      final close = manager.closeActive();
-      await database.closeStarted.future.timeout(const Duration(seconds: 1));
-
-      await expectLater(
-        sendMessageWithContainer(container, 'Must not be written', null),
-        throwsA(
-          isA<StateError>().having(
-            (error) => error.message,
-            'message',
-            contains('database is closing'),
-          ),
+        suffix: 'auth-revoke-a',
+      ),
+      ChatStorageKind.openWebUi,
+    );
+    final epochState = NotifierProvider<_EpochState, Object>(
+      () => _EpochState(Object()),
+    );
+    final container = ProviderContainer(
+      overrides: [
+        activeServerProvider.overrideWith((_) async => serverA),
+        databaseManagerProvider.overrideWithValue(manager),
+        activeConversationProvider.overrideWith(_ActiveConversation.new),
+        selectedModelProvider.overrideWithValue(model),
+        reviewerModeProvider.overrideWithValue(false),
+        isAuthenticatedProvider2.overrideWithValue(false),
+        apiServiceProvider.overrideWithValue(null),
+        socketServiceProvider.overrideWithValue(null),
+        appDatabaseProvider.overrideWithValue(databaseA),
+        directLocalDatabaseProvider.overrideWithValue(directLocal),
+        chatDatabaseRepositoryProvider.overrideWithValue(repository),
+        directModelRegistryProvider.overrideWithValue(modelRegistry),
+        directConnectionProfilesProvider.overrideWith(() => _Profiles(profile)),
+        directProviderAdapterRegistryProvider.overrideWithValue(
+          DirectProviderAdapterRegistry([adapter]),
         ),
-      );
-      expect(adapter.startCalls, 0);
-      final rows = await database.messagesDao.getForChat(chat.id);
-      expect(
-        rows.where((row) => row.content == 'Must not be written'),
-        isEmpty,
-      );
-
-      closeGate.complete();
-      await close.timeout(const Duration(seconds: 1));
-    },
-  );
-
-  test(
-    'OpenWebUI auth revocation detaches a silent direct run and releases its lease',
-    () async {
-      final directory = Directory.systemTemp.createTempSync(
-        'conduit_direct_auth_revoke_',
-      );
-      final manager = DatabaseManager(
-        databaseDirectory: () async => directory,
-        openDatabase: (fileName) => AppDatabase(
-          NativeDatabase(File(p.join(directory.path, '$fileName.sqlite'))),
+        openWebUiAuthSessionEpochProvider.overrideWith(
+          (ref) => ref.watch(epochState),
         ),
-      );
-      addTearDown(() async {
-        await manager.closeActive();
-        if (directory.existsSync()) directory.deleteSync(recursive: true);
-      });
-      const serverA = ServerConfig(
-        id: 'auth-revoke-a',
-        name: 'Server A',
-        url: 'https://a.example.test',
-      );
-      const serverB = ServerConfig(
-        id: 'auth-revoke-b',
-        name: 'Server B',
-        url: 'https://b.example.test',
-      );
-      final databaseA = manager.openFor(serverA);
-      final directLocal = AppDatabase(NativeDatabase.memory());
-      addTearDown(directLocal.close);
-      final repository = ChatDatabaseRepository(
-        openWebUiDatabase: databaseA,
-        directLocalDatabase: directLocal,
-      );
-      final profile = DirectConnectionProfile(
-        id: 'profile',
-        name: 'Provider',
-        adapterKey: 'test-adapter',
-        baseUrl: 'http://localhost:11434',
-      );
-      final modelRegistry = DirectModelRegistry();
-      final model = modelRegistry.replaceProfileModels(profile, [
-        DirectRemoteModel(id: 'model'),
-      ]).single;
-      final adapter = _GatedAdapter(hostileCancellation: true);
-      addTearDown(adapter.dispose);
-      final chat = withChatStorageProvenance(
-        await _seedDirectConversation(
-          db: databaseA,
-          chatId: 'auth-revoke-chat',
-          modelId: model.id,
-          suffix: 'auth-revoke-a',
-        ),
-        ChatStorageKind.openWebUi,
-      );
-      final epochState = NotifierProvider<_EpochState, Object>(
-        () => _EpochState(Object()),
-      );
-      final container = ProviderContainer(
-        overrides: [
-          activeServerProvider.overrideWith((_) async => serverA),
-          databaseManagerProvider.overrideWithValue(manager),
-          activeConversationProvider.overrideWith(_ActiveConversation.new),
-          selectedModelProvider.overrideWithValue(model),
-          reviewerModeProvider.overrideWithValue(false),
-          isAuthenticatedProvider2.overrideWithValue(false),
-          apiServiceProvider.overrideWithValue(null),
-          socketServiceProvider.overrideWithValue(null),
-          appDatabaseProvider.overrideWithValue(databaseA),
-          directLocalDatabaseProvider.overrideWithValue(directLocal),
-          chatDatabaseRepositoryProvider.overrideWithValue(repository),
-          directModelRegistryProvider.overrideWithValue(modelRegistry),
-          directConnectionProfilesProvider.overrideWith(
-            () => _Profiles(profile),
-          ),
-          directProviderAdapterRegistryProvider.overrideWithValue(
-            DirectProviderAdapterRegistry([adapter]),
-          ),
-          openWebUiAuthSessionEpochProvider.overrideWith(
-            (ref) => ref.watch(epochState),
-          ),
-        ],
-      );
-      addTearDown(container.dispose);
-      container
-          .read(openWebUiCertifiedDatabaseServerProvider.notifier)
-          .set(serverA.id);
-      container.read(openWebUiDatabaseAccessProvider.notifier).open();
-      container.read(activeConversationProvider.notifier).set(chat);
-      container.read(chatMessagesProvider.notifier).setMessages(chat.messages);
+      ],
+    );
+    addTearDown(container.dispose);
+    container
+        .read(openWebUiCertifiedDatabaseServerProvider.notifier)
+        .set(serverA.id);
+    container.read(openWebUiDatabaseAccessProvider.notifier).open();
+    container.read(activeConversationProvider.notifier).set(chat);
+    container.read(chatMessagesProvider.notifier).setMessages(chat.messages);
 
-      final started = adapter.nextRun();
-      final send = sendMessageWithContainer(
-        container,
-        'Wait forever unless auth revokes ownership',
-        null,
-      );
-      final run = await started.timeout(const Duration(seconds: 1));
-      addTearDown(run.close);
+    final started = adapter.nextRun();
+    final send = sendMessageWithContainer(
+      container,
+      'Wait forever unless auth revokes ownership',
+      null,
+    );
+    final run = await started.timeout(const Duration(seconds: 1));
+    addTearDown(run.close);
 
-      final databaseB = manager.openFor(serverB);
-      expect(await databaseB.customSelect('SELECT 1').get(), isNotEmpty);
-      expect(await databaseA.customSelect('SELECT 1').get(), isNotEmpty);
+    final databaseB = manager.openFor(serverB);
+    expect(await databaseB.customSelect('SELECT 1').get(), isNotEmpty);
+    expect(await databaseA.customSelect('SELECT 1').get(), isNotEmpty);
 
-      container.read(epochState.notifier).rotate();
-      await send.timeout(const Duration(seconds: 1));
+    container.read(epochState.notifier).rotate();
+    await send.timeout(const Duration(seconds: 1));
 
-      expect(run.run.isCancelled, isTrue);
-      await _waitForDatabaseClosed(databaseA);
-    },
-  );
+    expect(run.run.isCancelled, isTrue);
+    await _waitForDatabaseClosed(databaseA);
+  });
 
   test(
     'hidden OpenWebUI direct final write keeps its leased database alive',
@@ -4803,9 +4760,8 @@ void main() {
 
       final reopenedA = manager.openFor(serverA);
       expect(identical(reopenedA, databaseA), isFalse);
-      final finalRow = (await reopenedA.messagesDao.getForChat(
-        chatA.id,
-      )).singleWhere((row) => row.id == assistantId);
+      final finalRow = (await reopenedA.messagesDao.getForChat(chatA.id))
+          .singleWhere((row) => row.id == assistantId);
       expect(finalRow.content, finalContent);
     },
   );

--- a/test/features/chat/providers/follow_ups_socket_event_test.dart
+++ b/test/features/chat/providers/follow_ups_socket_event_test.dart
@@ -3,6 +3,27 @@ import 'package:conduit/features/chat/providers/chat_providers.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
+  test('comparable assistant body strips semantic details with divergent '
+      'attributes', () {
+    const localRender =
+        '<details type="reasoning" done="true" duration="0">'
+        '<summary>Thought for 0 seconds</summary>\nthinking\n</details>\n'
+        'The answer body.';
+    const serverRender =
+        '<details type="reasoning" done="true" duration="7">'
+        '<summary>Thought for 7 seconds</summary>\nthinking\n</details>\n'
+        'The answer body.';
+
+    check(debugComparableAssistantBodyForTesting(localRender))
+        .equals(debugComparableAssistantBodyForTesting(serverRender));
+    check(debugComparableAssistantBodyForTesting(localRender))
+        .equals('The answer body.');
+    // Ordinary user-authored details blocks are content and must survive.
+    const plainDetails = '<details><summary>FAQ</summary>body</details>';
+    check(debugComparableAssistantBodyForTesting(plainDetails))
+        .equals(plainDetails);
+  });
+
   test('parses the server follow-ups envelope', () {
     final parsed = debugParseFollowUpsSocketEventForTesting({
       'chat_id': 'chat-1',

--- a/test/features/chat/providers/follow_ups_socket_event_test.dart
+++ b/test/features/chat/providers/follow_ups_socket_event_test.dart
@@ -1,5 +1,6 @@
 import 'package:checks/checks.dart';
-import 'package:conduit/features/chat/providers/chat_providers.dart';
+import 'package:conduit/core/utils/semantic_details.dart';
+import 'package:conduit/features/chat/utils/follow_ups_socket_event.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
@@ -14,18 +15,16 @@ void main() {
         '<summary>Thought for 7 seconds</summary>\nthinking\n</details>\n'
         'The answer body.';
 
-    check(debugComparableAssistantBodyForTesting(localRender))
-        .equals(debugComparableAssistantBodyForTesting(serverRender));
-    check(debugComparableAssistantBodyForTesting(localRender))
-        .equals('The answer body.');
+    check(comparableAssistantBody(localRender))
+        .equals(comparableAssistantBody(serverRender));
+    check(comparableAssistantBody(localRender)).equals('The answer body.');
     // Ordinary user-authored details blocks are content and must survive.
     const plainDetails = '<details><summary>FAQ</summary>body</details>';
-    check(debugComparableAssistantBodyForTesting(plainDetails))
-        .equals(plainDetails);
+    check(comparableAssistantBody(plainDetails)).equals(plainDetails);
   });
 
   test('parses the server follow-ups envelope', () {
-    final parsed = debugParseFollowUpsSocketEventForTesting({
+    final parsed = parseFollowUpsSocketEvent({
       'chat_id': 'chat-1',
       'message_id': 'msg-1',
       'data': {
@@ -42,7 +41,7 @@ void main() {
   });
 
   test('accepts camelCase payload key and nested message_id', () {
-    final parsed = debugParseFollowUpsSocketEventForTesting({
+    final parsed = parseFollowUpsSocketEvent({
       'data': {
         'type': 'chat:message:follow_ups',
         'message_id': 'msg-2',
@@ -59,7 +58,7 @@ void main() {
 
   test('rejects other event types, missing ids, and empty lists', () {
     check(
-      debugParseFollowUpsSocketEventForTesting({
+      parseFollowUpsSocketEvent({
         'message_id': 'msg-1',
         'data': {
           'type': 'chat:title',
@@ -70,7 +69,7 @@ void main() {
       }),
     ).isNull();
     check(
-      debugParseFollowUpsSocketEventForTesting({
+      parseFollowUpsSocketEvent({
         'data': {
           'type': 'chat:message:follow_ups',
           'data': {
@@ -80,7 +79,7 @@ void main() {
       }),
     ).isNull();
     check(
-      debugParseFollowUpsSocketEventForTesting({
+      parseFollowUpsSocketEvent({
         'message_id': 'msg-1',
         'data': {
           'type': 'chat:message:follow_ups',

--- a/test/features/chat/providers/follow_ups_socket_event_test.dart
+++ b/test/features/chat/providers/follow_ups_socket_event_test.dart
@@ -1,0 +1,75 @@
+import 'package:conduit/features/chat/providers/chat_providers.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('parses the server follow-ups envelope', () {
+    final parsed = debugParseFollowUpsSocketEventForTesting({
+      'chat_id': 'chat-1',
+      'message_id': 'msg-1',
+      'data': {
+        'type': 'chat:message:follow_ups',
+        'data': {
+          'follow_ups': ['One?', '  Two?  ', ''],
+        },
+      },
+    });
+
+    expect(parsed, isNotNull);
+    expect(parsed!.messageId, 'msg-1');
+    expect(parsed.followUps, ['One?', 'Two?']);
+  });
+
+  test('accepts camelCase payload key and nested message_id', () {
+    final parsed = debugParseFollowUpsSocketEventForTesting({
+      'data': {
+        'type': 'chat:message:follow_ups',
+        'message_id': 'msg-2',
+        'data': {
+          'followUps': ['A?'],
+        },
+      },
+    });
+
+    expect(parsed, isNotNull);
+    expect(parsed!.messageId, 'msg-2');
+    expect(parsed.followUps, ['A?']);
+  });
+
+  test('rejects other event types, missing ids, and empty lists', () {
+    expect(
+      debugParseFollowUpsSocketEventForTesting({
+        'message_id': 'msg-1',
+        'data': {
+          'type': 'chat:title',
+          'data': {
+            'follow_ups': ['One?'],
+          },
+        },
+      }),
+      isNull,
+    );
+    expect(
+      debugParseFollowUpsSocketEventForTesting({
+        'data': {
+          'type': 'chat:message:follow_ups',
+          'data': {
+            'follow_ups': ['One?'],
+          },
+        },
+      }),
+      isNull,
+    );
+    expect(
+      debugParseFollowUpsSocketEventForTesting({
+        'message_id': 'msg-1',
+        'data': {
+          'type': 'chat:message:follow_ups',
+          'data': {
+            'follow_ups': ['', '   '],
+          },
+        },
+      }),
+      isNull,
+    );
+  });
+}

--- a/test/features/chat/providers/follow_ups_socket_event_test.dart
+++ b/test/features/chat/providers/follow_ups_socket_event_test.dart
@@ -1,3 +1,4 @@
+import 'package:checks/checks.dart';
 import 'package:conduit/features/chat/providers/chat_providers.dart';
 import 'package:flutter_test/flutter_test.dart';
 
@@ -14,9 +15,9 @@ void main() {
       },
     });
 
-    expect(parsed, isNotNull);
-    expect(parsed!.messageId, 'msg-1');
-    expect(parsed.followUps, ['One?', 'Two?']);
+    check(parsed).isNotNull();
+    check(parsed!.messageId).equals('msg-1');
+    check(parsed.followUps).deepEquals(['One?', 'Two?']);
   });
 
   test('accepts camelCase payload key and nested message_id', () {
@@ -30,13 +31,13 @@ void main() {
       },
     });
 
-    expect(parsed, isNotNull);
-    expect(parsed!.messageId, 'msg-2');
-    expect(parsed.followUps, ['A?']);
+    check(parsed).isNotNull();
+    check(parsed!.messageId).equals('msg-2');
+    check(parsed.followUps).deepEquals(['A?']);
   });
 
   test('rejects other event types, missing ids, and empty lists', () {
-    expect(
+    check(
       debugParseFollowUpsSocketEventForTesting({
         'message_id': 'msg-1',
         'data': {
@@ -46,9 +47,8 @@ void main() {
           },
         },
       }),
-      isNull,
-    );
-    expect(
+    ).isNull();
+    check(
       debugParseFollowUpsSocketEventForTesting({
         'data': {
           'type': 'chat:message:follow_ups',
@@ -57,9 +57,8 @@ void main() {
           },
         },
       }),
-      isNull,
-    );
-    expect(
+    ).isNull();
+    check(
       debugParseFollowUpsSocketEventForTesting({
         'message_id': 'msg-1',
         'data': {
@@ -69,7 +68,6 @@ void main() {
           },
         },
       }),
-      isNull,
-    );
+    ).isNull();
   });
 }

--- a/test/features/chat/providers/hermes_run_remap_test.dart
+++ b/test/features/chat/providers/hermes_run_remap_test.dart
@@ -313,9 +313,8 @@ void main() {
     check(destinationCancelled).equals(0);
     check(destinationToken.isCancelled).isFalse();
     check(registry.runIdFor(destinationKey)).equals('destination-run');
-    check(
-      registry.owns(destinationKey, cancelToken: destinationToken),
-    ).isTrue();
+    check(registry.owns(destinationKey, cancelToken: destinationToken))
+        .isTrue();
   });
 
   test(

--- a/test/features/chat/providers/knowledge_cache_provider_test.dart
+++ b/test/features/chat/providers/knowledge_cache_provider_test.dart
@@ -80,24 +80,21 @@ void main() {
 
         container.read(_activeKnowledgeApiProvider.notifier).set(firstApi);
         await container.read(knowledgeCacheProvider.notifier).ensureBases();
-        check(
-          container.read(knowledgeCacheProvider).bases.single.id,
-        ).equals('kb-a');
+        check(container.read(knowledgeCacheProvider).bases.single.id)
+            .equals('kb-a');
 
         container.read(_activeKnowledgeApiProvider.notifier).set(secondApi);
         await container.read(knowledgeCacheProvider.notifier).ensureBases();
 
-        check(
-          container.read(knowledgeCacheProvider).bases.single.id,
-        ).equals('kb-b');
+        check(container.read(knowledgeCacheProvider).bases.single.id)
+            .equals('kb-b');
         check(secondApi.basesCallCount).equals(1);
 
         container.read(_activeKnowledgeApiProvider.notifier).set(firstApi);
         await container.read(knowledgeCacheProvider.notifier).ensureBases();
 
-        check(
-          container.read(knowledgeCacheProvider).bases.single.id,
-        ).equals('kb-a');
+        check(container.read(knowledgeCacheProvider).bases.single.id)
+            .equals('kb-a');
         check(firstApi.basesCallCount).equals(1);
       },
     );
@@ -296,15 +293,13 @@ void main() {
 
       freshGate.complete();
       await freshRequest;
-      check(
-        container.read(knowledgeCacheProvider).files['kb-1']!.single.id,
-      ).equals('fresh-owner-file');
+      check(container.read(knowledgeCacheProvider).files['kb-1']!.single.id)
+          .equals('fresh-owner-file');
 
       staleGate.complete();
       await staleRequest;
-      check(
-        container.read(knowledgeCacheProvider).files['kb-1']!.single.id,
-      ).equals('fresh-owner-file');
+      check(container.read(knowledgeCacheProvider).files['kb-1']!.single.id)
+          .equals('fresh-owner-file');
       check(api.fileCalls['kb-1']).equals(2);
     });
 
@@ -350,15 +345,13 @@ void main() {
 
         freshGate.complete();
         await freshRequest;
-        check(
-          container.read(knowledgeCacheProvider).bases.single.id,
-        ).equals('fresh-base');
+        check(container.read(knowledgeCacheProvider).bases.single.id)
+            .equals('fresh-base');
 
         staleGate.complete();
         await staleRequest;
-        check(
-          container.read(knowledgeCacheProvider).bases.single.id,
-        ).equals('fresh-base');
+        check(container.read(knowledgeCacheProvider).bases.single.id)
+            .equals('fresh-base');
       });
 
       test('${clearAll ? 'clearAllCaches' : 'clearCache'} fences an older '
@@ -400,15 +393,13 @@ void main() {
 
         freshGate.complete();
         await freshRequest;
-        check(
-          container.read(knowledgeCacheProvider).files['kb-1']!.single.id,
-        ).equals('fresh-file');
+        check(container.read(knowledgeCacheProvider).files['kb-1']!.single.id)
+            .equals('fresh-file');
 
         staleGate.complete();
         await staleRequest;
-        check(
-          container.read(knowledgeCacheProvider).files['kb-1']!.single.id,
-        ).equals('fresh-file');
+        check(container.read(knowledgeCacheProvider).files['kb-1']!.single.id)
+            .equals('fresh-file');
       });
     }
   });

--- a/test/features/chat/providers/local_echo_payload_test.dart
+++ b/test/features/chat/providers/local_echo_payload_test.dart
@@ -1,0 +1,101 @@
+import 'package:checks/checks.dart';
+import 'package:conduit/core/models/chat_message.dart';
+import 'package:conduit/features/chat/providers/chat_providers.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('localEchoRowForMessage', () {
+    final message = ChatMessage(
+      id: 'assistant-1',
+      role: 'assistant',
+      content: 'Answer',
+      timestamp: DateTime.fromMillisecondsSinceEpoch(1700000000000),
+      model: 'gpt-4o',
+      isStreaming: false,
+      metadata: const <String, dynamic>{'modelName': 'GPT-4o'},
+      output: const <Map<String, dynamic>>[
+        <String, dynamic>{'type': 'text', 'text': 'Answer'},
+      ],
+      files: const <Map<String, dynamic>>[
+        <String, dynamic>{'type': 'image', 'url': 'https://x/img.png'},
+      ],
+      embeds: const <Map<String, dynamic>>[
+        <String, dynamic>{'html': '<iframe></iframe>'},
+      ],
+      usage: const <String, dynamic>{'total_tokens': 42},
+      sources: const <ChatSourceReference>[
+        ChatSourceReference(
+          id: 'src-1',
+          title: 'Docs',
+          url: 'https://example.com',
+          snippet: 'Snippet text',
+          type: 'web_search',
+        ),
+      ],
+      statusHistory: const <ChatStatusUpdate>[
+        ChatStatusUpdate(description: 'Searching', done: true),
+      ],
+      codeExecutions: const <ChatCodeExecution>[
+        ChatCodeExecution(
+          id: 'exec-1',
+          name: 'run',
+          language: 'python',
+          code: 'print(1)',
+          result: ChatCodeExecutionResult(output: '1'),
+        ),
+      ],
+      followUps: const <String>['Next?'],
+      error: const ChatMessageError(content: 'boom'),
+    );
+
+    test('carries every durable field the sync outbox must replay', () {
+      // The outbox rebuilds the full chat blob from these rows and the server
+      // replaces each message object wholesale — a key missing here is a key
+      // wiped from the server copy on the next push.
+      final payload = localEchoRowForMessage('chat-1', message).payload;
+
+      const durableKeys = {
+        'id',
+        'parentId',
+        'childrenIds',
+        'role',
+        'content',
+        'timestamp',
+        'isStreaming',
+        'done',
+        'model',
+        'metadata',
+        'output',
+        'files',
+        'embeds',
+        'usage',
+        'sources',
+        'statusHistory',
+        'code_executions',
+        'followUps',
+        'error',
+      };
+      check(durableKeys.difference(payload.keys.toSet())).isEmpty();
+    });
+
+    test('persists sources and code executions in the server shape', () {
+      // The OWUI web client reads citation-shaped `sources` and snake_case
+      // `code_executions`; client-model shapes would break that client for
+      // any chat synced from Conduit.
+      final payload = localEchoRowForMessage('chat-1', message).payload;
+
+      final source =
+          (payload['sources'] as List).single as Map<String, dynamic>;
+      check(source['source']).isA<Map<String, dynamic>>();
+      check(source['document']).isA<List<dynamic>>();
+      check(source.containsKey('snippet')).isFalse();
+
+      final execution =
+          (payload['code_executions'] as List).single as Map<String, dynamic>;
+      check(execution['id']).equals('exec-1');
+      check((execution['result'] as Map<String, dynamic>)['output'])
+          .equals('1');
+      check(payload.containsKey('codeExecutions')).isFalse();
+    });
+  });
+}

--- a/test/features/chat/providers/queued_completion_provider_test.dart
+++ b/test/features/chat/providers/queued_completion_provider_test.dart
@@ -320,15 +320,14 @@ void main() {
           .cancel(info!);
 
       check(removed).equals(1);
-      check(
-        identical(container.read(activeConversationProvider), native),
-      ).isTrue();
+      check(identical(container.read(activeConversationProvider), native))
+          .isTrue();
       check(
         isNativeHermesConversation(container.read(activeConversationProvider)),
       ).isTrue();
-      check(
-        container.read(chatMessagesProvider),
-      ).single.has((message) => message.id, 'id').equals(assistantId);
+      check(container.read(chatMessagesProvider)).single
+          .has((message) => message.id, 'id')
+          .equals(assistantId);
     },
   );
 
@@ -379,9 +378,8 @@ void main() {
       check(await actions.cancel(staleInfo)).equals(0);
 
       check((await db.select(db.outboxOps).get()).single).equals(beforeA);
-      check(
-        (await databaseB.select(databaseB.outboxOps).get()).single,
-      ).equals(beforeB);
+      check((await databaseB.select(databaseB.outboxOps).get()).single)
+          .equals(beforeB);
     },
   );
 
@@ -551,90 +549,86 @@ void main() {
     check(drainBarrier.databaseOwnedDrainCalls).equals(1);
     check(drainBarrier.genericDrainCalls).equals(0);
     check(drainBarrier.expectedDatabase).identicalTo(db);
-    check(
-      (await databaseB.select(databaseB.outboxOps).get()).single,
-    ).equals(beforeB);
+    check((await databaseB.select(databaseB.outboxOps).get()).single)
+        .equals(beforeB);
   });
 
-  test(
-    'ApiService identity churn without an auth-epoch change republishes a '
-    'current snapshot so retry still executes',
-    () async {
-      const chatId = 'same-chat';
-      const assistantId = 'same-assistant';
-      final seq = await enqueueCompletion(chatId, assistantId);
-      await db.outboxDao.markParked(seq, error: 'boom');
+  test('ApiService identity churn without an auth-epoch change republishes a '
+      'current snapshot so retry still executes', () async {
+    const chatId = 'same-chat';
+    const assistantId = 'same-assistant';
+    final seq = await enqueueCompletion(chatId, assistantId);
+    await db.outboxDao.markParked(seq, error: 'boom');
 
-      final workerManager = WorkerManager(debugIsWebOverride: true);
-      addTearDown(workerManager.dispose);
-      ApiService buildApi() {
-        final api = ApiService(
-          serverConfig: const ServerConfig(
-            id: 'server-1',
-            name: 'Open WebUI',
-            url: 'https://openwebui.example.com',
-          ),
-          workerManager: workerManager,
-        );
-        addTearDown(api.dispose);
-        return api;
-      }
-
-      var currentApi = buildApi();
-      final syncEngine = _NoopSyncEngine();
-      final container = ProviderContainer(
-        overrides: [
-          appDatabaseProvider.overrideWith((ref) => db),
-          isOnlineProvider.overrideWith((ref) => true),
-          apiServiceProvider.overrideWith((ref) => currentApi),
-          syncEngineProvider.overrideWith(() => syncEngine),
-        ],
+    final workerManager = WorkerManager(debugIsWebOverride: true);
+    addTearDown(workerManager.dispose);
+    ApiService buildApi() {
+      final api = ApiService(
+        serverConfig: const ServerConfig(
+          id: 'server-1',
+          name: 'Open WebUI',
+          url: 'https://openwebui.example.com',
+        ),
+        workerManager: workerManager,
       );
-      addTearDown(container.dispose);
-      container.read(activeConversationProvider.notifier).set(conv(chatId));
+      addTearDown(api.dispose);
+      return api;
+    }
 
-      final staleInfo = await firstInfo(container, assistantId);
-      check(staleInfo).isNotNull();
+    var currentApi = buildApi();
+    final syncEngine = _NoopSyncEngine();
+    final container = ProviderContainer(
+      overrides: [
+        appDatabaseProvider.overrideWith((ref) => db),
+        isOnlineProvider.overrideWith((ref) => true),
+        apiServiceProvider.overrideWith((ref) => currentApi),
+        syncEngineProvider.overrideWith(() => syncEngine),
+      ],
+    );
+    addTearDown(container.dispose);
+    container.read(activeConversationProvider.notifier).set(conv(chatId));
 
-      // Recreate the ApiService with no auth-epoch transition, as happens for
-      // ref.invalidate(apiServiceProvider) during an auth-state rollback or a
-      // logout-fence toggle. The stale snapshot must stay fenced out, but the
-      // provider must republish a fresh snapshot whose actions work.
-      currentApi = buildApi();
-      container.invalidate(apiServiceProvider);
-      check(container.read(apiServiceProvider)).identicalTo(currentApi);
+    final staleInfo = await firstInfo(container, assistantId);
+    check(staleInfo).isNotNull();
 
-      final before = (await db.select(db.outboxOps).get()).single;
-      final actions = container.read(queuedCompletionActionsProvider);
-      await actions.retry(staleInfo!);
-      check((await db.select(db.outboxOps).get()).single).equals(before);
-      check(syncEngine.databaseOwnedDrainCalls).equals(0);
+    // Recreate the ApiService with no auth-epoch transition, as happens for
+    // ref.invalidate(apiServiceProvider) during an auth-state rollback or a
+    // logout-fence toggle. The stale snapshot must stay fenced out, but the
+    // provider must republish a fresh snapshot whose actions work.
+    currentApi = buildApi();
+    container.invalidate(apiServiceProvider);
+    check(container.read(apiServiceProvider)).identicalTo(currentApi);
 
-      // Wait for the rebuilt stream to publish an info owned by the new
-      // ApiService identity (distinct ownership token from the stale one).
-      final freshCompleter = Completer<QueuedCompletionInfo>();
-      final sub = container.listen(
-        queuedCompletionInfoForMessageProvider(assistantId),
-        (_, next) {
-          final info = next.hasValue ? next.value : null;
-          if (info != null && info != staleInfo && !freshCompleter.isCompleted) {
-            freshCompleter.complete(info);
-          }
-        },
-        fireImmediately: true,
-      );
-      addTearDown(sub.close);
-      final freshInfo = await freshCompleter.future.timeout(
-        const Duration(seconds: 5),
-      );
+    final before = (await db.select(db.outboxOps).get()).single;
+    final actions = container.read(queuedCompletionActionsProvider);
+    await actions.retry(staleInfo!);
+    check((await db.select(db.outboxOps).get()).single).equals(before);
+    check(syncEngine.databaseOwnedDrainCalls).equals(0);
 
-      await actions.retry(freshInfo);
+    // Wait for the rebuilt stream to publish an info owned by the new
+    // ApiService identity (distinct ownership token from the stale one).
+    final freshCompleter = Completer<QueuedCompletionInfo>();
+    final sub = container.listen(
+      queuedCompletionInfoForMessageProvider(assistantId),
+      (_, next) {
+        final info = next.hasValue ? next.value : null;
+        if (info != null && info != staleInfo && !freshCompleter.isCompleted) {
+          freshCompleter.complete(info);
+        }
+      },
+      fireImmediately: true,
+    );
+    addTearDown(sub.close);
+    final freshInfo = await freshCompleter.future.timeout(
+      const Duration(seconds: 5),
+    );
 
-      final after = (await db.select(db.outboxOps).get()).single;
-      check(after.status).equals(OutboxStatus.pending);
-      check(syncEngine.databaseOwnedDrainCalls).equals(1);
-    },
-  );
+    await actions.retry(freshInfo);
+
+    final after = (await db.select(db.outboxOps).get()).single;
+    check(after.status).equals(OutboxStatus.pending);
+    check(syncEngine.databaseOwnedDrainCalls).equals(1);
+  });
 
   test('queued actions retain their Ref across an async boundary', () async {
     final container = makeContainer(online: true, chatId: 'c1');

--- a/test/features/chat/providers/reasoning_effort_provider_test.dart
+++ b/test/features/chat/providers/reasoning_effort_provider_test.dart
@@ -92,9 +92,8 @@ final class _ModelDetailsAdapter implements HttpClientAdapter {
     if (!requested.isCompleted) requested.complete();
     check(options.method).equals('GET');
     check(options.path).equals('/api/v1/models/model');
-    check(
-      options.queryParameters,
-    ).deepEquals(<String, dynamic>{'id': 'workspace-reasoning-model'});
+    check(options.queryParameters)
+        .deepEquals(<String, dynamic>{'id': 'workspace-reasoning-model'});
     if (requestCount <= failuresBeforeSuccess) {
       return ResponseBody.fromString(
         '{"detail":"temporary failure"}',
@@ -165,9 +164,8 @@ void main() {
 
     await setReasoningEffortForModel(container.read, models.last, 'high');
 
-    check(
-      reasoningEffortForModel(container.read, models.first),
-    ).equals('automatic');
+    check(reasoningEffortForModel(container.read, models.first))
+        .equals('automatic');
     check(reasoningEffortForModel(container.read, models.last)).equals('high');
     check(container.read(selectedModelProvider)).identicalTo(models.first);
   });
@@ -259,9 +257,8 @@ void main() {
       await container.read(serverModelReasoningEffortProvider(model).future);
 
       check(adapter.requestCount).equals(1);
-      check(
-        container.read(configuredReasoningEffortProvider),
-      ).equals('vendor_ultra');
+      check(container.read(configuredReasoningEffortProvider))
+          .equals('vendor_ultra');
     },
   );
 
@@ -297,15 +294,13 @@ void main() {
     addTearDown(container.dispose);
 
     check(
-      (await container.read(
-        serverModelReasoningEffortProvider(model).future,
-      )).value,
+      (await container.read(serverModelReasoningEffortProvider(model).future))
+          .value,
     ).isNull();
     await container.pump();
     check(
-      (await container.read(
-        serverModelReasoningEffortProvider(model).future,
-      )).value,
+      (await container.read(serverModelReasoningEffortProvider(model).future))
+          .value,
     ).equals('vendor_ultra');
     check(adapter.requestCount).equals(2);
   });
@@ -374,21 +369,18 @@ void main() {
     final container = ProviderContainer();
     addTearDown(container.dispose);
 
-    check(
-      reasoningEffortPolicyForModel(container.read, unsupported).visible,
-    ).isFalse();
+    check(reasoningEffortPolicyForModel(container.read, unsupported).visible)
+        .isFalse();
     check(
       reasoningEffortPolicyForModel(
         container.read,
         explicitlyUnsupported,
       ).visible,
     ).isFalse();
-    check(
-      reasoningEffortPolicyForModel(container.read, supported).visible,
-    ).isTrue();
-    check(
-      reasoningEffortPolicyForModel(container.read, hermes).visible,
-    ).isTrue();
+    check(reasoningEffortPolicyForModel(container.read, supported).visible)
+        .isTrue();
+    check(reasoningEffortPolicyForModel(container.read, hermes).visible)
+        .isTrue();
   });
 
   test('chat payload omits effort for unsupported server models', () {
@@ -466,9 +458,9 @@ void main() {
 
     final configuredModelItem = buildLocalModelItemForTest(configuredModel);
     final aliasModelItem = buildLocalModelItemForTest(aliasModel);
-    check(configuredModelItem['params']).isA<Map<String, dynamic>>().deepEquals(
-      <String, dynamic>{'reasoning_effort': 'vendor_ultra'},
-    );
+    check(configuredModelItem['params'])
+        .isA<Map<String, dynamic>>()
+        .deepEquals(<String, dynamic>{'reasoning_effort': 'vendor_ultra'});
     check(aliasModelItem['base_model_id']).equals('gpt-5');
     check(
       (build(configuredModel, 'vendor_ultra')['params']
@@ -493,9 +485,8 @@ void main() {
       final container = ProviderContainer();
       addTearDown(container.dispose);
 
-      check(
-        container.read(localReasoningEffortsProvider),
-      ).deepEquals({'hermes:valid': 'high'});
+      check(container.read(localReasoningEffortsProvider))
+          .deepEquals({'hermes:valid': 'high'});
     },
   );
 
@@ -626,9 +617,8 @@ void main() {
     addTearDown(container.dispose);
 
     final policy = reasoningEffortPolicyForModel(container.read, model);
-    check(
-      policy.options,
-    ).deepEquals(['automatic', ...kOpenRouterReasoningEfforts]);
+    check(policy.options)
+        .deepEquals(['automatic', ...kOpenRouterReasoningEfforts]);
   });
 
   test(
@@ -662,15 +652,12 @@ void main() {
           .read(localReasoningEffortsProvider.notifier)
           .set(key, 'medium');
 
-      check(
-        reasoningEffortPolicyForModel(container.read, models.first).visible,
-      ).isFalse();
-      check(
-        reasoningEffortForModel(container.read, models.last),
-      ).equals('automatic');
-      check(
-        container.read(localReasoningEffortsProvider)[key],
-      ).equals('medium');
+      check(reasoningEffortPolicyForModel(container.read, models.first).visible)
+          .isFalse();
+      check(reasoningEffortForModel(container.read, models.last))
+          .equals('automatic');
+      check(container.read(localReasoningEffortsProvider)[key])
+          .equals('medium');
       await check(
         setReasoningEffortForModel(container.read, models.last, 'medium'),
       ).throws<FormatException>();

--- a/test/features/chat/providers/remap_route_sync_test.dart
+++ b/test/features/chat/providers/remap_route_sync_test.dart
@@ -200,9 +200,8 @@ void main() {
             toId: 'server-context-failure',
           ),
     ).returnsNormally();
-    check(
-      container.read(activeConversationProvider)?.id,
-    ).equals('server-context-failure');
+    check(container.read(activeConversationProvider)?.id)
+        .equals('server-context-failure');
   });
 
   test('note route remap preserves query params', () {

--- a/test/features/chat/send_guard_test.dart
+++ b/test/features/chat/send_guard_test.dart
@@ -28,9 +28,8 @@ final _hermesModel = hermesSyntheticModel();
 void main() {
   group('isSendBlocked', () {
     test('blocks when no model is selected', () {
-      check(
-        isSendBlocked(reviewerMode: false, api: null, selectedModel: null),
-      ).isTrue();
+      check(isSendBlocked(reviewerMode: false, api: null, selectedModel: null))
+          .isTrue();
       // ...even with an api present.
       check(
         isSendBlocked(
@@ -293,9 +292,8 @@ void main() {
       addTearDown(container.dispose);
 
       check(container.read(visionCapableModelsProvider)).isEmpty();
-      check(
-        container.read(fileUploadCapableModelsProvider),
-      ).deepEquals([textModel.id]);
+      check(container.read(fileUploadCapableModelsProvider))
+          .deepEquals([textModel.id]);
     });
 
     test('direct-like server model keeps OpenWebUI vision behavior', () {
@@ -315,9 +313,8 @@ void main() {
       );
       addTearDown(container.dispose);
 
-      check(
-        container.read(visionCapableModelsProvider),
-      ).deepEquals([serverModel.id]);
+      check(container.read(visionCapableModelsProvider))
+          .deepEquals([serverModel.id]);
     });
 
     test(
@@ -338,14 +335,13 @@ void main() {
         );
         addTearDown(container.dispose);
 
-        check(
-          container.read(visionCapableModelsProvider),
-        ).deepEquals([visionModel.id]);
+        check(container.read(visionCapableModelsProvider))
+            .deepEquals([visionModel.id]);
 
         registry.removeProfile(_directProfile.id);
-        final discovery =
-            container.read(directModelDiscoveryProvider.notifier)
-                as _DiscoveryPulseController;
+        final discovery = container.read(
+          directModelDiscoveryProvider.notifier,
+        ) as _DiscoveryPulseController;
         discovery.pulse();
         await Future<void>.delayed(Duration.zero);
 
@@ -389,9 +385,8 @@ void main() {
       final payload = directPersistedMessagePayloadForTest(message);
       final versions = payload['versions'] as List<dynamic>;
       check(versions).length.equals(1);
-      check(
-        (versions.single as Map<String, dynamic>)['content'],
-      ).equals('Previous answer');
+      check((versions.single as Map<String, dynamic>)['content'])
+          .equals('Previous answer');
     });
   });
 }

--- a/test/features/chat/services/chat_history_reader_test.dart
+++ b/test/features/chat/services/chat_history_reader_test.dart
@@ -105,63 +105,60 @@ void main() {
     ).throws<StateError>();
   });
 
-  test(
-    'unmaterialized durable history uses the authoritative loader, not its window',
-    () async {
-      final localDatabase = AppDatabase(NativeDatabase.memory());
-      addTearDown(localDatabase.close);
-      final repository = ChatDatabaseRepository(
-        openWebUiDatabase: null,
-        directLocalDatabase: localDatabase,
-      );
-      final now = DateTime(2026);
-      final completeMessages = [
-        for (var index = 0; index < 500; index += 1)
-          ChatMessage(
-            id: 'm$index',
-            role: index.isEven ? 'user' : 'assistant',
-            content: 'message $index',
-            timestamp: now.add(Duration(seconds: index)),
-          ),
-      ];
-      final window = annotateConversationStorage(
-        Conversation(
-          id: 'pending-server-body',
-          title: 'Pending',
-          createdAt: now,
-          updatedAt: now,
-          messages: completeMessages.sublist(450),
+  test('unmaterialized durable history uses the authoritative loader, not its window', () async {
+    final localDatabase = AppDatabase(NativeDatabase.memory());
+    addTearDown(localDatabase.close);
+    final repository = ChatDatabaseRepository(
+      openWebUiDatabase: null,
+      directLocalDatabase: localDatabase,
+    );
+    final now = DateTime(2026);
+    final completeMessages = [
+      for (var index = 0; index < 500; index += 1)
+        ChatMessage(
+          id: 'm$index',
+          role: index.isEven ? 'user' : 'assistant',
+          content: 'message $index',
+          timestamp: now.add(Duration(seconds: index)),
         ),
-        ChatStorageKind.openWebUi,
-      );
-      var authoritativeReads = 0;
-      final reader = ChatHistoryReader(
-        repository: repository,
-        authoritativeLoader: (conversation) async {
-          authoritativeReads += 1;
-          return annotateConversationStorage(
-            conversation.copyWith(messages: completeMessages),
-            ChatStorageKind.openWebUi,
-          );
-        },
-        offload: (envelope) =>
-            Future.value(parseFullConversationModelWorker(envelope)),
-      );
+    ];
+    final window = annotateConversationStorage(
+      Conversation(
+        id: 'pending-server-body',
+        title: 'Pending',
+        createdAt: now,
+        updatedAt: now,
+        messages: completeMessages.sublist(450),
+      ),
+      ChatStorageKind.openWebUi,
+    );
+    var authoritativeReads = 0;
+    final reader = ChatHistoryReader(
+      repository: repository,
+      authoritativeLoader: (conversation) async {
+        authoritativeReads += 1;
+        return annotateConversationStorage(
+          conversation.copyWith(messages: completeMessages),
+          ChatStorageKind.openWebUi,
+        );
+      },
+      offload: (envelope) =>
+          Future.value(parseFullConversationModelWorker(envelope)),
+    );
 
-      final complete = await reader.readCompleteActiveBranch(
-        conversation: window,
-        visibleOverlay: [
-          ...window.messages.take(49),
-          window.messages.last.copyWith(content: 'unflushed tail'),
-        ],
-        ownerIsCurrent: () => true,
-      );
+    final complete = await reader.readCompleteActiveBranch(
+      conversation: window,
+      visibleOverlay: [
+        ...window.messages.take(49),
+        window.messages.last.copyWith(content: 'unflushed tail'),
+      ],
+      ownerIsCurrent: () => true,
+    );
 
-      check(authoritativeReads).equals(1);
-      check(complete.messages.length).equals(500);
-      check(complete.messages.last.content).equals('unflushed tail');
-    },
-  );
+    check(authoritativeReads).equals(1);
+    check(complete.messages.length).equals(500);
+    check(complete.messages.last.content).equals('unflushed tail');
+  });
 }
 
 Conversation _runtimeConversation() {

--- a/test/features/chat/services/clipboard_attachment_service_test.dart
+++ b/test/features/chat/services/clipboard_attachment_service_test.dart
@@ -305,9 +305,8 @@ void main() {
       check(fixture.pendingMarker.existsSync()).isFalse();
       check(fixture.dartOwnedMarker.existsSync()).isTrue();
       check(attachments).length.equals(1);
-      check(
-        attachments.single.file.path,
-      ).equals(fixture.item.resolveSymbolicLinksSync());
+      check(attachments.single.file.path)
+          .equals(fixture.item.resolveSymbolicLinksSync());
     });
 
     check(callbackCalls).equals(1);

--- a/test/features/chat/services/historical_message_regeneration_test.dart
+++ b/test/features/chat/services/historical_message_regeneration_test.dart
@@ -585,9 +585,8 @@ void main() {
 
         check(api.completionCalls).equals(1);
         final messages = container.read(chatMessagesProvider);
-        check(
-          messages.where((message) => message.role == 'assistant').length,
-        ).equals(2);
+        check(messages.where((message) => message.role == 'assistant').length)
+            .equals(2);
         check(messages.last.content).equals('Regenerated answer');
       },
     );
@@ -644,18 +643,15 @@ void main() {
         check(api.settingsCalls).equals(2);
 
         settingsGate.complete();
-        await Future.wait([
-          regeneration,
-          replacementRegeneration,
-        ]).timeout(const Duration(seconds: 1));
+        await Future.wait([regeneration, replacementRegeneration])
+            .timeout(const Duration(seconds: 1));
         await _flushAsyncWork();
 
         // Only the replacement operation can submit. The stale operation was
         // displaced before its await resumed and cannot reacquire A by id.
         check(api.completionCalls).equals(1);
-        check(
-          container.read(chatMessagesProvider).last.content,
-        ).equals('Regenerated answer');
+        check(container.read(chatMessagesProvider).last.content)
+            .equals('Regenerated answer');
       },
     );
 
@@ -817,18 +813,17 @@ void main() {
         final expectedOwnedMetadata = Map<String, dynamic>.from(
           ownedBefore.metadata!,
         )..remove('conduitOpenWebUiRegenerationAttemptId');
-        check(
-          ownedAfter.metadata,
-        ).isA<Map<String, dynamic>>().deepEquals(expectedOwnedMetadata);
-        check(
-          ownedAfter.copyWith(metadata: ownedBefore.metadata),
-        ).equals(ownedBefore);
+        check(ownedAfter.metadata)
+            .isA<Map<String, dynamic>>()
+            .deepEquals(expectedOwnedMetadata);
+        check(ownedAfter.copyWith(metadata: ownedBefore.metadata))
+            .equals(ownedBefore);
         check(ownedAfter.error).isNull();
         check(messages.last).equals(newer);
         check(messages.last.error).isNull();
-        check(messages.last.metadata).isA<Map<String, dynamic>>().deepEquals(
-          const <String, dynamic>{'sentinel': 'newer'},
-        );
+        check(messages.last.metadata)
+            .isA<Map<String, dynamic>>()
+            .deepEquals(const <String, dynamic>{'sentinel': 'newer'});
       },
     );
 
@@ -917,9 +912,8 @@ void main() {
 
         check(api.completionCalls).equals(1);
         check(api.lastConversationId).equals('remote-conv-remap');
-        check(
-          container.read(activeConversationProvider)?.id,
-        ).equals('remote-conv-remap');
+        check(container.read(activeConversationProvider)?.id)
+            .equals('remote-conv-remap');
       },
     );
 
@@ -1077,9 +1071,8 @@ void main() {
         await _flushAsyncWork();
 
         check(api.completionCalls).equals(1);
-        check(
-          api.lastMessages.map((message) => message['role']).toList(),
-        ).deepEquals(['user']);
+        check(api.lastMessages.map((message) => message['role']).toList())
+            .deepEquals(['user']);
         check(api.lastMessages.single['content']).equals('First prompt');
       },
     );
@@ -1107,9 +1100,8 @@ void main() {
 
         var messages = container.read(chatMessagesProvider);
         final firstReplay = messages.last;
-        check(
-          firstReplay.versions.map((version) => version.id).toList(),
-        ).deepEquals(['a1']);
+        check(firstReplay.versions.map((version) => version.id).toList())
+            .deepEquals(['a1']);
 
         await regenerateHistoricalMessageById(container, firstReplay.id);
         await _flushAsyncWork();
@@ -1117,12 +1109,10 @@ void main() {
         messages = container.read(chatMessagesProvider);
         final secondReplay = messages.last;
         check(secondReplay.content).equals('Regenerated answer');
-        check(
-          secondReplay.versions.map((version) => version.id).toList(),
-        ).deepEquals(['a1', firstReplay.id]);
-        check(
-          secondReplay.versions.map((version) => version.content).toList(),
-        ).deepEquals(['First answer', 'Regenerated answer']);
+        check(secondReplay.versions.map((version) => version.id).toList())
+            .deepEquals(['a1', firstReplay.id]);
+        check(secondReplay.versions.map((version) => version.content).toList())
+            .deepEquals(['First answer', 'Regenerated answer']);
       },
     );
   });

--- a/test/features/chat/services/ios_native_paste_service_test.dart
+++ b/test/features/chat/services/ios_native_paste_service_test.dart
@@ -300,9 +300,8 @@ void main() {
       ],
     });
 
-    check(
-      (platformPayload as IosNativeImagePaste).deliveryId,
-    ).equals(_deliveryId);
+    check((platformPayload as IosNativeImagePaste).deliveryId)
+        .equals(_deliveryId);
     check((mapPayload as IosNativeImagePaste).deliveryId).equals(_deliveryId);
   });
 }

--- a/test/features/chat/services/request_completion_runner_test.dart
+++ b/test/features/chat/services/request_completion_runner_test.dart
@@ -133,9 +133,8 @@ void main() {
     );
     container; // silence unused.
 
-    await check(
-      runner.run(chatId: chatId, payload: payload('asst-1')),
-    ).throws<CompletionBusyException>();
+    await check(runner.run(chatId: chatId, payload: payload('asst-1')))
+        .throws<CompletionBusyException>();
   });
 
   test(
@@ -205,9 +204,8 @@ void main() {
       ),
     ]);
 
-    await check(
-      runner.run(chatId: chatId, payload: payload('asst-own')),
-    ).throws<StateError>();
+    await check(runner.run(chatId: chatId, payload: payload('asst-own')))
+        .throws<StateError>();
   });
 
   test('defers when no active database is attached', () async {
@@ -278,9 +276,8 @@ void main() {
 
       await runner.run(chatId: chatId, payload: payload('asst-headless'));
 
-      check(
-        container.read(activeConversationProvider)?.id,
-      ).equals('a-different-chat');
+      check(container.read(activeConversationProvider)?.id)
+          .equals('a-different-chat');
     },
   );
 
@@ -306,9 +303,8 @@ void main() {
     );
     container;
 
-    await check(
-      runner.run(chatId: chatId, payload: payload('asst-partial')),
-    ).throws<StateError>();
+    await check(runner.run(chatId: chatId, payload: payload('asst-partial')))
+        .throws<StateError>();
   });
 
   test('returns early when the chat row vanished (delete won the race)', () async {
@@ -397,9 +393,8 @@ void main() {
     ).throws<StateError>(); // "runHeadlessCompletion requires an API service"
 
     // The user's active conversation is untouched (Option B: no yank).
-    check(
-      container.read(activeConversationProvider)?.id,
-    ).equals('a-different-chat');
+    check(container.read(activeConversationProvider)?.id)
+        .equals('a-different-chat');
   });
 
   test(
@@ -413,108 +408,103 @@ void main() {
         active: null,
       );
 
-      await check(
-        runner.run(chatId: chatId, payload: payload('asst-5')),
-      ).throws<StateError>();
+      await check(runner.run(chatId: chatId, payload: payload('asst-5')))
+          .throws<StateError>();
       // Headless never sets an active conversation.
       check(container.read(activeConversationProvider)).isNull();
     },
   );
 
-  test(
-    'DB await followed by a colliding direct-local active chat chooses headless',
-    () async {
-      const chatId = 'storage-collision';
-      const assistantId = 'shared-assistant';
-      await seedChat(chatId);
-      await seedMessage(chatId, assistantId, '');
+  test('DB await followed by a colliding direct-local active chat chooses headless', () async {
+    const chatId = 'storage-collision';
+    const assistantId = 'shared-assistant';
+    await seedChat(chatId);
+    await seedMessage(chatId, assistantId, '');
 
-      final (:container, :runner) = makeRunner(
+    final (:container, :runner) = makeRunner(
+      isStreaming: true,
+      active: conv(chatId),
+    );
+    final aMessages = <ChatMessage>[
+      ChatMessage(
+        id: 'user-a',
+        role: 'user',
+        content: 'A',
+        timestamp: DateTime.utc(2026, 7, 13),
+      ),
+      ChatMessage(
+        id: assistantId,
+        role: 'assistant',
+        content: '',
+        timestamp: DateTime.utc(2026, 7, 13, 0, 0, 1),
         isStreaming: true,
-        active: conv(chatId),
-      );
-      final aMessages = <ChatMessage>[
-        ChatMessage(
-          id: 'user-a',
-          role: 'user',
-          content: 'A',
-          timestamp: DateTime.utc(2026, 7, 13),
-        ),
-        ChatMessage(
-          id: assistantId,
-          role: 'assistant',
-          content: '',
-          timestamp: DateTime.utc(2026, 7, 13, 0, 0, 1),
-          isStreaming: true,
-        ),
-      ];
-      container.read(chatMessagesProvider.notifier).setMessages(aMessages);
+      ),
+    ];
+    container.read(chatMessagesProvider.notifier).setMessages(aMessages);
 
-      final transactionEntered = Completer<void>();
-      final releaseTransaction = Completer<void>();
-      final transaction = db.transaction(() async {
-        transactionEntered.complete();
-        await releaseTransaction.future;
-      });
-      await transactionEntered.future;
+    final transactionEntered = Completer<void>();
+    final releaseTransaction = Completer<void>();
+    final transaction = db.transaction(() async {
+      transactionEntered.complete();
+      await releaseTransaction.future;
+    });
+    await transactionEntered.future;
 
-      final completion = runner.run(
-        chatId: chatId,
-        payload: payload(assistantId),
-      );
-      final expectation = expectLater(
-        completion,
-        throwsA(
-          isA<StateError>().having(
-            (error) => error.message,
-            'message',
-            contains('runHeadlessCompletion'),
-          ),
+    final completion = runner.run(
+      chatId: chatId,
+      payload: payload(assistantId),
+    );
+    final expectation = expectLater(
+      completion,
+      throwsA(
+        isA<StateError>().having(
+          (error) => error.message,
+          'message',
+          contains('runHeadlessCompletion'),
         ),
-      );
+      ),
+    );
 
-      final bMessages = <ChatMessage>[
-        ChatMessage(
-          id: 'user-b',
-          role: 'user',
-          content: 'B must stay intact',
-          timestamp: DateTime.utc(2026, 7, 13),
-        ),
-        ChatMessage(
-          id: assistantId,
-          role: 'assistant',
-          content: 'B streaming bytes',
-          timestamp: DateTime.utc(2026, 7, 13, 0, 0, 1),
-          isStreaming: true,
-        ),
-      ];
-      final directB = withChatStorageProvenance(
-        conv(chatId).copyWith(messages: bMessages),
-        ChatStorageKind.directLocal,
-      );
-      container.read(activeConversationProvider.notifier).set(directB);
-      container.read(chatMessagesProvider.notifier).setMessages(bMessages);
-      final bSnapshot = jsonEncode(
-        bMessages.map((message) => message.toJson()).toList(),
-      );
+    final bMessages = <ChatMessage>[
+      ChatMessage(
+        id: 'user-b',
+        role: 'user',
+        content: 'B must stay intact',
+        timestamp: DateTime.utc(2026, 7, 13),
+      ),
+      ChatMessage(
+        id: assistantId,
+        role: 'assistant',
+        content: 'B streaming bytes',
+        timestamp: DateTime.utc(2026, 7, 13, 0, 0, 1),
+        isStreaming: true,
+      ),
+    ];
+    final directB = withChatStorageProvenance(
+      conv(chatId).copyWith(messages: bMessages),
+      ChatStorageKind.directLocal,
+    );
+    container.read(activeConversationProvider.notifier).set(directB);
+    container.read(chatMessagesProvider.notifier).setMessages(bMessages);
+    final bSnapshot = jsonEncode(
+      bMessages.map((message) => message.toJson()).toList(),
+    );
 
-      releaseTransaction.complete();
-      await transaction;
-      await expectation;
+    releaseTransaction.complete();
+    await transaction;
+    await expectation;
 
-      check(
-        jsonEncode(
-          container
-              .read(chatMessagesProvider)
-              .map((message) => message.toJson())
-              .toList(),
-        ),
-      ).equals(bSnapshot);
-      check(
-        chatStorageKindOf(container.read(activeConversationProvider)),
-      ).equals(ChatStorageKind.directLocal);
-    },
-  );
+    check(
+      jsonEncode(
+        container
+            .read(chatMessagesProvider)
+            .map((message) => message.toJson())
+            .toList(),
+      ),
+    ).equals(bSnapshot);
+    check(chatStorageKindOf(container.read(activeConversationProvider)))
+        .equals(ChatStorageKind.directLocal);
+  });
 }
 
 class _SeededActive extends ActiveConversationNotifier {

--- a/test/features/chat/utils/message_targeting_test.dart
+++ b/test/features/chat/utils/message_targeting_test.dart
@@ -63,9 +63,8 @@ void main() {
         includeTarget: true,
       );
 
-      check(
-        truncated.map((message) => message.id).toList(),
-      ).deepEquals(['u1', 'a1', 'u2', 'a2']);
+      check(truncated.map((message) => message.id).toList())
+          .deepEquals(['u1', 'a1', 'u2', 'a2']);
     });
 
     test('drops the target when includeTarget is false', () {
@@ -75,9 +74,8 @@ void main() {
         includeTarget: false,
       );
 
-      check(
-        truncated.map((message) => message.id).toList(),
-      ).deepEquals(['u1', 'a1']);
+      check(truncated.map((message) => message.id).toList())
+          .deepEquals(['u1', 'a1']);
     });
   });
 }

--- a/test/features/chat/views/chat_page_layout_metadata_test.dart
+++ b/test/features/chat/views/chat_page_layout_metadata_test.dart
@@ -21,11 +21,6 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
-  test('message cache extent is stable across streaming transitions', () {
-    check(debugChatMessageScrollCachePixels(streaming: false)).equals(600);
-    check(debugChatMessageScrollCachePixels(streaming: true)).equals(600);
-  });
-
   testWidgets(
     'assistant row state survives the live-tail to history transition',
     (tester) async {

--- a/test/features/chat/views/chat_page_layout_metadata_test.dart
+++ b/test/features/chat/views/chat_page_layout_metadata_test.dart
@@ -21,9 +21,9 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
-  test('message cache shrinks only while streaming', () {
+  test('message cache extent is stable across streaming transitions', () {
     check(debugChatMessageScrollCachePixels(streaming: false)).equals(600);
-    check(debugChatMessageScrollCachePixels(streaming: true)).equals(120);
+    check(debugChatMessageScrollCachePixels(streaming: true)).equals(600);
   });
 
   testWidgets(

--- a/test/features/chat/views/chat_timeline_render_model_test.dart
+++ b/test/features/chat/views/chat_timeline_render_model_test.dart
@@ -32,9 +32,8 @@ void main() {
     expect(timeline.tailAssistantSourceIndex, 1);
     expect(timeline.tailAssistantPhase, ChatTurnPhase.completed);
     expect(timeline.runningFooterHost, isNull);
-    check(
-      timeline.listIndexByMessageId,
-    ).deepEquals({'user-1': 0, 'assistant-1': 1});
+    check(timeline.listIndexByMessageId)
+        .deepEquals({'user-1': 0, 'assistant-1': 1});
     check(timeline.listItemCount).equals(2);
     check(timeline.messageIds).deepEquals(['user-1', 'assistant-1']);
     check(timeline.sourceIndexByRenderIndex).deepEquals([0, 1]);
@@ -72,9 +71,8 @@ void main() {
     expect(timeline.tailAssistantSourceIndex, 1);
     expect(timeline.tailAssistantPhase, ChatTurnPhase.running);
     expect(timeline.runningFooterHost?.messageId, 'assistant-live');
-    check(
-      timeline.listIndexByMessageId,
-    ).deepEquals({'user-1': 0, 'assistant-live': 1});
+    check(timeline.listIndexByMessageId)
+        .deepEquals({'user-1': 0, 'assistant-live': 1});
     check(timeline.listItemCount).equals(2);
     check(timeline.tailAssistantRenderIndex).equals(1);
   });
@@ -117,9 +115,8 @@ void main() {
         ),
       ]);
       check(tailDuplicate.messageIds).deepEquals(['duplicate', 'distinct']);
-      check(
-        tailDuplicate.listIndexByMessageId,
-      ).deepEquals({'duplicate': 0, 'distinct': 1});
+      check(tailDuplicate.listIndexByMessageId)
+          .deepEquals({'duplicate': 0, 'distinct': 1});
       check(tailDuplicate.sourceIndexByRenderIndex).deepEquals([0, 1]);
       check(tailDuplicate.listItemCount).equals(2);
       check(tailDuplicate.tailAssistant?.content).equals('Malformed live tail');
@@ -137,17 +134,14 @@ void main() {
           isStreaming: true,
         ),
       ]);
-      check(
-        uniqueTailAfterDuplicate.messageIds,
-      ).deepEquals(['duplicate', 'assistant-live']);
-      check(
-        uniqueTailAfterDuplicate.sourceIndexByRenderIndex,
-      ).deepEquals([0, 2]);
+      check(uniqueTailAfterDuplicate.messageIds)
+          .deepEquals(['duplicate', 'assistant-live']);
+      check(uniqueTailAfterDuplicate.sourceIndexByRenderIndex)
+          .deepEquals([0, 2]);
       check(uniqueTailAfterDuplicate.tailAssistantSourceIndex).equals(2);
       check(uniqueTailAfterDuplicate.tailAssistantRenderIndex).equals(1);
-      check(
-        uniqueTailAfterDuplicate.indexForMessageId('assistant-live'),
-      ).equals(1);
+      check(uniqueTailAfterDuplicate.indexForMessageId('assistant-live'))
+          .equals(1);
       check(uniqueTailAfterDuplicate.sourceIndexAtRenderIndex(1)).equals(2);
       check(uniqueTailAfterDuplicate.sourceIndexAtRenderIndex(-1)).isNull();
       check(uniqueTailAfterDuplicate.sourceIndexAtRenderIndex(2)).isNull();
@@ -289,12 +283,10 @@ void main() {
       'assistant-streaming',
       'user-final',
     ]);
-    check(
-      nonTailTimeline.listIndexByMessageId,
-    ).deepEquals({'assistant-streaming': 0, 'user-final': 1});
-    check(
-      nonTailTimeline.messageIds,
-    ).deepEquals(['assistant-streaming', 'user-final']);
+    check(nonTailTimeline.listIndexByMessageId)
+        .deepEquals({'assistant-streaming': 0, 'user-final': 1});
+    check(nonTailTimeline.messageIds)
+        .deepEquals(['assistant-streaming', 'user-final']);
   });
 
   test(
@@ -378,9 +370,8 @@ void main() {
       'user-1',
       'assistant-archived',
     ]);
-    check(
-      timeline.listIndexByMessageId,
-    ).deepEquals({'user-1': 0, 'assistant-archived': 1});
+    check(timeline.listIndexByMessageId)
+        .deepEquals({'user-1': 0, 'assistant-archived': 1});
   });
 
   test('fromMessages([]) yields an empty, tail-less timeline', () {

--- a/test/features/chat/voice_mode/chat_voice_mode_controller_test.dart
+++ b/test/features/chat/voice_mode/chat_voice_mode_controller_test.dart
@@ -68,9 +68,8 @@ void main() {
 
     await controller.cancelSpeaking();
 
-    check(
-      container.read(chatVoiceModeControllerProvider).phase,
-    ).equals(ChatVoiceModePhase.idle);
+    check(container.read(chatVoiceModeControllerProvider).phase)
+        .equals(ChatVoiceModePhase.idle);
     check(tts.stopStreamingCalls).equals(0);
     check(tts.stopCalls).equals(0);
   });
@@ -112,9 +111,8 @@ void main() {
 
     check(input.beginCalls).equals(1);
     check(audioSession.listeningCalls).equals(1);
-    check(
-      container.read(chatVoiceModeControllerProvider).phase,
-    ).equals(ChatVoiceModePhase.listening);
+    check(container.read(chatVoiceModeControllerProvider).phase)
+        .equals(ChatVoiceModePhase.listening);
     await container.read(chatVoiceModeControllerProvider.notifier).stop();
   });
 
@@ -222,12 +220,10 @@ void main() {
 
     check(await start).equals(ChatVoiceModeStartResult.cancelled);
     check(input.beginCalls).equals(0);
-    check(
-      container.read(chatVoiceModeControllerProvider).phase,
-    ).equals(ChatVoiceModePhase.ended);
-    check(
-      container.read(activeConversationProvider)?.id,
-    ).equals(conversation.id);
+    check(container.read(chatVoiceModeControllerProvider).phase)
+        .equals(ChatVoiceModePhase.ended);
+    check(container.read(activeConversationProvider)?.id)
+        .equals(conversation.id);
   });
 
   test('stop cancels a start waiting for voice readiness', () async {
@@ -262,13 +258,11 @@ void main() {
 
     await controller.stop().timeout(const Duration(seconds: 1));
 
-    check(
-      await start.timeout(const Duration(seconds: 1)),
-    ).equals(ChatVoiceModeStartResult.cancelled);
+    check(await start.timeout(const Duration(seconds: 1)))
+        .equals(ChatVoiceModeStartResult.cancelled);
     check(input.initializeCalls).equals(0);
-    check(
-      container.read(chatVoiceModeControllerProvider).phase,
-    ).equals(ChatVoiceModePhase.idle);
+    check(container.read(chatVoiceModeControllerProvider).phase)
+        .equals(ChatVoiceModePhase.idle);
   });
 
   test(
@@ -374,14 +368,12 @@ void main() {
     final stop = controller.stop();
     input.initializeGate!.complete(true);
 
-    check(
-      await start.timeout(const Duration(seconds: 1)),
-    ).equals(ChatVoiceModeStartResult.cancelled);
+    check(await start.timeout(const Duration(seconds: 1)))
+        .equals(ChatVoiceModeStartResult.cancelled);
     await stop.timeout(const Duration(seconds: 1));
     check(input.beginCalls).equals(0);
-    check(
-      container.read(chatVoiceModeControllerProvider).phase,
-    ).equals(ChatVoiceModePhase.ended);
+    check(container.read(chatVoiceModeControllerProvider).phase)
+        .equals(ChatVoiceModePhase.ended);
   });
 
   test('provider disposal cancels a start during initialization', () async {
@@ -417,65 +409,55 @@ void main() {
     container.dispose();
     input.initializeGate!.complete(true);
 
-    check(
-      await start.timeout(const Duration(seconds: 1)),
-    ).equals(ChatVoiceModeStartResult.cancelled);
+    check(await start.timeout(const Duration(seconds: 1)))
+        .equals(ChatVoiceModeStartResult.cancelled);
   });
 
-  test(
-    'new voice conversation preserves an admitted model after selection changes',
-    () async {
-      final input = _FakeVoiceInputService();
-      final container = ProviderContainer(
-        overrides: [
-          ...openWebUiStorageOpenOverrides(),
-          authNavigationStateProvider.overrideWithValue(
-            AuthNavigationState.authenticated,
-          ),
-          reviewerModeProvider.overrideWithValue(true),
-          selectedModelProvider.overrideWith(
-            () => _SeededSelectedModel(_fallbackModel),
-          ),
-          isManualModelSelectionProvider.overrideWith(
-            _ManualModelSelection.new,
-          ),
-          modelsProvider.overrideWith(
-            () => _FixedModels(const [_fallbackModel]),
-          ),
-          optimizedStorageServiceProvider.overrideWithValue(
-            _FakeOptimizedStorageService(),
-          ),
-          appSettingsProvider.overrideWithValue(
-            const AppSettings(defaultModel: 'fallback-model'),
-          ),
-          voiceInputServiceProvider.overrideWithValue(input),
-          textToSpeechServiceProvider.overrideWithValue(
-            _FakeTextToSpeechService(),
-          ),
-          callKitServiceProvider.overrideWithValue(
-            _UnavailableCallKitService(),
-          ),
-          chatVoiceModeBackgroundCoordinatorProvider.overrideWithValue(
-            _FakeChatVoiceBackgroundCoordinator(),
-          ),
-          chatVoiceAudioSessionCoordinatorProvider.overrideWithValue(
-            _FakeChatVoiceAudioSessionCoordinator(),
-          ),
-        ],
-      );
-      addTearDown(container.dispose);
+  test('new voice conversation preserves an admitted model after selection changes', () async {
+    final input = _FakeVoiceInputService();
+    final container = ProviderContainer(
+      overrides: [
+        ...openWebUiStorageOpenOverrides(),
+        authNavigationStateProvider.overrideWithValue(
+          AuthNavigationState.authenticated,
+        ),
+        reviewerModeProvider.overrideWithValue(true),
+        selectedModelProvider.overrideWith(
+          () => _SeededSelectedModel(_fallbackModel),
+        ),
+        isManualModelSelectionProvider.overrideWith(_ManualModelSelection.new),
+        modelsProvider.overrideWith(() => _FixedModels(const [_fallbackModel])),
+        optimizedStorageServiceProvider.overrideWithValue(
+          _FakeOptimizedStorageService(),
+        ),
+        appSettingsProvider.overrideWithValue(
+          const AppSettings(defaultModel: 'fallback-model'),
+        ),
+        voiceInputServiceProvider.overrideWithValue(input),
+        textToSpeechServiceProvider.overrideWithValue(
+          _FakeTextToSpeechService(),
+        ),
+        callKitServiceProvider.overrideWithValue(_UnavailableCallKitService()),
+        chatVoiceModeBackgroundCoordinatorProvider.overrideWithValue(
+          _FakeChatVoiceBackgroundCoordinator(),
+        ),
+        chatVoiceAudioSessionCoordinatorProvider.overrideWithValue(
+          _FakeChatVoiceAudioSessionCoordinator(),
+        ),
+      ],
+    );
+    addTearDown(container.dispose);
 
-      final result = await container
-          .read(chatVoiceModeControllerProvider.notifier)
-          .start(startNewConversation: true, admittedModel: _model);
-      final resolvedDefault = await container.read(defaultModelProvider.future);
+    final result = await container
+        .read(chatVoiceModeControllerProvider.notifier)
+        .start(startNewConversation: true, admittedModel: _model);
+    final resolvedDefault = await container.read(defaultModelProvider.future);
 
-      check(result).equals(ChatVoiceModeStartResult.started);
-      check(resolvedDefault).identicalTo(_model);
-      check(container.read(selectedModelProvider)).identicalTo(_model);
-      check(container.read(isManualModelSelectionProvider)).isTrue();
-    },
-  );
+    check(result).equals(ChatVoiceModeStartResult.started);
+    check(resolvedDefault).identicalTo(_model);
+    check(container.read(selectedModelProvider)).identicalTo(_model);
+    check(container.read(isManualModelSelectionProvider)).isTrue();
+  });
 
   test(
     'new voice conversation owns a transcript emitted during listener startup',
@@ -569,9 +551,8 @@ void main() {
       check(oldConversationTranscripts).isEmpty();
       final activeConversationId = activeConversation.id;
       check(activeConversationId).isNotNull();
-      check(
-        activeConversationId,
-      ).not((id) => id.equals(existingConversation.id));
+      check(activeConversationId)
+          .not((id) => id.equals(existingConversation.id));
     },
   );
 
@@ -614,9 +595,8 @@ void main() {
     final eligibility = container.read(voiceCallEligibilityProvider);
 
     check(eligibility.canStart).isFalse();
-    check(
-      eligibility.reason,
-    ).equals(VoiceCallEligibilityReason.authenticationRequired);
+    check(eligibility.reason)
+        .equals(VoiceCallEligibilityReason.authenticationRequired);
     check(eligibility.errorMessage).equals('Sign in to start a voice call.');
   });
 
@@ -644,9 +624,8 @@ void main() {
     final eligibility = container.read(voiceCallEligibilityProvider);
 
     check(eligibility.canStart).isFalse();
-    check(
-      eligibility.reason,
-    ).equals(VoiceCallEligibilityReason.backendUnavailable);
+    check(eligibility.reason)
+        .equals(VoiceCallEligibilityReason.backendUnavailable);
     check(eligibility.errorMessage).isNotNull().contains('Hermes');
   });
 
@@ -792,9 +771,8 @@ void main() {
           .timeout(const Duration(seconds: 1));
 
       check(eligibility.canStart).isFalse();
-      check(
-        eligibility.reason,
-      ).equals(VoiceCallEligibilityReason.modelRequired);
+      check(eligibility.reason)
+          .equals(VoiceCallEligibilityReason.modelRequired);
     },
   );
 
@@ -950,9 +928,8 @@ void main() {
 
       check(container.read(chatMessagesProvider)).isEmpty();
       check(tts.startedStreaming).isFalse();
-      check(
-        container.read(chatVoiceModeControllerProvider).phase,
-      ).equals(ChatVoiceModePhase.listening);
+      check(container.read(chatVoiceModeControllerProvider).phase)
+          .equals(ChatVoiceModePhase.listening);
     },
   );
 
@@ -1000,9 +977,8 @@ void main() {
             ChatVoiceModePhase.listening,
       );
 
-      check(
-        container.read(chatMessagesProvider).first.content,
-      ).equals('continuous final');
+      check(container.read(chatMessagesProvider).first.content)
+          .equals('continuous final');
       check(input.beginCalls).equals(1);
       check(input.stopCalls).equals(0);
       check(input.isListening).isTrue();
@@ -1140,9 +1116,8 @@ void main() {
           .where((message) => message.role == 'user')
           .map((message) => message.content)
           .toList();
-      check(
-        userMessages,
-      ).deepEquals(<String>['first assistant turn', 'second barge in turn']);
+      check(userMessages)
+          .deepEquals(<String>['first assistant turn', 'second barge in turn']);
       await _until(() => tts.finishedTexts.length == 2);
       check(tts.stopStreamingCalls).equals(1);
       check(tts.stopCalls).equals(1);
@@ -1211,64 +1186,59 @@ void main() {
     await controller.stop();
   });
 
-  test(
-    'holds a voice background lease and uses managed audio during CallKit session',
-    () async {
-      final input = _FakeVoiceInputService()
-        ..localSttAvailable = false
-        ..serverSttAvailable = true
-        ..sttPreference = SttPreference.serverOnly;
-      final tts = _FakeTextToSpeechService();
-      final callKit = _AvailableCallKitService();
-      final background = _FakeChatVoiceBackgroundCoordinator();
-      final audioSession = _FakeChatVoiceAudioSessionCoordinator();
-      final container = ProviderContainer(
-        overrides: [
-          ...openWebUiStorageOpenOverrides(),
-          authNavigationStateProvider.overrideWithValue(
-            AuthNavigationState.authenticated,
-          ),
-          selectedModelProvider.overrideWithValue(_model),
-          appSettingsProvider.overrideWithValue(
-            const AppSettings(sttPreference: SttPreference.serverOnly),
-          ),
-          reviewerModeProvider.overrideWithValue(true),
-          voiceInputServiceProvider.overrideWithValue(input),
-          textToSpeechServiceProvider.overrideWithValue(tts),
-          callKitServiceProvider.overrideWithValue(callKit),
-          chatVoiceModeBackgroundCoordinatorProvider.overrideWithValue(
-            background,
-          ),
-          chatVoiceAudioSessionCoordinatorProvider.overrideWithValue(
-            audioSession,
-          ),
-        ],
-      );
-      addTearDown(container.dispose);
-      addTearDown(callKit.dispose);
+  test('holds a voice background lease and uses managed audio during CallKit session', () async {
+    final input = _FakeVoiceInputService()
+      ..localSttAvailable = false
+      ..serverSttAvailable = true
+      ..sttPreference = SttPreference.serverOnly;
+    final tts = _FakeTextToSpeechService();
+    final callKit = _AvailableCallKitService();
+    final background = _FakeChatVoiceBackgroundCoordinator();
+    final audioSession = _FakeChatVoiceAudioSessionCoordinator();
+    final container = ProviderContainer(
+      overrides: [
+        ...openWebUiStorageOpenOverrides(),
+        authNavigationStateProvider.overrideWithValue(
+          AuthNavigationState.authenticated,
+        ),
+        selectedModelProvider.overrideWithValue(_model),
+        appSettingsProvider.overrideWithValue(
+          const AppSettings(sttPreference: SttPreference.serverOnly),
+        ),
+        reviewerModeProvider.overrideWithValue(true),
+        voiceInputServiceProvider.overrideWithValue(input),
+        textToSpeechServiceProvider.overrideWithValue(tts),
+        callKitServiceProvider.overrideWithValue(callKit),
+        chatVoiceModeBackgroundCoordinatorProvider.overrideWithValue(
+          background,
+        ),
+        chatVoiceAudioSessionCoordinatorProvider.overrideWithValue(
+          audioSession,
+        ),
+      ],
+    );
+    addTearDown(container.dispose);
+    addTearDown(callKit.dispose);
 
-      final controller = container.read(
-        chatVoiceModeControllerProvider.notifier,
-      );
+    final controller = container.read(chatVoiceModeControllerProvider.notifier);
 
-      await controller.start(startNewConversation: false);
+    await controller.start(startNewConversation: false);
 
-      expect(background.started, hasLength(1));
-      expect(background.started.single.leaseId, startsWith('chat-voice-mode-'));
-      expect(background.started.single.requiresMicrophone, isTrue);
-      expect(background.externalAudioSessionOwners, contains(false));
-      expect(input.managedAudioFlags, <bool>[true]);
-      expect(audioSession.listeningCalls, 1);
-      await _until(() => callKit.connectedCallIds.contains('call-1'));
+    expect(background.started, hasLength(1));
+    expect(background.started.single.leaseId, startsWith('chat-voice-mode-'));
+    expect(background.started.single.requiresMicrophone, isTrue);
+    expect(background.externalAudioSessionOwners, contains(false));
+    expect(input.managedAudioFlags, <bool>[true]);
+    expect(audioSession.listeningCalls, 1);
+    await _until(() => callKit.connectedCallIds.contains('call-1'));
 
-      await controller.stop();
+    await controller.stop();
 
-      expect(background.stopped, <String>[background.started.single.leaseId]);
-      expect(callKit.endedCallIds, <String>['call-1']);
-      expect(background.externalAudioSessionOwners.last, isFalse);
-      expect(audioSession.deactivateCalls, 1);
-    },
-  );
+    expect(background.stopped, <String>[background.started.single.leaseId]);
+    expect(callKit.endedCallIds, <String>['call-1']);
+    expect(background.externalAudioSessionOwners.last, isFalse);
+    expect(audioSession.deactivateCalls, 1);
+  });
 
   test('pausing during sending defers assistant TTS until resume', () async {
     final input = _FakeVoiceInputService();
@@ -1375,9 +1345,8 @@ void main() {
       check(background.externalAudioSessionOwners.last).isFalse();
       check(audioSession.deactivateCalls).equals(1);
       check(callKit.endedCallIds).deepEquals(<String>['call-1']);
-      check(
-        container.read(chatVoiceModeControllerProvider).phase,
-      ).equals(ChatVoiceModePhase.ended);
+      check(container.read(chatVoiceModeControllerProvider).phase)
+          .equals(ChatVoiceModePhase.ended);
     },
   );
 
@@ -1495,9 +1464,8 @@ void main() {
     await stopFuture;
     await replacementStart;
 
-    check(
-      container.read(chatVoiceModeControllerProvider).phase,
-    ).equals(ChatVoiceModePhase.listening);
+    check(container.read(chatVoiceModeControllerProvider).phase)
+        .equals(ChatVoiceModePhase.listening);
     check(input.isListening).isTrue();
 
     await input.completeCurrent('replacement session turn');
@@ -1552,9 +1520,8 @@ void main() {
     staleInputGate.complete();
     await replacementStart;
 
-    check(
-      container.read(chatVoiceModeControllerProvider).phase,
-    ).equals(ChatVoiceModePhase.listening);
+    check(container.read(chatVoiceModeControllerProvider).phase)
+        .equals(ChatVoiceModePhase.listening);
     check(input.isListening).isTrue();
     await replacementController.stop();
   });
@@ -1604,12 +1571,11 @@ void main() {
 
     check(input.beginCalls).equals(1);
     check(input.isListening).isTrue();
-    check(
-      container.read(chatVoiceModeControllerProvider).phase,
-    ).equals(ChatVoiceModePhase.error);
-    check(
-      container.read(chatVoiceModeControllerProvider).errorMessage,
-    ).isNotNull().contains('timed out');
+    check(container.read(chatVoiceModeControllerProvider).phase)
+        .equals(ChatVoiceModePhase.error);
+    check(container.read(chatVoiceModeControllerProvider).errorMessage)
+        .isNotNull()
+        .contains('timed out');
 
     staleInputGate.complete();
     await _until(() => !input.isListening);
@@ -1617,9 +1583,8 @@ void main() {
     await Future<void>.delayed(const Duration(milliseconds: 20));
 
     check(input.beginCalls).equals(1);
-    check(
-      container.read(chatVoiceModeControllerProvider).phase,
-    ).equals(ChatVoiceModePhase.error);
+    check(container.read(chatVoiceModeControllerProvider).phase)
+        .equals(ChatVoiceModePhase.error);
 
     await replacementController
         .start(startNewConversation: false)
@@ -1627,9 +1592,8 @@ void main() {
 
     check(input.beginCalls).equals(2);
     check(input.isListening).isTrue();
-    check(
-      container.read(chatVoiceModeControllerProvider).phase,
-    ).equals(ChatVoiceModePhase.listening);
+    check(container.read(chatVoiceModeControllerProvider).phase)
+        .equals(ChatVoiceModePhase.listening);
     await replacementController.stop();
   });
 

--- a/test/features/chat/widgets/assistant_message_widget_footer_test.dart
+++ b/test/features/chat/widgets/assistant_message_widget_footer_test.dart
@@ -577,35 +577,27 @@ void main() {
     );
   });
 
-  testWidgets('pending-only finished statuses do not leave an empty gap', (
+  testWidgets('pending-only finished statuses keep the last row visible', (
     tester,
   ) async {
-    final baseline = ChatMessage(
-      id: 'assistant-baseline',
+    // Hiding the whole row at settle shifted the bottom-anchored layout by
+    // the row height and lost the only description of what the turn did;
+    // the last update stays visible (without the pending spinner) instead.
+    final pendingOnly = ChatMessage(
+      id: 'assistant-pending',
       role: 'assistant',
       content: 'Visible response body',
       timestamp: DateTime(2024, 1, 1),
-    );
-    final pendingOnly = baseline.copyWith(
-      id: 'assistant-pending',
       statusHistory: const [
         ChatStatusUpdate(description: 'Searching...', done: false),
       ],
     );
 
-    await tester.pumpWidget(_buildAssistantHarness(baseline));
-    await tester.pumpAndSettle();
-    final baselineDy = tester.getTopLeft(find.text('Visible response body')).dy;
-
     await tester.pumpWidget(_buildAssistantHarness(pendingOnly));
     await tester.pumpAndSettle();
 
-    expect(find.byType(StreamingStatusWidget), findsNothing);
-    expect(find.text('Searching...'), findsNothing);
-    expect(
-      tester.getTopLeft(find.text('Visible response body')).dy,
-      closeTo(baselineDy, 0.001),
-    );
+    expect(find.byType(StreamingStatusWidget), findsOneWidget);
+    expect(find.text('Searching...'), findsOneWidget);
   });
 
   testWidgets('finished nullable-done statuses remain visible', (tester) async {

--- a/test/features/chat/widgets/assistant_message_widget_image_test.dart
+++ b/test/features/chat/widgets/assistant_message_widget_image_test.dart
@@ -229,9 +229,8 @@ void main() {
       check(message.files).isNotNull();
       check(message.files!).length.equals(1);
       check(isImageFile(message.files!.first)).isTrue();
-      check(
-        getFileUrl(message.files!.first),
-      ).equals('https://example.com/gen1.png');
+      check(getFileUrl(message.files!.first))
+          .equals('https://example.com/gen1.png');
     });
 
     test('ChatMessage with multiple generated images', () {
@@ -396,9 +395,8 @@ void main() {
       // The original order within each group is preserved
       check(getFileUrl(imageFiles[0])).equals('https://example.com/gen1.png');
       check(getFileUrl(nonImageFiles[0])).equals('https://example.com/doc.pdf');
-      check(
-        getFileUrl(nonImageFiles[1]),
-      ).equals('https://example.com/readme.txt');
+      check(getFileUrl(nonImageFiles[1]))
+          .equals('https://example.com/readme.txt');
     });
   });
 }

--- a/test/features/chat/widgets/enhanced_image_attachment_cache_test.dart
+++ b/test/features/chat/widgets/enhanced_image_attachment_cache_test.dart
@@ -173,9 +173,8 @@ void main() {
   });
 
   test('SVG URL detection ignores fragments and inspects URI query data', () {
-    check(
-      imageAttachmentUrlIsSvg('https://example.test/icon.svg#dark-symbol'),
-    ).isTrue();
+    check(imageAttachmentUrlIsSvg('https://example.test/icon.svg#dark-symbol'))
+        .isTrue();
     check(
       imageAttachmentUrlIsSvg(
         'https://example.test/render?format=image/svg+xml#preview',
@@ -186,9 +185,8 @@ void main() {
         'https://example.test/render?format=image%2Fsvg%2Bxml#preview',
       ),
     ).isTrue();
-    check(
-      imageAttachmentUrlIsSvg('https://example.test/icon.png#fallback.svg'),
-    ).isFalse();
+    check(imageAttachmentUrlIsSvg('https://example.test/icon.png#fallback.svg'))
+        .isFalse();
   });
 
   test('core cache deduplicates concurrent loads for the same owner', () async {
@@ -300,9 +298,8 @@ void main() {
       releaseOldLoad.complete();
       await check(oldLoad).throws<StateError>();
 
-      check(
-        imageAttachmentCacheStore.read(attachmentId)!.bytes!.toList(),
-      ).deepEquals([9]);
+      check(imageAttachmentCacheStore.read(attachmentId)!.bytes!.toList())
+          .deepEquals([9]);
     },
   );
 
@@ -325,9 +322,8 @@ void main() {
       Uint8List.fromList(const [2]),
       scope: oldScope,
     );
-    check(
-      imageAttachmentCacheStore.read(attachmentId, scope: oldScope),
-    ).isNull();
+    check(imageAttachmentCacheStore.read(attachmentId, scope: oldScope))
+        .isNull();
 
     final newScope = ImageAttachmentCacheScope(
       api: null,
@@ -435,9 +431,8 @@ void main() {
     );
 
     check(debugHasDecodedImageAttachment(attachmentId, scope: scopeA)).isTrue();
-    check(
-      debugHasDecodedImageAttachment(attachmentId, scope: scopeB),
-    ).isFalse();
+    check(debugHasDecodedImageAttachment(attachmentId, scope: scopeB))
+        .isFalse();
 
     debugSeedImageAttachmentError(
       attachmentId,
@@ -487,38 +482,29 @@ void main() {
     },
   );
 
-  test(
-    'cached resolved image data decodes without refetching through the api',
-    () async {
-      final workerManager = WorkerManager(maxConcurrentTasks: 1);
-      addTearDown(workerManager.dispose);
-      const attachmentId = 'cached-image';
-      final scope = ImageAttachmentCacheScope(
-        api: null,
-        authSessionEpoch: Object(),
-      );
-      const pngDataUrl =
-          'data:image/png;base64,'
-          'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+aF9sAAAAASUVORK5CYII=';
+  test('cached resolved image data decodes without refetching through the api', () async {
+    final workerManager = WorkerManager(maxConcurrentTasks: 1);
+    addTearDown(workerManager.dispose);
+    const attachmentId = 'cached-image';
+    final scope = ImageAttachmentCacheScope(
+      api: null,
+      authSessionEpoch: Object(),
+    );
+    const pngDataUrl =
+        'data:image/png;base64,'
+        'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+aF9sAAAAASUVORK5CYII=';
 
-      debugSeedResolvedImageAttachment(attachmentId, pngDataUrl, scope: scope);
-      expect(
-        debugHasDecodedImageAttachment(attachmentId, scope: scope),
-        isFalse,
-      );
+    debugSeedResolvedImageAttachment(attachmentId, pngDataUrl, scope: scope);
+    expect(debugHasDecodedImageAttachment(attachmentId, scope: scope), isFalse);
 
-      await debugDecodeCachedResolvedImageAttachment(
-        attachmentId: attachmentId,
-        workerManager: workerManager,
-        scope: scope,
-      );
+    await debugDecodeCachedResolvedImageAttachment(
+      attachmentId: attachmentId,
+      workerManager: workerManager,
+      scope: scope,
+    );
 
-      expect(
-        debugHasDecodedImageAttachment(attachmentId, scope: scope),
-        isTrue,
-      );
-    },
-  );
+    expect(debugHasDecodedImageAttachment(attachmentId, scope: scope), isTrue);
+  });
 
   test(
     'invalid cached image data maps to the localized decode error',
@@ -598,9 +584,8 @@ void main() {
         scope: scope,
       );
       check(error).isNotNull();
-      check(
-        debugHasImageAttachmentError('server-file-id', scope: scope),
-      ).isFalse();
+      check(debugHasImageAttachmentError('server-file-id', scope: scope))
+          .isFalse();
     }
     check(api.fileInfoAttempts).equals(2);
   });

--- a/test/features/chat/widgets/model_selector_sheet_test.dart
+++ b/test/features/chat/widgets/model_selector_sheet_test.dart
@@ -21,17 +21,15 @@ void main() {
     test('moves pinned models to the top in pinned order', () {
       final sorted = sortModelsWithPinnedOrder(models, ['charlie', 'alpha']);
 
-      check(
-        sorted.map((model) => model.id).toList(),
-      ).deepEquals(['charlie', 'alpha', 'bravo', 'delta']);
+      check(sorted.map((model) => model.id).toList())
+          .deepEquals(['charlie', 'alpha', 'bravo', 'delta']);
     });
 
     test('ignores stale pinned ids and keeps unpinned order stable', () {
       final sorted = sortModelsWithPinnedOrder(models, ['missing', 'delta']);
 
-      check(
-        sorted.map((model) => model.id).toList(),
-      ).deepEquals(['delta', 'alpha', 'bravo', 'charlie']);
+      check(sorted.map((model) => model.id).toList())
+          .deepEquals(['delta', 'alpha', 'bravo', 'charlie']);
     });
 
     test('deduplicates pinned ids using the first pinned position', () {
@@ -41,9 +39,8 @@ void main() {
         ' bravo ',
       ]);
 
-      check(
-        sorted.map((model) => model.id).toList(),
-      ).deepEquals(['bravo', 'charlie', 'alpha', 'delta']);
+      check(sorted.map((model) => model.id).toList())
+          .deepEquals(['bravo', 'charlie', 'alpha', 'delta']);
     });
   });
 
@@ -62,8 +59,7 @@ void main() {
   });
 
   test('custom server reasoning effort uses its configured level name', () {
-    check(
-      reasoningEffortLabelForTest(AppLocalizationsEn(), 'vendor_ultra'),
-    ).equals('vendor_ultra');
+    check(reasoningEffortLabelForTest(AppLocalizationsEn(), 'vendor_ultra'))
+        .equals('vendor_ultra');
   });
 }

--- a/test/features/chat/widgets/settle_height_test.dart
+++ b/test/features/chat/widgets/settle_height_test.dart
@@ -1,0 +1,178 @@
+import 'package:conduit/core/models/chat_message.dart';
+import 'package:conduit/core/services/settings_service.dart';
+import 'package:conduit/features/chat/providers/chat_providers.dart';
+import 'package:conduit/features/chat/providers/text_to_speech_provider.dart';
+import 'package:conduit/features/chat/widgets/assistant_message_widget.dart';
+import 'package:conduit/features/chat/widgets/streaming_turn_footer.dart';
+import 'package:conduit/l10n/app_localizations.dart';
+import 'package:conduit/l10n/conduit_localizations.dart';
+import 'package:conduit/shared/theme/app_theme.dart';
+import 'package:conduit/shared/theme/tweakcn_themes.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:material_ui/material_ui.dart';
+
+class _TestTextToSpeechController extends TextToSpeechController {
+  @override
+  TextToSpeechState build() => const TextToSpeechState();
+}
+
+Widget _harness({
+  required Widget child,
+  required bool isChatStreaming,
+  required double textScale,
+}) {
+  return ProviderScope(
+    overrides: [
+      appSettingsProvider.overrideWithValue(
+        const AppSettings(disableHapticsWhileStreaming: true),
+      ),
+      streamingHapticsEnabledProvider.overrideWithValue(false),
+      textToSpeechControllerProvider.overrideWith(
+        _TestTextToSpeechController.new,
+      ),
+      isChatStreamingProvider.overrideWithValue(isChatStreaming),
+    ],
+    child: MaterialApp(
+      theme: AppTheme.light(TweakcnThemes.t3Chat),
+      localizationsDelegates: conduitLocalizationsDelegates,
+      supportedLocales: AppLocalizations.supportedLocales,
+      builder: (context, c) => MediaQuery(
+        data: MediaQuery.of(context).copyWith(
+          disableAnimations: true,
+          textScaler: TextScaler.linear(textScale),
+        ),
+        child: c!,
+      ),
+      home: Scaffold(
+        body: Align(alignment: Alignment.topLeft, child: child),
+      ),
+    ),
+  );
+}
+
+Widget _card(ChatMessage message, {required bool isStreaming}) {
+  return AssistantMessageWidget(
+    message: message,
+    isStreaming: isStreaming,
+    showFollowUps: false,
+    animateOnMount: false,
+    modelName: message.model,
+    onCopy: () {},
+    onRegenerate: () {},
+    onDelete: () {},
+  );
+}
+
+void main() {
+  Future<void> probe(
+    WidgetTester tester,
+    String name, {
+    required double textScale,
+    List<ChatMessageVersion> versions = const [],
+    List<ChatSourceReference> sources = const [],
+    List<ChatStatusUpdate> statusHistory = const [],
+    String content = 'Hello, this is the answer text for the probe.',
+  }) async {
+    final streamingMsg = ChatMessage(
+      id: 'm-$name',
+      role: 'assistant',
+      content: content,
+      timestamp: DateTime(2026),
+      isStreaming: true,
+      model: 'gpt-test',
+      versions: versions,
+      sources: sources,
+      statusHistory: statusHistory,
+    );
+    final settledMsg = streamingMsg.copyWith(
+      isStreaming: false,
+      metadata: {'responseDone': true},
+    );
+
+    await tester.pumpWidget(
+      _harness(
+        isChatStreaming: true,
+        textScale: textScale,
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            _card(streamingMsg, isStreaming: true),
+            StreamingTurnFooter(message: streamingMsg),
+          ],
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+    final streamingTotal = tester.getSize(find.byType(Column).first).height;
+
+    await tester.pumpWidget(
+      _harness(
+        isChatStreaming: false,
+        textScale: textScale,
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [_card(settledMsg, isStreaming: false)],
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+    final settledTotal = tester.getSize(find.byType(Column).first).height;
+
+    expect(
+      settledTotal,
+      moreOrLessEquals(streamingTotal, epsilon: 0.5),
+      reason:
+          '$name (scale $textScale): the settle transition must be '
+          'extent-neutral — streaming card + typing indicator '
+          '($streamingTotal) vs settled card ($settledTotal)',
+    );
+  }
+
+  // The timeline swaps the typing-indicator footer (16 + 28 + 4) for the
+  // in-card action row (16 + 32) at settle. These cases must be
+  // extent-neutral so the bottom-anchored viewport does not jump; growth
+  // from settle-only UI (sources row, text-scaled chips) is animated by the
+  // AnimatedSize around the footer slot instead.
+  testWidgets('the streaming-to-settled swap is extent-neutral', (
+    tester,
+  ) async {
+    await probe(tester, 'plain-1.0', textScale: 1.0);
+    await probe(tester, 'plain-1.3', textScale: 1.3);
+    await probe(
+      tester,
+      'versions-1.0',
+      textScale: 1.0,
+      versions: [
+        ChatMessageVersion(id: 'v1', content: 'old', timestamp: DateTime(2026)),
+      ],
+    );
+    await probe(
+      tester,
+      'status-pending-1.0',
+      textScale: 1.0,
+      statusHistory: const [
+        ChatStatusUpdate(description: 'Searching the web', done: false),
+      ],
+    );
+    await probe(
+      tester,
+      'status-done-1.0',
+      textScale: 1.0,
+      statusHistory: const [
+        ChatStatusUpdate(description: 'Searched the web', done: true),
+      ],
+    );
+    await probe(
+      tester,
+      'reasoning-1.0',
+      textScale: 1.0,
+      content:
+          '<details type="reasoning" done="true" duration="3">\n'
+          '<summary>Thought for 3 seconds</summary>\n'
+          '> thinking\n'
+          '</details>\n'
+          'Hello, this is the answer text for the probe.',
+    );
+  });
+}

--- a/test/features/chat/widgets/streaming_status_widget_test.dart
+++ b/test/features/chat/widgets/streaming_status_widget_test.dart
@@ -110,18 +110,22 @@ void main() {
     expect(bottomSheetTitle.maxLines, isNull);
   });
 
-  testWidgets('hides incomplete status rows once streaming has finished', (
-    tester,
-  ) async {
-    await tester.pumpWidget(
-      buildHarness(const [
-        ChatStatusUpdate(description: 'Searching...', done: false),
-      ], isStreaming: false),
-    );
+  testWidgets(
+    'keeps the last incomplete status row when settling would empty the list',
+    (tester) async {
+      // Dropping the whole row at settle shifted the bottom-anchored layout
+      // by the row height and lost the only description of what the turn
+      // did; the last update stays visible instead.
+      await tester.pumpWidget(
+        buildHarness(const [
+          ChatStatusUpdate(description: 'Searching...', done: false),
+        ], isStreaming: false),
+      );
 
-    expect(find.text('Searching...'), findsNothing);
-    expect(find.byType(StreamingStatusWidget), findsOneWidget);
-  });
+      expect(find.text('Searching...'), findsOneWidget);
+      expect(find.byType(StreamingStatusWidget), findsOneWidget);
+    },
+  );
 
   testWidgets('keeps completed status rows visible after streaming finishes', (
     tester,

--- a/test/features/direct_connections/direct_adapters_test.dart
+++ b/test/features/direct_connections/direct_adapters_test.dart
@@ -781,12 +781,11 @@ void main() {
       'supports_max_tokens': false,
       'mandatory': true,
     });
-    check(
-      model('all-efforts').capabilities['reasoning'],
-    ).isA<Map>().deepEquals({'supported_efforts': null, 'mandatory': false});
-    check(
-      model('not-reasoning').capabilities.containsKey('reasoning'),
-    ).isFalse();
+    check(model('all-efforts').capabilities['reasoning'])
+        .isA<Map>()
+        .deepEquals({'supported_efforts': null, 'mandatory': false});
+    check(model('not-reasoning').capabilities.containsKey('reasoning'))
+        .isFalse();
     check(model('malformed').capabilities.containsKey('reasoning')).isFalse();
   });
 
@@ -927,9 +926,8 @@ void main() {
           .toList();
 
       check(http.requests).isEmpty();
-      check(
-        events.whereType<DirectStreamError>().single.message,
-      ).equals('OpenRouter reasoning configuration is invalid.');
+      check(events.whereType<DirectStreamError>().single.message)
+          .equals('OpenRouter reasoning configuration is invalid.');
     },
   );
 
@@ -1571,9 +1569,8 @@ void main() {
         .toList();
 
     check(http.requests).isEmpty();
-    check(
-      events.whereType<DirectStreamError>().single.message,
-    ).equals('The PDF attachment is invalid.');
+    check(events.whereType<DirectStreamError>().single.message)
+        .equals('The PDF attachment is invalid.');
   });
 
   test('OpenRouter deduplicates cumulative streamed extensions', () async {
@@ -3856,124 +3853,121 @@ void main() {
     expect(events.whereType<DirectStreamDone>(), hasLength(1));
   });
 
-  test(
-    'OpenAI adapter streams Responses API reasoning and owns routing keys',
-    () async {
-      final completed = {
-        'type': 'response.completed',
-        'response': {
-          'id': 'resp_1',
-          'object': 'response',
-          'created_at': 1,
-          'status': 'completed',
-          'output': <Object>[],
-          'usage': {'input_tokens': 2, 'output_tokens': 3, 'total_tokens': 5},
-        },
-      };
-      final http = _QueuedAdapter([
-        _Reply.stream([
-          utf8.encode(
-            'data: ${jsonEncode({'type': 'response.reasoning_summary_text.delta', 'output_index': 0, 'summary_index': 0, 'delta': 'summary '})}\n\n'
-            'data: ${jsonEncode({'type': 'response.reasoning.delta', 'delta': 'detail'})}\n\n'
-            'data: ${jsonEncode({'type': 'response.output_text.delta', 'output_index': 0, 'content_index': 0, 'delta': 'answer'})}\n\n'
-            'data: ${jsonEncode(completed)}\n\n',
+  test('OpenAI adapter streams Responses API reasoning and owns routing keys', () async {
+    final completed = {
+      'type': 'response.completed',
+      'response': {
+        'id': 'resp_1',
+        'object': 'response',
+        'created_at': 1,
+        'status': 'completed',
+        'output': <Object>[],
+        'usage': {'input_tokens': 2, 'output_tokens': 3, 'total_tokens': 5},
+      },
+    };
+    final http = _QueuedAdapter([
+      _Reply.stream([
+        utf8.encode(
+          'data: ${jsonEncode({'type': 'response.reasoning_summary_text.delta', 'output_index': 0, 'summary_index': 0, 'delta': 'summary '})}\n\n'
+          'data: ${jsonEncode({'type': 'response.reasoning.delta', 'delta': 'detail'})}\n\n'
+          'data: ${jsonEncode({'type': 'response.output_text.delta', 'output_index': 0, 'content_index': 0, 'delta': 'answer'})}\n\n'
+          'data: ${jsonEncode(completed)}\n\n',
+        ),
+      ], contentType: 'text/event-stream'),
+    ]);
+    final adapter = OpenAiCompatibleAdapter(
+      dioFactory: (_) => _dio(http),
+      closeClients: false,
+    );
+    final run = adapter.startCompletion(
+      _openAiProfile(
+        openAiApiMode: DirectOpenAiApiMode.responses,
+        apiKeyAuthMode: DirectApiKeyAuthMode.apiKeyHeader,
+        apiVersion: '2025-04-01-preview',
+      ),
+      DirectCompletionRequest(
+        remoteModelId: 'trusted-model',
+        messages: [
+          DirectChatMessage(
+            role: 'system',
+            parts: const [
+              DirectImagePart('data:image/png;base64,c3lzdGVtLW9ubHk='),
+            ],
           ),
-        ], contentType: 'text/event-stream'),
-      ]);
-      final adapter = OpenAiCompatibleAdapter(
-        dioFactory: (_) => _dio(http),
-        closeClients: false,
-      );
-      final run = adapter.startCompletion(
-        _openAiProfile(
-          openAiApiMode: DirectOpenAiApiMode.responses,
-          apiKeyAuthMode: DirectApiKeyAuthMode.apiKeyHeader,
-          apiVersion: '2025-04-01-preview',
-        ),
-        DirectCompletionRequest(
-          remoteModelId: 'trusted-model',
-          messages: [
-            DirectChatMessage(
-              role: 'system',
-              parts: const [
-                DirectImagePart('data:image/png;base64,c3lzdGVtLW9ubHk='),
-              ],
-            ),
-            DirectChatMessage(
-              role: 'assistant',
-              parts: const [
-                DirectImagePart('data:image/png;base64,YXNzaXN0YW50LW9ubHk='),
-              ],
-            ),
-            DirectChatMessage.text(role: 'system', text: 'be concise'),
-            DirectChatMessage.text(
-              role: 'observer',
-              text: 'compatible-provider extension role',
-            ),
-            DirectChatMessage(
-              role: 'assistant',
-              parts: const [
-                DirectTextPart('previous answer'),
-                DirectImagePart('data:image/png;base64,YXNzaXN0YW50'),
-              ],
-            ),
-            DirectChatMessage(
-              role: 'user',
-              parts: const [
-                DirectTextPart('describe'),
-                DirectImagePart('data:image/png;base64,aW1hZ2U='),
-              ],
-            ),
-          ],
-          parameters: const {
-            'model': 'forged-model',
-            'input': 'forged-input',
-            'stream': false,
-            'store': false,
-            'repeat_penalty': 1.1,
-          },
-        ),
-      );
+          DirectChatMessage(
+            role: 'assistant',
+            parts: const [
+              DirectImagePart('data:image/png;base64,YXNzaXN0YW50LW9ubHk='),
+            ],
+          ),
+          DirectChatMessage.text(role: 'system', text: 'be concise'),
+          DirectChatMessage.text(
+            role: 'observer',
+            text: 'compatible-provider extension role',
+          ),
+          DirectChatMessage(
+            role: 'assistant',
+            parts: const [
+              DirectTextPart('previous answer'),
+              DirectImagePart('data:image/png;base64,YXNzaXN0YW50'),
+            ],
+          ),
+          DirectChatMessage(
+            role: 'user',
+            parts: const [
+              DirectTextPart('describe'),
+              DirectImagePart('data:image/png;base64,aW1hZ2U='),
+            ],
+          ),
+        ],
+        parameters: const {
+          'model': 'forged-model',
+          'input': 'forged-input',
+          'stream': false,
+          'store': false,
+          'repeat_penalty': 1.1,
+        },
+      ),
+    );
 
-      final events = await run.events.toList();
+    final events = await run.events.toList();
 
-      expect(
-        events
-            .whereType<DirectReasoningDelta>()
-            .map((event) => event.content)
-            .join(),
-        'summary detail',
-      );
-      expect(events.whereType<DirectContentDelta>().single.content, 'answer');
-      expect(
-        events.whereType<DirectUsageUpdate>().single.usage['total_tokens'],
-        5,
-      );
-      expect(events.whereType<DirectStreamDone>(), hasLength(1));
+    expect(
+      events
+          .whereType<DirectReasoningDelta>()
+          .map((event) => event.content)
+          .join(),
+      'summary detail',
+    );
+    expect(events.whereType<DirectContentDelta>().single.content, 'answer');
+    expect(
+      events.whereType<DirectUsageUpdate>().single.usage['total_tokens'],
+      5,
+    );
+    expect(events.whereType<DirectStreamDone>(), hasLength(1));
 
-      final sent = http.requests.single;
-      expect(
-        sent.uri.toString(),
-        'https://api.test/v1/responses?api-version=2025-04-01-preview',
-      );
-      expect(sent.headers['api-key'], 'secret');
-      expect(sent.headers['Authorization'], isNull);
-      final body = sent.data as Map;
-      expect(body['model'], 'trusted-model');
-      expect(body['stream'], isTrue);
-      expect(body['store'], isFalse);
-      expect(body['repeat_penalty'], 1.1);
-      final input = body['input'] as List;
-      expect(input, hasLength(4));
-      expect((input.first as Map)['type'], 'message');
-      expect((input.first as Map)['role'], 'system');
-      expect((input[1] as Map)['role'], 'observer');
-      final assistantContent = (input[2] as Map)['content'] as List;
-      expect((assistantContent.single as Map)['type'], 'output_text');
-      final userContent = (input.last as Map)['content'] as List;
-      expect((userContent.last as Map)['type'], 'input_image');
-    },
-  );
+    final sent = http.requests.single;
+    expect(
+      sent.uri.toString(),
+      'https://api.test/v1/responses?api-version=2025-04-01-preview',
+    );
+    expect(sent.headers['api-key'], 'secret');
+    expect(sent.headers['Authorization'], isNull);
+    final body = sent.data as Map;
+    expect(body['model'], 'trusted-model');
+    expect(body['stream'], isTrue);
+    expect(body['store'], isFalse);
+    expect(body['repeat_penalty'], 1.1);
+    final input = body['input'] as List;
+    expect(input, hasLength(4));
+    expect((input.first as Map)['type'], 'message');
+    expect((input.first as Map)['role'], 'system');
+    expect((input[1] as Map)['role'], 'observer');
+    final assistantContent = (input[2] as Map)['content'] as List;
+    expect((assistantContent.single as Map)['type'], 'output_text');
+    final userContent = (input.last as Map)['content'] as List;
+    expect((userContent.last as Map)['type'], 'input_image');
+  });
 
   test(
     'OpenAI adapter normalizes a non-stream Responses API payload',
@@ -4257,150 +4251,144 @@ void main() {
     },
   );
 
-  test(
-    'Responses completion appends missing text and reasoning suffixes',
-    () async {
-      final completed = {
-        'type': 'response.completed',
-        'response': {
-          'id': 'resp_1',
-          'object': 'response',
-          'created_at': 1,
-          'status': 'completed',
-          'output': [
-            {
-              'type': 'reasoning',
-              'id': 'reason_1',
-              'summary': [
-                {'type': 'summary_text', 'text': 'complete-thought'},
-              ],
-            },
-            {
-              'type': 'message',
-              'id': 'msg_1',
-              'role': 'assistant',
-              'status': 'completed',
-              'content': [
-                {'type': 'output_text', 'text': 'recovered-answer'},
-              ],
-            },
-          ],
-        },
-      };
-      final http = _QueuedAdapter([
-        _Reply.stream([
-          utf8.encode(
-            'data: ${jsonEncode({'type': 'response.reasoning_summary_text.delta', 'output_index': 0, 'summary_index': 0, 'delta': 'complete-'})}\n\n'
-            'data: ${jsonEncode({'type': 'response.output_text.delta', 'output_index': 1, 'content_index': 0, 'delta': 'recovered-'})}\n\n'
-            'data: ${jsonEncode(completed)}\n\n',
+  test('Responses completion appends missing text and reasoning suffixes', () async {
+    final completed = {
+      'type': 'response.completed',
+      'response': {
+        'id': 'resp_1',
+        'object': 'response',
+        'created_at': 1,
+        'status': 'completed',
+        'output': [
+          {
+            'type': 'reasoning',
+            'id': 'reason_1',
+            'summary': [
+              {'type': 'summary_text', 'text': 'complete-thought'},
+            ],
+          },
+          {
+            'type': 'message',
+            'id': 'msg_1',
+            'role': 'assistant',
+            'status': 'completed',
+            'content': [
+              {'type': 'output_text', 'text': 'recovered-answer'},
+            ],
+          },
+        ],
+      },
+    };
+    final http = _QueuedAdapter([
+      _Reply.stream([
+        utf8.encode(
+          'data: ${jsonEncode({'type': 'response.reasoning_summary_text.delta', 'output_index': 0, 'summary_index': 0, 'delta': 'complete-'})}\n\n'
+          'data: ${jsonEncode({'type': 'response.output_text.delta', 'output_index': 1, 'content_index': 0, 'delta': 'recovered-'})}\n\n'
+          'data: ${jsonEncode(completed)}\n\n',
+        ),
+      ], contentType: 'text/event-stream'),
+    ]);
+    final adapter = OpenAiCompatibleAdapter(
+      dioFactory: (_) => _dio(http),
+      closeClients: false,
+    );
+
+    final events = await adapter
+        .startCompletion(
+          _openAiProfile(openAiApiMode: DirectOpenAiApiMode.responses),
+          DirectCompletionRequest(
+            remoteModelId: 'model',
+            messages: [DirectChatMessage.text(role: 'user', text: 'hello')],
           ),
-        ], contentType: 'text/event-stream'),
-      ]);
-      final adapter = OpenAiCompatibleAdapter(
-        dioFactory: (_) => _dio(http),
-        closeClients: false,
-      );
+        )
+        .events
+        .toList();
 
-      final events = await adapter
-          .startCompletion(
-            _openAiProfile(openAiApiMode: DirectOpenAiApiMode.responses),
-            DirectCompletionRequest(
-              remoteModelId: 'model',
-              messages: [DirectChatMessage.text(role: 'user', text: 'hello')],
-            ),
-          )
-          .events
-          .toList();
+    expect(
+      events
+          .whereType<DirectReasoningDelta>()
+          .map((event) => event.content)
+          .join(),
+      'complete-thought',
+    );
+    expect(
+      events
+          .whereType<DirectContentDelta>()
+          .map((event) => event.content)
+          .join(),
+      'recovered-answer',
+    );
+    expect(events.whereType<DirectStreamDone>(), hasLength(1));
+  });
 
-      expect(
-        events
-            .whereType<DirectReasoningDelta>()
-            .map((event) => event.content)
-            .join(),
-        'complete-thought',
-      );
-      expect(
-        events
-            .whereType<DirectContentDelta>()
-            .map((event) => event.content)
-            .join(),
-        'recovered-answer',
-      );
-      expect(events.whereType<DirectStreamDone>(), hasLength(1));
-    },
-  );
+  test('Responses completion keeps reasoning text and summary channels distinct', () async {
+    final completed = {
+      'type': 'response.completed',
+      'response': {
+        'id': 'resp_reasoning_channels',
+        'object': 'response',
+        'created_at': 1,
+        'status': 'completed',
+        'output': [
+          {
+            'type': 'reasoning',
+            'id': 'reason_channels',
+            'content': [
+              {'type': 'reasoning_text', 'text': 'detail-full'},
+            ],
+            'summary': [
+              {'type': 'summary_text', 'text': 'summary-full'},
+            ],
+          },
+          {
+            'type': 'message',
+            'id': 'msg_channels',
+            'role': 'assistant',
+            'status': 'completed',
+            'content': [
+              {'type': 'output_text', 'text': 'answer'},
+            ],
+          },
+        ],
+      },
+    };
+    final http = _QueuedAdapter([
+      _Reply.stream([
+        utf8.encode(
+          'data: ${jsonEncode({'type': 'response.reasoning_text.delta', 'output_index': 0, 'content_index': 0, 'delta': 'detail-full'})}\n\n'
+          'data: ${jsonEncode({'type': 'response.reasoning_summary_text.delta', 'output_index': 0, 'summary_index': 0, 'delta': 'summary-full'})}\n\n'
+          'data: ${jsonEncode({'type': 'response.output_text.delta', 'output_index': 1, 'content_index': 0, 'delta': 'answer'})}\n\n'
+          'data: ${jsonEncode(completed)}\n\n',
+        ),
+      ], contentType: 'text/event-stream'),
+    ]);
+    final adapter = OpenAiCompatibleAdapter(
+      dioFactory: (_) => _dio(http),
+      closeClients: false,
+    );
 
-  test(
-    'Responses completion keeps reasoning text and summary channels distinct',
-    () async {
-      final completed = {
-        'type': 'response.completed',
-        'response': {
-          'id': 'resp_reasoning_channels',
-          'object': 'response',
-          'created_at': 1,
-          'status': 'completed',
-          'output': [
-            {
-              'type': 'reasoning',
-              'id': 'reason_channels',
-              'content': [
-                {'type': 'reasoning_text', 'text': 'detail-full'},
-              ],
-              'summary': [
-                {'type': 'summary_text', 'text': 'summary-full'},
-              ],
-            },
-            {
-              'type': 'message',
-              'id': 'msg_channels',
-              'role': 'assistant',
-              'status': 'completed',
-              'content': [
-                {'type': 'output_text', 'text': 'answer'},
-              ],
-            },
-          ],
-        },
-      };
-      final http = _QueuedAdapter([
-        _Reply.stream([
-          utf8.encode(
-            'data: ${jsonEncode({'type': 'response.reasoning_text.delta', 'output_index': 0, 'content_index': 0, 'delta': 'detail-full'})}\n\n'
-            'data: ${jsonEncode({'type': 'response.reasoning_summary_text.delta', 'output_index': 0, 'summary_index': 0, 'delta': 'summary-full'})}\n\n'
-            'data: ${jsonEncode({'type': 'response.output_text.delta', 'output_index': 1, 'content_index': 0, 'delta': 'answer'})}\n\n'
-            'data: ${jsonEncode(completed)}\n\n',
+    final events = await adapter
+        .startCompletion(
+          _openAiProfile(openAiApiMode: DirectOpenAiApiMode.responses),
+          DirectCompletionRequest(
+            remoteModelId: 'model',
+            messages: [DirectChatMessage.text(role: 'user', text: 'hello')],
           ),
-        ], contentType: 'text/event-stream'),
-      ]);
-      final adapter = OpenAiCompatibleAdapter(
-        dioFactory: (_) => _dio(http),
-        closeClients: false,
-      );
+        )
+        .events
+        .toList();
 
-      final events = await adapter
-          .startCompletion(
-            _openAiProfile(openAiApiMode: DirectOpenAiApiMode.responses),
-            DirectCompletionRequest(
-              remoteModelId: 'model',
-              messages: [DirectChatMessage.text(role: 'user', text: 'hello')],
-            ),
-          )
-          .events
-          .toList();
-
-      expect(
-        events
-            .whereType<DirectReasoningDelta>()
-            .map((event) => event.content)
-            .toList(),
-        ['detail-full', 'summary-full'],
-      );
-      expect(events.whereType<DirectContentDelta>().single.content, 'answer');
-      expect(events.whereType<DirectStreamError>(), isEmpty);
-      expect(events.whereType<DirectStreamDone>(), hasLength(1));
-    },
-  );
+    expect(
+      events
+          .whereType<DirectReasoningDelta>()
+          .map((event) => event.content)
+          .toList(),
+      ['detail-full', 'summary-full'],
+    );
+    expect(events.whereType<DirectContentDelta>().single.content, 'answer');
+    expect(events.whereType<DirectStreamError>(), isEmpty);
+    expect(events.whereType<DirectStreamDone>(), hasLength(1));
+  });
 
   test('Responses completion preserves streamed reasoning item boundaries', () async {
     final completed = {

--- a/test/features/direct_connections/direct_chat_bridge_test.dart
+++ b/test/features/direct_connections/direct_chat_bridge_test.dart
@@ -328,10 +328,7 @@ void main() {
         final presentationContent = accumulator.render(done: true);
 
         expect(presentationContent, isNot(rawAssistantAnswer));
-        expect(
-          presentationContent,
-          contains('&lt;tag data=&quot;a&amp;b&quot;&gt;'),
-        );
+        expect(presentationContent, contains('&lt;tag data="a&amp;b"&gt;'));
         expect(
           presentationContent,
           contains('&amp;lt;existing-entity&amp;gt;'),
@@ -417,9 +414,8 @@ void main() {
 
       check(output).isNotNull();
       final item = output!.single;
-      check(
-        item['id'],
-      ).equals('$kConduitDirectReplayOutputIdPrefix${'assistant_one'}');
+      check(item['id'])
+          .equals('$kConduitDirectReplayOutputIdPrefix${'assistant_one'}');
       check(item['type']).equals('message');
       check(item['role']).equals('assistant');
       check(item['status']).equals('completed');
@@ -455,9 +451,9 @@ void main() {
         rawContent: '',
         useIncompleteAnswerSentinel: true,
       )!;
-      check(
-        incomplete.single['id'],
-      ).isA<String>().startsWith(kConduitDirectNoFinalReplayOutputIdPrefix);
+      check(incomplete.single['id'])
+          .isA<String>()
+          .startsWith(kConduitDirectNoFinalReplayOutputIdPrefix);
       check(
         parseConduitDirectReplayOutput(incomplete)?.isIncompleteAnswerSentinel,
       ).equals(true);
@@ -1291,16 +1287,15 @@ void main() {
           output.first['arguments'] as Map<String, dynamic>;
       final persistedFilters =
           persistedArguments['filters'] as Map<String, dynamic>;
-      check(
-        persistedFilters['domains'],
-      ).isA<List<dynamic>>().deepEquals(['ollama.com']);
+      check(persistedFilters['domains'])
+          .isA<List<dynamic>>()
+          .deepEquals(['ollama.com']);
       final persistedResult = output.last['output'] as Map<String, dynamic>;
       check(persistedResult['results']).isA<List<dynamic>>().deepEquals([
         {'title': 'Original'},
       ]);
-      check(
-        () => (persistedFilters['domains'] as List).add('another.example'),
-      ).throws<UnsupportedError>();
+      check(() => (persistedFilters['domains'] as List).add('another.example'))
+          .throws<UnsupportedError>();
       check(() => output.first['name'] = 'changed').throws<UnsupportedError>();
     });
 
@@ -1331,8 +1326,13 @@ void main() {
 
       expect(visible, accumulator.render(done: false));
       expect(visible, isNot(contains('<details type="reasoning"')));
-      expect(visible, contains('&lt;details type=&quot;reasoning&quot;'));
-      expect(accumulator.render(done: true), isNot(contains('done="false"')));
+      expect(visible, contains('&lt;details type="reasoning"'));
+      // The neutralized spoof TEXT may contain the literal substring
+      // done="false"; only a real (unescaped) element would be a spoof.
+      expect(
+        accumulator.render(done: true),
+        isNot(contains('<details type="reasoning" done="false"')),
+      );
     });
 
     test(

--- a/test/features/direct_connections/direct_connection_editor_controller_test.dart
+++ b/test/features/direct_connections/direct_connection_editor_controller_test.dart
@@ -52,9 +52,8 @@ void main() {
     check(result.profile).isNull();
     check(result.errors.name).equals(DirectDraftValidationIssue.nameRequired);
     check(result.errors.url).equals(DirectDraftValidationIssue.invalidUrl);
-    check(
-      result.errors.apiKey,
-    ).equals(DirectDraftValidationIssue.apiKeyRequired);
+    check(result.errors.apiKey)
+        .equals(DirectDraftValidationIssue.apiKeyRequired);
   });
 
   test('custom-header validation is typed and case-insensitive', () {
@@ -63,9 +62,8 @@ void main() {
 
     editor.form.headerName.text = 'Authorization';
     check(editor.form.addCustomHeader()).isFalse();
-    check(
-      editor.form.headerError?.issue,
-    ).equals(DirectHeaderValidationIssue.reservedName);
+    check(editor.form.headerError?.issue)
+        .equals(DirectHeaderValidationIssue.reservedName);
 
     editor.form.headerName.text = 'X-Tenant';
     editor.form.headerValue.text = 'one';
@@ -73,9 +71,8 @@ void main() {
     editor.form.headerName.text = 'x-tenant';
     editor.form.headerValue.text = 'two';
     check(editor.form.addCustomHeader()).isFalse();
-    check(
-      editor.form.headerError?.issue,
-    ).equals(DirectHeaderValidationIssue.duplicateName);
+    check(editor.form.headerError?.issue)
+        .equals(DirectHeaderValidationIssue.duplicateName);
   });
 
   test('custom-header validation publishes only through the owning form', () {
@@ -151,9 +148,8 @@ void main() {
         messages: _messages,
         confirmCredentialTransfer: (_) async => true,
       );
-      check(
-        editor.workflow.state.operation,
-      ).equals(DirectEditorOperation.testing);
+      check(editor.workflow.state.operation)
+          .equals(DirectEditorOperation.testing);
 
       final concurrentSave = await editor.workflow.save(
         messages: _messages,
@@ -189,9 +185,8 @@ void main() {
     check(target.savedProfile).isNotNull();
     check(target.savedProfile!.name).equals('My provider');
     check(target.savedIntent).isNotNull();
-    check(
-      target.savedIntent!.authentication,
-    ).equals(DirectAuthenticationMode.none);
+    check(target.savedIntent!.authentication)
+        .equals(DirectAuthenticationMode.none);
   });
 
   test('owner identity is captured once and includes auth epoch identity', () {
@@ -274,9 +269,8 @@ void main() {
         DirectConnectionProfileConflictException(currentProfiles: const []),
       );
 
-      check(
-        (await result).outcome,
-      ).equals(DirectEditorActionOutcome.unavailable);
+      check((await result).outcome)
+          .equals(DirectEditorActionOutcome.unavailable);
     },
   );
 }

--- a/test/features/direct_connections/direct_live_endpoint_test.dart
+++ b/test/features/direct_connections/direct_live_endpoint_test.dart
@@ -142,9 +142,8 @@ void main() {
         ),
         _ =>
           (chatModels..sort((left, right) {
-                final sizeOrder = _ollamaSmokeModelScore(
-                  left.id,
-                ).compareTo(_ollamaSmokeModelScore(right.id));
+                final sizeOrder = _ollamaSmokeModelScore(left.id)
+                    .compareTo(_ollamaSmokeModelScore(right.id));
                 return sizeOrder != 0 ? sizeOrder : left.id.compareTo(right.id);
               }))
               .first,
@@ -200,9 +199,8 @@ void main() {
               .where((candidate) => !_looksNonChatModel(candidate.id))
               .toList()
             ..sort((left, right) {
-              final sizeOrder = _ollamaSmokeModelScore(
-                left.id,
-              ).compareTo(_ollamaSmokeModelScore(right.id));
+              final sizeOrder = _ollamaSmokeModelScore(left.id)
+                  .compareTo(_ollamaSmokeModelScore(right.id));
               return sizeOrder != 0 ? sizeOrder : left.id.compareTo(right.id);
             });
       expect(chatModels, isNotEmpty);

--- a/test/features/direct_connections/direct_local_document_service_test.dart
+++ b/test/features/direct_connections/direct_local_document_service_test.dart
@@ -55,9 +55,8 @@ void main() {
       check(document.id).startsWith('ddoc_');
       check(document.sourceId).equals('direct-local:notes');
       check(document.extractedText).equals('Local Direct context');
-      check(
-        document.renderForPrompt(),
-      ).contains('<<<BEGIN_DIRECT_UNTRUSTED_REFERENCE_');
+      check(document.renderForPrompt())
+          .contains('<<<BEGIN_DIRECT_UNTRUSTED_REFERENCE_');
     });
 
     test('signed descriptors survive persistence and reject tampering', () {
@@ -100,17 +99,15 @@ void main() {
         name: 'notes.txt',
         mimeType: 'text/plain',
         size: 10,
-        extractedText:
-            'before DIRECT_UNTRUSTED_REFERENCE_DDOC_0123456789ABCDEF01234567 after',
+        extractedText: 'before DIRECT_UNTRUSTED_REFERENCE_DDOC_0123456789ABCDEF01234567 after',
         truncated: false,
       );
 
       final rendered = document.renderForPrompt();
       check(rendered).contains('DIRECT_UNTRUSTED_REFERENCE_[MARKER_REMOVED]');
       check(
-        RegExp(
-          'DIRECT_UNTRUSTED_REFERENCE_DDOC_0123456789ABCDEF01234567',
-        ).allMatches(rendered),
+        RegExp('DIRECT_UNTRUSTED_REFERENCE_DDOC_0123456789ABCDEF01234567')
+            .allMatches(rendered),
       ).length.equals(2);
     });
 

--- a/test/features/direct_connections/direct_profile_security_test.dart
+++ b/test/features/direct_connections/direct_profile_security_test.dart
@@ -13,28 +13,21 @@ void main() {
   test('OpenRouter identity requires its exact HTTPS API root', () {
     check(isOpenRouterApiBaseUrl(kOpenRouterApiBaseUrl)).isTrue();
     check(isOpenRouterApiBaseUrl('https://eu.openrouter.ai/api/v1/')).isTrue();
-    check(
-      isOpenRouterApiBaseUrl('https://openrouter.ai/api/v1/extra'),
-    ).isFalse();
+    check(isOpenRouterApiBaseUrl('https://openrouter.ai/api/v1/extra'))
+        .isFalse();
     check(isOpenRouterApiBaseUrl('http://openrouter.ai/api/v1')).isFalse();
-    check(
-      isOpenRouterApiBaseUrl('https://openrouter.example/api/v1'),
-    ).isFalse();
-    check(
-      isOpenRouterApiBaseUrl('https://openrouter.ai.evil.test/api/v1'),
-    ).isFalse();
-    check(
-      isOpenRouterApiBaseUrl('https://user:pass@openrouter.ai/api/v1'),
-    ).isFalse();
-    check(
-      isOpenRouterApiBaseUrl('https://openrouter.ai/api/v1?key=leak'),
-    ).isFalse();
-    check(
-      isOpenRouterApiBaseUrl('https://openrouter.ai/api/v1#fragment'),
-    ).isFalse();
-    check(
-      isOpenRouterApiBaseUrl('https://openrouter.ai:8443/api/v1'),
-    ).isFalse();
+    check(isOpenRouterApiBaseUrl('https://openrouter.example/api/v1'))
+        .isFalse();
+    check(isOpenRouterApiBaseUrl('https://openrouter.ai.evil.test/api/v1'))
+        .isFalse();
+    check(isOpenRouterApiBaseUrl('https://user:pass@openrouter.ai/api/v1'))
+        .isFalse();
+    check(isOpenRouterApiBaseUrl('https://openrouter.ai/api/v1?key=leak'))
+        .isFalse();
+    check(isOpenRouterApiBaseUrl('https://openrouter.ai/api/v1#fragment'))
+        .isFalse();
+    check(isOpenRouterApiBaseUrl('https://openrouter.ai:8443/api/v1'))
+        .isFalse();
   });
 
   group('DirectConnectionProfile security', () {
@@ -131,15 +124,15 @@ void main() {
         throwsFormatException,
       );
       expect(
-        () => _profile(
-          customHeaders: const {'authorization': 'Basic forged'},
-        ).validate(),
+        () =>
+            _profile(customHeaders: const {'authorization': 'Basic forged'})
+                .validate(),
         throwsFormatException,
       );
       expect(
-        () => _profile(
-          customHeaders: const {'X-Test': 'ok\r\nHost: bad'},
-        ).validate(),
+        () =>
+            _profile(customHeaders: const {'X-Test': 'ok\r\nHost: bad'})
+                .validate(),
         throwsFormatException,
       );
       expect(
@@ -185,9 +178,8 @@ void main() {
       }
 
       expect(
-        _profile(
-          customHeaders: const {'X-Test': 'visible ASCII\twith tab'},
-        ).validateOrNull(),
+        _profile(customHeaders: const {'X-Test': 'visible ASCII\twith tab'})
+            .validateOrNull(),
         isNull,
       );
     });

--- a/test/features/direct_connections/direct_providers_test.dart
+++ b/test/features/direct_connections/direct_providers_test.dart
@@ -472,9 +472,8 @@ void main() {
     () async {
       final old = _profile(apiKey: 'old-secret');
       FlutterSecureStorage.setMockInitialValues({
-        'direct_connection_profiles_v1': DirectConnectionProfilesDocument([
-          old,
-        ]).encode(),
+        'direct_connection_profiles_v1': DirectConnectionProfilesDocument([old])
+            .encode(),
       });
       final container = _container(_QueuedAdapter());
       addTearDown(container.dispose);

--- a/test/features/direct_connections/direct_storage_test.dart
+++ b/test/features/direct_connections/direct_storage_test.dart
@@ -91,12 +91,10 @@ void main() {
 
       check(loaded.ollamaKeepAliveFor('llama3.2:latest')).equals('30m');
       check(loaded.ollamaKeepAliveFor('qwen3:latest')).equals('-1');
-      check(
-        loaded.ollamaThinkingFor('gpt-oss:120b'),
-      ).equals(OllamaThinkingSetting.medium);
-      check(
-        loaded.ollamaThinkingFor('qwen3:latest'),
-      ).equals(OllamaThinkingSetting.high);
+      check(loaded.ollamaThinkingFor('gpt-oss:120b'))
+          .equals(OllamaThinkingSetting.medium);
+      check(loaded.ollamaThinkingFor('qwen3:latest'))
+          .equals(OllamaThinkingSetting.high);
       check(sameDirectConnectionProfileValues(profile, loaded)).isTrue();
     },
   );

--- a/test/features/direct_connections/openwebui_direct_connection_providers_test.dart
+++ b/test/features/direct_connections/openwebui_direct_connection_providers_test.dart
@@ -66,42 +66,39 @@ void main() {
     expect(second, first);
   });
 
-  test(
-    'effective profiles merge compatible server records and exclude unsupported auth',
-    () async {
-      final local = _localProfile();
-      final store = _storeFor(
-        _settings(
-          urls: const [
-            'https://compatible.example/v1',
-            'https://session.example/v1',
-          ],
-          authTypes: const ['bearer', 'session'],
-        ),
-      );
-      final container = _container(local: [local], store: store);
-      addTearDown(container.dispose);
+  test('effective profiles merge compatible server records and exclude unsupported auth', () async {
+    final local = _localProfile();
+    final store = _storeFor(
+      _settings(
+        urls: const [
+          'https://compatible.example/v1',
+          'https://session.example/v1',
+        ],
+        authTypes: const ['bearer', 'session'],
+      ),
+    );
+    final container = _container(local: [local], store: store);
+    addTearDown(container.dispose);
 
-      final snapshot = await container.read(
-        openWebUiDirectConnectionsProvider.future,
-      );
-      final effective = await container.read(
-        effectiveDirectConnectionProfilesFutureProvider.future,
-      );
+    final snapshot = await container.read(
+      openWebUiDirectConnectionsProvider.future,
+    );
+    final effective = await container.read(
+      effectiveDirectConnectionProfilesFutureProvider.future,
+    );
 
-      expect(snapshot, isNotNull);
-      expect(snapshot!.records, hasLength(2));
-      expect(
-        snapshot.records.last.compatibility,
-        OpenWebUiDirectConnectionCompatibility.unsupportedAuthentication,
-      );
-      expect(effective.map((profile) => profile.id), [
-        local.id,
-        snapshot.records.first.profile.id,
-      ]);
-      expect(effective, isNot(contains(snapshot.records.last.profile)));
-    },
-  );
+    expect(snapshot, isNotNull);
+    expect(snapshot!.records, hasLength(2));
+    expect(
+      snapshot.records.last.compatibility,
+      OpenWebUiDirectConnectionCompatibility.unsupportedAuthentication,
+    );
+    expect(effective.map((profile) => profile.id), [
+      local.id,
+      snapshot.records.first.profile.id,
+    ]);
+    expect(effective, isNot(contains(snapshot.records.last.profile)));
+  });
 
   test('server load errors fail open to healthy local profiles', () async {
     final local = _localProfile();

--- a/test/features/direct_connections/openwebui_direct_connection_store_test.dart
+++ b/test/features/direct_connections/openwebui_direct_connection_store_test.dart
@@ -58,17 +58,16 @@ void main() {
       check(first.profile.openAiApiMode).equals(DirectOpenAiApiMode.responses);
       check(first.profile.apiVersion).equals('2026-07-01');
       check(first.profile.modelIdPrefix).equals('corp');
-      check(
-        first.profile.manualModelIds,
-      ).deepEquals(['first-model', 'second-model']);
+      check(first.profile.manualModelIds)
+          .deepEquals(['first-model', 'second-model']);
       check(first.profile.tags).deepEquals(['plain', 'object']);
       check(first.profile.enabled).isFalse();
       check(first.profile.apiKey).equals('alpha-secret');
       check(first.profile.customHeaders).deepEquals({'X-Tenant': 'blue'});
       check(first.isCompatible).isTrue();
-      check(
-        first.rawConfig['futureConfig'],
-      ).isA<Map>().deepEquals({'nested': true});
+      check(first.rawConfig['futureConfig'])
+          .isA<Map>()
+          .deepEquals({'nested': true});
 
       check(second.compatibility).equals(
         OpenWebUiDirectConnectionCompatibility.unsupportedAuthentication,
@@ -81,9 +80,8 @@ void main() {
         serverId: 'private-server-id',
         accountId: 'different-account',
       ).decode(settings);
-      check(
-        otherOwner.records.first.profile.id,
-      ).not((it) => it.equals(first.profile.id));
+      check(otherOwner.records.first.profile.id)
+          .not((it) => it.equals(first.profile.id));
       check(first.profile.id).not((it) => it.contains('private-server-id'));
       check(first.profile.id).not((it) => it.contains('private-account-id'));
       check(first.profile.id).not((it) => it.contains('alpha-secret'));
@@ -92,9 +90,8 @@ void main() {
       check(first.toString()).not((it) => it.contains('https://alpha.test'));
       check(snapshot.toString()).not((it) => it.contains('alpha-secret'));
 
-      check(
-        () => (first.rawConfig['futureConfig'] as Map)['nested'] = false,
-      ).throws<UnsupportedError>();
+      check(() => (first.rawConfig['futureConfig'] as Map)['nested'] = false)
+          .throws<UnsupportedError>();
     });
 
     test('supports no-auth records without mapping their key', () {
@@ -172,9 +169,8 @@ void main() {
         ).decode(settings);
 
         check(duplicateIds[0]).not((it) => it.equals(duplicateIds[1]));
-        check(
-          after.records.map((record) => record.profile.id),
-        ).deepEquals(duplicateIds);
+        check(after.records.map((record) => record.profile.id))
+            .deepEquals(duplicateIds);
       },
     );
 
@@ -230,12 +226,10 @@ void main() {
             },
           });
 
-      check(
-        normalized.records.single.profile.id,
-      ).equals(before.records.single.profile.id);
-      check(
-        normalized.records.single.revision,
-      ).not((it) => it.equals(before.records.single.revision));
+      check(normalized.records.single.profile.id)
+          .equals(before.records.single.profile.id);
+      check(normalized.records.single.revision)
+          .not((it) => it.equals(before.records.single.revision));
     });
 
     test('keyed identity rotates for secret and semantic edits', () {
@@ -320,12 +314,10 @@ void main() {
         final before = decode(<String>['tenant-a-key', 'tenant-b-key']);
         final after = decode(<String>['tenant-b-key']);
 
-        check(
-          before.records.first.profile.id,
-        ).not((it) => it.equals(before.records.last.profile.id));
-        check(
-          after.records.single.profile.id,
-        ).equals(before.records.last.profile.id);
+        check(before.records.first.profile.id)
+            .not((it) => it.equals(before.records.last.profile.id));
+        check(after.records.single.profile.id)
+            .equals(before.records.last.profile.id);
       },
     );
 
@@ -345,9 +337,8 @@ void main() {
           });
 
       check(snapshot.records).length.equals(1);
-      check(
-        snapshot.records.single.compatibility,
-      ).equals(OpenWebUiDirectConnectionCompatibility.invalidProfile);
+      check(snapshot.records.single.compatibility)
+          .equals(OpenWebUiDirectConnectionCompatibility.invalidProfile);
       check(snapshot.compatibleProfiles).isEmpty();
     });
   });
@@ -401,20 +392,20 @@ void main() {
         check(server.readCount).equals(3);
         check(server.writeCount).equals(1);
         check(server.lastPayload!.keys).deepEquals(['rootField', 'ui']);
-        check(
-          server.lastPayload!['rootField'],
-        ).isA<Map>().deepEquals({'preserved': true});
-        check(
-          server.settings['rootField'],
-        ).isA<Map>().deepEquals({'preserved': true});
+        check(server.lastPayload!['rootField'])
+            .isA<Map>()
+            .deepEquals({'preserved': true});
+        check(server.settings['rootField'])
+            .isA<Map>()
+            .deepEquals({'preserved': true});
         final postedUi = server.lastPayload!['ui'] as Map<String, dynamic>;
         check(postedUi['theme']).equals('dark');
         check(postedUi['futureUi']).isA<Map>().deepEquals({'keep': true});
         final direct = postedUi['directConnections'] as Map<String, dynamic>;
         check(direct['futureDocumentField']).equals(42);
-        check(
-          direct['OPENAI_API_BASE_URLS'],
-        ).isA<List>().deepEquals(['https://new.test/openai/v1']);
+        check(direct['OPENAI_API_BASE_URLS'])
+            .isA<List>()
+            .deepEquals(['https://new.test/openai/v1']);
         check(direct['OPENAI_API_KEYS']).isA<List>().deepEquals(['new-secret']);
         final config = (direct['OPENAI_API_CONFIGS'] as Map)['0'] as Map;
         check(config['connection_type']).equals('external');
@@ -430,17 +421,15 @@ void main() {
           {'name': 'two'},
         ]);
 
-        check(
-          after.records.single.profile.baseUrl,
-        ).equals('https://new.test/openai/v1');
-        check(
-          after.records.single.profile.id,
-        ).not((it) => it.equals(record.profile.id));
+        check(after.records.single.profile.baseUrl)
+            .equals('https://new.test/openai/v1');
+        check(after.records.single.profile.id)
+            .not((it) => it.equals(record.profile.id));
         check(after.records.single.profile.name).equals('new.test · 1');
         check(after.records.single.profile.apiKey).equals('new-secret');
-        check(
-          after.records.single.rawConfig['futureConfig'],
-        ).isA<Map>().deepEquals({'keep': true});
+        check(after.records.single.rawConfig['futureConfig'])
+            .isA<Map>()
+            .deepEquals({'keep': true});
       },
     );
 
@@ -466,15 +455,12 @@ void main() {
       }
 
       check(server.writeCount).equals(0);
-      check(
-        conflict.currentSnapshot.records.single.profile.apiKey,
-      ).equals('winning-secret');
-      check(
-        conflict.currentSnapshot.records.single.profile.id,
-      ).not((it) => it.equals(stale.profile.id));
-      check(
-        conflict.currentSnapshot.records.single.revision,
-      ).not((it) => it.equals(stale.revision));
+      check(conflict.currentSnapshot.records.single.profile.apiKey)
+          .equals('winning-secret');
+      check(conflict.currentSnapshot.records.single.profile.id)
+          .not((it) => it.equals(stale.profile.id));
+      check(conflict.currentSnapshot.records.single.revision)
+          .not((it) => it.equals(stale.revision));
       for (final secret in <String>['first-secret', 'winning-secret']) {
         check(conflict.toString()).not((it) => it.contains(secret));
       }
@@ -500,9 +486,8 @@ void main() {
 
       final direct = after.ui['directConnections'] as Map;
       check(direct['OPENAI_API_KEYS']).isA<List>().deepEquals(['']);
-      check(
-        ((direct['OPENAI_API_CONFIGS'] as Map)['0'] as Map)['auth_type'],
-      ).equals('bearer');
+      check(((direct['OPENAI_API_CONFIGS'] as Map)['0'] as Map)['auth_type'])
+          .equals('bearer');
       check(
         ((direct['OPENAI_API_CONFIGS'] as Map)['0'] as Map).containsKey(
           'connection_type',
@@ -583,12 +568,12 @@ void main() {
         check(server.writeCount).equals(0);
         final direct =
             (server.settings['ui'] as Map)['directConnections'] as Map;
-        check(
-          direct['OPENAI_API_BASE_URLS'],
-        ).isA<List>().deepEquals(['https://session.test/v1']);
-        check(
-          direct['OPENAI_API_KEYS'],
-        ).isA<List>().deepEquals(['opaque-session-key']);
+        check(direct['OPENAI_API_BASE_URLS'])
+            .isA<List>()
+            .deepEquals(['https://session.test/v1']);
+        check(direct['OPENAI_API_KEYS'])
+            .isA<List>()
+            .deepEquals(['opaque-session-key']);
       },
     );
 
@@ -619,18 +604,17 @@ void main() {
         );
 
         final direct = after.ui['directConnections'] as Map;
-        check(
-          direct['OPENAI_API_BASE_URLS'],
-        ).isA<List>().deepEquals(['https://different.test/v1']);
-        check(
-          direct['OPENAI_API_KEYS'],
-        ).isA<List>().deepEquals([conversion.apiKey ?? '']);
-        check(
-          ((direct['OPENAI_API_CONFIGS'] as Map)['0'] as Map)['auth_type'],
-        ).equals(conversion.authType);
-        check(
-          ((direct['OPENAI_API_CONFIGS'] as Map)['0'] as Map)['future'],
-        ).isA<Map>().deepEquals({'preserved': true});
+        check(direct['OPENAI_API_BASE_URLS'])
+            .isA<List>()
+            .deepEquals(['https://different.test/v1']);
+        check(direct['OPENAI_API_KEYS'])
+            .isA<List>()
+            .deepEquals([conversion.apiKey ?? '']);
+        check(((direct['OPENAI_API_CONFIGS'] as Map)['0'] as Map)['auth_type'])
+            .equals(conversion.authType);
+        check(((direct['OPENAI_API_CONFIGS'] as Map)['0'] as Map)['future'])
+            .isA<Map>()
+            .deepEquals({'preserved': true});
       });
     }
 
@@ -654,13 +638,13 @@ void main() {
         );
 
         final direct = after.ui['directConnections'] as Map;
-        check(
-          direct['OPENAI_API_KEYS'],
-        ).isA<List>().deepEquals(['opaque-session-key']);
+        check(direct['OPENAI_API_KEYS'])
+            .isA<List>()
+            .deepEquals(['opaque-session-key']);
         check(after.records.single.authType).equals('session');
-        check(
-          ((direct['OPENAI_API_CONFIGS'] as Map)['0'] as Map)['future'],
-        ).isA<Map>().deepEquals({'preserved': true});
+        check(((direct['OPENAI_API_CONFIGS'] as Map)['0'] as Map)['future'])
+            .isA<Map>()
+            .deepEquals({'preserved': true});
       },
     );
 
@@ -725,23 +709,20 @@ void main() {
         check(server.writeCount).equals(1);
         final committedDirect =
             (server.settings['ui'] as Map)['directConnections'] as Map;
-        check(
-          committedDirect['OPENAI_API_BASE_URLS'],
-        ).isA<List>().deepEquals(['https://new.test/v1']);
-        check(
-          committedDirect['OPENAI_API_KEYS'],
-        ).isA<List>().deepEquals(['committed-secret']);
-        check(
-          uncertain.toString(),
-        ).not((it) => it.contains('committed-secret'));
-        check(
-          uncertain.toString(),
-        ).not((it) => it.contains('reflected-read-error'));
+        check(committedDirect['OPENAI_API_BASE_URLS'])
+            .isA<List>()
+            .deepEquals(['https://new.test/v1']);
+        check(committedDirect['OPENAI_API_KEYS'])
+            .isA<List>()
+            .deepEquals(['committed-secret']);
+        check(uncertain.toString())
+            .not((it) => it.contains('committed-secret'));
+        check(uncertain.toString())
+            .not((it) => it.contains('reflected-read-error'));
 
         final reloaded = await store.load();
-        check(
-          reloaded.records.single.profile.apiKey,
-        ).equals('committed-secret');
+        check(reloaded.records.single.profile.apiKey)
+            .equals('committed-secret');
       },
     );
 
@@ -772,17 +753,16 @@ void main() {
         apiKey: 'committed-secret',
       );
 
-      await check(
-        store.add(profile),
-      ).throws<OpenWebUiDirectConnectionCommitUncertainException>();
+      await check(store.add(profile))
+          .throws<OpenWebUiDirectConnectionCommitUncertainException>();
 
       final direct = (settings['ui'] as Map)['directConnections'] as Map;
-      check(
-        direct['OPENAI_API_BASE_URLS'],
-      ).isA<List>().deepEquals(<String>['https://new.test/v1']);
-      check(
-        direct['OPENAI_API_KEYS'],
-      ).isA<List>().deepEquals(<String>['committed-secret']);
+      check(direct['OPENAI_API_BASE_URLS'])
+          .isA<List>()
+          .deepEquals(<String>['https://new.test/v1']);
+      check(direct['OPENAI_API_KEYS'])
+          .isA<List>()
+          .deepEquals(<String>['committed-secret']);
     });
 
     test(
@@ -820,9 +800,9 @@ void main() {
         final after = await store.add(profile);
 
         final direct = after.ui['directConnections'] as Map;
-        check(
-          direct['OPENAI_API_KEYS'],
-        ).isA<List>().deepEquals(['key-a', '', 'key-c']);
+        check(direct['OPENAI_API_KEYS'])
+            .isA<List>()
+            .deepEquals(['key-a', '', 'key-c']);
         check(after.records[1].profile.apiKey).isNull();
         check(after.records[2].profile.apiKey).equals('key-c');
 
@@ -847,9 +827,9 @@ void main() {
 
         final afterExtraKey = await extraKeyStore.add(profile);
 
-        check(
-          (afterExtraKey.ui['directConnections'] as Map)['OPENAI_API_KEYS'],
-        ).isA<List>().deepEquals(['key-a', 'key-b', 'key-c']);
+        check((afterExtraKey.ui['directConnections'] as Map)['OPENAI_API_KEYS'])
+            .isA<List>()
+            .deepEquals(['key-a', 'key-b', 'key-c']);
       },
     );
 
@@ -885,12 +865,12 @@ void main() {
 
         final afterDelete = await store.delete(beforeDelete.records[1]);
         var direct = afterDelete.ui['directConnections'] as Map;
-        check(
-          direct['OPENAI_API_BASE_URLS'],
-        ).isA<List>().deepEquals(['https://a.test/v1', 'https://c.test/v1']);
-        check(
-          direct['OPENAI_API_KEYS'],
-        ).isA<List>().deepEquals(['key-a', 'key-c']);
+        check(direct['OPENAI_API_BASE_URLS'])
+            .isA<List>()
+            .deepEquals(['https://a.test/v1', 'https://c.test/v1']);
+        check(direct['OPENAI_API_KEYS'])
+            .isA<List>()
+            .deepEquals(['key-a', 'key-c']);
         check(direct['OPENAI_API_CONFIGS']).isA<Map>().deepEquals({
           '0': {'marker': 'a'},
           '1': {'marker': 'c'},
@@ -898,9 +878,8 @@ void main() {
         check(direct['documentExtra']).isA<bool>().isTrue();
         check(afterDelete.ui['unrelated']).equals('preserved');
         check(afterDelete.records[1].profile.name).equals('c.test · 2');
-        check(
-          afterDelete.records[1].profile.id,
-        ).equals(beforeDelete.records[2].profile.id);
+        check(afterDelete.records[1].profile.id)
+            .equals(beforeDelete.records[2].profile.id);
 
         final addedProfile = DirectConnectionProfile(
           id: 'temporary-local-form-id',
@@ -919,24 +898,23 @@ void main() {
           'https://c.test/v1',
           'https://d.test/v1',
         ]);
-        check(
-          direct['OPENAI_API_KEYS'],
-        ).isA<List>().deepEquals(['key-a', 'key-c', '']);
-        check((direct['OPENAI_API_CONFIGS'] as Map)['2']).isA<Map>().deepEquals(
-          {
-            'enable': true,
-            'tags': [
-              {'name': 'new'},
-            ],
-            'prefix_id': '',
-            'model_ids': <String>[],
-            'auth_type': 'none',
-            'connection_type': 'external',
-          },
-        );
-        check(
-          afterAdd.records.last.profile.id,
-        ).not((it) => it.equals(addedProfile.id));
+        check(direct['OPENAI_API_KEYS'])
+            .isA<List>()
+            .deepEquals(['key-a', 'key-c', '']);
+        check((direct['OPENAI_API_CONFIGS'] as Map)['2'])
+            .isA<Map>()
+            .deepEquals({
+              'enable': true,
+              'tags': [
+                {'name': 'new'},
+              ],
+              'prefix_id': '',
+              'model_ids': <String>[],
+              'auth_type': 'none',
+              'connection_type': 'external',
+            });
+        check(afterAdd.records.last.profile.id)
+            .not((it) => it.equals(addedProfile.id));
         check(afterAdd.records.last.profile.apiKey).isNull();
         check(afterAdd.records.last.authType).equals('none');
       },

--- a/test/features/hermes/hermes_api_service_test.dart
+++ b/test/features/hermes/hermes_api_service_test.dart
@@ -239,9 +239,8 @@ void main() {
       check(combinedLogs).not((value) => value.contains(sessionKey));
       check(combinedLogs).not((value) => value.contains(runId));
       check(combinedLogs).not((value) => value.contains(stackSecret));
-      check(
-        combinedLogs,
-      ).not((value) => value.contains('provider-error-secret'));
+      check(combinedLogs)
+          .not((value) => value.contains('provider-error-secret'));
     });
 
     test('createRun posts explicit history with session headers', () async {
@@ -288,9 +287,8 @@ void main() {
 
         for (final invalidId in invalidIds) {
           final capture = _CaptureInterceptor({'run_id': invalidId});
-          await check(
-            _service(capture).createRun(input: 'hello'),
-          ).throws<FormatException>();
+          await check(_service(capture).createRun(input: 'hello'))
+              .throws<FormatException>();
         }
       },
     );
@@ -396,9 +394,8 @@ void main() {
       });
 
       await check(
-        _service(
-          capture,
-        ).getSessionMessages('session-1', cancelToken: cancelToken),
+        _service(capture)
+            .getSessionMessages('session-1', cancelToken: cancelToken),
       ).throws<HermesStreamGuardException>();
 
       check(cancelToken.isCancelled).isTrue();
@@ -466,9 +463,8 @@ void main() {
           ),
         );
 
-        await check(
-          service.getRun('r1', cancelToken: cancelToken),
-        ).throws<HermesStreamGuardException>();
+        await check(service.getRun('r1', cancelToken: cancelToken))
+            .throws<HermesStreamGuardException>();
 
         check(cancelToken.isCancelled).isTrue();
         check(capture.requests.single.responseType).equals(ResponseType.stream);
@@ -504,9 +500,8 @@ void main() {
         streamLimits: const HermesStreamLimits(maxCharacters: 4),
       );
 
-      await check(
-        service.getRun('r1', cancelToken: cancelToken),
-      ).throws<HermesStreamGuardException>();
+      await check(service.getRun('r1', cancelToken: cancelToken))
+          .throws<HermesStreamGuardException>();
 
       check(cancelToken.isCancelled).isTrue();
     });
@@ -531,9 +526,8 @@ void main() {
       final cancelToken = CancelToken();
 
       await check(
-        _service(
-          _CaptureInterceptor(cyclic),
-        ).getRun('r1', cancelToken: cancelToken),
+        _service(_CaptureInterceptor(cyclic))
+            .getRun('r1', cancelToken: cancelToken),
       ).throws<FormatException>();
 
       check(cancelToken.isCancelled).isTrue();
@@ -550,15 +544,12 @@ void main() {
         ),
       );
 
-      check(
-        (await service.getRun('r1', cancelToken: cancelToken))['output'],
-      ).equals('0123456789');
-      check(
-        (await service.getRun('r1', cancelToken: cancelToken))['output'],
-      ).equals('0123456789');
-      check(
-        (await service.getRun('r1', cancelToken: cancelToken))['output'],
-      ).equals('0123456789');
+      check((await service.getRun('r1', cancelToken: cancelToken))['output'])
+          .equals('0123456789');
+      check((await service.getRun('r1', cancelToken: cancelToken))['output'])
+          .equals('0123456789');
+      check((await service.getRun('r1', cancelToken: cancelToken))['output'])
+          .equals('0123456789');
 
       check(cancelToken.isCancelled).isFalse();
     });
@@ -589,9 +580,8 @@ void main() {
         await check(poll()).throws<HermesStreamGuardException>();
 
         check(capture.requests).length.equals(2);
-        check(
-          capture.requests[1].receiveTimeout,
-        ).equals(const Duration(seconds: 4));
+        check(capture.requests[1].receiveTimeout)
+            .equals(const Duration(seconds: 4));
         check(cancelToken.isCancelled).isTrue();
       });
     }
@@ -973,9 +963,8 @@ void main() {
           final cancelToken = CancelToken();
           final service = _service(_CaptureInterceptor(body));
 
-          await check(
-            _collectEvents(service, endpoint, cancelToken),
-          ).throws<FormatException>();
+          await check(_collectEvents(service, endpoint, cancelToken))
+              .throws<FormatException>();
 
           check(cancelToken.isCancelled).isTrue();
         });
@@ -1063,12 +1052,10 @@ void main() {
         check(
           events.whereType<HermesResponseCreated>().map((e) => e.responseId),
         ).deepEquals(['resp_1', 'resp_1']);
-        check(
-          events.whereType<HermesTokenDelta>().single.content,
-        ).equals('hello');
-        check(
-          events.whereType<HermesFinalOutput>().single.text,
-        ).equals('hello');
+        check(events.whereType<HermesTokenDelta>().single.content)
+            .equals('hello');
+        check(events.whereType<HermesFinalOutput>().single.text)
+            .equals('hello');
         check(events.last).isA<HermesRunDone>();
 
         final req = capture.requests.single;
@@ -1164,24 +1151,21 @@ void main() {
       });
       final cancelToken = CancelToken();
 
-      final response = await _service(
-        capture,
-      ).getResponse('resp/1#fragment', cancelToken: cancelToken);
+      final response = await _service(capture)
+          .getResponse('resp/1#fragment', cancelToken: cancelToken);
 
       check(response['status']).equals('completed');
       final req = capture.requests.single;
-      check(
-        req.path,
-      ).equals('http://host:8642/v1/responses/resp%2F1%23fragment');
+      check(req.path)
+          .equals('http://host:8642/v1/responses/resp%2F1%23fragment');
       check(req.cancelToken).identicalTo(cancelToken);
     });
 
     test('getResponse rejects a non-object payload', () async {
       final capture = _CaptureInterceptor('not an object');
 
-      await check(
-        _service(capture).getResponse('resp_1'),
-      ).throws<FormatException>();
+      await check(_service(capture).getResponse('resp_1'))
+          .throws<FormatException>();
     });
 
     test('getResponse rejects deeply nested recovery JSON safely', () async {
@@ -1270,9 +1254,8 @@ void main() {
           schedule: oversizedSchedule,
         ),
       ).throws<ArgumentError>();
-      await check(
-        service.updateJob('job-1', schedule: oversizedSchedule),
-      ).throws<ArgumentError>();
+      await check(service.updateJob('job-1', schedule: oversizedSchedule))
+          .throws<ArgumentError>();
 
       check(capture.requests).isEmpty();
     });
@@ -1310,9 +1293,8 @@ void main() {
       'resolveApproval posts the official deny choice and legacy fields',
       () async {
         final capture = _CaptureInterceptor({});
-        await _service(
-          capture,
-        ).resolveApproval('r1', approvalId: 'a1', approved: false);
+        await _service(capture)
+            .resolveApproval('r1', approvalId: 'a1', approved: false);
         final req = capture.requests.single;
         check(req.path).equals('http://host:8642/v1/runs/r1/approval');
         check(req.data as Map<String, dynamic>).deepEquals({
@@ -1326,9 +1308,8 @@ void main() {
 
     test('resolveApproval maps approval to the official once choice', () async {
       final capture = _CaptureInterceptor({});
-      await _service(
-        capture,
-      ).resolveApproval('r1', approvalId: 'a1', approved: true);
+      await _service(capture)
+          .resolveApproval('r1', approvalId: 'a1', approved: true);
 
       check(capture.requests.single.data as Map<String, dynamic>).deepEquals({
         'choice': 'once',

--- a/test/features/hermes/hermes_local_document_service_test.dart
+++ b/test/features/hermes/hermes_local_document_service_test.dart
@@ -12,9 +12,8 @@ void main() {
     test('production picker offers text and DOCX but not PDF', () {
       check(kHermesLocalDocumentPickerExtensions).contains('txt');
       check(kHermesLocalDocumentPickerExtensions).contains('docx');
-      check(
-        kHermesLocalDocumentPickerExtensions,
-      ).not((it) => it.contains('pdf'));
+      check(kHermesLocalDocumentPickerExtensions)
+          .not((it) => it.contains('pdf'));
     });
 
     test(
@@ -63,9 +62,8 @@ void main() {
 
         check(prepared.name).equals('local-secret.txt');
         check(prepared.extractedText).equals('on-device only');
-        check(
-          prepared.renderForPrompt(),
-        ).not((value) => value.contains(directory.path));
+        check(prepared.renderForPrompt())
+            .not((value) => value.contains(directory.path));
       },
     );
 
@@ -80,9 +78,8 @@ void main() {
 
       check(error.code).equals(HermesLocalDocumentError.readFailed);
       check(error.documentName).equals(missingName);
-      check(
-        error.toString(),
-      ).not((value) => value.contains(Directory.systemTemp.path));
+      check(error.toString())
+          .not((value) => value.contains(Directory.systemTemp.path));
     });
 
     test('accepts safe hidden UTF-8 configuration filenames', () async {
@@ -132,9 +129,8 @@ void main() {
           bytes: utf8.encode('text'),
         );
 
-        check(
-          (await _failureOf(service.prepareAll([small, small]))).code,
-        ).equals(HermesLocalDocumentError.tooManyFiles);
+        check((await _failureOf(service.prepareAll([small, small]))).code)
+            .equals(HermesLocalDocumentError.tooManyFiles);
         check(
           (await _failureOf(
             service.prepare(
@@ -239,9 +235,11 @@ void main() {
         check(prepared.extractedText).equals('Page text');
 
         final tooLong = HermesLocalDocumentService(
-          pdfExtractor:
-              (bytes, {required maxPages, required maxCharacters}) async =>
-                  const HermesPdfExtraction(text: '', pageCount: 4),
+          pdfExtractor: (
+            bytes, {
+            required maxPages,
+            required maxCharacters,
+          }) async => const HermesPdfExtraction(text: '', pageCount: 4),
           limits: const HermesLocalDocumentLimits(maxPdfPages: 3),
         );
         check(
@@ -346,8 +344,7 @@ void main() {
       final prepared = await HermesLocalDocumentService().prepare(
         HermesLocalDocumentSource.fromBytes(
           name: 'notes.docx',
-          mimeType:
-              'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+          mimeType: 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
           bytes: docx,
         ),
       );
@@ -636,9 +633,9 @@ void main() {
       final rendered = prepared.renderForPrompt();
       check(rendered).contains('HERMES_UNTRUSTED_REFERENCE_[MARKER_REMOVED]');
       check(
-        RegExp(
-          'HERMES_UNTRUSTED_REFERENCE_HDOC_TEST',
-        ).allMatches(rendered).length,
+        RegExp('HERMES_UNTRUSTED_REFERENCE_HDOC_TEST')
+            .allMatches(rendered)
+            .length,
       ).equals(2);
     });
   });

--- a/test/features/hermes/hermes_local_document_trust_store_test.dart
+++ b/test/features/hermes/hermes_local_document_trust_store_test.dart
@@ -253,10 +253,8 @@ void main() {
     ).isEmpty();
 
     releaseWrite.complete();
-    await Future.wait<void>([
-      remember,
-      prepare,
-    ]).timeout(const Duration(seconds: 1));
+    await Future.wait<void>([remember, prepare])
+        .timeout(const Duration(seconds: 1));
 
     // Model restart: no in-memory tombstone may be required to hide a late
     // trust write after the reuse purge has reported success.
@@ -305,10 +303,8 @@ void main() {
     );
 
     releaseWrite.complete();
-    await Future.wait<void>([
-      remember,
-      forget,
-    ]).timeout(const Duration(seconds: 1));
+    await Future.wait<void>([remember, forget])
+        .timeout(const Duration(seconds: 1));
 
     HermesLocalDocumentTrustStore.debugResetRuntimeState();
     check(

--- a/test/features/hermes/hermes_only_mode_test.dart
+++ b/test/features/hermes/hermes_only_mode_test.dart
@@ -865,9 +865,8 @@ void main() {
         final selected = await container.read(defaultModelProvider.future);
 
         check(selected).identicalTo(preferredModel);
-        check(
-          container.read(selectedModelProvider),
-        ).identicalTo(preferredModel);
+        check(container.read(selectedModelProvider))
+            .identicalTo(preferredModel);
       },
     );
 
@@ -912,9 +911,8 @@ void main() {
         await container.read(authStateManagerProvider.future);
         await container.read(directModelDiscoveryProvider.future);
 
-        check(
-          container.read(selectedModelProvider),
-        ).identicalTo(preferredModel);
+        check(container.read(selectedModelProvider))
+            .identicalTo(preferredModel);
       },
     );
 
@@ -954,23 +952,22 @@ void main() {
             .set(_CachedOpenWebUiStorage.staleModel);
         container.read(isManualModelSelectionProvider.notifier).set(true);
 
-        (container.read(authStateManagerProvider.notifier)
-                as _RefreshingAuthStateManager)
-            .beginRefresh();
+        (container.read(
+          authStateManagerProvider.notifier,
+        ) as _RefreshingAuthStateManager).beginRefresh();
         await container.read(modelsProvider.future);
         final selectedDefault = await container.read(
           defaultModelProvider.future,
         );
 
         check(selectedDefault).identicalTo(_CachedOpenWebUiStorage.staleModel);
-        check(
-          container.read(selectedModelProvider),
-        ).identicalTo(_CachedOpenWebUiStorage.staleModel);
+        check(container.read(selectedModelProvider))
+            .identicalTo(_CachedOpenWebUiStorage.staleModel);
         check(container.read(isManualModelSelectionProvider)).isTrue();
 
-        (container.read(authStateManagerProvider.notifier)
-                as _RefreshingAuthStateManager)
-            .finishSignedOut();
+        (container.read(
+          authStateManagerProvider.notifier,
+        ) as _RefreshingAuthStateManager).finishSignedOut();
         await container.read(modelsProvider.future);
         await Future<void>.delayed(Duration.zero);
 
@@ -1016,18 +1013,16 @@ void main() {
         await container.read(modelsProvider.future);
         storage.savedModelLists.clear();
 
-        (container.read(authStateManagerProvider.notifier)
-                as _RefreshingAuthStateManager)
-            .beginRefresh();
+        (container.read(
+          authStateManagerProvider.notifier,
+        ) as _RefreshingAuthStateManager).beginRefresh();
         await container.read(modelsProvider.notifier).refresh();
         await Future<void>.delayed(Duration.zero);
 
-        check(
-          container.read(modelsProvider).requireValue,
-        ).deepEquals(const [_CachedOpenWebUiStorage.staleModel]);
-        check(
-          storage.savedModelLists.any((models) => models.isEmpty),
-        ).isFalse();
+        check(container.read(modelsProvider).requireValue)
+            .deepEquals(const [_CachedOpenWebUiStorage.staleModel]);
+        check(storage.savedModelLists.any((models) => models.isEmpty))
+            .isFalse();
       },
     );
 
@@ -1062,17 +1057,16 @@ void main() {
         await container.read(modelsProvider.future);
         storage.savedModelLists.clear();
 
-        (container.read(authStateManagerProvider.notifier)
-                as _CandidateTokenAuthStateManager)
-            .beginForegroundLogin();
+        (container.read(
+          authStateManagerProvider.notifier,
+        ) as _CandidateTokenAuthStateManager).beginForegroundLogin();
         await container.read(modelsProvider.notifier).refresh();
         await Future<void>.delayed(Duration.zero);
 
         check(api.modelFetches).equals(0);
         check(storage.savedModelLists).isEmpty();
-        check(
-          container.read(modelsProvider).requireValue,
-        ).deepEquals(const [_CachedOpenWebUiStorage.staleModel]);
+        check(container.read(modelsProvider).requireValue)
+            .deepEquals(const [_CachedOpenWebUiStorage.staleModel]);
       },
     );
 
@@ -1142,9 +1136,9 @@ void main() {
       await Future<void>.delayed(Duration.zero);
       check(container.read(selectedModelProvider)).identicalTo(direct.model);
 
-      (container.read(preferredBackendProvider.notifier)
-              as _MutablePreferredBackendController)
-          .publish(PreferredBackend.hermes);
+      (container.read(
+        preferredBackendProvider.notifier,
+      ) as _MutablePreferredBackendController).publish(PreferredBackend.hermes);
       await container.read(modelsProvider.future);
       await Future<void>.delayed(Duration.zero);
 
@@ -1199,9 +1193,8 @@ void main() {
       await Future<void>.delayed(Duration.zero);
       await Future<void>.delayed(Duration.zero);
 
-      check(
-        container.read(selectedModelProvider),
-      ).identicalTo(directModels.last);
+      check(container.read(selectedModelProvider))
+          .identicalTo(directModels.last);
       check(container.read(isManualModelSelectionProvider)).isTrue();
     });
 
@@ -1412,9 +1405,9 @@ void main() {
       addTearDown(workerManager.dispose);
 
       check(await container.read(defaultModelProvider.future)).isNull();
-      (container.read(authStateManagerProvider.notifier)
-              as _BackgroundLoginAuthStateManager)
-          .finishAuthenticated();
+      (container.read(
+        authStateManagerProvider.notifier,
+      ) as _BackgroundLoginAuthStateManager).finishAuthenticated();
       for (var attempt = 0; attempt < 10; attempt++) {
         await Future<void>.delayed(Duration.zero);
         if (container.read(selectedModelProvider) != null) break;
@@ -1480,9 +1473,9 @@ void main() {
           container.read(selectedModelProvider.notifier).set(localModel);
           container.read(isManualModelSelectionProvider.notifier).set(false);
 
-          (container.read(authStateManagerProvider.notifier)
-                  as _BackgroundLoginAuthStateManager)
-              .finishAuthenticated();
+          (container.read(
+            authStateManagerProvider.notifier,
+          ) as _BackgroundLoginAuthStateManager).finishAuthenticated();
           for (var attempt = 0; attempt < 20; attempt++) {
             await Future<void>.delayed(Duration.zero);
             if (container.read(selectedModelProvider)?.id == 'owui-stale') {
@@ -1490,9 +1483,8 @@ void main() {
             }
           }
 
-          check(
-            container.read(selectedModelProvider),
-          ).identicalTo(_CachedOpenWebUiStorage.staleModel);
+          check(container.read(selectedModelProvider))
+              .identicalTo(_CachedOpenWebUiStorage.staleModel);
           check(container.read(isManualModelSelectionProvider)).isFalse();
         },
       );
@@ -1538,9 +1530,9 @@ void main() {
 
         final pendingDefault = container.read(defaultModelProvider.future);
         await Future<void>.delayed(Duration.zero);
-        (container.read(authStateManagerProvider.notifier)
-                as _TokenRetainingErrorAuthStateManager)
-            .publishError();
+        (container.read(
+          authStateManagerProvider.notifier,
+        ) as _TokenRetainingErrorAuthStateManager).publishError();
         await Future<void>.delayed(Duration.zero);
         await Future<void>.delayed(Duration.zero);
         final localSelection = container.read(selectedModelProvider);
@@ -1551,9 +1543,8 @@ void main() {
         final resolved = await pendingDefault;
 
         check(resolved).identicalTo(localSelection);
-        check(
-          container.read(selectedModelProvider),
-        ).identicalTo(localSelection);
+        check(container.read(selectedModelProvider))
+            .identicalTo(localSelection);
       },
     );
 
@@ -1602,17 +1593,16 @@ void main() {
 
         final pendingDefault = container.read(defaultModelProvider.future);
         await Future<void>.delayed(Duration.zero);
-        (container.read(authStateManagerProvider.notifier)
-                as _SessionSwitchAuthStateManager)
-            .publishSessionB();
+        (container.read(
+          authStateManagerProvider.notifier,
+        ) as _SessionSwitchAuthStateManager).publishSessionB();
         await Future<void>.delayed(Duration.zero);
         pendingModels.complete(const [_CachedOpenWebUiStorage.staleModel]);
         final resolved = await pendingDefault;
 
         check(resolved).identicalTo(sessionBSelection);
-        check(
-          container.read(selectedModelProvider),
-        ).identicalTo(sessionBSelection);
+        check(container.read(selectedModelProvider))
+            .identicalTo(sessionBSelection);
       },
     );
 
@@ -1646,9 +1636,9 @@ void main() {
       final pendingDefault = container.read(defaultModelProvider.future);
       unawaited(pendingDefault.catchError((_) => null));
       await Future<void>.delayed(Duration.zero);
-      (container.read(preferredBackendProvider.notifier)
-              as _MutablePreferredBackendController)
-          .publish(PreferredBackend.hermes);
+      (container.read(
+        preferredBackendProvider.notifier,
+      ) as _MutablePreferredBackendController).publish(PreferredBackend.hermes);
       await Future<void>.delayed(Duration.zero);
       pendingDiscovery.complete(
         DirectModelDiscoveryState(models: [direct.model]),

--- a/test/features/hermes/hermes_payload_coercion_test.dart
+++ b/test/features/hermes/hermes_payload_coercion_test.dart
@@ -288,9 +288,9 @@ void main() {
         {'id': 'target-1', 'role': 'user', 'content': 'same'},
       ],
     );
-    check(
-      valid,
-    ).isNotNull().deepEquals(<String, String>{'source-1': 'target-1'});
+    check(valid)
+        .isNotNull()
+        .deepEquals(<String, String>{'source-1': 'target-1'});
     check(
       alignHermesForkedMessageIds(
         const <Map<String, dynamic>>[
@@ -412,9 +412,8 @@ void main() {
         ]);
         check(mapped).length.equals(1);
         check(mapped.single.content).equals(sharedPrefix);
-        check(
-          mapped.single.content.runes.length,
-        ).equals(kHermesMaxHistoryMessageTextCharacters);
+        check(mapped.single.content.runes.length)
+            .equals(kHermesMaxHistoryMessageTextCharacters);
       },
     );
 
@@ -423,9 +422,8 @@ void main() {
         for (var index = 0; index < kHermesMaxHistoryContentNodes - 1; index++)
           'x',
       ];
-      check(
-        hermesMessageTextContent(atBoundary),
-      ).equals(_repeat('x', kHermesMaxHistoryContentNodes - 1));
+      check(hermesMessageTextContent(atBoundary))
+          .equals(_repeat('x', kHermesMaxHistoryContentNodes - 1));
       final overBoundary = <Object?>[...atBoundary, 'different-tail'];
       check(hermesMessageTextContent(overBoundary)).isNull();
 

--- a/test/features/hermes/hermes_real_payloads_test.dart
+++ b/test/features/hermes/hermes_real_payloads_test.dart
@@ -129,12 +129,12 @@ void main() {
         'data: {"event":"run.completed","output":"hi"}\n\n',
       );
       final uint8Stream = Stream<Uint8List>.value(Uint8List.fromList(bytes));
-      final events = await parseHermesRunStream(
-        uint8Stream.cast<List<int>>(),
-      ).toList();
-      check(
-        events.first,
-      ).isA<HermesTokenDelta>().has((e) => e.content, 'content').equals('hi');
+      final events = await parseHermesRunStream(uint8Stream.cast<List<int>>())
+          .toList();
+      check(events.first)
+          .isA<HermesTokenDelta>()
+          .has((e) => e.content, 'content')
+          .equals('hi');
       check(events.last).isA<HermesRunDone>();
     },
   );
@@ -157,25 +157,29 @@ void main() {
       ..has((e) => e.done, 'done').isTrue();
   });
 
-  test('SSE: real message.delta / reasoning.available / run.completed', () async {
-    final frames = [
-      'data: {"event":"message.delta","run_id":"r","delta":"pong"}\n\n',
-      'data: {"event":"reasoning.available","run_id":"r","text":"pong"}\n\n',
-      'data: {"event":"run.completed","run_id":"r","output":"pong","usage":{"total_tokens":1}}\n\n',
-    ];
-    final events = await parseHermesRunStream(
-      Stream<List<int>>.fromIterable(frames.map(utf8.encode)),
-    ).toList();
+  test(
+    'SSE: real message.delta / reasoning.available / run.completed',
+    () async {
+      final frames = [
+        'data: {"event":"message.delta","run_id":"r","delta":"pong"}\n\n',
+        'data: {"event":"reasoning.available","run_id":"r","text":"pong"}\n\n',
+        'data: {"event":"run.completed","run_id":"r","output":"pong","usage":{"total_tokens":1}}\n\n',
+      ];
+      final events = await parseHermesRunStream(
+        Stream<List<int>>.fromIterable(frames.map(utf8.encode)),
+      ).toList();
 
-    // message.delta → token; reasoning.available skipped (would duplicate);
-    // run.completed → final output fallback + done.
-    check(
-      events[0],
-    ).isA<HermesTokenDelta>().has((e) => e.content, 'content').equals('pong');
-    check(events.any((e) => e is HermesReasoningDelta)).isFalse();
-    check(events.whereType<HermesFinalOutput>().single.text).equals('pong');
-    check(events.last).isA<HermesRunDone>();
-  });
+      // message.delta → token; reasoning.available skipped (would duplicate);
+      // run.completed → final output fallback + done.
+      check(events[0])
+          .isA<HermesTokenDelta>()
+          .has((e) => e.content, 'content')
+          .equals('pong');
+      check(events.any((e) => e is HermesReasoningDelta)).isFalse();
+      check(events.whereType<HermesFinalOutput>().single.text).equals('pong');
+      check(events.last).isA<HermesRunDone>();
+    },
+  );
 
   test('SSE: real Responses created / delta / completed envelopes', () async {
     final created = {
@@ -233,9 +237,8 @@ void main() {
       Stream<List<int>>.fromIterable(frames.map(utf8.encode)),
     ).toList();
 
-    check(
-      events.whereType<HermesResponseCreated>().map((e) => e.responseId),
-    ).deepEquals(['resp_123', 'resp_123']);
+    check(events.whereType<HermesResponseCreated>().map((e) => e.responseId))
+        .deepEquals(['resp_123', 'resp_123']);
     check(events.whereType<HermesLifecycle>().single.status).equals('created');
     check(events.whereType<HermesTokenDelta>().single.content).equals('hello');
     check(events.whereType<HermesFinalOutput>().single.text).equals('hello');

--- a/test/features/hermes/hermes_run_transport_test.dart
+++ b/test/features/hermes/hermes_run_transport_test.dart
@@ -533,6 +533,38 @@ void main() {
       check(content.toString()).equals('Hello world');
     });
 
+    test('a final output that is a strict prefix of the streamed text does not '
+        'truncate it', () async {
+      final fake = _FakeHermesApiService(
+        const [],
+        responseEvents: const [
+          HermesResponseCreated('resp-prefix'),
+          HermesTokenDelta('Hello'),
+          HermesTokenDelta(' world, full streamed answer'),
+          HermesFinalOutput('Hello'),
+          HermesRunDone(),
+        ],
+      );
+      final content = StringBuffer();
+      String? replaced;
+
+      await _dispatchFakeHermesResponse(
+        service: fake,
+        registry: HermesRunRegistry(),
+        assistantMessageId: 'm',
+        input: HermesChatInput.text('hello'),
+        appendContent: content.write,
+        replaceContent: (value) => replaced = value,
+        appendStatus: (_) {},
+        updateMessage: (_) {},
+        finishStreaming: () {},
+        completeStreamingUi: () {},
+      );
+
+      check(replaced).isNull();
+      check(content.toString()).equals('Hello world, full streamed answer');
+    });
+
     test('many tiny response deltas reconcile in exact order', () async {
       const deltaCount = 20000;
       final expected = List<String>.filled(deltaCount, 'x').join();

--- a/test/features/hermes/hermes_session_provenance_test.dart
+++ b/test/features/hermes/hermes_session_provenance_test.dart
@@ -45,9 +45,8 @@ void main() {
         ),
       ),
     ).isTrue();
-    check(
-      isNativeHermesConversation(native.copyWith(title: 'Untrusted copy')),
-    ).isFalse();
+    check(isNativeHermesConversation(native.copyWith(title: 'Untrusted copy')))
+        .isFalse();
   });
 
   test(

--- a/test/features/hermes/hermes_sessions_test.dart
+++ b/test/features/hermes/hermes_sessions_test.dart
@@ -144,22 +144,18 @@ void main() {
       () {
         const epochMilliseconds = 1781947724528;
 
-        check(
-          parseHermesTimestamp(1781947724.528)!.millisecondsSinceEpoch,
-        ).equals(epochMilliseconds);
-        check(
-          parseHermesTimestamp(epochMilliseconds)!.millisecondsSinceEpoch,
-        ).equals(epochMilliseconds);
-        check(
-          parseHermesTimestamp('1781947724.528')!.millisecondsSinceEpoch,
-        ).equals(epochMilliseconds);
+        check(parseHermesTimestamp(1781947724.528)!.millisecondsSinceEpoch)
+            .equals(epochMilliseconds);
+        check(parseHermesTimestamp(epochMilliseconds)!.millisecondsSinceEpoch)
+            .equals(epochMilliseconds);
+        check(parseHermesTimestamp('1781947724.528')!.millisecondsSinceEpoch)
+            .equals(epochMilliseconds);
       },
     );
 
     test('parses ISO-8601 values and rejects invalid values', () {
-      check(
-        parseHermesTimestamp('2026-06-20T10:00:00Z'),
-      ).equals(DateTime.utc(2026, 6, 20, 10));
+      check(parseHermesTimestamp('2026-06-20T10:00:00Z'))
+          .equals(DateTime.utc(2026, 6, 20, 10));
       check(parseHermesTimestamp('not-a-timestamp')).isNull();
       check(parseHermesTimestamp(null)).isNull();
     });
@@ -192,9 +188,8 @@ void main() {
 
       for (final invalidId in invalidIds) {
         final capture = _CaptureInterceptor((_) => {'id': invalidId});
-        await check(
-          _service(capture).createSession(),
-        ).throws<FormatException>();
+        await check(_service(capture).createSession())
+            .throws<FormatException>();
       }
     });
 
@@ -215,9 +210,8 @@ void main() {
         ),
       );
 
-      await check(
-        _service(capture).createSession(cancelToken: cancelToken),
-      ).throws<FormatException>();
+      await check(_service(capture).createSession(cancelToken: cancelToken))
+          .throws<FormatException>();
 
       check(cancelToken.isCancelled).isTrue();
       check(hermesCancellationWasInternal(cancelToken)).isTrue();
@@ -230,9 +224,8 @@ void main() {
         },
       );
       final id = await _service(capture).forkSession('s1');
-      check(
-        capture.requests.single.path,
-      ).equals('http://host:8642/api/sessions/s1/fork');
+      check(capture.requests.single.path)
+          .equals('http://host:8642/api/sessions/s1/fork');
       check(id).equals('s2');
     });
 
@@ -243,9 +236,8 @@ void main() {
       await service.renameSession('s1', 'New');
       await service.deleteSession('s1', cancelToken: deleteCancelToken);
       check(capture.requests[0].method).equals('PATCH');
-      check(
-        capture.requests[0].path,
-      ).equals('http://host:8642/api/sessions/s1');
+      check(capture.requests[0].path)
+          .equals('http://host:8642/api/sessions/s1');
       check((capture.requests[0].data as Map)['title']).equals('New');
       check(capture.requests[1].method).equals('DELETE');
       check(capture.requests[1].cancelToken).identicalTo(deleteCancelToken);
@@ -269,19 +261,15 @@ void main() {
       await service.deleteSession(sessionId);
       check(await service.forkSession(sessionId)).equals('branched');
 
-      check(
-        capture.requests[0].path,
-      ).equals('http://host:8642/api/sessions/$encoded/messages');
+      check(capture.requests[0].path)
+          .equals('http://host:8642/api/sessions/$encoded/messages');
       check(capture.requests[0].cancelToken).identicalTo(historyCancelToken);
-      check(
-        capture.requests[1].path,
-      ).equals('http://host:8642/api/sessions/$encoded');
-      check(
-        capture.requests[2].path,
-      ).equals('http://host:8642/api/sessions/$encoded');
-      check(
-        capture.requests[3].path,
-      ).equals('http://host:8642/api/sessions/$encoded/fork');
+      check(capture.requests[1].path)
+          .equals('http://host:8642/api/sessions/$encoded');
+      check(capture.requests[2].path)
+          .equals('http://host:8642/api/sessions/$encoded');
+      check(capture.requests[3].path)
+          .equals('http://host:8642/api/sessions/$encoded/fork');
     });
   });
 
@@ -317,9 +305,9 @@ void main() {
       for (final message in messages.take(3)) {
         check(message.id).isNotEmpty();
       }
-      check(
-        messages.take(3).map((message) => message.id).toSet(),
-      ).has((ids) => ids.length, 'unique generated ids').equals(3);
+      check(messages.take(3).map((message) => message.id).toSet())
+          .has((ids) => ids.length, 'unique generated ids')
+          .equals(3);
       check(messages.last.id).equals('server-id');
     });
 
@@ -387,12 +375,10 @@ void main() {
       );
       check(toolActivity.statusHistory.single.description).equals('web_search');
       check(toolActivity.statusHistory.single.done).equals(true);
-      check(
-        toolActivity.statusHistory.single.occurredAt,
-      ).equals(DateTime.utc(2026, 7, 16, 10, 0, 1));
-      check(
-        toolActivity.statusHistory.single.description!,
-      ).not((value) => value.contains('untrusted provider result'));
+      check(toolActivity.statusHistory.single.occurredAt)
+          .equals(DateTime.utc(2026, 7, 16, 10, 0, 1));
+      check(toolActivity.statusHistory.single.description!)
+          .not((value) => value.contains('untrusted provider result'));
       check(messages.last.content).equals('Here is the answer.');
     });
 
@@ -441,9 +427,8 @@ void main() {
       check(messages).has((m) => m.length, 'length').equals(1);
       final message = messages.single;
       check(message.content).equals('Compare these');
-      check(
-        message.attachmentIds!,
-      ).deepEquals([pngDataUrl, jpegDataUrl, remoteImageUrl]);
+      check(message.attachmentIds!)
+          .deepEquals([pngDataUrl, jpegDataUrl, remoteImageUrl]);
       check(message.files!).deepEquals([
         {'type': 'image', 'url': pngDataUrl, 'content_type': 'image/png'},
         {'type': 'image', 'url': jpegDataUrl, 'content_type': 'image/jpeg'},
@@ -526,9 +511,8 @@ void main() {
       final message = messages.single;
       check(message.content).equals('Summarize the findings.');
       check(message.content).not((value) => value.contains('untrusted'));
-      check(
-        message.content,
-      ).not((value) => value.contains(document.extractedText));
+      check(message.content)
+          .not((value) => value.contains(document.extractedText));
       check(message.attachmentIds).isNull();
       check(message.files!).deepEquals([
         {
@@ -727,12 +711,11 @@ void main() {
 
       check(messages).has((m) => m.length, 'length').equals(1);
       check(messages.single.content).isEmpty();
-      check(
-        messages.single.files!,
-      ).has((files) => files.length, 'length').equals(2);
-      check(
-        messages.single.files!.map((file) => file['id']).toList(),
-      ).deepEquals([first.id, second.id]);
+      check(messages.single.files!)
+          .has((files) => files.length, 'length')
+          .equals(2);
+      check(messages.single.files!.map((file) => file['id']).toList())
+          .deepEquals([first.id, second.id]);
       check(
         messages.single.files!
             .map((file) => file['hermes_extracted_text'])
@@ -836,9 +819,9 @@ void main() {
       {'id': '21', 'role': 'assistant', 'content': 'same answer'},
     ];
 
-    check(
-      alignHermesForkedMessageIds(source, target),
-    ).isNotNull().deepEquals(<String, String>{'10': '20', '11': '21'});
+    check(alignHermesForkedMessageIds(source, target))
+        .isNotNull()
+        .deepEquals(<String, String>{'10': '20', '11': '21'});
     check(
       alignHermesForkedMessageIds(source, <Map<String, dynamic>>[target.first]),
     ).isNull();

--- a/test/features/hermes/hermes_skill_prompts_test.dart
+++ b/test/features/hermes/hermes_skill_prompts_test.dart
@@ -44,33 +44,36 @@ void main() {
     check(skills.single['name']).equals('gif-search');
   });
 
-  test('hermesSkillPromptsProvider maps skills to slash-command prompts', () async {
-    final capture = _CaptureInterceptor({
-      'skills': [
-        {'name': 'gif-search', 'description': 'Find GIFs'},
-        {'name': 'plan', 'description': 'Plan a rollout'},
-        {'description': 'no name — skipped'},
-      ],
-    });
-    final dio = Dio()..interceptors.add(capture);
-    final service = HermesApiService(
-      config: const HermesConfig(
-        enabled: true,
-        baseUrl: 'http://host:8642',
-        apiKey: 'k',
-      ),
-      dio: dio,
-    );
+  test(
+    'hermesSkillPromptsProvider maps skills to slash-command prompts',
+    () async {
+      final capture = _CaptureInterceptor({
+        'skills': [
+          {'name': 'gif-search', 'description': 'Find GIFs'},
+          {'name': 'plan', 'description': 'Plan a rollout'},
+          {'description': 'no name — skipped'},
+        ],
+      });
+      final dio = Dio()..interceptors.add(capture);
+      final service = HermesApiService(
+        config: const HermesConfig(
+          enabled: true,
+          baseUrl: 'http://host:8642',
+          apiKey: 'k',
+        ),
+        dio: dio,
+      );
 
-    final container = ProviderContainer(
-      overrides: [hermesApiServiceProvider.overrideWithValue(service)],
-    );
-    addTearDown(container.dispose);
+      final container = ProviderContainer(
+        overrides: [hermesApiServiceProvider.overrideWithValue(service)],
+      );
+      addTearDown(container.dispose);
 
-    final prompts = await container.read(hermesSkillPromptsProvider.future);
-    check(prompts).has((p) => p.length, 'length').equals(2);
-    check(prompts.first.command).equals('/gif-search');
-    check(prompts.first.title).equals('Find GIFs');
-    check(prompts.first.content).equals('/gif-search ');
-  });
+      final prompts = await container.read(hermesSkillPromptsProvider.future);
+      check(prompts).has((p) => p.length, 'length').equals(2);
+      check(prompts.first.command).equals('/gif-search');
+      check(prompts.first.title).equals('Find GIFs');
+      check(prompts.first.content).equals('/gif-search ');
+    },
+  );
 }

--- a/test/features/hermes/hermes_stream_parser_test.dart
+++ b/test/features/hermes/hermes_stream_parser_test.dart
@@ -100,9 +100,10 @@ void main() {
       check(events[0]).isA<HermesToolProgress>()
         ..has((e) => e.toolName, 'toolName').equals('terminal')
         ..has((e) => e.done, 'done').isFalse();
-      check(
-        events[1],
-      ).isA<HermesTokenDelta>().has((e) => e.content, 'content').equals('Hi');
+      check(events[1])
+          .isA<HermesTokenDelta>()
+          .has((e) => e.content, 'content')
+          .equals('Hi');
       check(events[2]).isA<HermesToolProgress>()
         ..has((e) => e.toolName, 'toolName').equals('terminal')
         ..has((e) => e.done, 'done').isTrue();
@@ -117,9 +118,9 @@ void main() {
         ).toList();
 
         check(events.whereType<HermesRunError>()).isNotEmpty();
-        check(
-          events.whereType<HermesRunError>().first,
-        ).has((e) => e.message, 'message').equals('Hermes run failed.');
+        check(events.whereType<HermesRunError>().first)
+            .has((e) => e.message, 'message')
+            .equals('Hermes run failed.');
       },
     );
 
@@ -128,9 +129,9 @@ void main() {
         _sse(['event: run.failed\ndata: {"error":"boom"}\n\n']),
       ).toList();
 
-      check(
-        events.whereType<HermesRunError>().first,
-      ).has((e) => e.message, 'message').equals('boom');
+      check(events.whereType<HermesRunError>().first)
+          .has((e) => e.message, 'message')
+          .equals('boom');
     });
 
     test('response.failed surfaces an error event', () async {
@@ -149,9 +150,9 @@ void main() {
         ]),
       ).toList();
 
-      check(
-        events.whereType<HermesToolProgress>().first,
-      ).has((e) => e.done, 'done').isTrue();
+      check(events.whereType<HermesToolProgress>().first)
+          .has((e) => e.done, 'done')
+          .isTrue();
     });
 
     test('tool.failed keeps a string error scoped to the tool', () async {
@@ -292,9 +293,8 @@ void main() {
         ]),
       ).toList();
 
-      check(
-        events.whereType<HermesApprovalRequested>().single.approvalId,
-      ).equals('a1');
+      check(events.whereType<HermesApprovalRequested>().single.approvalId)
+          .equals('a1');
     });
 
     test('legacy approval identifiers take precedence over run_id', () async {
@@ -305,9 +305,8 @@ void main() {
         ]),
       ).toList();
 
-      check(
-        events.whereType<HermesApprovalRequested>().single.approvalId,
-      ).equals('legacy-a1');
+      check(events.whereType<HermesApprovalRequested>().single.approvalId)
+          .equals('legacy-a1');
     });
 
     test('decodes Responses created, text delta, and completed envelope', () async {
@@ -326,9 +325,10 @@ void main() {
           .isA<HermesResponseCreated>()
           .has((e) => e.responseId, 'responseId')
           .equals('resp_1');
-      check(
-        events[1],
-      ).isA<HermesLifecycle>().has((e) => e.status, 'status').equals('created');
+      check(events[1])
+          .isA<HermesLifecycle>()
+          .has((e) => e.status, 'status')
+          .equals('created');
       check(events[2])
           .isA<HermesTokenDelta>()
           .has((e) => e.content, 'content')
@@ -337,9 +337,10 @@ void main() {
           .isA<HermesResponseCreated>()
           .has((e) => e.responseId, 'responseId')
           .equals('resp_1');
-      check(
-        events[4],
-      ).isA<HermesFinalOutput>().has((e) => e.text, 'text').equals('world');
+      check(events[4])
+          .isA<HermesFinalOutput>()
+          .has((e) => e.text, 'text')
+          .equals('world');
       check(events[5]).isA<HermesRunDone>();
     });
 
@@ -359,9 +360,8 @@ void main() {
       ).toList();
 
       check(events.whereType<HermesResponseCreated>()).isEmpty();
-      check(
-        events.whereType<HermesLifecycle>().single.status,
-      ).equals('created');
+      check(events.whereType<HermesLifecycle>().single.status)
+          .equals('created');
     });
 
     test(
@@ -376,9 +376,8 @@ void main() {
           ]),
         ).toList();
 
-        check(
-          events.whereType<HermesFinalOutput>().single.text,
-        ).equals('Hello world');
+        check(events.whereType<HermesFinalOutput>().single.text)
+            .equals('Hello world');
         check(events.last).isA<HermesRunDone>();
       },
     );
@@ -408,9 +407,10 @@ void main() {
         _sse(['data: {"error":{"message":"boom"}}\n\n']),
       ).toList();
       check(events).has((e) => e.length, 'length').equals(1);
-      check(
-        events[0],
-      ).isA<HermesRunError>().has((e) => e.message, 'message').equals('boom');
+      check(events[0])
+          .isA<HermesRunError>()
+          .has((e) => e.message, 'message')
+          .equals('boom');
     });
 
     test('surfaces top-level type error messages', () async {
@@ -419,9 +419,10 @@ void main() {
       ).toList();
 
       check(events).has((e) => e.length, 'length').equals(1);
-      check(
-        events.single,
-      ).isA<HermesRunError>().has((e) => e.message, 'message').equals('boom');
+      check(events.single)
+          .isA<HermesRunError>()
+          .has((e) => e.message, 'message')
+          .equals('boom');
     });
 
     test('does not coerce a nested type into protocol routing text', () async {
@@ -485,31 +486,26 @@ void main() {
   });
 
   group('parseHermesResponseStream', () {
-    test(
-      'maps sparse response terminal output shape to a typed run error',
-      () async {
-        Object? output = 'leaf';
-        for (var depth = 0; depth <= 128; depth++) {
-          output = <Object?>[output];
-        }
+    test('maps sparse response terminal output shape to a typed run error', () async {
+      Object? output = 'leaf';
+      for (var depth = 0; depth <= 128; depth++) {
+        output = <Object?>[output];
+      }
 
-        final events = await parseHermesResponseStream(
-          _sse([
-            'event: response.completed\n'
-                'data: ${jsonEncode(<String, Object?>{
-                  'response': <String, Object?>{'id': 'resp_deep', 'status': 'completed', 'output': output},
-                })}\n\n',
-          ]),
-        ).toList();
+      final events = await parseHermesResponseStream(
+        _sse([
+          'event: response.completed\n'
+              'data: ${jsonEncode(<String, Object?>{
+                'response': <String, Object?>{'id': 'resp_deep', 'status': 'completed', 'output': output},
+              })}\n\n',
+        ]),
+      ).toList();
 
-        check(
-          events.whereType<HermesResponseCreated>().single.responseId,
-        ).equals('resp_deep');
-        check(
-          events.whereType<HermesRunError>().single.message,
-        ).contains('size or shape limit');
-      },
-    );
+      check(events.whereType<HermesResponseCreated>().single.responseId)
+          .equals('resp_deep');
+      check(events.whereType<HermesRunError>().single.message)
+          .contains('size or shape limit');
+    });
 
     test(
       'delegates event-only terminal frames to the Hermes fallback',
@@ -603,9 +599,8 @@ void main() {
           (event) => event.responseId,
         ),
       ).deepEquals(['resp_sdk', 'resp_sdk']);
-      check(
-        events.whereType<HermesTokenDelta>().map((event) => event.content),
-      ).deepEquals(['hello', ' declined']);
+      check(events.whereType<HermesTokenDelta>().map((event) => event.content))
+          .deepEquals(['hello', ' declined']);
       check(
         events.whereType<HermesReasoningDelta>().map((event) => event.content),
       ).deepEquals(['think', 'summary', 'final thought']);
@@ -633,18 +628,14 @@ void main() {
         ]),
       ).toList();
 
-      check(
-        events.whereType<HermesTokenDelta>().single.content,
-      ).equals('legacy');
-      check(
-        events.whereType<HermesReasoningDelta>().single.content,
-      ).equals('alias');
-      check(
-        events.whereType<HermesToolProgress>().single.toolName,
-      ).equals('terminal');
-      check(
-        events.whereType<HermesApprovalRequested>().single.approvalId,
-      ).equals('a1');
+      check(events.whereType<HermesTokenDelta>().single.content)
+          .equals('legacy');
+      check(events.whereType<HermesReasoningDelta>().single.content)
+          .equals('alias');
+      check(events.whereType<HermesToolProgress>().single.toolName)
+          .equals('terminal');
+      check(events.whereType<HermesApprovalRequested>().single.approvalId)
+          .equals('a1');
     });
 
     test('surfaces typed incomplete responses as terminal errors', () async {
@@ -668,9 +659,8 @@ void main() {
           .isA<HermesResponseCreated>()
           .has((event) => event.responseId, 'responseId')
           .equals('resp_incomplete');
-      check(
-        events.whereType<HermesRunError>().single.message,
-      ).contains('max_output_tokens');
+      check(events.whereType<HermesRunError>().single.message)
+          .contains('max_output_tokens');
       check(events.last).isA<HermesRunDone>();
     });
 
@@ -686,9 +676,8 @@ void main() {
           .isA<HermesResponseCreated>()
           .has((event) => event.responseId, 'responseId')
           .equals('resp_cancelled');
-      check(
-        events.whereType<HermesRunError>().single.message,
-      ).contains('cancelled');
+      check(events.whereType<HermesRunError>().single.message)
+          .contains('cancelled');
       check(events.last).isA<HermesRunDone>();
     });
 
@@ -704,9 +693,8 @@ void main() {
           .isA<HermesResponseCreated>()
           .has((event) => event.responseId, 'responseId')
           .equals('resp_sparse');
-      check(
-        events.whereType<HermesRunError>().single.message,
-      ).contains('content_filter');
+      check(events.whereType<HermesRunError>().single.message)
+          .contains('content_filter');
       check(events.last).isA<HermesRunDone>();
     });
   });

--- a/test/features/hermes/hermes_tier1_test.dart
+++ b/test/features/hermes/hermes_tier1_test.dart
@@ -204,9 +204,8 @@ void main() {
       final toolsets = await service.listToolsets();
       await service.getRun('r1');
 
-      check(
-        capture.requests[0].path,
-      ).equals('http://host:8642/v1/capabilities');
+      check(capture.requests[0].path)
+          .equals('http://host:8642/v1/capabilities');
       check(capture.requests[1].path).equals('http://host:8642/v1/toolsets');
       check(capture.requests[2].path).equals('http://host:8642/v1/runs/r1');
       check(toolsets.single['name']).equals('web');
@@ -232,15 +231,12 @@ void main() {
       check((capture.requests[0].data as Map)['schedule']).equals('0 9 * * *');
       check(capture.requests[1].method).equals('PATCH');
       check((capture.requests[1].data as Map)['enabled']).equals(false);
-      check(
-        capture.requests[2].path,
-      ).equals('http://host:8642/api/jobs/j1/pause');
-      check(
-        capture.requests[3].path,
-      ).equals('http://host:8642/api/jobs/j1/resume');
-      check(
-        capture.requests[4].path,
-      ).equals('http://host:8642/api/jobs/j1/run');
+      check(capture.requests[2].path)
+          .equals('http://host:8642/api/jobs/j1/pause');
+      check(capture.requests[3].path)
+          .equals('http://host:8642/api/jobs/j1/resume');
+      check(capture.requests[4].path)
+          .equals('http://host:8642/api/jobs/j1/run');
       check(capture.requests[5].method).equals('DELETE');
     });
 
@@ -312,12 +308,10 @@ void main() {
 
         final jobs = await service.listJobs();
 
-        check(
-          capture.requests.single.queryParameters['include_disabled'],
-        ).equals(true);
-        check(
-          jobs.map((job) => job['id'] ?? job['job_id']).toList(),
-        ).deepEquals(['job-safe', 'legacy-safe']);
+        check(capture.requests.single.queryParameters['include_disabled'])
+            .equals(true);
+        check(jobs.map((job) => job['id'] ?? job['job_id']).toList())
+            .deepEquals(['job-safe', 'legacy-safe']);
       },
     );
 
@@ -344,9 +338,8 @@ void main() {
 
       final jobs = await service.listJobs();
 
-      check(
-        jobs.map((job) => job['id']).toList(),
-      ).deepEquals(['abcdef123456', 'bcdef1234567']);
+      check(jobs.map((job) => job['id']).toList())
+          .deepEquals(['abcdef123456', 'bcdef1234567']);
     });
   });
 

--- a/test/features/navigation/providers/conversation_selection_provider_test.dart
+++ b/test/features/navigation/providers/conversation_selection_provider_test.dart
@@ -197,9 +197,8 @@ void main() {
       final container = await _createContainer(
         activeConversation: previous,
         extraOverrides: [
-          loadConversationProvider(
-            conversationScopedId(summary),
-          ).overrideWith((ref) async => full),
+          loadConversationProvider(conversationScopedId(summary))
+              .overrideWith((ref) async => full),
         ],
       );
       container
@@ -239,9 +238,8 @@ void main() {
       final container = await _createContainer(
         activeConversation: previous,
         extraOverrides: [
-          loadConversationProvider(
-            conversationScopedId(summary),
-          ).overrideWith((ref) async => full),
+          loadConversationProvider(conversationScopedId(summary))
+              .overrideWith((ref) async => full),
         ],
       );
       container
@@ -342,9 +340,8 @@ void main() {
               () => _PendingAccountStorageIsolation(isolationGate.future),
             ),
         extraOverrides: [
-          loadConversationProvider(
-            conversationScopedId(second),
-          ).overrideWith((ref) async => secondFull),
+          loadConversationProvider(conversationScopedId(second))
+              .overrideWith((ref) async => secondFull),
         ],
       );
 
@@ -390,9 +387,8 @@ void main() {
       );
       final container = await _createContainer(
         extraOverrides: [
-          loadConversationProvider(
-            conversationScopedId(second),
-          ).overrideWith((ref) async => secondFull),
+          loadConversationProvider(conversationScopedId(second))
+              .overrideWith((ref) async => secondFull),
         ],
       );
 
@@ -431,12 +427,10 @@ void main() {
     final secondGate = Completer<Conversation>();
     final container = await _createContainer(
       extraOverrides: [
-        loadConversationProvider(
-          conversationScopedId(first),
-        ).overrideWith((ref) => firstGate.future),
-        loadConversationProvider(
-          conversationScopedId(second),
-        ).overrideWith((ref) => secondGate.future),
+        loadConversationProvider(conversationScopedId(first))
+            .overrideWith((ref) => firstGate.future),
+        loadConversationProvider(conversationScopedId(second))
+            .overrideWith((ref) => secondGate.future),
       ],
     );
 
@@ -497,9 +491,8 @@ void main() {
     final container = await _createContainer(
       activeConversation: previous,
       extraOverrides: [
-        loadConversationProvider(
-          scopedId,
-        ).overrideWith((ref) => loadGate.future),
+        loadConversationProvider(scopedId)
+            .overrideWith((ref) => loadGate.future),
       ],
     );
     _certifyOpenWebUiStorage(container);
@@ -536,9 +529,8 @@ void main() {
     final container = await _createContainer(
       activeConversation: previous,
       extraOverrides: [
-        loadConversationProvider(
-          conversationScopedId(summary),
-        ).overrideWith((ref) => loadGate.future),
+        loadConversationProvider(conversationScopedId(summary))
+            .overrideWith((ref) => loadGate.future),
       ],
     );
     _certifyOpenWebUiStorage(container);
@@ -578,9 +570,8 @@ void main() {
     final container = await _createContainer(
       activeConversation: previous,
       extraOverrides: [
-        loadConversationProvider(
-          conversationScopedId(summary),
-        ).overrideWith((ref) => loadGate.future),
+        loadConversationProvider(conversationScopedId(summary))
+            .overrideWith((ref) => loadGate.future),
       ],
     );
     _certifyOpenWebUiStorage(container);
@@ -621,9 +612,8 @@ void main() {
       activeConversation: previous,
       timeout: const Duration(milliseconds: 50),
       extraOverrides: [
-        loadConversationProvider(
-          conversationScopedId(summary),
-        ).overrideWith((ref) => loadGate.future),
+        loadConversationProvider(conversationScopedId(summary))
+            .overrideWith((ref) => loadGate.future),
       ],
     );
     _certifyOpenWebUiStorage(container);
@@ -647,9 +637,8 @@ void main() {
     final loadGate = Completer<Conversation>();
     final container = await _createContainer(
       extraOverrides: [
-        loadConversationProvider(
-          conversationScopedId(summary),
-        ).overrideWith((ref) => loadGate.future),
+        loadConversationProvider(conversationScopedId(summary))
+            .overrideWith((ref) => loadGate.future),
       ],
     );
 
@@ -720,17 +709,15 @@ void main() {
     final container = await _createContainer(
       timeout: const Duration(seconds: 1),
       extraOverrides: [
-        loadConversationProvider(conversationScopedId(first)).overrideWith((
-          ref,
-        ) async {
-          attempts += 1;
-          throw OpenWebUiConversationOwnershipException(
-            OpenWebUiConversationOwnershipFailureReason.changedWhileLoading,
-          );
-        }),
-        loadConversationProvider(
-          conversationScopedId(second),
-        ).overrideWith((ref) async => secondFull),
+        loadConversationProvider(conversationScopedId(first))
+            .overrideWith((ref) async {
+              attempts += 1;
+              throw OpenWebUiConversationOwnershipException(
+                OpenWebUiConversationOwnershipFailureReason.changedWhileLoading,
+              );
+            }),
+        loadConversationProvider(conversationScopedId(second))
+            .overrideWith((ref) async => secondFull),
       ],
     );
     _certifyOpenWebUiStorage(container);

--- a/test/features/navigation/providers/sidebar_providers_test.dart
+++ b/test/features/navigation/providers/sidebar_providers_test.dart
@@ -19,9 +19,8 @@ void main() {
     final container = ProviderContainer();
     addTearDown(container.dispose);
 
-    check(
-      container.read(sidebarActiveTabProvider),
-    ).equals(SidebarTabId.channels);
+    check(container.read(sidebarActiveTabProvider))
+        .equals(SidebarTabId.channels);
   });
 
   test('set persists the selected tab identity', () async {
@@ -32,12 +31,10 @@ void main() {
     final controller = container.read(sidebarActiveTabProvider.notifier);
 
     controller.set(SidebarTabId.channels);
-    check(
-      container.read(sidebarActiveTabProvider),
-    ).equals(SidebarTabId.channels);
-    check(
-      PreferencesStore.get<String>(PreferenceKeys.sidebarActiveTab),
-    ).equals(SidebarTabId.channels.name);
+    check(container.read(sidebarActiveTabProvider))
+        .equals(SidebarTabId.channels);
+    check(PreferencesStore.get<String>(PreferenceKeys.sidebarActiveTab))
+        .equals(SidebarTabId.channels.name);
   });
 
   test('legacy numeric tab positions resolve against visible tabs', () async {
@@ -64,12 +61,10 @@ void main() {
     // user selection completes the migration to a stable identity.
     check(PreferencesStore.getRaw(PreferenceKeys.sidebarActiveTab)).equals(2);
     controller.set(selected);
-    check(
-      container.read(sidebarActiveTabProvider),
-    ).equals(SidebarTabId.channels);
-    check(
-      PreferencesStore.get<String>(PreferenceKeys.sidebarActiveTab),
-    ).equals(SidebarTabId.channels.name);
+    check(container.read(sidebarActiveTabProvider))
+        .equals(SidebarTabId.channels);
+    check(PreferencesStore.get<String>(PreferenceKeys.sidebarActiveTab))
+        .equals(SidebarTabId.channels.name);
   });
 
   test('legacy selection is not persisted during capability changes', () async {
@@ -135,40 +130,33 @@ void main() {
     final controller = container.read(sidebarTabletWidthProvider.notifier);
 
     controller.setWidth(600);
-    check(
-      container.read(sidebarTabletWidthProvider),
-    ).equals(maximumSidebarTabletWidth);
+    check(container.read(sidebarTabletWidthProvider))
+        .equals(maximumSidebarTabletWidth);
     await Future<void>.delayed(const Duration(milliseconds: 250));
-    check(
-      PreferencesStore.get<num>(PreferenceKeys.sidebarTabletWidth),
-    ).equals(maximumSidebarTabletWidth);
+    check(PreferencesStore.get<num>(PreferenceKeys.sidebarTabletWidth))
+        .equals(maximumSidebarTabletWidth);
 
     controller.setWidth(120);
-    check(
-      container.read(sidebarTabletWidthProvider),
-    ).equals(minimumSidebarTabletWidth);
+    check(container.read(sidebarTabletWidthProvider))
+        .equals(minimumSidebarTabletWidth);
     await Future<void>.delayed(const Duration(milliseconds: 250));
-    check(
-      PreferencesStore.get<num>(PreferenceKeys.sidebarTabletWidth),
-    ).equals(minimumSidebarTabletWidth);
+    check(PreferencesStore.get<num>(PreferenceKeys.sidebarTabletWidth))
+        .equals(minimumSidebarTabletWidth);
 
     final clampedContainer = ProviderContainer();
     addTearDown(clampedContainer.dispose);
-    check(
-      clampedContainer.read(sidebarTabletWidthProvider),
-    ).equals(minimumSidebarTabletWidth);
+    check(clampedContainer.read(sidebarTabletWidthProvider))
+        .equals(minimumSidebarTabletWidth);
 
     controller.reset();
-    check(
-      container.read(sidebarTabletWidthProvider),
-    ).equals(defaultSidebarTabletWidth);
+    check(container.read(sidebarTabletWidthProvider))
+        .equals(defaultSidebarTabletWidth);
     await Future<void>.delayed(const Duration(milliseconds: 250));
 
     final restoredContainer = ProviderContainer();
     addTearDown(restoredContainer.dispose);
-    check(
-      restoredContainer.read(sidebarTabletWidthProvider),
-    ).equals(defaultSidebarTabletWidth);
+    check(restoredContainer.read(sidebarTabletWidthProvider))
+        .equals(defaultSidebarTabletWidth);
   });
 
   test('legacy tablet widths below 320 restore at the new minimum', () async {
@@ -179,9 +167,8 @@ void main() {
     final container = ProviderContainer();
     addTearDown(container.dispose);
 
-    check(
-      container.read(sidebarTabletWidthProvider),
-    ).equals(minimumSidebarTabletWidth);
+    check(container.read(sidebarTabletWidthProvider))
+        .equals(minimumSidebarTabletWidth);
     check(minimumSidebarTabletWidth).equals(320);
   });
 }

--- a/test/features/notes/services/note_audio_upload_service_test.dart
+++ b/test/features/notes/services/note_audio_upload_service_test.dart
@@ -268,9 +268,8 @@ void main() {
         await durable.delete();
         final interrupted = File('${durable.parent.path}/.staging.m4a');
         await interrupted.writeAsBytes(completeBytes.take(512).toList());
-        await File(
-          '${cache.path}/source.m4a',
-        ).writeAsBytes(completeBytes, flush: true);
+        await File('${cache.path}/source.m4a')
+            .writeAsBytes(completeBytes, flush: true);
 
         final recovered = await NoteAudioUploadStore(
           applicationSupportDirectory: () async => root,
@@ -342,9 +341,8 @@ void main() {
         check(uploadCalls).equals(1);
         check(firstAttachCalls).equals(1);
         check(replacementAttachCalls).equals(1);
-        check(
-          await store.loadForNote(serverId: 'server-1', noteId: 'note-1'),
-        ).isEmpty();
+        check(await store.loadForNote(serverId: 'server-1', noteId: 'note-1'))
+            .isEmpty();
       },
     );
 
@@ -404,9 +402,8 @@ void main() {
           attach: (_, _) async => fail('must not attach a completed job'),
         ).process(staged);
         check(repeated).isNull();
-        check(
-          await store.loadForNote(serverId: 'server-1', noteId: 'note-1'),
-        ).isEmpty();
+        check(await store.loadForNote(serverId: 'server-1', noteId: 'note-1'))
+            .isEmpty();
       },
     );
 
@@ -838,9 +835,8 @@ void main() {
       }
       check(await processing).isNull();
 
-      check(
-        await store.loadForNote(serverId: 'server-1', noteId: 'note-1'),
-      ).isEmpty();
+      check(await store.loadForNote(serverId: 'server-1', noteId: 'note-1'))
+          .isEmpty();
     });
 
     test(

--- a/test/features/notifications/notification_event_classifier_test.dart
+++ b/test/features/notifications/notification_event_classifier_test.dart
@@ -106,9 +106,8 @@ void main() {
     });
 
     test('malformed envelopes return null without throwing', () {
-      check(
-        classifier.classifyChatEvent({}, currentUserId: currentUserId),
-      ).isNull();
+      check(classifier.classifyChatEvent({}, currentUserId: currentUserId))
+          .isNull();
       check(
         classifier.classifyChatEvent({
           'data': 'not-a-map',
@@ -187,9 +186,7 @@ void main() {
 
     test('message with missing/empty author is ignored as malformed', () {
       final result = classifier.classifyChannelEvent(
-        channelEvent(
-          inner: const {'id': 'msg-3', 'content': 'no author'},
-        ),
+        channelEvent(inner: const {'id': 'msg-3', 'content': 'no author'}),
         currentUserId: currentUserId,
       );
       check(result).isNull();
@@ -237,9 +234,8 @@ void main() {
     });
 
     test('malformed envelopes return null without throwing', () {
-      check(
-        classifier.classifyChannelEvent({}, currentUserId: currentUserId),
-      ).isNull();
+      check(classifier.classifyChannelEvent({}, currentUserId: currentUserId))
+          .isNull();
       check(
         classifier.classifyChannelEvent({
           'channel_id': 'c',

--- a/test/features/notifications/notification_router_test.dart
+++ b/test/features/notifications/notification_router_test.dart
@@ -8,7 +8,8 @@ import 'package:conduit/features/notifications/services/notification_sound_servi
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 
-class _MockLocalNotifications extends Mock implements LocalNotificationService {}
+class _MockLocalNotifications extends Mock
+    implements LocalNotificationService {}
 
 class _MockSound extends Mock implements NotificationSoundService {}
 
@@ -56,7 +57,8 @@ void main() {
     sound = _MockSound();
     banners = [];
     unreads = [];
-    when(() => local.show(any(), playSound: any(named: 'playSound'))).thenAnswer((_) async {});
+    when(() => local.show(any(), playSound: any(named: 'playSound')))
+        .thenAnswer((_) async {});
     when(() => sound.play()).thenAnswer((_) async {});
   });
 
@@ -97,46 +99,43 @@ void main() {
       final router = build(
         settings: allOn.copyWith(notificationChannelEnabled: false),
       );
-      check(
-        await router.route(_channel()),
-      ).equals(NotificationSurface.suppressed);
+      check(await router.route(_channel()))
+          .equals(NotificationSurface.suppressed);
     });
 
     test('duplicate dedupKey is suppressed on the second delivery', () async {
       final router = build();
-      check(await router.route(_chat(key: 'dup'))).equals(
-        NotificationSurface.banner,
-      );
-      check(
-        await router.route(_chat(key: 'dup')),
-      ).equals(NotificationSurface.suppressed);
+      check(await router.route(_chat(key: 'dup')))
+          .equals(NotificationSurface.banner);
+      check(await router.route(_chat(key: 'dup')))
+          .equals(NotificationSurface.suppressed);
     });
 
     test('currently viewing the chat suppresses its completion', () async {
       final router = build(view: const ActiveView(chatId: 'chat-1'));
-      check(
-        await router.route(_chat(id: 'chat-1')),
-      ).equals(NotificationSurface.suppressed);
+      check(await router.route(_chat(id: 'chat-1')))
+          .equals(NotificationSurface.suppressed);
     });
 
     test('currently viewing the channel suppresses its message', () async {
       final router = build(view: const ActiveView(channelId: 'chan-1'));
-      check(
-        await router.route(_channel(id: 'chan-1')),
-      ).equals(NotificationSurface.suppressed);
+      check(await router.route(_channel(id: 'chan-1')))
+          .equals(NotificationSurface.suppressed);
     });
 
-    test('backgrounded, the active chat still notifies (not suppressed)', () async {
-      // Start a chat (it is the active view), then background the app: the
-      // completion must still fire an OS notification.
-      final router = build(
-        foreground: false,
-        view: const ActiveView(chatId: 'chat-1'),
-      );
-      check(
-        await router.route(_chat(id: 'chat-1')),
-      ).equals(NotificationSurface.system);
-    });
+    test(
+      'backgrounded, the active chat still notifies (not suppressed)',
+      () async {
+        // Start a chat (it is the active view), then background the app: the
+        // completion must still fire an OS notification.
+        final router = build(
+          foreground: false,
+          view: const ActiveView(chatId: 'chat-1'),
+        );
+        check(await router.route(_chat(id: 'chat-1')))
+            .equals(NotificationSurface.system);
+      },
+    );
   });
 
   group('surface selection', () {
@@ -160,22 +159,29 @@ void main() {
       final router = build(foreground: false);
       check(await router.route(_chat())).equals(NotificationSurface.system);
       check(banners).isEmpty();
-      verify(() => local.show(any(), playSound: any(named: 'playSound'))).called(1);
+      verify(() => local.show(any(), playSound: any(named: 'playSound')))
+          .called(1);
     });
 
-    test('system notification sound follows the notificationSound pref', () async {
-      final router = build(
-        foreground: false,
-        settings: allOn.copyWith(notificationSound: false),
-      );
-      await router.route(_chat());
-      final played =
-          verify(
-                () => local.show(any(), playSound: captureAny(named: 'playSound')),
-              ).captured.single
-              as bool;
-      check(played).isFalse();
-    });
+    test(
+      'system notification sound follows the notificationSound pref',
+      () async {
+        final router = build(
+          foreground: false,
+          settings: allOn.copyWith(notificationSound: false),
+        );
+        await router.route(_chat());
+        final played =
+            verify(
+                  () => local.show(
+                    any(),
+                    playSound: captureAny(named: 'playSound'),
+                  ),
+                ).captured.single
+                as bool;
+        check(played).isFalse();
+      },
+    );
 
     test('background with system off is silent', () async {
       final router = build(

--- a/test/features/release_notes/services/release_notes_service_test.dart
+++ b/test/features/release_notes/services/release_notes_service_test.dart
@@ -47,9 +47,8 @@ void main() {
 
     check(decision.type).equals(ReleaseNotesDecisionType.show);
     check(decision.previousVersion).equals('3.3.1');
-    check(
-      decision.notes.map((release) => release.version),
-    ).deepEquals(['3.3.2', '3.4.0']);
+    check(decision.notes.map((release) => release.version))
+        .deepEquals(['3.3.2', '3.4.0']);
   });
 
   test('missing baked note still advances current version', () {

--- a/test/features/terminal/controllers/terminal_context_controller_test.dart
+++ b/test/features/terminal/controllers/terminal_context_controller_test.dart
@@ -49,9 +49,8 @@ void main() {
       when(
         () => service.isTerminalFeatureEnabled(server, sessionScopeId: 'scope'),
       ).thenAnswer((_) async => true);
-      when(
-        () => service.getCwd(server, sessionScopeId: 'scope'),
-      ).thenAnswer((_) async => '/workspace');
+      when(() => service.getCwd(server, sessionScopeId: 'scope'))
+          .thenAnswer((_) async => '/workspace');
       when(
         () => service.listFiles(server, '/workspace/', sessionScopeId: 'scope'),
       ).thenAnswer(
@@ -63,9 +62,8 @@ void main() {
           ),
         ],
       );
-      when(
-        () => service.getListeningPorts(server, sessionScopeId: 'scope'),
-      ).thenAnswer((_) async => const [TerminalListeningPort(port: 8080)]);
+      when(() => service.getListeningPorts(server, sessionScopeId: 'scope'))
+          .thenAnswer((_) async => const [TerminalListeningPort(port: 8080)]);
       final harness = _TerminalControllerHarness(gateway);
       addTearDown(harness.dispose);
 
@@ -211,9 +209,8 @@ void main() {
     when(
       () => service.listFiles(server, '/workspace/', sessionScopeId: 'scope-a'),
     ).thenAnswer((_) async => const []);
-    when(
-      () => service.getListeningPorts(server, sessionScopeId: 'scope-a'),
-    ).thenAnswer((_) async => const []);
+    when(() => service.getListeningPorts(server, sessionScopeId: 'scope-a'))
+        .thenAnswer((_) async => const []);
 
     await harness.browser.renameEntry(capturedContext, entry, 'renamed.md');
     await harness.browser.deleteEntry(capturedContext, entry);

--- a/test/features/terminal/providers/terminal_channel_connector_test.dart
+++ b/test/features/terminal/providers/terminal_channel_connector_test.dart
@@ -60,10 +60,8 @@ Future<List<String>> _captureHandshakeUserAgents(
     final userAgents = await captured.future.timeout(
       const Duration(seconds: 5),
     );
-    await Future.wait([
-      readyFinished,
-      streamFinished,
-    ]).timeout(const Duration(seconds: 5));
+    await Future.wait([readyFinished, streamFinished])
+        .timeout(const Duration(seconds: 5));
     return userAgents;
   } finally {
     await server.close(force: true);

--- a/test/features/terminal/providers/terminal_tab_visible_test.dart
+++ b/test/features/terminal/providers/terminal_tab_visible_test.dart
@@ -30,21 +30,24 @@ void main() {
     check(container.read(terminalTabVisibleProvider)).isTrue();
   });
 
-  test('live: an empty server list hides the tab (terminal disabled)', () async {
-    final container = ProviderContainer(
-      overrides: [
-        terminalAvailableServersProvider.overrideWith(
-          (ref) async => const <TerminalServerInfo>[],
-        ),
-      ],
-    );
-    addTearDown(container.dispose);
+  test(
+    'live: an empty server list hides the tab (terminal disabled)',
+    () async {
+      final container = ProviderContainer(
+        overrides: [
+          terminalAvailableServersProvider.overrideWith(
+            (ref) async => const <TerminalServerInfo>[],
+          ),
+        ],
+      );
+      addTearDown(container.dispose);
 
-    await container.read(terminalAvailableServersProvider.future);
-    // Let the deferred cache write-back microtask run while alive.
-    await Future<void>.delayed(Duration.zero);
-    check(container.read(terminalTabVisibleProvider)).isFalse();
-  });
+      await container.read(terminalAvailableServersProvider.future);
+      // Let the deferred cache write-back microtask run while alive.
+      await Future<void>.delayed(Duration.zero);
+      check(container.read(terminalTabVisibleProvider)).isFalse();
+    },
+  );
 
   test(
     'offline (server list unresolved): falls back to the cached flag — a '

--- a/test/features/workspace/models/workspace_model_draft_test.dart
+++ b/test/features/workspace/models/workspace_model_draft_test.dart
@@ -116,15 +116,12 @@ void main() {
       (copy.extraMeta['custom'] as Map)['enabled'] = false;
 
       check(copy.description).equals('  unsaved spacing  ');
-      check(
-        ((draft.advancedParams['nested'] as Map)['values'] as List),
-      ).deepEquals([1]);
-      check(
-        ((draft.builtinTools['search'] as Map)['options'] as List),
-      ).deepEquals(['safe']);
-      check(
-        ((draft.knowledge.single.raw['metadata'] as Map)['labels'] as List),
-      ).deepEquals(['one']);
+      check(((draft.advancedParams['nested'] as Map)['values'] as List))
+          .deepEquals([1]);
+      check(((draft.builtinTools['search'] as Map)['options'] as List))
+          .deepEquals(['safe']);
+      check(((draft.knowledge.single.raw['metadata'] as Map)['labels'] as List))
+          .deepEquals(['one']);
       check((draft.extraMeta['custom'] as Map)['enabled']).equals(true);
     });
 

--- a/test/features/workspace/models/workspace_models_test.dart
+++ b/test/features/workspace/models/workspace_models_test.dart
@@ -138,9 +138,8 @@ void main() {
 
       check(prompt.tags).isEmpty();
       check(legacyTool.specs.single['name']).equals('legacy_function');
-      check(
-        () => Tool.fromJson({'name': 'Missing id'}),
-      ).throws<FormatException>();
+      check(() => Tool.fromJson({'name': 'Missing id'}))
+          .throws<FormatException>();
     },
   );
 }

--- a/test/features/workspace/models/workspace_prompt_command_test.dart
+++ b/test/features/workspace/models/workspace_prompt_command_test.dart
@@ -14,7 +14,8 @@ void main() {
     });
 
     test('leaves a bare token untouched', () {
-      check(WorkspacePromptCommand.strip('translate-now')).equals('translate-now');
+      check(WorkspacePromptCommand.strip('translate-now'))
+          .equals('translate-now');
     });
   });
 
@@ -45,7 +46,8 @@ void main() {
 
   group('WorkspacePromptCommand.slugify', () {
     test('lowercases and hyphenates whitespace', () {
-      check(WorkspacePromptCommand.slugify('Summarize This')).equals('summarize-this');
+      check(WorkspacePromptCommand.slugify('Summarize This'))
+          .equals('summarize-this');
     });
 
     test('strips accents and illegal characters', () {
@@ -53,7 +55,8 @@ void main() {
     });
 
     test('keeps hyphens and underscores', () {
-      check(WorkspacePromptCommand.slugify('multi_word-name')).equals('multi_word-name');
+      check(WorkspacePromptCommand.slugify('multi_word-name'))
+          .equals('multi_word-name');
     });
   });
 }

--- a/test/features/workspace/models/workspace_skill_content_test.dart
+++ b/test/features/workspace/models/workspace_skill_content_test.dart
@@ -15,7 +15,8 @@ description: Step-by-step instructions for code reviews
 Do the thing.''';
       final fm = WorkspaceSkillContent.parseFrontmatter(content);
       check(fm['name']).equals('Code Review Guidelines');
-      check(fm['description']).equals('Step-by-step instructions for code reviews');
+      check(fm['description'])
+          .equals('Step-by-step instructions for code reviews');
     });
 
     test('strips a single layer of surrounding quotes and keeps colons', () {
@@ -25,7 +26,8 @@ Do the thing.''';
     });
 
     test('returns empty when there is no front-matter', () {
-      check(WorkspaceSkillContent.parseFrontmatter('# Just markdown')).isEmpty();
+      check(WorkspaceSkillContent.parseFrontmatter('# Just markdown'))
+          .isEmpty();
       check(WorkspaceSkillContent.parseFrontmatter('')).isEmpty();
     });
   });

--- a/test/features/workspace/models/workspace_tool_content_test.dart
+++ b/test/features/workspace/models/workspace_tool_content_test.dart
@@ -29,15 +29,13 @@ class Tools:
 
   group('nameToId', () {
     test('lowercases, folds accents, and underscores separators', () {
-      check(WorkspaceToolContent.nameToId('Wéb Search Tool!')).equals(
-        'web_search_tool',
-      );
+      check(WorkspaceToolContent.nameToId('Wéb Search Tool!'))
+          .equals('web_search_tool');
     });
 
     test('trims leading and trailing underscores', () {
-      check(WorkspaceToolContent.nameToId('  ***My Tool***  ')).equals(
-        'my_tool',
-      );
+      check(WorkspaceToolContent.nameToId('  ***My Tool***  '))
+          .equals('my_tool');
     });
   });
 

--- a/test/features/workspace/providers/workspace_providers_test.dart
+++ b/test/features/workspace/providers/workspace_providers_test.dart
@@ -32,9 +32,8 @@ void main() {
       await container.read(workspaceModelsProvider.notifier).loadMore();
 
       final loaded = container.read(workspaceModelsProvider).requireValue;
-      check(
-        loaded.items.map((item) => item.id),
-      ).deepEquals(['model-1', 'model-2']);
+      check(loaded.items.map((item) => item.id))
+          .deepEquals(['model-1', 'model-2']);
       check(loaded.page).equals(2);
       check(loaded.hasMore).isFalse();
     },
@@ -79,9 +78,8 @@ void main() {
     await container.read(workspaceModelsProvider.future);
     api.refreshError = StateError('server rejected management request');
 
-    await check(
-      container.read(workspaceModelsProvider.notifier).refresh(),
-    ).throws<StateError>();
+    await check(container.read(workspaceModelsProvider.notifier).refresh())
+        .throws<StateError>();
 
     final state = container.read(workspaceModelsProvider).requireValue;
     check(state.items.map((item) => item.id)).deepEquals(['model-1']);
@@ -141,11 +139,8 @@ void main() {
         .read(workspacePromptsProvider.notifier)
         .loadAllForExport();
 
-    check(all.map((item) => item.id)).deepEquals([
-      'prompt-1',
-      'prompt-2',
-      'prompt-3',
-    ]);
+    check(all.map((item) => item.id))
+        .deepEquals(['prompt-1', 'prompt-2', 'prompt-3']);
     // The export paged past the first page rather than stopping at it.
     check(api.pagesRequested).deepEquals([1, 2]);
   });
@@ -172,10 +167,8 @@ void main() {
 
     // The removed regular tool is pruned; the surviving regular tool and the
     // direct-server selection are both preserved.
-    check(container.read(selectedToolIdsProvider)).deepEquals([
-      'beta_tool',
-      'direct_server:mcp-1',
-    ]);
+    check(container.read(selectedToolIdsProvider))
+        .deepEquals(['beta_tool', 'direct_server:mcp-1']);
   });
 
   test('newer model query wins when responses complete out of order', () async {
@@ -221,9 +214,8 @@ void main() {
 
       await container.read(workspaceKnowledgeProvider.notifier).loadMore();
       state = container.read(workspaceKnowledgeProvider).requireValue;
-      check(
-        state.items.map((item) => item.id),
-      ).deepEquals(['knowledge-1', 'knowledge-2']);
+      check(state.items.map((item) => item.id))
+          .deepEquals(['knowledge-1', 'knowledge-2']);
       check(state.total).equals(2);
       check(state.hasMore).isFalse();
       check(api.requests).deepEquals([
@@ -274,16 +266,15 @@ void main() {
     // reflects only the surviving tool.
     final container = _toolsContainer(
       api,
-      cacheTools: [
-        const Tool(id: 'beta_tool', name: 'Beta'),
-      ],
+      cacheTools: [const Tool(id: 'beta_tool', name: 'Beta')],
     );
     addTearDown(container.dispose);
 
     await container.read(workspaceToolsProvider.future);
-    container
-        .read(selectedToolIdsProvider.notifier)
-        .set(['alpha', 'beta_tool']);
+    container.read(selectedToolIdsProvider.notifier).set([
+      'alpha',
+      'beta_tool',
+    ]);
 
     api.remaining = [
       const WorkspaceToolSummary(id: 'beta_tool', name: 'Beta', userId: 'u'),
@@ -414,7 +405,8 @@ class _WorkspaceKnowledgeApi extends ApiService {
   }) async {
     requests.add((query: query, view: viewOption, page: page));
     sources.add(source);
-    final filtered = (query != null && query.isNotEmpty) ||
+    final filtered =
+        (query != null && query.isNotEmpty) ||
         (source != null && source.isNotEmpty);
     if (!filtered) {
       return const WorkspacePagedResponse(items: [], total: 0);

--- a/test/features/workspace/views/workspace_model_editor_controller_test.dart
+++ b/test/features/workspace/views/workspace_model_editor_controller_test.dart
@@ -81,9 +81,8 @@ void main() {
     controller.fields.params.text = '{"temperature": 0.5}';
     controller.fields.builtinTools.text = 'not-json';
     check(controller.syncTextIntoDraft()).isFalse();
-    check(
-      controller.syncIssue,
-    ).equals(WorkspaceModelDraftSyncIssue.builtinTools);
+    check(controller.syncIssue)
+        .equals(WorkspaceModelDraftSyncIssue.builtinTools);
 
     controller.fields.builtinTools.text = '{"search": true}';
     check(controller.syncTextIntoDraft()).isTrue();
@@ -118,16 +117,14 @@ void main() {
         },
         present: (options, selectedIds) async {
           calls.add('present:${selectedIds.join(',')}');
-          check(
-            options.map((option) => option.id).toList(),
-          ).deepEquals(['tool-a', 'tool-b']);
+          check(options.map((option) => option.id).toList())
+              .deepEquals(['tool-a', 'tool-b']);
           return ['tool-b'];
         },
       );
 
-      check(
-        result.outcome,
-      ).equals(WorkspaceModelRelationshipPickOutcome.updated);
+      check(result.outcome)
+          .equals(WorkspaceModelRelationshipPickOutcome.updated);
       check(calls).deepEquals(['load', 'present:tool-a']);
       check(controller.draft.toolIds).deepEquals(['tool-b']);
       check(controller.session.dirty).isTrue();

--- a/test/features/workspace/widgets/workspace_resource_editor_host_test.dart
+++ b/test/features/workspace/widgets/workspace_resource_editor_host_test.dart
@@ -17,9 +17,8 @@ void main() {
       resourceId: '  resource-id  ',
     );
     check(existing).isA<WorkspaceExistingEditorTarget>();
-    check(
-      (existing as WorkspaceExistingEditorTarget).resourceId,
-    ).equals('resource-id');
+    check((existing as WorkspaceExistingEditorTarget).resourceId)
+        .equals('resource-id');
 
     check(
       WorkspaceEditorTarget.fromRoute(

--- a/test/features/workspace/workspace_navigation_test.dart
+++ b/test/features/workspace/workspace_navigation_test.dart
@@ -14,39 +14,31 @@ void main() {
 
     final permitted = permittedWorkspaceSections(capabilities);
 
-    check(
-      permitted,
-    ).deepEquals([WorkspaceSection.prompts, WorkspaceSection.tools]);
+    check(permitted)
+        .deepEquals([WorkspaceSection.prompts, WorkspaceSection.tools]);
     check(permitted.first.path).equals('/workspace/prompts');
   });
 
   test('detail and edit paths resolve to their protected section', () {
-    check(
-      workspaceSectionForPath('/workspace/models/model-1/edit'),
-    ).equals(WorkspaceSection.models);
-    check(
-      workspaceSectionForPath('/workspace/knowledge/kb-1'),
-    ).equals(WorkspaceSection.knowledge);
+    check(workspaceSectionForPath('/workspace/models/model-1/edit'))
+        .equals(WorkspaceSection.models);
+    check(workspaceSectionForPath('/workspace/knowledge/kb-1'))
+        .equals(WorkspaceSection.knowledge);
     check(workspaceSectionForPath('/profile')).isNull();
   });
 
   test('descriptors are the source for production paths and names', () {
     check(Routes.workspace).equals('/workspace');
-    check(
-      WorkspaceSection.models.routes.createPattern,
-    ).equals('/workspace/models/create');
-    check(
-      WorkspaceSection.knowledge.routes.detailPattern,
-    ).equals('/workspace/knowledge/:id');
-    check(
-      WorkspaceSection.prompts.routes.editPattern,
-    ).equals('/workspace/prompts/:id/edit');
-    check(
-      WorkspaceSection.tools.routes.collectionName,
-    ).equals('workspace-tools');
-    check(
-      WorkspaceSection.skills.routes.editName,
-    ).equals('workspace-skill-edit');
+    check(WorkspaceSection.models.routes.createPattern)
+        .equals('/workspace/models/create');
+    check(WorkspaceSection.knowledge.routes.detailPattern)
+        .equals('/workspace/knowledge/:id');
+    check(WorkspaceSection.prompts.routes.editPattern)
+        .equals('/workspace/prompts/:id/edit');
+    check(WorkspaceSection.tools.routes.collectionName)
+        .equals('workspace-tools');
+    check(WorkspaceSection.skills.routes.editName)
+        .equals('workspace-skill-edit');
   });
 
   test('resource locations encode IDs without changing route matching', () {
@@ -55,13 +47,11 @@ void main() {
     );
     final edit = WorkspaceSection.models.routes.editLocation('model/one');
 
-    check(
-      detail,
-    ).equals('/workspace/knowledge/folder%2Fid%20with%20spaces%3F%23');
+    check(detail)
+        .equals('/workspace/knowledge/folder%2Fid%20with%20spaces%3F%23');
     check(edit).equals('/workspace/models/model%2Fone/edit');
-    check(
-      workspaceSectionForPath('$detail?tab=files'),
-    ).equals(WorkspaceSection.knowledge);
+    check(workspaceSectionForPath('$detail?tab=files'))
+        .equals(WorkspaceSection.knowledge);
     check(workspaceSectionForPath('/workspace/models-extra/id')).isNull();
   });
 }

--- a/test/shared/widgets/markdown/markdown_compile_service_test.dart
+++ b/test/shared/widgets/markdown/markdown_compile_service_test.dart
@@ -650,48 +650,42 @@ void main() {
     },
   );
 
-  test(
-    'prepareContent falls back to sync when the async prepare backend fails',
-    () async {
-      MarkdownPrepareExecutionPath? executionPath;
-      final service = MarkdownCompileService(
-        workerManager: WorkerManager(),
-        debugOnPrepareExecution: (path) => executionPath = path,
-        debugPrepareContentOverride: (content, streaming) async {
-          throw StateError(
-            'prepare backend failed: streaming=$streaming length=${content.length}',
-          );
-        },
-      );
-      addTearDown(service.dispose);
+  test('prepareContent falls back to sync when the async prepare backend fails', () async {
+    MarkdownPrepareExecutionPath? executionPath;
+    final service = MarkdownCompileService(
+      workerManager: WorkerManager(),
+      debugOnPrepareExecution: (path) => executionPath = path,
+      debugPrepareContentOverride: (content, streaming) async {
+        throw StateError(
+          'prepare backend failed: streaming=$streaming length=${content.length}',
+        );
+      },
+    );
+    addTearDown(service.dispose);
 
-      final longPrefix = List<String>.filled(220, 'stream chunk').join(' ');
-      final content = [
-        longPrefix,
-        '<details type="tool_calls" name="search">',
-        '<summary>Tool Executed</summary>',
-        '{"q":"cats"}',
-      ].join('\n\n');
+    final longPrefix = List<String>.filled(220, 'stream chunk').join(' ');
+    final content = [
+      longPrefix,
+      '<details type="tool_calls" name="search">',
+      '<summary>Tool Executed</summary>',
+      '{"q":"cats"}',
+    ].join('\n\n');
 
-      expect(
-        service.shouldPrepareSynchronously(content, widgetTest: false),
-        isFalse,
-      );
+    expect(
+      service.shouldPrepareSynchronously(content, widgetTest: false),
+      isFalse,
+    );
 
-      final prepared = await service.prepareContent(
-        content,
-        streaming: true,
-        allowSynchronous: true,
-        widgetTest: false,
-      );
+    final prepared = await service.prepareContent(
+      content,
+      streaming: true,
+      allowSynchronous: true,
+      widgetTest: false,
+    );
 
-      expect(
-        prepared,
-        equals(prepareMarkdownContent(content, streaming: true)),
-      );
-      expect(executionPath, MarkdownPrepareExecutionPath.fallbackSync);
-    },
-  );
+    expect(prepared, equals(prepareMarkdownContent(content, streaming: true)));
+    expect(executionPath, MarkdownPrepareExecutionPath.fallbackSync);
+  });
 
   test(
     'compilePreparedBatch preserves order and dedupes cache entries',
@@ -782,9 +776,8 @@ void main() {
     await Future<void>.delayed(Duration.zero);
 
     check(service.preparedInputs).deepEquals(contents);
-    check(
-      service.batchCalls.map((batch) => batch.length),
-    ).deepEquals([8, 8, 1]);
+    check(service.batchCalls.map((batch) => batch.length))
+        .deepEquals([8, 8, 1]);
   });
 
   test('prewarmContents yields before admitting the next raw batch', () async {

--- a/test/shared/widgets/markdown/markdown_document_controller_test.dart
+++ b/test/shared/widgets/markdown/markdown_document_controller_test.dart
@@ -227,6 +227,37 @@ void main() {
     expect(split['fallbackReason'], 'referenceDefinitions');
   });
 
+  test('a literal incomplete details tag inside the body does not leave '
+      'depth tracking stale past the close', () {
+    // The parser only counts complete `<details ...>` tags; crediting the
+    // partial line kept the scanner "inside" the block after the parser
+    // closed it, so the document-level definition after the block was
+    // treated as body content and never triggered the fallback.
+    const content =
+        'See [docs][d].\n\n<details>\n<details is an HTML tag\n'
+        '</details>\n\n[d]: https://example.com';
+
+    final split = debugSplitStreamingPreparedContentForTesting(content);
+
+    expect(split['frozenPrefix'], isEmpty);
+    expect(split['mutableTail'], content);
+    expect(split['canIncrementallyCompile'], isFalse);
+    expect(split['fallbackReason'], 'referenceDefinitions');
+  });
+
+  test('an incomplete details entry tag keeps the tail mutable', () {
+    // Until the tag completes the parser sees only a paragraph; freezing a
+    // boundary here would shift on the next flush.
+    const content = 'Intro paragraph.\n\n<details type="reasoning';
+
+    final split = debugSplitStreamingPreparedContentForTesting(content);
+
+    expect(split['frozenPrefix'], 'Intro paragraph.\n\n');
+    expect(split['mutableTail'], '<details type="reasoning');
+    expect(split['canIncrementallyCompile'], isTrue);
+    expect(split['fallbackReason'], isNull);
+  });
+
   test('a definition-shaped line inside a details body does not force the '
       'reference-definitions fallback', () {
     // The parser lifts details bodies into a `body_markdown` attribute

--- a/test/shared/widgets/markdown/markdown_document_controller_test.dart
+++ b/test/shared/widgets/markdown/markdown_document_controller_test.dart
@@ -129,6 +129,22 @@ void main() {
   });
 
   test(
+    'a reference definition after a raw HTML block still keeps the region '
+    'mutable',
+    () {
+      const content =
+          'See [docs][d].\n\n<div>\nraw html\n</div>\n\n[d]: https://example.com';
+
+      final split = debugSplitStreamingPreparedContentForTesting(content);
+
+      expect(split['frozenPrefix'], isEmpty);
+      expect(split['mutableTail'], content);
+      expect(split['canIncrementallyCompile'], isFalse);
+      expect(split['fallbackReason'], 'referenceDefinitions');
+    },
+  );
+
+  test(
     'reference-definition-shaped lines inside fenced code do not disable '
     'incremental splitting',
     () {

--- a/test/shared/widgets/markdown/markdown_document_controller_test.dart
+++ b/test/shared/widgets/markdown/markdown_document_controller_test.dart
@@ -106,16 +106,42 @@ void main() {
     },
   );
 
-  test('splitter keeps CommonMark raw HTML blocks fully mutable', () {
+  test('splitter keeps CommonMark raw HTML blocks mutable from their start', () {
     const content = '<pre>\nraw line\n\n**not markdown**\n</pre>\n\nTail';
 
     final split = debugSplitStreamingPreparedContentForTesting(content);
 
     expect(split['frozenPrefix'], isEmpty);
     expect(split['mutableTail'], content);
-    expect(split['canIncrementallyCompile'], isFalse);
-    expect(split['fallbackReason'], 'rawHtmlBlock');
+    expect(split['canIncrementallyCompile'], isTrue);
+    expect(split['fallbackReason'], isNull);
   });
+
+  test('splitter freezes blocks that precede a raw HTML block', () {
+    const content = 'Intro paragraph.\n\n<div>\nraw html\n</div>\n\nTail';
+
+    final split = debugSplitStreamingPreparedContentForTesting(content);
+
+    expect(split['frozenPrefix'], 'Intro paragraph.\n\n');
+    expect(split['mutableTail'], '<div>\nraw html\n</div>\n\nTail');
+    expect(split['canIncrementallyCompile'], isTrue);
+    expect(split['fallbackReason'], isNull);
+  });
+
+  test(
+    'reference-definition-shaped lines inside fenced code do not disable '
+    'incremental splitting',
+    () {
+      const content = '```md\n[d]: https://example.com\n```\n\nTail';
+
+      final split = debugSplitStreamingPreparedContentForTesting(content);
+
+      expect(split['frozenPrefix'], '```md\n[d]: https://example.com\n```\n\n');
+      expect(split['mutableTail'], 'Tail');
+      expect(split['canIncrementallyCompile'], isTrue);
+      expect(split['fallbackReason'], isNull);
+    },
+  );
 
   test('splitter keeps loose list continuations in the mutable tail', () {
     const content = '- First paragraph.\n\n  Second paragraph.';

--- a/test/shared/widgets/markdown/markdown_document_controller_test.dart
+++ b/test/shared/widgets/markdown/markdown_document_controller_test.dart
@@ -171,6 +171,23 @@ void main() {
     expect(split['fallbackReason'], 'referenceDefinitions');
   });
 
+  test('a details-close lookalike inside the body does not hide a later '
+      'reference definition', () {
+    // `</details >` is NOT a close for the details parser; treating it as
+    // one exited details tracking early, and the body backtick then opened
+    // a phantom outer fence that swallowed the definition after the block.
+    const content =
+        'See [docs][d].\n\n<details>\nbody with </details > lookalike\n'
+        '```\n</details>\n\n[d]: https://example.com';
+
+    final split = debugSplitStreamingPreparedContentForTesting(content);
+
+    expect(split['frozenPrefix'], isEmpty);
+    expect(split['mutableTail'], content);
+    expect(split['canIncrementallyCompile'], isFalse);
+    expect(split['fallbackReason'], 'referenceDefinitions');
+  });
+
   test(
     'a closed details block with no unsafe lines still freezes normally',
     () {

--- a/test/shared/widgets/markdown/markdown_document_controller_test.dart
+++ b/test/shared/widgets/markdown/markdown_document_controller_test.dart
@@ -145,6 +145,36 @@ void main() {
   );
 
   test(
+    'backtick lines inside raw HTML do not hide a later reference definition',
+    () {
+      const content =
+          'See [docs][d].\n\n<pre>\n```\ncontent\n</pre>\n\n'
+          '[d]: https://example.com';
+
+      final split = debugSplitStreamingPreparedContentForTesting(content);
+
+      expect(split['frozenPrefix'], isEmpty);
+      expect(split['mutableTail'], content);
+      expect(split['canIncrementallyCompile'], isFalse);
+      expect(split['fallbackReason'], 'referenceDefinitions');
+    },
+  );
+
+  test(
+    'definition-shaped lines inside raw HTML fall back conservatively',
+    () {
+      const content = 'Intro.\n\n<pre>\n[d]: https://example.com\n</pre>';
+
+      final split = debugSplitStreamingPreparedContentForTesting(content);
+
+      expect(split['frozenPrefix'], isEmpty);
+      expect(split['mutableTail'], content);
+      expect(split['canIncrementallyCompile'], isFalse);
+      expect(split['fallbackReason'], 'referenceDefinitions');
+    },
+  );
+
+  test(
     'reference-definition-shaped lines inside fenced code do not disable '
     'incremental splitting',
     () {

--- a/test/shared/widgets/markdown/markdown_document_controller_test.dart
+++ b/test/shared/widgets/markdown/markdown_document_controller_test.dart
@@ -207,6 +207,26 @@ void main() {
     expect(split['fallbackReason'], 'referenceDefinitions');
   });
 
+  test('an indented nested details open inside the body does not hide a '
+      'later reference definition', () {
+    // The details parser counts tags on the raw line regardless of
+    // indentation inside the block; routing depth counting through the
+    // dedented block-starter candidate (null for 4+-space lines) missed
+    // the nested open, so the first close exited details tracking early
+    // and the body backtick opened a phantom fence.
+    const content =
+        'See [docs][d].\n\n<details>\n    intro <details type="tool_calls" '
+        'done="true">\n</details>\n```\n</details>\n\n'
+        '[d]: https://example.com';
+
+    final split = debugSplitStreamingPreparedContentForTesting(content);
+
+    expect(split['frozenPrefix'], isEmpty);
+    expect(split['mutableTail'], content);
+    expect(split['canIncrementallyCompile'], isFalse);
+    expect(split['fallbackReason'], 'referenceDefinitions');
+  });
+
   test('a definition-shaped line inside a details body does not force the '
       'reference-definitions fallback', () {
     // The parser lifts details bodies into a `body_markdown` attribute

--- a/test/shared/widgets/markdown/markdown_document_controller_test.dart
+++ b/test/shared/widgets/markdown/markdown_document_controller_test.dart
@@ -92,30 +92,30 @@ void main() {
     },
   );
 
-  test(
-    'splitter falls back to the full document when reference definitions are present',
-    () {
-      const content = 'See [docs][d].\n\n[d]: https://example.com';
-
-      final split = debugSplitStreamingPreparedContentForTesting(content);
-
-      expect(split['frozenPrefix'], isEmpty);
-      expect(split['mutableTail'], content);
-      expect(split['canIncrementallyCompile'], isFalse);
-      expect(split['fallbackReason'], 'referenceDefinitions');
-    },
-  );
-
-  test('splitter keeps CommonMark raw HTML blocks mutable from their start', () {
-    const content = '<pre>\nraw line\n\n**not markdown**\n</pre>\n\nTail';
+  test('splitter falls back to the full document when reference definitions are present', () {
+    const content = 'See [docs][d].\n\n[d]: https://example.com';
 
     final split = debugSplitStreamingPreparedContentForTesting(content);
 
     expect(split['frozenPrefix'], isEmpty);
     expect(split['mutableTail'], content);
-    expect(split['canIncrementallyCompile'], isTrue);
-    expect(split['fallbackReason'], isNull);
+    expect(split['canIncrementallyCompile'], isFalse);
+    expect(split['fallbackReason'], 'referenceDefinitions');
   });
+
+  test(
+    'splitter keeps CommonMark raw HTML blocks mutable from their start',
+    () {
+      const content = '<pre>\nraw line\n\n**not markdown**\n</pre>\n\nTail';
+
+      final split = debugSplitStreamingPreparedContentForTesting(content);
+
+      expect(split['frozenPrefix'], isEmpty);
+      expect(split['mutableTail'], content);
+      expect(split['canIncrementallyCompile'], isTrue);
+      expect(split['fallbackReason'], isNull);
+    },
+  );
 
   test('splitter freezes blocks that precede a raw HTML block', () {
     const content = 'Intro paragraph.\n\n<div>\nraw html\n</div>\n\nTail';
@@ -128,12 +128,25 @@ void main() {
     expect(split['fallbackReason'], isNull);
   });
 
+  test('a reference definition after a raw HTML block still keeps the region '
+      'mutable', () {
+    const content =
+        'See [docs][d].\n\n<div>\nraw html\n</div>\n\n[d]: https://example.com';
+
+    final split = debugSplitStreamingPreparedContentForTesting(content);
+
+    expect(split['frozenPrefix'], isEmpty);
+    expect(split['mutableTail'], content);
+    expect(split['canIncrementallyCompile'], isFalse);
+    expect(split['fallbackReason'], 'referenceDefinitions');
+  });
+
   test(
-    'a reference definition after a raw HTML block still keeps the region '
-    'mutable',
+    'reference definitions with escaped brackets in the label are detected',
     () {
       const content =
-          'See [docs][d].\n\n<div>\nraw html\n</div>\n\n[d]: https://example.com';
+          'See [docs][a\\]b].\n\n<div>\nraw html\n</div>\n\n'
+          '[a\\]b]: https://example.com';
 
       final split = debugSplitStreamingPreparedContentForTesting(content);
 
@@ -160,34 +173,28 @@ void main() {
     },
   );
 
-  test(
-    'definition-shaped lines inside raw HTML fall back conservatively',
-    () {
-      const content = 'Intro.\n\n<pre>\n[d]: https://example.com\n</pre>';
+  test('definition-shaped lines inside raw HTML fall back conservatively', () {
+    const content = 'Intro.\n\n<pre>\n[d]: https://example.com\n</pre>';
 
-      final split = debugSplitStreamingPreparedContentForTesting(content);
+    final split = debugSplitStreamingPreparedContentForTesting(content);
 
-      expect(split['frozenPrefix'], isEmpty);
-      expect(split['mutableTail'], content);
-      expect(split['canIncrementallyCompile'], isFalse);
-      expect(split['fallbackReason'], 'referenceDefinitions');
-    },
-  );
+    expect(split['frozenPrefix'], isEmpty);
+    expect(split['mutableTail'], content);
+    expect(split['canIncrementallyCompile'], isFalse);
+    expect(split['fallbackReason'], 'referenceDefinitions');
+  });
 
-  test(
-    'reference-definition-shaped lines inside fenced code do not disable '
-    'incremental splitting',
-    () {
-      const content = '```md\n[d]: https://example.com\n```\n\nTail';
+  test('reference-definition-shaped lines inside fenced code do not disable '
+      'incremental splitting', () {
+    const content = '```md\n[d]: https://example.com\n```\n\nTail';
 
-      final split = debugSplitStreamingPreparedContentForTesting(content);
+    final split = debugSplitStreamingPreparedContentForTesting(content);
 
-      expect(split['frozenPrefix'], '```md\n[d]: https://example.com\n```\n\n');
-      expect(split['mutableTail'], 'Tail');
-      expect(split['canIncrementallyCompile'], isTrue);
-      expect(split['fallbackReason'], isNull);
-    },
-  );
+    expect(split['frozenPrefix'], '```md\n[d]: https://example.com\n```\n\n');
+    expect(split['mutableTail'], 'Tail');
+    expect(split['canIncrementallyCompile'], isTrue);
+    expect(split['fallbackReason'], isNull);
+  });
 
   test('splitter keeps loose list continuations in the mutable tail', () {
     const content = '- First paragraph.\n\n  Second paragraph.';
@@ -219,18 +226,15 @@ void main() {
     expect(split['canIncrementallyCompile'], isTrue);
   });
 
-  test(
-    'splitter keeps paragraph continuations that look like ordered lists together',
-    () {
-      const content = 'This wraps\n2. not a list\n\nTail';
+  test('splitter keeps paragraph continuations that look like ordered lists together', () {
+    const content = 'This wraps\n2. not a list\n\nTail';
 
-      final split = debugSplitStreamingPreparedContentForTesting(content);
+    final split = debugSplitStreamingPreparedContentForTesting(content);
 
-      expect(split['frozenPrefix'], 'This wraps\n2. not a list\n\n');
-      expect(split['mutableTail'], 'Tail');
-      expect(split['canIncrementallyCompile'], isTrue);
-    },
-  );
+    expect(split['frozenPrefix'], 'This wraps\n2. not a list\n\n');
+    expect(split['mutableTail'], 'Tail');
+    expect(split['canIncrementallyCompile'], isTrue);
+  });
 
   test('splitter keeps loose multi-item lists together before freezing', () {
     const content = '- one\n\n- two\n\nTail';
@@ -242,28 +246,25 @@ void main() {
     expect(split['canIncrementallyCompile'], isTrue);
   });
 
-  test(
-    'splitter keeps indented code blocks that resemble markdown starters together',
-    () {
-      const firstLines = <String>[
-        '# not a heading',
-        '```',
-        '> not a quote',
-        '- not a list',
-      ];
+  test('splitter keeps indented code blocks that resemble markdown starters together', () {
+    const firstLines = <String>[
+      '# not a heading',
+      '```',
+      '> not a quote',
+      '- not a list',
+    ];
 
-      for (final firstLine in firstLines) {
-        final frozenPrefix = '    $firstLine\n    still code\n\n';
-        final split = debugSplitStreamingPreparedContentForTesting(
-          '${frozenPrefix}Tail',
-        );
+    for (final firstLine in firstLines) {
+      final frozenPrefix = '    $firstLine\n    still code\n\n';
+      final split = debugSplitStreamingPreparedContentForTesting(
+        '${frozenPrefix}Tail',
+      );
 
-        expect(split['frozenPrefix'], frozenPrefix, reason: firstLine);
-        expect(split['mutableTail'], 'Tail', reason: firstLine);
-        expect(split['canIncrementallyCompile'], isTrue, reason: firstLine);
-      }
-    },
-  );
+      expect(split['frozenPrefix'], frozenPrefix, reason: firstLine);
+      expect(split['mutableTail'], 'Tail', reason: firstLine);
+      expect(split['canIncrementallyCompile'], isTrue, reason: firstLine);
+    }
+  });
 
   test('splitter keeps an unterminated heading line mutable at EOF', () {
     const content = '### Partial heading';
@@ -328,82 +329,76 @@ Body
     ]);
   });
 
-  test(
-    'compose regroups adjacent tool call blocks across segment boundaries',
-    () {
-      final firstToolCall = compilePreparedMarkdownSync(
-        [
-          '<details type="tool_calls" done="true" name="search">',
-          '<summary>search</summary>',
-          '</details>',
-        ].join('\n'),
-      );
-      final secondToolCall = compilePreparedMarkdownSync(
-        [
-          '<details type="tool_calls" done="true" name="browser">',
-          '<summary>browser</summary>',
-          '</details>',
-        ].join('\n'),
-      ).rebaseRootIds(rootNodeOffset: firstToolCall.rootNodeCount);
+  test('compose regroups adjacent tool call blocks across segment boundaries', () {
+    final firstToolCall = compilePreparedMarkdownSync(
+      [
+        '<details type="tool_calls" done="true" name="search">',
+        '<summary>search</summary>',
+        '</details>',
+      ].join('\n'),
+    );
+    final secondToolCall = compilePreparedMarkdownSync(
+      [
+        '<details type="tool_calls" done="true" name="browser">',
+        '<summary>browser</summary>',
+        '</details>',
+      ].join('\n'),
+    ).rebaseRootIds(rootNodeOffset: firstToolCall.rootNodeCount);
 
-      final composed = CompiledMarkdownDocument.compose(
-        normalizedContent:
-            '${firstToolCall.normalizedContent}\n${secondToolCall.normalizedContent}',
-        segments: <CompiledMarkdownDocument>[firstToolCall, secondToolCall],
-      );
+    final composed = CompiledMarkdownDocument.compose(
+      normalizedContent:
+          '${firstToolCall.normalizedContent}\n${secondToolCall.normalizedContent}',
+      segments: <CompiledMarkdownDocument>[firstToolCall, secondToolCall],
+    );
 
-      expect(composed.blocks, hasLength(1));
-      final group = composed.blocks.single as CompiledMarkdownDetailsGroup;
-      expect(group.blockId, 'group:n0:tool_calls');
-      expect(group.items.map((item) => item.blockId).toList(), <String>[
-        'n0',
-        'n1',
-      ]);
-    },
-  );
+    expect(composed.blocks, hasLength(1));
+    final group = composed.blocks.single as CompiledMarkdownDetailsGroup;
+    expect(group.blockId, 'group:n0:tool_calls');
+    expect(group.items.map((item) => item.blockId).toList(), <String>[
+      'n0',
+      'n1',
+    ]);
+  });
 
-  test(
-    'compose realigns the mutable tail index when a tool_calls details merges across the boundary',
-    () {
-      final frozenToolCall = compilePreparedMarkdownSync(
-        [
-          '<details type="tool_calls" done="true" name="search">',
-          '<summary>search</summary>',
-          '</details>',
-        ].join('\n'),
-      );
-      final tail = compilePreparedMarkdownSync(
-        [
-          '<details type="tool_calls" done="true" name="browser">',
-          '<summary>browser</summary>',
-          '</details>',
-          '',
-          'Visible response',
-        ].join('\n'),
-      ).rebaseRootIds(rootNodeOffset: frozenToolCall.rootNodeCount);
+  test('compose realigns the mutable tail index when a tool_calls details merges across the boundary', () {
+    final frozenToolCall = compilePreparedMarkdownSync(
+      [
+        '<details type="tool_calls" done="true" name="search">',
+        '<summary>search</summary>',
+        '</details>',
+      ].join('\n'),
+    );
+    final tail = compilePreparedMarkdownSync(
+      [
+        '<details type="tool_calls" done="true" name="browser">',
+        '<summary>browser</summary>',
+        '</details>',
+        '',
+        'Visible response',
+      ].join('\n'),
+    ).rebaseRootIds(rootNodeOffset: frozenToolCall.rootNodeCount);
 
-      final composed = CompiledMarkdownDocument.compose(
-        normalizedContent:
-            '${frozenToolCall.normalizedContent}\n${tail.normalizedContent}',
-        segments: <CompiledMarkdownDocument>[frozenToolCall, tail],
-        // Pre-merge index: the frozen prefix contributes one block. The boundary
-        // tool_calls blocks then merge into a single group, shifting the tail.
-        mutableBlockStartIndex: frozenToolCall.rootBlockCount,
-      );
+    final composed = CompiledMarkdownDocument.compose(
+      normalizedContent:
+          '${frozenToolCall.normalizedContent}\n${tail.normalizedContent}',
+      segments: <CompiledMarkdownDocument>[frozenToolCall, tail],
+      // Pre-merge index: the frozen prefix contributes one block. The boundary
+      // tool_calls blocks then merge into a single group, shifting the tail.
+      mutableBlockStartIndex: frozenToolCall.rootBlockCount,
+    );
 
-      // Composed list is [group(search, browser), paragraph]. The merged group
-      // still carries the streaming tail item, so it must be the mutable tail —
-      // not left below the (pre-merge) start index and treated as frozen.
-      expect(composed.blocks, hasLength(2));
-      expect(composed.blocks.first, isA<CompiledMarkdownDetailsGroup>());
-      expect(composed.mutableBlockStartIndex, 0);
-      expect(composed.isMutableRootBlock(0), isTrue);
-      expect(composed.isMutableRootBlock(1), isTrue);
+    // Composed list is [group(search, browser), paragraph]. The merged group
+    // still carries the streaming tail item, so it must be the mutable tail —
+    // not left below the (pre-merge) start index and treated as frozen.
+    expect(composed.blocks, hasLength(2));
+    expect(composed.blocks.first, isA<CompiledMarkdownDetailsGroup>());
+    expect(composed.mutableBlockStartIndex, 0);
+    expect(composed.isMutableRootBlock(0), isTrue);
+    expect(composed.isMutableRootBlock(1), isTrue);
 
-      final parts = buildMarkdownDisplayParts(composed, isStreaming: true);
-      expect(parts.first.isMutableTail, isTrue);
-    },
-  );
+    final parts = buildMarkdownDisplayParts(composed, isStreaming: true);
+    expect(parts.first.isMutableTail, isTrue);
+  });
 
   test('compose stamps the mutable index on a single tail-only segment', () {
     final tail = compilePreparedMarkdownSync('### Partial heading');
@@ -511,68 +506,65 @@ Body
     },
   );
 
-  test(
-    'patch controller preserves frozen compilation and compiles only the new tail',
-    () async {
-      final compiler = _RecordingIncrementalMarkdownCompileService();
-      addTearDown(compiler.dispose);
-      final engine = StreamingMarkdownPreparationEngine();
-      var prepared = const PreparedMarkdownText.empty();
-      CompiledMarkdownDocument? latestDocument;
-      final controller = MarkdownDocumentController(
-        readCompiler: () => compiler,
-        isWidgetTest: () => false,
-        onStateChanged: (document) => latestDocument = document,
-      );
-      addTearDown(controller.dispose);
+  test('patch controller preserves frozen compilation and compiles only the new tail', () async {
+    final compiler = _RecordingIncrementalMarkdownCompileService();
+    addTearDown(compiler.dispose);
+    final engine = StreamingMarkdownPreparationEngine();
+    var prepared = const PreparedMarkdownText.empty();
+    CompiledMarkdownDocument? latestDocument;
+    final controller = MarkdownDocumentController(
+      readCompiler: () => compiler,
+      isWidgetTest: () => false,
+      onStateChanged: (document) => latestDocument = document,
+    );
+    addTearDown(controller.dispose);
 
-      final firstPatch = engine.prepare(
-        const MarkdownPreparationRequest(
-          sessionId: 'message-1',
-          revision: 1,
-          expectedBaseRevision: 0,
-          content: 'First paragraph.\n\nSecond',
-          streaming: true,
-          collectMetrics: false,
-          verifyParity: true,
-        ),
-      );
-      prepared = prepared.applyPatch(firstPatch);
-      controller.resolveStreamingPreparedPatch(prepared, firstPatch);
-      await _flushAsyncWork();
+    final firstPatch = engine.prepare(
+      const MarkdownPreparationRequest(
+        sessionId: 'message-1',
+        revision: 1,
+        expectedBaseRevision: 0,
+        content: 'First paragraph.\n\nSecond',
+        streaming: true,
+        collectMetrics: false,
+        verifyParity: true,
+      ),
+    );
+    prepared = prepared.applyPatch(firstPatch);
+    controller.resolveStreamingPreparedPatch(prepared, firstPatch);
+    await _flushAsyncWork();
 
-      expect(compiler.batchCalls, <List<String>>[
-        <String>['First paragraph.\n\n', 'Second'],
-      ]);
-      compiler.batchCalls.clear();
-      compiler.singleCalls.clear();
+    expect(compiler.batchCalls, <List<String>>[
+      <String>['First paragraph.\n\n', 'Second'],
+    ]);
+    compiler.batchCalls.clear();
+    compiler.singleCalls.clear();
 
-      final secondPatch = engine.prepare(
-        const MarkdownPreparationRequest(
-          sessionId: 'message-1',
-          revision: 2,
-          expectedBaseRevision: 1,
-          content: 'First paragraph.\n\nSecond grows',
-          streaming: true,
-          collectMetrics: false,
-          verifyParity: true,
-        ),
-      );
-      prepared = prepared.applyPatch(secondPatch);
-      controller.resolveStreamingPreparedPatch(prepared, secondPatch);
-      await _flushAsyncWork();
+    final secondPatch = engine.prepare(
+      const MarkdownPreparationRequest(
+        sessionId: 'message-1',
+        revision: 2,
+        expectedBaseRevision: 1,
+        content: 'First paragraph.\n\nSecond grows',
+        streaming: true,
+        collectMetrics: false,
+        verifyParity: true,
+      ),
+    );
+    prepared = prepared.applyPatch(secondPatch);
+    controller.resolveStreamingPreparedPatch(prepared, secondPatch);
+    await _flushAsyncWork();
 
-      expect(compiler.batchCalls, isEmpty);
-      expect(compiler.singleCalls, <String>['Second grows']);
-      expect(latestDocument, isNotNull);
-      expect(latestDocument!.preparedContent.segmentCount, greaterThan(1));
-      expect(
-        latestDocument!.normalizedContent,
-        'First paragraph.\n\nSecond grows',
-      );
-      expect(latestDocument!.mutableBlockStartIndex, 1);
-    },
-  );
+    expect(compiler.batchCalls, isEmpty);
+    expect(compiler.singleCalls, <String>['Second grows']);
+    expect(latestDocument, isNotNull);
+    expect(latestDocument!.preparedContent.segmentCount, greaterThan(1));
+    expect(
+      latestDocument!.normalizedContent,
+      'First paragraph.\n\nSecond grows',
+    );
+    expect(latestDocument!.mutableBlockStartIndex, 1);
+  });
 
   test(
     'patch controller reuses a verified frozen prefix across skipped revisions',
@@ -698,89 +690,83 @@ Body
     },
   );
 
-  test(
-    'controller recompiles the full document when reference definitions arrive later',
-    () async {
-      final compiler = _RecordingIncrementalMarkdownCompileService();
-      addTearDown(compiler.dispose);
+  test('controller recompiles the full document when reference definitions arrive later', () async {
+    final compiler = _RecordingIncrementalMarkdownCompileService();
+    addTearDown(compiler.dispose);
 
-      final controller = MarkdownDocumentController(
-        readCompiler: () => compiler,
-        isWidgetTest: () => false,
-        onStateChanged: (_) {},
-      );
-      addTearDown(controller.dispose);
+    final controller = MarkdownDocumentController(
+      readCompiler: () => compiler,
+      isWidgetTest: () => false,
+      onStateChanged: (_) {},
+    );
+    addTearDown(controller.dispose);
 
-      controller.resolveStreamingPrepared('See [docs][d].\n\nTail');
-      await _flushAsyncWork();
+    controller.resolveStreamingPrepared('See [docs][d].\n\nTail');
+    await _flushAsyncWork();
 
-      expect(compiler.batchCalls, <List<String>>[
-        <String>['See [docs][d].\n\n', 'Tail'],
-      ]);
-      expect(compiler.singleCalls, isEmpty);
+    expect(compiler.batchCalls, <List<String>>[
+      <String>['See [docs][d].\n\n', 'Tail'],
+    ]);
+    expect(compiler.singleCalls, isEmpty);
 
-      compiler.batchCalls.clear();
-      compiler.singleCalls.clear();
+    compiler.batchCalls.clear();
+    compiler.singleCalls.clear();
 
-      controller.resolveStreamingPrepared(
-        'See [docs][d].\n\nTail\n\n[d]: https://example.com',
-      );
-      await _flushAsyncWork();
+    controller.resolveStreamingPrepared(
+      'See [docs][d].\n\nTail\n\n[d]: https://example.com',
+    );
+    await _flushAsyncWork();
 
-      expect(compiler.batchCalls, isEmpty);
-      expect(compiler.singleCalls, <String>[
-        'See [docs][d].\n\nTail\n\n[d]: https://example.com',
-      ]);
-    },
-  );
+    expect(compiler.batchCalls, isEmpty);
+    expect(compiler.singleCalls, <String>[
+      'See [docs][d].\n\nTail\n\n[d]: https://example.com',
+    ]);
+  });
 
-  test(
-    'controller keeps indented code blocks with starter-like first lines together across streaming updates',
-    () async {
-      final compiler = _RecordingIncrementalMarkdownCompileService();
-      addTearDown(compiler.dispose);
+  test('controller keeps indented code blocks with starter-like first lines together across streaming updates', () async {
+    final compiler = _RecordingIncrementalMarkdownCompileService();
+    addTearDown(compiler.dispose);
 
-      CompiledMarkdownDocument? latestDocument;
-      final controller = MarkdownDocumentController(
-        readCompiler: () => compiler,
-        isWidgetTest: () => false,
-        onStateChanged: (document) => latestDocument = document,
-      );
-      addTearDown(controller.dispose);
+    CompiledMarkdownDocument? latestDocument;
+    final controller = MarkdownDocumentController(
+      readCompiler: () => compiler,
+      isWidgetTest: () => false,
+      onStateChanged: (document) => latestDocument = document,
+    );
+    addTearDown(controller.dispose);
 
-      const partialContent = '    # not a heading\n    still code';
-      controller.resolveStreamingPrepared(partialContent);
-      await _flushAsyncWork();
+    const partialContent = '    # not a heading\n    still code';
+    controller.resolveStreamingPrepared(partialContent);
+    await _flushAsyncWork();
 
-      expect(compiler.batchCalls, isEmpty);
-      expect(compiler.singleCalls, <String>[partialContent]);
-      expect(latestDocument, isNotNull);
-      expect(
-        (latestDocument!.blocks.single as CompiledMarkdownNodeBlock).kind,
-        CompiledMarkdownNodeBlockKind.codeBlock,
-      );
+    expect(compiler.batchCalls, isEmpty);
+    expect(compiler.singleCalls, <String>[partialContent]);
+    expect(latestDocument, isNotNull);
+    expect(
+      (latestDocument!.blocks.single as CompiledMarkdownNodeBlock).kind,
+      CompiledMarkdownNodeBlockKind.codeBlock,
+    );
 
-      compiler.batchCalls.clear();
-      compiler.singleCalls.clear();
+    compiler.batchCalls.clear();
+    compiler.singleCalls.clear();
 
-      const completedContent = '    # not a heading\n    still code\n\nTail';
-      controller.resolveStreamingPrepared(completedContent);
-      await _flushAsyncWork();
+    const completedContent = '    # not a heading\n    still code\n\nTail';
+    controller.resolveStreamingPrepared(completedContent);
+    await _flushAsyncWork();
 
-      expect(compiler.batchCalls, <List<String>>[
-        <String>['    # not a heading\n    still code\n\n', 'Tail'],
-      ]);
-      expect(compiler.singleCalls, isEmpty);
-      expect(
-        (latestDocument!.blocks.first as CompiledMarkdownNodeBlock).kind,
-        CompiledMarkdownNodeBlockKind.codeBlock,
-      );
-      expect(
-        latestDocument!.blocks.map((block) => block.blockId).toList(),
-        <String>['n0', 'n1'],
-      );
-    },
-  );
+    expect(compiler.batchCalls, <List<String>>[
+      <String>['    # not a heading\n    still code\n\n', 'Tail'],
+    ]);
+    expect(compiler.singleCalls, isEmpty);
+    expect(
+      (latestDocument!.blocks.first as CompiledMarkdownNodeBlock).kind,
+      CompiledMarkdownNodeBlockKind.codeBlock,
+    );
+    expect(
+      latestDocument!.blocks.map((block) => block.blockId).toList(),
+      <String>['n0', 'n1'],
+    );
+  });
 
   test(
     'controller preserves setext headings when incrementally composing blocks',
@@ -814,261 +800,238 @@ Body
     },
   );
 
-  test(
-    'controller regroups adjacent tool calls that arrive across streaming updates',
-    () async {
-      final compiler = _RecordingIncrementalMarkdownCompileService();
-      addTearDown(compiler.dispose);
+  test('controller regroups adjacent tool calls that arrive across streaming updates', () async {
+    final compiler = _RecordingIncrementalMarkdownCompileService();
+    addTearDown(compiler.dispose);
 
-      CompiledMarkdownDocument? latestDocument;
-      final controller = MarkdownDocumentController(
-        readCompiler: () => compiler,
-        isWidgetTest: () => false,
-        onStateChanged: (document) => latestDocument = document,
-      );
-      addTearDown(controller.dispose);
+    CompiledMarkdownDocument? latestDocument;
+    final controller = MarkdownDocumentController(
+      readCompiler: () => compiler,
+      isWidgetTest: () => false,
+      onStateChanged: (document) => latestDocument = document,
+    );
+    addTearDown(controller.dispose);
 
-      controller.resolveStreamingPrepared(
+    controller.resolveStreamingPrepared(
+      [
+        '<details type="tool_calls" done="true" name="search">',
+        '<summary>search</summary>',
+        '</details>',
+      ].join('\n'),
+    );
+    await _flushAsyncWork();
+
+    expect(compiler.batchCalls, isEmpty);
+    expect(compiler.singleCalls, <String>[
+      [
+        '<details type="tool_calls" done="true" name="search">',
+        '<summary>search</summary>',
+        '</details>',
+      ].join('\n'),
+    ]);
+    expect(latestDocument!.blocks, hasLength(1));
+    expect(latestDocument!.blocks.single, isA<CompiledMarkdownDetailsBlock>());
+
+    compiler.batchCalls.clear();
+    compiler.singleCalls.clear();
+
+    controller.resolveStreamingPrepared(
+      [
+        '<details type="tool_calls" done="true" name="search">',
+        '<summary>search</summary>',
+        '</details>',
+        '<details type="tool_calls" done="true" name="browser">',
+        '<summary>browser</summary>',
+        '</details>',
+      ].join('\n'),
+    );
+    await _flushAsyncWork();
+
+    expect(compiler.batchCalls, <List<String>>[
+      <String>[
         [
           '<details type="tool_calls" done="true" name="search">',
           '<summary>search</summary>',
           '</details>',
+          '',
         ].join('\n'),
-      );
-      await _flushAsyncWork();
-
-      expect(compiler.batchCalls, isEmpty);
-      expect(compiler.singleCalls, <String>[
         [
-          '<details type="tool_calls" done="true" name="search">',
-          '<summary>search</summary>',
-          '</details>',
-        ].join('\n'),
-      ]);
-      expect(latestDocument!.blocks, hasLength(1));
-      expect(
-        latestDocument!.blocks.single,
-        isA<CompiledMarkdownDetailsBlock>(),
-      );
-
-      compiler.batchCalls.clear();
-      compiler.singleCalls.clear();
-
-      controller.resolveStreamingPrepared(
-        [
-          '<details type="tool_calls" done="true" name="search">',
-          '<summary>search</summary>',
-          '</details>',
           '<details type="tool_calls" done="true" name="browser">',
           '<summary>browser</summary>',
           '</details>',
         ].join('\n'),
-      );
-      await _flushAsyncWork();
+      ],
+    ]);
+    expect(compiler.singleCalls, isEmpty);
+    expect(latestDocument!.blocks, hasLength(1));
+    final group = latestDocument!.blocks.single as CompiledMarkdownDetailsGroup;
+    expect(group.items.map((item) => item.name).toList(), <String>[
+      'search',
+      'browser',
+    ]);
+  });
 
-      expect(compiler.batchCalls, <List<String>>[
-        <String>[
-          [
-            '<details type="tool_calls" done="true" name="search">',
-            '<summary>search</summary>',
-            '</details>',
-            '',
-          ].join('\n'),
-          [
-            '<details type="tool_calls" done="true" name="browser">',
-            '<summary>browser</summary>',
-            '</details>',
-          ].join('\n'),
-        ],
-      ]);
-      expect(compiler.singleCalls, isEmpty);
-      expect(latestDocument!.blocks, hasLength(1));
-      final group =
-          latestDocument!.blocks.single as CompiledMarkdownDetailsGroup;
-      expect(group.items.map((item) => item.name).toList(), <String>[
-        'search',
-        'browser',
-      ]);
-    },
-  );
+  test('controller preserves lazy blockquote continuations when incrementally composing blocks', () async {
+    final compiler = _RecordingIncrementalMarkdownCompileService();
+    addTearDown(compiler.dispose);
 
-  test(
-    'controller preserves lazy blockquote continuations when incrementally composing blocks',
-    () async {
-      final compiler = _RecordingIncrementalMarkdownCompileService();
-      addTearDown(compiler.dispose);
+    CompiledMarkdownDocument? latestDocument;
+    final controller = MarkdownDocumentController(
+      readCompiler: () => compiler,
+      isWidgetTest: () => false,
+      onStateChanged: (document) => latestDocument = document,
+    );
+    addTearDown(controller.dispose);
 
-      CompiledMarkdownDocument? latestDocument;
-      final controller = MarkdownDocumentController(
-        readCompiler: () => compiler,
-        isWidgetTest: () => false,
-        onStateChanged: (document) => latestDocument = document,
-      );
-      addTearDown(controller.dispose);
+    controller.resolveStreamingPrepared('> quoted\ncontinued\n\nTail');
+    await _flushAsyncWork();
 
-      controller.resolveStreamingPrepared('> quoted\ncontinued\n\nTail');
-      await _flushAsyncWork();
+    expect(compiler.batchCalls, <List<String>>[
+      <String>['> quoted\ncontinued\n\n', 'Tail'],
+    ]);
+    expect(compiler.singleCalls, isEmpty);
 
-      expect(compiler.batchCalls, <List<String>>[
-        <String>['> quoted\ncontinued\n\n', 'Tail'],
-      ]);
-      expect(compiler.singleCalls, isEmpty);
+    final blockquoteBlock =
+        latestDocument!.blocks.first as CompiledMarkdownNodeBlock;
+    expect(blockquoteBlock.kind, CompiledMarkdownNodeBlockKind.blockquote);
+    expect(
+      latestDocument!.blocks.map((block) => block.blockId).toList(),
+      <String>['n0', 'n1'],
+    );
+  });
 
-      final blockquoteBlock =
-          latestDocument!.blocks.first as CompiledMarkdownNodeBlock;
-      expect(blockquoteBlock.kind, CompiledMarkdownNodeBlockKind.blockquote);
-      expect(
-        latestDocument!.blocks.map((block) => block.blockId).toList(),
-        <String>['n0', 'n1'],
-      );
-    },
-  );
+  test('controller preserves paragraph continuations that use non-1 ordered markers', () async {
+    final compiler = _RecordingIncrementalMarkdownCompileService();
+    addTearDown(compiler.dispose);
 
-  test(
-    'controller preserves paragraph continuations that use non-1 ordered markers',
-    () async {
-      final compiler = _RecordingIncrementalMarkdownCompileService();
-      addTearDown(compiler.dispose);
+    CompiledMarkdownDocument? latestDocument;
+    final controller = MarkdownDocumentController(
+      readCompiler: () => compiler,
+      isWidgetTest: () => false,
+      onStateChanged: (document) => latestDocument = document,
+    );
+    addTearDown(controller.dispose);
 
-      CompiledMarkdownDocument? latestDocument;
-      final controller = MarkdownDocumentController(
-        readCompiler: () => compiler,
-        isWidgetTest: () => false,
-        onStateChanged: (document) => latestDocument = document,
-      );
-      addTearDown(controller.dispose);
+    controller.resolveStreamingPrepared('This wraps\n2. not a list\n\nTail');
+    await _flushAsyncWork();
 
-      controller.resolveStreamingPrepared('This wraps\n2. not a list\n\nTail');
-      await _flushAsyncWork();
+    expect(compiler.batchCalls, <List<String>>[
+      <String>['This wraps\n2. not a list\n\n', 'Tail'],
+    ]);
+    expect(compiler.singleCalls, isEmpty);
 
-      expect(compiler.batchCalls, <List<String>>[
-        <String>['This wraps\n2. not a list\n\n', 'Tail'],
-      ]);
-      expect(compiler.singleCalls, isEmpty);
+    final paragraphBlock =
+        latestDocument!.blocks.first as CompiledMarkdownNodeBlock;
+    expect(paragraphBlock.kind, CompiledMarkdownNodeBlockKind.paragraph);
+    expect(
+      latestDocument!.blocks.map((block) => block.blockId).toList(),
+      <String>['n0', 'n1'],
+    );
+  });
 
-      final paragraphBlock =
-          latestDocument!.blocks.first as CompiledMarkdownNodeBlock;
-      expect(paragraphBlock.kind, CompiledMarkdownNodeBlockKind.paragraph);
-      expect(
-        latestDocument!.blocks.map((block) => block.blockId).toList(),
-        <String>['n0', 'n1'],
-      );
-    },
-  );
+  test('controller preserves loose multi-item lists when incrementally composing blocks', () async {
+    final compiler = _RecordingIncrementalMarkdownCompileService();
+    addTearDown(compiler.dispose);
 
-  test(
-    'controller preserves loose multi-item lists when incrementally composing blocks',
-    () async {
-      final compiler = _RecordingIncrementalMarkdownCompileService();
-      addTearDown(compiler.dispose);
+    CompiledMarkdownDocument? latestDocument;
+    final controller = MarkdownDocumentController(
+      readCompiler: () => compiler,
+      isWidgetTest: () => false,
+      onStateChanged: (document) => latestDocument = document,
+    );
+    addTearDown(controller.dispose);
 
-      CompiledMarkdownDocument? latestDocument;
-      final controller = MarkdownDocumentController(
-        readCompiler: () => compiler,
-        isWidgetTest: () => false,
-        onStateChanged: (document) => latestDocument = document,
-      );
-      addTearDown(controller.dispose);
+    controller.resolveStreamingPrepared('- one\n\n- two\n\nTail');
+    await _flushAsyncWork();
 
-      controller.resolveStreamingPrepared('- one\n\n- two\n\nTail');
-      await _flushAsyncWork();
+    expect(compiler.batchCalls, <List<String>>[
+      <String>['- one\n\n- two\n\n', 'Tail'],
+    ]);
+    expect(compiler.singleCalls, isEmpty);
 
-      expect(compiler.batchCalls, <List<String>>[
-        <String>['- one\n\n- two\n\n', 'Tail'],
-      ]);
-      expect(compiler.singleCalls, isEmpty);
+    final listBlock = latestDocument!.blocks.first as CompiledMarkdownNodeBlock;
+    expect(listBlock.kind, CompiledMarkdownNodeBlockKind.unorderedList);
+    expect(
+      latestDocument!.blocks.map((block) => block.blockId).toList(),
+      <String>['n0', 'n1'],
+    );
+  });
 
-      final listBlock =
-          latestDocument!.blocks.first as CompiledMarkdownNodeBlock;
-      expect(listBlock.kind, CompiledMarkdownNodeBlockKind.unorderedList);
-      expect(
-        latestDocument!.blocks.map((block) => block.blockId).toList(),
-        <String>['n0', 'n1'],
-      );
-    },
-  );
+  test('controller keeps a growing heading line in the mutable tail across updates', () async {
+    final compiler = _RecordingIncrementalMarkdownCompileService();
+    addTearDown(compiler.dispose);
 
-  test(
-    'controller keeps a growing heading line in the mutable tail across updates',
-    () async {
-      final compiler = _RecordingIncrementalMarkdownCompileService();
-      addTearDown(compiler.dispose);
+    CompiledMarkdownDocument? latestDocument;
+    final controller = MarkdownDocumentController(
+      readCompiler: () => compiler,
+      isWidgetTest: () => false,
+      onStateChanged: (document) => latestDocument = document,
+    );
+    addTearDown(controller.dispose);
 
-      CompiledMarkdownDocument? latestDocument;
-      final controller = MarkdownDocumentController(
-        readCompiler: () => compiler,
-        isWidgetTest: () => false,
-        onStateChanged: (document) => latestDocument = document,
-      );
-      addTearDown(controller.dispose);
+    controller.resolveStreamingPrepared('### Partial');
+    await _flushAsyncWork();
 
-      controller.resolveStreamingPrepared('### Partial');
-      await _flushAsyncWork();
+    expect(compiler.batchCalls, isEmpty);
+    expect(compiler.singleCalls, <String>['### Partial']);
+    expect(latestDocument!.blocks, hasLength(1));
+    expect(
+      (latestDocument!.blocks.single as CompiledMarkdownNodeBlock).kind,
+      CompiledMarkdownNodeBlockKind.heading3,
+    );
 
-      expect(compiler.batchCalls, isEmpty);
-      expect(compiler.singleCalls, <String>['### Partial']);
-      expect(latestDocument!.blocks, hasLength(1));
-      expect(
-        (latestDocument!.blocks.single as CompiledMarkdownNodeBlock).kind,
-        CompiledMarkdownNodeBlockKind.heading3,
-      );
+    compiler.batchCalls.clear();
+    compiler.singleCalls.clear();
 
-      compiler.batchCalls.clear();
-      compiler.singleCalls.clear();
+    controller.resolveStreamingPrepared('### Partial heading');
+    await _flushAsyncWork();
 
-      controller.resolveStreamingPrepared('### Partial heading');
-      await _flushAsyncWork();
+    expect(compiler.batchCalls, isEmpty);
+    expect(compiler.singleCalls, <String>['### Partial heading']);
+    expect(latestDocument!.blocks, hasLength(1));
+    expect(
+      (latestDocument!.blocks.single as CompiledMarkdownNodeBlock).kind,
+      CompiledMarkdownNodeBlockKind.heading3,
+    );
+  });
 
-      expect(compiler.batchCalls, isEmpty);
-      expect(compiler.singleCalls, <String>['### Partial heading']);
-      expect(latestDocument!.blocks, hasLength(1));
-      expect(
-        (latestDocument!.blocks.single as CompiledMarkdownNodeBlock).kind,
-        CompiledMarkdownNodeBlockKind.heading3,
-      );
-    },
-  );
+  test('controller keeps same-line text after closing details in the mutable tail across updates', () async {
+    final compiler = _RecordingIncrementalMarkdownCompileService();
+    addTearDown(compiler.dispose);
 
-  test(
-    'controller keeps same-line text after closing details in the mutable tail across updates',
-    () async {
-      final compiler = _RecordingIncrementalMarkdownCompileService();
-      addTearDown(compiler.dispose);
+    CompiledMarkdownDocument? latestDocument;
+    final controller = MarkdownDocumentController(
+      readCompiler: () => compiler,
+      isWidgetTest: () => false,
+      onStateChanged: (document) => latestDocument = document,
+    );
+    addTearDown(controller.dispose);
 
-      CompiledMarkdownDocument? latestDocument;
-      final controller = MarkdownDocumentController(
-        readCompiler: () => compiler,
-        isWidgetTest: () => false,
-        onStateChanged: (document) => latestDocument = document,
-      );
-      addTearDown(controller.dispose);
-
-      const firstContent = '''
+    const firstContent = '''
 <details type="reasoning" done="true">
 <summary>Thinking…</summary>
 Body
 </details>Visible''';
-      controller.resolveStreamingPrepared(firstContent);
-      await _flushAsyncWork();
+    controller.resolveStreamingPrepared(firstContent);
+    await _flushAsyncWork();
 
-      expect(compiler.batchCalls, isEmpty);
-      expect(compiler.singleCalls, <String>[firstContent]);
-      expect(latestDocument!.normalizedContent, firstContent);
+    expect(compiler.batchCalls, isEmpty);
+    expect(compiler.singleCalls, <String>[firstContent]);
+    expect(latestDocument!.normalizedContent, firstContent);
 
-      compiler.batchCalls.clear();
-      compiler.singleCalls.clear();
+    compiler.batchCalls.clear();
+    compiler.singleCalls.clear();
 
-      const secondContent = '''
+    const secondContent = '''
 <details type="reasoning" done="true">
 <summary>Thinking…</summary>
 Body
 </details>Visible response''';
-      controller.resolveStreamingPrepared(secondContent);
-      await _flushAsyncWork();
+    controller.resolveStreamingPrepared(secondContent);
+    await _flushAsyncWork();
 
-      expect(compiler.batchCalls, isEmpty);
-      expect(compiler.singleCalls, <String>[secondContent]);
-      expect(latestDocument!.normalizedContent, secondContent);
-    },
-  );
+    expect(compiler.batchCalls, isEmpty);
+    expect(compiler.singleCalls, <String>[secondContent]);
+    expect(latestDocument!.normalizedContent, secondContent);
+  });
 }

--- a/test/shared/widgets/markdown/markdown_document_controller_test.dart
+++ b/test/shared/widgets/markdown/markdown_document_controller_test.dart
@@ -157,6 +157,40 @@ void main() {
     },
   );
 
+  test('an unmatched fence inside a details body does not hide a later '
+      'reference definition', () {
+    const content =
+        'See [docs][d].\n\n<details>\nsome text\n```\nunmatched\n'
+        '</details>\n\n[d]: https://example.com';
+
+    final split = debugSplitStreamingPreparedContentForTesting(content);
+
+    expect(split['frozenPrefix'], isEmpty);
+    expect(split['mutableTail'], content);
+    expect(split['canIncrementallyCompile'], isFalse);
+    expect(split['fallbackReason'], 'referenceDefinitions');
+  });
+
+  test(
+    'a closed details block with no unsafe lines still freezes normally',
+    () {
+      const content =
+          '<details type="reasoning" done="true">\n<summary>Thought'
+          '</summary>\nbody\n</details>\n\nTail';
+
+      final split = debugSplitStreamingPreparedContentForTesting(content);
+
+      expect(
+        split['frozenPrefix'],
+        '<details type="reasoning" done="true">\n<summary>Thought'
+        '</summary>\nbody\n</details>\n\n',
+      );
+      expect(split['mutableTail'], 'Tail');
+      expect(split['canIncrementallyCompile'], isTrue);
+      expect(split['fallbackReason'], isNull);
+    },
+  );
+
   test(
     'backtick lines inside raw HTML do not hide a later reference definition',
     () {

--- a/test/shared/widgets/markdown/markdown_document_controller_test.dart
+++ b/test/shared/widgets/markdown/markdown_document_controller_test.dart
@@ -188,6 +188,25 @@ void main() {
     expect(split['fallbackReason'], 'referenceDefinitions');
   });
 
+  test('an inline nested details open inside the body does not hide a later '
+      'reference definition', () {
+    // The details parser counts `<details ...>` opens anywhere in a line;
+    // counting only line-anchored opens missed the nested inline open, so
+    // the first close exited details tracking early and the body backtick
+    // opened a phantom fence that swallowed the definition after the block.
+    const content =
+        'See [docs][d].\n\n<details>\nintro <details type="tool_calls" '
+        'done="true">\n</details>\n```\n</details>\n\n'
+        '[d]: https://example.com';
+
+    final split = debugSplitStreamingPreparedContentForTesting(content);
+
+    expect(split['frozenPrefix'], isEmpty);
+    expect(split['mutableTail'], content);
+    expect(split['canIncrementallyCompile'], isFalse);
+    expect(split['fallbackReason'], 'referenceDefinitions');
+  });
+
   test(
     'a closed details block with no unsafe lines still freezes normally',
     () {

--- a/test/shared/widgets/markdown/markdown_document_controller_test.dart
+++ b/test/shared/widgets/markdown/markdown_document_controller_test.dart
@@ -207,6 +207,27 @@ void main() {
     expect(split['fallbackReason'], 'referenceDefinitions');
   });
 
+  test('a definition-shaped line inside a details body does not force the '
+      'reference-definitions fallback', () {
+    // The parser lifts details bodies into a `body_markdown` attribute
+    // compiled as its own document, so a definition inside the body is not
+    // document-scoped and cannot couple frozen and mutable segments.
+    const content =
+        '<details type="reasoning" done="true">\n<summary>Thought'
+        '</summary>\n[d]: https://example.com\n</details>\n\nTail';
+
+    final split = debugSplitStreamingPreparedContentForTesting(content);
+
+    expect(
+      split['frozenPrefix'],
+      '<details type="reasoning" done="true">\n<summary>Thought'
+      '</summary>\n[d]: https://example.com\n</details>\n\n',
+    );
+    expect(split['mutableTail'], 'Tail');
+    expect(split['canIncrementallyCompile'], isTrue);
+    expect(split['fallbackReason'], isNull);
+  });
+
   test(
     'a closed details block with no unsafe lines still freezes normally',
     () {

--- a/test/shared/widgets/markdown/markdown_preprocessor_test.dart
+++ b/test/shared/widgets/markdown/markdown_preprocessor_test.dart
@@ -268,9 +268,8 @@ after''';
       );
       check(result).contains('Before');
       check(result).contains('after');
-      check(
-        result,
-      ).contains('<details><summary>Hidden</summary>tool output</details>');
+      check(result)
+          .contains('<details><summary>Hidden</summary>tool output</details>');
     });
 
     test('preserves generic html content to mirror OpenWebUI', () {

--- a/test/shared/widgets/markdown/streaming_markdown_preparation_test.dart
+++ b/test/shared/widgets/markdown/streaming_markdown_preparation_test.dart
@@ -113,43 +113,40 @@ void main() {
     );
   });
 
-  test(
-    'hidden incomplete tool call trims retained whitespace without parity checks',
-    () {
-      final engine = StreamingMarkdownPreparationEngine();
-      var prepared = const PreparedMarkdownText.empty();
+  test('hidden incomplete tool call trims retained whitespace without parity checks', () {
+    final engine = StreamingMarkdownPreparationEngine();
+    var prepared = const PreparedMarkdownText.empty();
 
-      final first = engine.prepare(
-        _request(
-          sessionId: 'message-1',
-          revision: 1,
-          baseRevision: 0,
-          content: 'Visible\n\nDraft',
-          verifyParity: false,
-        ),
-      );
-      prepared = prepared.applyPatch(first);
+    final first = engine.prepare(
+      _request(
+        sessionId: 'message-1',
+        revision: 1,
+        baseRevision: 0,
+        content: 'Visible\n\nDraft',
+        verifyParity: false,
+      ),
+    );
+    prepared = prepared.applyPatch(first);
 
-      const content = 'Visible\n\n<details type="tool_calls" name="search">';
-      final second = engine.prepare(
-        _request(
-          sessionId: 'message-1',
-          revision: 2,
-          baseRevision: 1,
-          content: content,
-          verifyParity: false,
-        ),
-      );
-      prepared = prepared.applyPatch(second);
+    const content = 'Visible\n\n<details type="tool_calls" name="search">';
+    final second = engine.prepare(
+      _request(
+        sessionId: 'message-1',
+        revision: 2,
+        baseRevision: 1,
+        content: content,
+        verifyParity: false,
+      ),
+    );
+    prepared = prepared.applyPatch(second);
 
-      expect(second.mode, MarkdownPreparationMode.incremental);
-      expect(prepared.materialize(), 'Visible');
-      expect(
-        prepared.materialize(),
-        prepareMarkdownContentCanonical(content, streaming: true),
-      );
-    },
-  );
+    expect(second.mode, MarkdownPreparationMode.incremental);
+    expect(prepared.materialize(), 'Visible');
+    expect(
+      prepared.materialize(),
+      prepareMarkdownContentCanonical(content, streaming: true),
+    );
+  });
 
   test('completed tool call restores its separator without parity checks', () {
     final engine = StreamingMarkdownPreparationEngine();

--- a/test/support/fake_open_webui_server_test.dart
+++ b/test/support/fake_open_webui_server_test.dart
@@ -123,14 +123,16 @@ void main() {
       );
     });
 
-    List<Object?> ids({bool includePinned = false, bool includeFolders = false}) =>
-        server
-            .getChatList(
-              includePinned: includePinned,
-              includeFolders: includeFolders,
-            )
-            .map((item) => item['id'])
-            .toList();
+    List<Object?> ids({
+      bool includePinned = false,
+      bool includeFolders = false,
+    }) => server
+        .getChatList(
+          includePinned: includePinned,
+          includeFolders: includeFolders,
+        )
+        .map((item) => item['id'])
+        .toList();
 
     test('excludes pinned, foldered, and archived by default', () {
       check(ids()).deepEquals(['plain']);
@@ -145,16 +147,15 @@ void main() {
     });
 
     test('archived chats are excluded even with both flags', () {
-      check(
-        ids(includePinned: true, includeFolders: true),
-      ).deepEquals(['foldered', 'pinned', 'plain']);
+      check(ids(includePinned: true, includeFolders: true))
+          .deepEquals(['foldered', 'pinned', 'plain']);
     });
 
     test('items have the ChatTitleIdResponse shape', () {
       final item = server.getChatList().single;
-      check(item.keys.toSet()).deepEquals(
-        {'id', 'title', 'updated_at', 'created_at', 'last_read_at'},
-      );
+      check(
+        item.keys.toSet(),
+      ).deepEquals({'id', 'title', 'updated_at', 'created_at', 'last_read_at'});
       check(item['title']).equals('plain');
       check(item['created_at']).equals(1);
       check(item['updated_at']).equals(10);
@@ -186,7 +187,8 @@ void main() {
       check(created['id']).isA<String>().matchesPattern(uuidV4);
       check(created['id']).not((it) => it.equals('client-chosen-id'));
       // The id key inside the chat blob is untouched server-side.
-      check(created['chat']).isA<Map<String, dynamic>>()['id']
+      check(created['chat'])
+          .isA<Map<String, dynamic>>()['id']
           .equals('client-chosen-id');
       check(server.getChatById('client-chosen-id')).isNull();
     });
@@ -281,7 +283,8 @@ void main() {
       check(chat['title']).equals('Seeded');
       check(chat['created_at']).equals(11);
       check(chat['updated_at']).equals(22);
-      check(chat['chat']).isA<Map<String, dynamic>>()['models']
+      check(chat['chat'])
+          .isA<Map<String, dynamic>>()['models']
           .isA<List<Object?>>()
           .deepEquals(['llama3']);
     });
@@ -304,9 +307,7 @@ void main() {
 
   group('updateChat', () {
     test('returns null for a missing id', () {
-      check(
-        FakeOpenWebUiServer().updateChat('nope', {'title': 'x'}),
-      ).isNull();
+      check(FakeOpenWebUiServer().updateChat('nope', {'title': 'x'})).isNull();
     });
 
     test('restamps updated_at from the clock, keeping created_at', () {
@@ -320,31 +321,30 @@ void main() {
       check(updated['updated_at']).equals(15);
     });
 
-    test(
-      'shallow-merges the incoming blob over the existing one '
-      '(vendored route does {**existing, **incoming})',
-      () {
-        final server = FakeOpenWebUiServer();
-        final id = server.createChat({
-          'title': 'Hello',
-          'models': ['llama3'],
-          'params': {'temperature': 0.5},
-        })['id'] as String;
+    test('shallow-merges the incoming blob over the existing one '
+        '(vendored route does {**existing, **incoming})', () {
+      final server = FakeOpenWebUiServer();
+      final id =
+          server.createChat({
+                'title': 'Hello',
+                'models': ['llama3'],
+                'params': {'temperature': 0.5},
+              })['id']
+              as String;
 
-        final updated = server.updateChat(id, {
-          'title': 'Renamed',
-          'params': {'top_p': 0.9},
-        })!;
-        final blob = updated['chat'] as Map<String, dynamic>;
-        // Untouched top-level keys survive.
-        check(blob['models']).isA<List<Object?>>().deepEquals(['llama3']);
-        // Provided top-level keys are replaced wholesale (not deep-merged).
-        check(blob['params']).isA<Map<String, dynamic>>().deepEquals({
-          'top_p': 0.9,
-        });
-        check(updated['title']).equals('Renamed');
-      },
-    );
+      final updated = server.updateChat(id, {
+        'title': 'Renamed',
+        'params': {'top_p': 0.9},
+      })!;
+      final blob = updated['chat'] as Map<String, dynamic>;
+      // Untouched top-level keys survive.
+      check(blob['models']).isA<List<Object?>>().deepEquals(['llama3']);
+      // Provided top-level keys are replaced wholesale (not deep-merged).
+      check(blob['params'])
+          .isA<Map<String, dynamic>>()
+          .deepEquals({'top_p': 0.9});
+      check(updated['title']).equals('Renamed');
+    });
 
     test('re-derives title from the merged blob', () {
       final server = FakeOpenWebUiServer();
@@ -378,42 +378,38 @@ void main() {
 
   group('updateChat output-to-content re-derivation', () {
     Map<String, dynamic> outputItem(String text) => <String, dynamic>{
-          'type': 'message',
-          'id': 'msg_1',
-          'status': 'completed',
-          'role': 'assistant',
-          'content': [
-            {'type': 'output_text', 'text': text, 'annotations': <Object?>[]},
-          ],
-        };
+      'type': 'message',
+      'id': 'msg_1',
+      'status': 'completed',
+      'role': 'assistant',
+      'content': [
+        {'type': 'output_text', 'text': text, 'annotations': <Object?>[]},
+      ],
+    };
 
     Map<String, dynamic> blobWith({
       required String content,
       List<Object?>? output,
       String role = 'assistant',
-    }) =>
-        <String, dynamic>{
-          'title': 'Rederive',
-          'history': {
-            'currentId': 'a1',
-            'messages': {
-              'a1': {
-                'id': 'a1',
-                'parentId': null,
-                'childrenIds': <String>[],
-                'role': role,
-                'content': content,
-                'timestamp': 1,
-                'output': ?output,
-              },
-            },
+    }) => <String, dynamic>{
+      'title': 'Rederive',
+      'history': {
+        'currentId': 'a1',
+        'messages': {
+          'a1': {
+            'id': 'a1',
+            'parentId': null,
+            'childrenIds': <String>[],
+            'role': role,
+            'content': content,
+            'timestamp': 1,
+            'output': ?output,
           },
-        };
+        },
+      },
+    };
 
-    Map<String, dynamic> storedMessage(
-      FakeOpenWebUiServer server,
-      String id,
-    ) {
+    Map<String, dynamic> storedMessage(FakeOpenWebUiServer server, String id) {
       final chat = server.getChatById(id)!['chat'] as Map<String, dynamic>;
       final history = chat['history'] as Map<String, dynamic>;
       final messages = history['messages'] as Map<String, dynamic>;
@@ -422,9 +418,14 @@ void main() {
 
     test('rewrites assistant content when output changed', () {
       final server = FakeOpenWebUiServer();
-      final id = server.createChat(
-        blobWith(content: 'old content', output: [outputItem('old text')]),
-      )['id'] as String;
+      final id =
+          server.createChat(
+                blobWith(
+                  content: 'old content',
+                  output: [outputItem('old text')],
+                ),
+              )['id']
+              as String;
 
       server.updateChat(
         id,
@@ -432,7 +433,8 @@ void main() {
       );
 
       check(
-        because: 'the vendored route rewrites content = '
+        because:
+            'the vendored route rewrites content = '
             'serialize_output(output) when output deep-differs '
             '(routers/chats.py update_chat_by_id)',
         storedMessage(server, id)['content'],
@@ -442,9 +444,11 @@ void main() {
     test('keeps content set independently when output is unchanged', () {
       final server = FakeOpenWebUiServer();
       final output = [outputItem('same text')];
-      final id = server.createChat(
-        blobWith(content: 'same text', output: output),
-      )['id'] as String;
+      final id =
+          server.createChat(
+                blobWith(content: 'same text', output: output),
+              )['id']
+              as String;
 
       // e.g. a `replace` event or an outlet-filter footer edited content
       // without touching output: the route must NOT revert it.
@@ -459,9 +463,9 @@ void main() {
 
     test('rewrites when output appears on a message that had none', () {
       final server = FakeOpenWebUiServer();
-      final id = server.createChat(
-        blobWith(content: 'streamed content'),
-      )['id'] as String;
+      final id =
+          server.createChat(blobWith(content: 'streamed content'))['id']
+              as String;
 
       server.updateChat(
         id,
@@ -473,13 +477,15 @@ void main() {
 
     test('ignores user messages and empty output lists', () {
       final server = FakeOpenWebUiServer();
-      final userId = server.createChat(
-        blobWith(
-          content: 'user content',
-          output: [outputItem('ignored')],
-          role: 'user',
-        ),
-      )['id'] as String;
+      final userId =
+          server.createChat(
+                blobWith(
+                  content: 'user content',
+                  output: [outputItem('ignored')],
+                  role: 'user',
+                ),
+              )['id']
+              as String;
       server.updateChat(
         userId,
         blobWith(
@@ -491,9 +497,11 @@ void main() {
       check(storedMessage(server, userId)['content']).equals('user content');
 
       // Python truthiness: an empty output list never triggers a rewrite.
-      final emptyId = server.createChat(
-        blobWith(content: 'kept', output: const <Object?>[]),
-      )['id'] as String;
+      final emptyId =
+          server.createChat(
+                blobWith(content: 'kept', output: const <Object?>[]),
+              )['id']
+              as String;
       server.updateChat(
         emptyId,
         blobWith(content: 'kept', output: const <Object?>[]),
@@ -521,16 +529,18 @@ void main() {
               as Map<String, dynamic>;
       final output = assistant['output'] as List<dynamic>;
       final messageItem = output[1] as Map<String, dynamic>;
-      ((messageItem['content'] as List).first as Map<String, dynamic>)['text'] =
-          'Edited: the night sky is dark because the universe is young and expanding.';
+      ((messageItem['content'] as List).first as Map<String, dynamic>)['text'] = 'Edited: the night sky is dark because the universe is young and expanding.';
 
       server.updateChat(id, edited);
 
       final stored = server.getChatById(id)!['chat'] as Map<String, dynamic>;
-      final storedAssistant = ((stored['history']
-              as Map<String, dynamic>)['messages']
-          as Map<String, dynamic>)['fa11fa11-2222-4333-8444-555566667777']
-          as Map<String, dynamic>;
+      final storedAssistant =
+          ((stored['history'] as Map<String, dynamic>)['messages']
+                  as Map<
+                    String,
+                    dynamic
+                  >)['fa11fa11-2222-4333-8444-555566667777']
+              as Map<String, dynamic>;
 
       // serialize_output renders the reasoning item as an HTML-escaped
       // blockquote details block, then the message text verbatim.
@@ -561,8 +571,7 @@ void main() {
       ).equals('hello\nworld');
     });
 
-    test('renders reasoning with quoting and Python html.escape semantics',
-        () {
+    test('renders reasoning with quoting and Python html.escape semantics', () {
       check(
         FakeOpenWebUiServer.serializeOutput([
           {
@@ -638,7 +647,8 @@ void main() {
           .has((e) => e.statusCode, 'statusCode')
           .equals(404);
       check(
-        because: 'the vendored route rejects the chat before inserting it '
+        because:
+            'the vendored route rejects the chat before inserting it '
             '(routers/chats.py create_new_chat)',
         server.getChatList(includeFolders: true),
       ).isEmpty();
@@ -665,8 +675,9 @@ void main() {
         updatedAt: 2,
         folderId: 'seeded-folder',
       );
-      final created =
-          server.createChat({'title': 'x'}, folderId: 'seeded-folder');
+      final created = server.createChat({
+        'title': 'x',
+      }, folderId: 'seeded-folder');
       check(created['folder_id']).equals('seeded-folder');
     });
   });
@@ -722,9 +733,8 @@ void main() {
         createdAt: 1,
         updatedAt: 200,
       );
-      check(
-        server.getChatList().map((item) => item['id']).toList(),
-      ).deepEquals(['new', 'old']);
+      check(server.getChatList().map((item) => item['id']).toList())
+          .deepEquals(['new', 'old']);
     });
   });
 }

--- a/test/tool/release_notes_validator_test.dart
+++ b/test/tool/release_notes_validator_test.dart
@@ -30,9 +30,8 @@ void main() {
   }
 
   void writeNotes(String locale, Object document) {
-    File(
-      '${notesDir.path}/$locale.json',
-    ).writeAsStringSync(jsonEncode(document));
+    File('${notesDir.path}/$locale.json')
+        .writeAsStringSync(jsonEncode(document));
   }
 
   Map<String, Object?> validArb() => {
@@ -81,9 +80,8 @@ void main() {
       'notes': [note('3.3.2')],
     });
 
-    check(
-      validate('4.0.0').errors,
-    ).contains('Missing baked release note for 4.0.0.');
+    check(validate('4.0.0').errors)
+        .contains('Missing baked release note for 4.0.0.');
   });
 
   test('fails when a locale is missing a version', () {
@@ -96,9 +94,8 @@ void main() {
       'notes': [note('3.3.2')],
     });
 
-    check(
-      validate('4.0.0').errors,
-    ).contains('de.json is missing version 4.0.0.');
+    check(validate('4.0.0').errors)
+        .contains('de.json is missing version 4.0.0.');
   });
 
   test('fails when an ARB locale has no release-note JSON file', () {
@@ -108,9 +105,8 @@ void main() {
       'notes': [note('4.0.0')],
     });
 
-    check(
-      validate('4.0.0').errors,
-    ).contains('Missing release-note JSON for ARB locale de.');
+    check(validate('4.0.0').errors)
+        .contains('Missing release-note JSON for ARB locale de.');
   });
 
   test('fails when release-note JSON has no matching ARB locale', () {
@@ -122,9 +118,8 @@ void main() {
       'notes': [note('4.0.0')],
     });
 
-    check(
-      validate('4.0.0').errors,
-    ).contains('Missing ARB locale for release-note JSON de.json.');
+    check(validate('4.0.0').errors)
+        .contains('Missing ARB locale for release-note JSON de.json.');
   });
 
   test('fails when a locale has a different bullet count', () {
@@ -137,9 +132,8 @@ void main() {
       'notes': [note('4.0.0', bulletCount: 2)],
     });
 
-    check(
-      validate('4.0.0').errors.single,
-    ).contains('de.json has 2 bullets for 4.0.0, expected 3');
+    check(validate('4.0.0').errors.single)
+        .contains('de.json has 2 bullets for 4.0.0, expected 3');
   });
 
   test('fails on unknown icon names and unsorted versions', () {
@@ -163,9 +157,8 @@ void main() {
       'notes': [note('4.0.0'), note('4.1.0')],
     });
 
-    check(
-      validate('4.0.0').errors.single,
-    ).contains('de.json has version 4.1.0');
+    check(validate('4.0.0').errors.single)
+        .contains('de.json has version 4.1.0');
   });
 
   test('fails when a locale ARB is missing a shell key', () {


### PR DESCRIPTION
## Summary

Two rounds of performance work on the chat timeline and the streaming markdown pipeline, based on a full audit of both. No behavior changes intended aside from the deliberate ones listed below.

### Scrolling: stop shell rebuilds from cascading into every mounted row

- The timeline `SliverList`s used a fresh `SliverChildBuilderDelegate` per build, whose default `shouldRebuild` always returns true — every `ChatPage` `setState` (drag start, keyboard-inset frames, composer resize, pin transitions) rebuilt every mounted row and its markdown. They now use `_TimelineRowDelegate` with a real `shouldRebuild` keyed on rowBuilder/entries identity and `centerIndex`.
- `ChatPage` memoizes the transcript window, `ChatTimelineRenderModel`, and the `rowBuilder` closure by identity. The fresh window list allocated per build was also defeating the existing stable-layout cache's identity fast path.
- Full `MediaQuery.of` dependencies replaced with scoped `paddingOf`/`sizeOf` lookups.
- Streaming `cacheExtent` raised 120px → 600px: the small extent evicted rows on scroll-up mid-stream, and remounting a settled row runs a synchronous markdown compile, so it bought hitches, not savings.

### Markdown: cut O(whole-message) work per streamed flush

- `buildMarkdownDisplayParts` (per-block sub-document derivation + deep compares) is memoized by compiled-document identity; previously it ran on every widget build, ~10x/s during streaming.
- `identical()` fast paths in `CompiledMarkdownDocument`/`PreparedMarkdownText` equality; rope equality compares segments instead of materializing both sides.
- The chat structure signature caches per-message fragments in an identity-keyed `Expando` instead of rebuilding O(messages × versions) strings on every message-list emission.
- Incremental preparation and the reference-definition strip now gate on one shared line-anchored predicate (`hasLinkReferenceDefinitionLine`). A bare `]:` substring (code samples, mid-line citations) no longer forces full re-preparation of the whole message on every flush.
- The streaming split's unsafe-line detection is fence-aware and single-pass: definition-shaped lines or raw HTML inside code fences no longer disable incremental compilation for the entire message, and a raw HTML block now caps freezing at its start line instead of keeping the whole document mutable (HTML cannot affect earlier blocks). The per-fenced-block `RegExp` compile was replaced with the existing fence-close helper.
- LaTeX extraction skips its four full regex passes when content has no `$` or `\`; the assistant footer's error-heuristic content scans are memoized; profiler data-map allocations are gated to profiling builds; the code-block line split is memoized and >50k-char code renders plain (bounds `highlight.parse` cost for expanded still-streaming blocks).

### Deliberate behavior changes

- Content containing `]:` without an actual reference-definition line no longer gets the incidental 3+-newline collapse and trim from the strip branch (render-equivalent in markdown).
- Code blocks over 50k characters render without syntax highlighting in any language.
- Streaming and idle scroll cache extents are now both 600px.

## Testing

- `flutter analyze` clean (only the pre-existing `tool/pigeon_codegen` package-context errors).
- Full `flutter test`: the only failures are the 11 pre-existing ones on Flutter 3.47 (9 `direct_connections` `scrollUntilVisible` framework-behavior failures, 2 `release_notes` golden mismatches), verified identical on a clean `main` via `git stash`.
- New/updated tests: splitter coverage for fenced reference definitions, raw-HTML freeze capping, and the updated cache-extent expectation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for displaying valid follow-up suggestions received through chat updates.
  * Improved streaming Markdown handling for raw HTML, link references, details blocks, code blocks, and incremental updates.

* **Performance Improvements**
  * Improved chat timeline scrolling and rendering smoothness during streaming.
  * Reduced unnecessary processing for repeated messages, error indicators, LaTeX, and Markdown.
  * Improved handling of large code blocks and repeated content updates.

* **Bug Fixes**
  * Prevented stale, duplicate, or shorter streaming updates from truncating newer content.
  * Preserved buffered and structured content when streaming is cancelled or completed.
  * Improved HTML entity handling, whitespace preservation, and Markdown escaping.
  * Prevented semantic reasoning details from affecting content comparisons.
  * Kept final streaming status updates visible when appropriate.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

## Also included: two pre-existing streaming bugs (not regressions from the perf work)

### Long responses truncated at completion

The streamed buffer is never periodically folded into message state, so `/api/chat/completed` was built from a stale prefix of the response, and the server's echo of that payload was merged back unguarded — overwriting the full content with the prefix (worst on the HTTP/SSE transport, which reached completion without any terminal flush; the truncated value then persisted). Fixed by flushing the buffer before building the completed payload, and guarding the three unguarded overwrite paths (completed echo, replay-gap authoritative recovery, cumulative `chat:completion` content snapshots) so a strict prefix of already-streamed content is never adopted. Genuine outlet-filter rewrites (non-prefix content) still apply.

### Follow-up suggestions never arriving

The server emits `chat:message:follow_ups` strictly after `chat:completion {done:true}` (the follow-up LLM call runs post-done), and the per-stream socket subscription is disposed synchronously by the done event — so the streaming handler for follow-ups was unreachable in production. The long-lived passive conversation subscription is the surviving delivery path; it now applies the pushed payload directly to the target message instead of relying on a debounced full refetch that races the server's own persistence (the event is emitted before the upsert). Known limitation: temporary (`local:`) chats still can't receive follow-ups — the server doesn't persist them for unsaved chats and the passive subscription doesn't cover them.

New regression tests: completed-payload flush ordering and echo-truncation guard on the HTTP/SSE path (with a buffer-accurate test double), plus the follow-ups envelope parser.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Improves streamed Markdown rendering so reference definitions and nested details content are handled consistently while content arrives incrementally.

## T-Rex validation blocked
Flutter and Dart are unavailable in the environment, so the focused Markdown harness and the existing controller test could not execute.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

No blocking failure remains.

No accepted blocking finding remains.
</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Attempted to run the focused streaming Markdown scenario test harness using Flutter in the repository, but Flutter CLI was not found and the command exited with code 127.
- Attempted to run the existing controller Flutter test for the focused scenario, but Flutter CLI was not found and the command exited with code 127.
- Attempted to fall back to a Dart test command for the streaming Markdown scenario, but the Dart tool was not found and the command exited with code 127.
- The before-capture baseline shows the base scanner’s loose close-token behavior and limited details-depth handling.
- Reviewed the Streaming Markdown PR diff and coverage capture to confirm test targets and mappings.

<a href="https://app.greptile.com/trex/runs/19259482/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (20): Last reviewed commit: ["fix: count only complete details tags; k..."](https://github.com/cogwheel0/conduit/commit/7daaa2e972d61d591ae07dd7a1b7e9c65ecf33d5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53811184)</sub>

<!-- /greptile_comment -->