### PR TITLE
fix: separate semantic details blocks

### DIFF
--- a/lib/core/services/semantic_message_builder.dart
+++ b/lib/core/services/semantic_message_builder.dart
@@ -134,7 +134,10 @@ String renderSemanticMessageBlocks(List<SemanticMessageBlock> blocks) {
     }
   }
 
-  return parts.join('\n');
+  // Keep semantic HTML blocks on separate Markdown block boundaries. A single
+  // newline can leave a following <details> attached to the preceding text
+  // paragraph, causing clients to render the tag as literal text.
+  return parts.join('\n\n');
 }
 
 /// Escapes one plain-text streaming fragment without allowing it to create

--- a/test/core/services/semantic_message_builder_test.dart
+++ b/test/core/services/semantic_message_builder_test.dart
@@ -1,5 +1,6 @@
 import 'package:checks/checks.dart';
 import 'package:conduit/core/services/semantic_message_builder.dart';
+import 'package:conduit/shared/widgets/markdown/renderer/details_block_syntax.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:markdown/markdown.dart' as md;
 
@@ -351,6 +352,35 @@ void main() {
 
       check(rendered).contains('&lt;details');
       check(rendered).not((it) => it.contains('<details type="reasoning">'));
+    });
+
+    test('separates text and semantic details onto Markdown block boundaries', () {
+      final rendered = renderSemanticMessageBlocks([
+        const SemanticTextBlock('I will search for that.'),
+        SemanticDetailsBlock.toolCall(
+          id: 'call-1',
+          name: 'search_web',
+          arguments: const {'query': 'current news'},
+          done: true,
+          result: const {'results': []},
+        ),
+        const SemanticTextBlock('Here is the answer.'),
+      ]);
+
+      check(rendered).contains(
+        'I will search for that.\n\n<details type="tool_calls"',
+      );
+      check(rendered).contains('</details>\n\nHere is the answer.');
+
+      final parsed = md.Document(
+        extensionSet: md.ExtensionSet.gitHubWeb,
+        blockSyntaxes: const [DetailsBlockSyntax()],
+        encodeHtml: false,
+      ).parse(rendered);
+      final details = _descendantElements(
+        parsed,
+      ).where((element) => element.tag == 'details');
+      check(details).length.equals(1);
     });
 
     test('preserves slashes in reasoning bodies while escaping tags', () {


### PR DESCRIPTION
Fixes #624.

## Summary

- separate semantic text, reasoning, tool-call, and code-interpreter blocks with blank Markdown block boundaries
- prevent a following `<details>` block from being absorbed into the preceding text paragraph and rendered literally
- add a regression test that checks both the serialized boundary and parsing through `DetailsBlockSyntax`

## Verification

- `flutter test test/core/services/semantic_message_builder_test.dart` — 24 tests passed
- `dart analyze lib/core/services/semantic_message_builder.dart test/core/services/semantic_message_builder_test.dart` — no issues found

Tested with Flutter 3.47.0 / Dart 3.13.0.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Markdown rendering for semantic message blocks by preserving blank-line separation.
  - Fixed formatting around tool-call details sections so surrounding text displays correctly.

- **Tests**
  - Added regression coverage to verify details sections render as a single, properly formatted element.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This change places blank Markdown boundaries between rendered semantic message blocks and updates the text/details/text regression coverage so semantic details render as their own block.

The reported regression was disproved: the serializer at `lib/core/services/semantic_message_builder.dart:140` joins blocks with two newlines, and the existing test at `test/core/services/semantic_message_builder_test.dart:370-373` already asserts those same two-newline boundaries before and after the details element. The executed check found no remaining assertion expecting single-newline boundaries.

### T-Rex validation blocked
The focused Flutter test could not run because the `flutter` tool is not installed in the environment.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The reviewed change is safe to merge based on the verified agreement between serialization behavior and its regression assertion.

No publishable defects remain: the reported failure path was contradicted by the current serializer and test expectations.

**Files Needing Attention:** No files require changes for the reviewed concern. The focused Flutter test should be run in an environment with Flutter installed for additional runtime coverage.
</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- An initial source-level validation script was run against the current serializer and regression assertion, confirming that lib/core/services/semantic\_message\_builder.dart:140 uses a double-newline boundary and that test/core/services/semantic\_message\_builder\_test.dart:370-373 expects the same boundary; an attempt to run the focused Flutter test flutter test test/core/services/semantic\_message\_builder\_test.dart --plain-name "separates text and semantic details onto Markdown block boundaries" could not execute because Flutter is not installed.
- A separate semantic-boundary validation script (sh trex-artifacts/semantic-boundary-validation.sh) was executed and it confirmed that the single-newline boundary does not exist at HEAD.

<a href="https://app.greptile.com/trex/runs/19167796/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix: separate semantic details blocks"](https://github.com/cogwheel0/conduit/commit/4dbde196b9712ac42ab5adcf0e69614c0da4c590) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53896199)</sub>

<!-- /greptile_comment -->