### PR TITLE
Fix voice call speech and default new calls to the speakerphone

### DIFF
--- a/android/app/src/main/kotlin/app/cogwheel/conduit/NativeTtsBridge.kt
+++ b/android/app/src/main/kotlin/app/cogwheel/conduit/NativeTtsBridge.kt
@@ -1,5 +1,7 @@
 package app.cogwheel.conduit
 
+import android.media.AudioAttributes
+import android.media.AudioManager
 import android.os.Build
 import android.os.Bundle
 import android.os.Handler
@@ -28,7 +30,8 @@ class NativeTtsBridge(private val activity: MainActivity) : MethodChannel.Method
         val voiceIdentifier: String?,
         val rate: Float,
         val pitch: Float,
-        val volume: Float
+        val volume: Float,
+        val voiceCall: Boolean
     )
 
     private data class ActiveUtterance(
@@ -48,6 +51,7 @@ class NativeTtsBridge(private val activity: MainActivity) : MethodChannel.Method
     private var lastProgressStart = 0
     private var suppressStopForUtteranceId: String? = null
     private val resumeUtteranceIds = mutableSetOf<String>()
+    private var appliedVoiceCallRouting: Boolean? = null
 
     fun setup(flutterEngine: FlutterEngine) {
         MethodChannel(
@@ -89,7 +93,8 @@ class NativeTtsBridge(private val activity: MainActivity) : MethodChannel.Method
                         ?.takeIf { it.isNotEmpty() },
                     rate = floatArgument(call, "rate", 0.5f, 0.1f, 3.0f),
                     pitch = floatArgument(call, "pitch", 1.0f, 0.1f, 2.0f),
-                    volume = floatArgument(call, "volume", 1.0f, 0.0f, 1.0f)
+                    volume = floatArgument(call, "volume", 1.0f, 0.0f, 1.0f),
+                    voiceCall = call.argument<Boolean>("voiceCall") == true
                 )
                 result.success(speakRequest(request, baseOffset = 0, isResume = false))
             }
@@ -120,6 +125,7 @@ class NativeTtsBridge(private val activity: MainActivity) : MethodChannel.Method
         tts?.shutdown()
         tts = null
         initState = InitState.NOT_STARTED
+        appliedVoiceCallRouting = null
         pendingInitCallbacks.clear()
     }
 
@@ -142,6 +148,9 @@ class NativeTtsBridge(private val activity: MainActivity) : MethodChannel.Method
         }
 
         initState = InitState.INITIALIZING
+        // A fresh engine starts on its default routing, so the next utterance
+        // has to set the attributes again rather than trust the cached value.
+        appliedVoiceCallRouting = null
         pendingInitCallbacks.add(callback)
         tts = TextToSpeech(activity.applicationContext) { status ->
             mainHandler.post {
@@ -249,6 +258,7 @@ class NativeTtsBridge(private val activity: MainActivity) : MethodChannel.Method
                 ?: parseLocale(requested)?.let { engine.language = it }
         }
 
+        applyAudioRouting(engine, request.voiceCall)
         engine.setSpeechRate(request.rate)
         engine.setPitch(request.pitch)
 
@@ -267,6 +277,16 @@ class NativeTtsBridge(private val activity: MainActivity) : MethodChannel.Method
 
         val params = Bundle().apply {
             putFloat(TextToSpeech.Engine.KEY_PARAM_VOLUME, request.volume)
+            // Audio attributes win over the stream param on engines that honour
+            // them, but older ones only read the stream, so send both.
+            putInt(
+                TextToSpeech.Engine.KEY_PARAM_STREAM,
+                if (request.voiceCall) {
+                    AudioManager.STREAM_VOICE_CALL
+                } else {
+                    AudioManager.STREAM_MUSIC
+                }
+            )
         }
         val started = engine.speak(text, TextToSpeech.QUEUE_FLUSH, params, utteranceId) ==
             TextToSpeech.SUCCESS
@@ -275,6 +295,28 @@ class NativeTtsBridge(private val activity: MainActivity) : MethodChannel.Method
             resumeUtteranceIds.remove(utteranceId)
         }
         return started
+    }
+
+    // Puts the engine on the voice-communication stream for the duration of a
+    // voice call. Without this the engine speaks as USAGE_MEDIA while the call
+    // holds audio focus as USAGE_VOICE_COMMUNICATION in MODE_IN_COMMUNICATION.
+    // The two are routed separately, so setCommunicationDevice() never moves
+    // device TTS to the call's speakerphone choice, and the media stream goes
+    // quiet once the app is backgrounded during the call.
+    private fun applyAudioRouting(engine: TextToSpeech, voiceCall: Boolean) {
+        if (appliedVoiceCallRouting == voiceCall) return
+        val attributes = AudioAttributes.Builder()
+            .setContentType(AudioAttributes.CONTENT_TYPE_SPEECH)
+            .setUsage(
+                if (voiceCall) {
+                    AudioAttributes.USAGE_VOICE_COMMUNICATION
+                } else {
+                    AudioAttributes.USAGE_MEDIA
+                }
+            )
+            .build()
+        engine.setAudioAttributes(attributes)
+        appliedVoiceCallRouting = voiceCall
     }
 
     private fun stopInternal(emitCancel: Boolean): Boolean {

--- a/lib/core/utils/semantic_details.dart
+++ b/lib/core/utils/semantic_details.dart
@@ -33,6 +33,29 @@ String stripRenderedSemanticDetails(String content) {
   return content.replaceAll(_semanticDetailsBlockPattern, '').trim();
 }
 
+/// Drops the tail starting at a semantic `<details>` opener that has no
+/// closing tag yet.
+///
+/// Mid-stream the wrapper stays open for many frames, so
+/// [stripRenderedSemanticDetails] — which only matches complete blocks —
+/// leaves the reasoning or tool-call body exposed. Consumers that surface
+/// partial content (notably text-to-speech) must withhold everything from the
+/// opener onwards until `</details>` lands and the block can be stripped
+/// outright.
+///
+/// Run this *after* stripping complete blocks; on unstripped content the opener
+/// of an already-closed block would truncate the answer that follows it.
+String dropUnterminatedSemanticDetails(String content) {
+  if (!content.contains('<details')) {
+    return content;
+  }
+  final match = _semanticDetailsOpenPattern.firstMatch(content);
+  if (match == null) {
+    return content;
+  }
+  return content.substring(0, match.start).trimRight();
+}
+
 /// True when [serverBody] is a strict prefix of [localBody] — a stale or
 /// mid-write server frame that must not truncate content already streamed.
 /// Callers pass comparable bodies (usually already details-stripped).

--- a/lib/core/utils/semantic_details.dart
+++ b/lib/core/utils/semantic_details.dart
@@ -65,6 +65,90 @@ String dropUnterminatedSemanticDetails(String content) {
   return content.substring(0, match.start).trimRight();
 }
 
+final RegExp _anyDetailsOpenPattern = RegExp(
+  r'<details\b[^>]*>',
+  caseSensitive: false,
+);
+
+final RegExp _detailsClosePattern = RegExp(
+  r'</details\s*>',
+  caseSensitive: false,
+);
+
+/// Removes every `<details>` block, nesting included, and truncates at a
+/// semantic block that has not closed yet.
+///
+/// For consumers that must never surface wrapper contents at all, notably
+/// text-to-speech. The pattern-based helpers above stop at the first
+/// `</details>`, which is right for content comparisons but leaks the tail of
+/// an outer block when a model nests one wrapper inside another:
+/// `<details><details>x</details>leaked</details>` would keep `leaked`.
+///
+/// An unterminated block is only cut when it is one of the semantic wrappers,
+/// matching [dropUnterminatedSemanticDetails]: an ordinary `<details>` still
+/// waiting for its close tag is left alone rather than silencing the rest of
+/// the answer.
+String stripDetailsForSpeech(String content) {
+  if (!_detailsTagHint.hasMatch(content)) {
+    return content;
+  }
+
+  final kept = StringBuffer();
+  var cursor = 0;
+  while (cursor < content.length) {
+    final open = _anyDetailsOpenPattern.firstMatch(content.substring(cursor));
+    if (open == null) {
+      kept.write(content.substring(cursor));
+      break;
+    }
+
+    final openStart = cursor + open.start;
+    kept.write(content.substring(cursor, openStart));
+    final blockEnd = _findDetailsBlockEnd(content, cursor + open.end);
+    if (blockEnd == null) {
+      final isSemantic = _semanticDetailsOpenPattern.matchAsPrefix(
+        content,
+        openStart,
+      );
+      if (isSemantic != null) {
+        // Still streaming, and everything after the opener belongs to the
+        // wrapper. Withhold it until the close tag arrives.
+        break;
+      }
+      kept.write(content.substring(openStart));
+      break;
+    }
+    cursor = blockEnd;
+  }
+
+  return kept.toString().trim();
+}
+
+/// The index just past the `</details>` that closes the block opened before
+/// [searchFrom], or null when the block is still open.
+int? _findDetailsBlockEnd(String content, int searchFrom) {
+  var depth = 1;
+  var cursor = searchFrom;
+  while (cursor < content.length) {
+    final open = _anyDetailsOpenPattern.firstMatch(content.substring(cursor));
+    final close = _detailsClosePattern.firstMatch(content.substring(cursor));
+    if (close == null) {
+      return null;
+    }
+    if (open != null && open.start < close.start) {
+      depth++;
+      cursor += open.end;
+      continue;
+    }
+    depth--;
+    cursor += close.end;
+    if (depth == 0) {
+      return cursor;
+    }
+  }
+  return null;
+}
+
 /// True when [serverBody] is a strict prefix of [localBody] — a stale or
 /// mid-write server frame that must not truncate content already streamed.
 /// Callers pass comparable bodies (usually already details-stripped).

--- a/lib/core/utils/semantic_details.dart
+++ b/lib/core/utils/semantic_details.dart
@@ -11,23 +11,32 @@
 /// of the tag patterns have caused real rendering bugs.
 library;
 
+// HTML tag and attribute names are case-insensitive, and the text these
+// patterns run over is model output, so an uppercase wrapper has to be caught
+// as well: a missed opener means a reasoning body reaches the reader or the
+// speaker.
 final RegExp _semanticDetailsOpenPattern = RegExp(
   r'''<details\b(?=[^>]*\btype\s*=\s*["'](?:reasoning|tool_calls|code_interpreter|openai_builtin_tool)["'])''',
+  caseSensitive: false,
 );
 
 final RegExp _semanticDetailsBlockPattern = RegExp(
   r'''<details\b(?=[^>]*\btype\s*=\s*["'](?:reasoning|tool_calls|code_interpreter|openai_builtin_tool)["'])[\s\S]*?</details>\s*''',
+  caseSensitive: false,
 );
 
+/// Cheap reject for the common case of content with no `<details>` at all.
+final RegExp _detailsTagHint = RegExp('<details', caseSensitive: false);
+
 bool containsRenderedSemanticDetails(String content) {
-  if (!content.contains('<details')) {
+  if (!_detailsTagHint.hasMatch(content)) {
     return false;
   }
   return _semanticDetailsOpenPattern.hasMatch(content);
 }
 
 String stripRenderedSemanticDetails(String content) {
-  if (!content.contains('<details')) {
+  if (!_detailsTagHint.hasMatch(content)) {
     return content;
   }
   return content.replaceAll(_semanticDetailsBlockPattern, '').trim();
@@ -46,7 +55,7 @@ String stripRenderedSemanticDetails(String content) {
 /// Run this *after* stripping complete blocks; on unstripped content the opener
 /// of an already-closed block would truncate the answer that follows it.
 String dropUnterminatedSemanticDetails(String content) {
-  if (!content.contains('<details')) {
+  if (!_detailsTagHint.hasMatch(content)) {
     return content;
   }
   final match = _semanticDetailsOpenPattern.firstMatch(content);

--- a/lib/core/utils/semantic_details.dart
+++ b/lib/core/utils/semantic_details.dart
@@ -103,8 +103,9 @@ String stripDetailsForSpeech(String content) {
     }
 
     final openStart = cursor + open.start;
+    final openEnd = cursor + open.end;
     kept.write(content.substring(cursor, openStart));
-    final blockEnd = _findDetailsBlockEnd(content, cursor + open.end);
+    final blockEnd = _findDetailsBlockEnd(content, openEnd);
     if (blockEnd == null) {
       final isSemantic = _semanticDetailsOpenPattern.matchAsPrefix(
         content,
@@ -115,8 +116,12 @@ String stripDetailsForSpeech(String content) {
         // wrapper. Withhold it until the close tag arrives.
         break;
       }
-      kept.write(content.substring(openStart));
-      break;
+      // An ordinary wrapper waiting for its close tag is no reason to silence
+      // the answer, but a wrapper nested inside it still has to be handled, so
+      // keep the tag and carry on from just past it.
+      kept.write(content.substring(openStart, openEnd));
+      cursor = openEnd;
+      continue;
     }
     cursor = blockEnd;
   }

--- a/lib/features/chat/services/native_tts_service.dart
+++ b/lib/features/chat/services/native_tts_service.dart
@@ -102,12 +102,19 @@ class NativeTtsService {
     }
   }
 
+  /// Speaks [text] on the device engine.
+  ///
+  /// [voiceCall] moves Android playback onto the voice-communication stream so
+  /// it follows the call's route (earpiece, speakerphone, headset) and survives
+  /// the app being backgrounded mid-call. iOS ignores it: AVSpeechSynthesizer
+  /// already shares the call's AVAudioSession.
   Future<bool> speak({
     required String text,
     String? voiceIdentifier,
     required double rate,
     required double pitch,
     required double volume,
+    bool voiceCall = false,
   }) async {
     final channel = _methodChannel;
     if (!isSupportedPlatform || channel == null) {
@@ -120,6 +127,7 @@ class NativeTtsService {
             'rate': rate,
             'pitch': pitch,
             'volume': volume,
+            'voiceCall': voiceCall,
           }) ??
           false;
     } on MissingPluginException {

--- a/lib/features/chat/services/text_to_speech_service.dart
+++ b/lib/features/chat/services/text_to_speech_service.dart
@@ -143,6 +143,12 @@ class TextToSpeechService {
     return available;
   }
 
+  /// Marks playback as belonging to a voice call so device TTS uses the
+  /// call's audio route instead of the media stream.
+  void setVoiceCallActive(bool active) {
+    TtsManager.instance.setVoiceCallActive(active);
+  }
+
   /// Speaks the given text.
   Future<void> speak(String text) async {
     if (text.trim().isEmpty) {

--- a/lib/features/chat/services/tts_manager.dart
+++ b/lib/features/chat/services/tts_manager.dart
@@ -811,16 +811,7 @@ class TtsManager {
   /// A semantic wrapper that is still open — the common case while a response
   /// streams — takes the rest of the body with it. Its contents would otherwise
   /// be read aloud in the frames before `</details>` arrives to hide them.
-  static final RegExp _completeDetailsPattern = RegExp(
-    r'<details[^>]*>[\s\S]*?<\/details>',
-    caseSensitive: false,
-  );
-
-  String _sanitizeForSpeech(String content) {
-    final withoutCompleteBlocks = stripRenderedSemanticDetails(content)
-        .replaceAll(_completeDetailsPattern, '');
-    return dropUnterminatedSemanticDetails(withoutCompleteBlocks);
-  }
+  String _sanitizeForSpeech(String content) => stripDetailsForSpeech(content);
 
   /// Gets available voices from the device TTS engine.
   Future<List<Map<String, dynamic>>> getDeviceVoices() async {

--- a/lib/features/chat/services/tts_manager.dart
+++ b/lib/features/chat/services/tts_manager.dart
@@ -170,6 +170,12 @@ StreamingChunkAdvance _advanceStreamingChunks({
     pending.add(trimmed);
   }
 
+  // Whatever is left of the old response playback heard stays on the end. Mid
+  // stream the trailing chunk is held back, so a sentence beyond it is heard
+  // history the next feed still has to match against; dropping it here would
+  // let finalization queue that sentence a second time.
+  spoken.write(alreadyHeard.substring(heardCursor));
+
   return StreamingChunkAdvance(
     chunks: pending,
     fedChunkCount: cursor,

--- a/lib/features/chat/services/tts_manager.dart
+++ b/lib/features/chat/services/tts_manager.dart
@@ -700,7 +700,15 @@ class TtsManager {
     // Reset playback state
     _resetPlaybackState();
     _activeSession = null;
-    _sessionCounter = 0;
+    // _sessionCounter is deliberately left where it is. A feed queued on the
+    // previous chain can still be waiting its turn here, and it only checks the
+    // active session's id, so handing that id back out would let it append its
+    // old text to the next session. The id also names the server chunk temp dir
+    // and the background lease, which the same stale work tears down.
+
+    // Whatever needed the call route is over; read-aloud belongs on the media
+    // stream.
+    _voiceCallActive = false;
 
     // Reset server audio buffer
     _serverAudioBuffer.clear();

--- a/lib/features/chat/services/tts_manager.dart
+++ b/lib/features/chat/services/tts_manager.dart
@@ -1401,7 +1401,9 @@ class TtsManager {
       lastEnqueuedIndex: _serverLastEnqueuedIndex,
     )) {
       if (_isStreamingSession &&
-          (!_streamingFinalized || _serverFetchingIndices.isNotEmpty)) {
+          (!_streamingFinalized ||
+              _serverFetchingIndices.isNotEmpty ||
+              _streamingFeedsPending > 0)) {
         _serverWaitingForNext = true;
         return;
       }

--- a/lib/features/chat/services/tts_manager.dart
+++ b/lib/features/chat/services/tts_manager.dart
@@ -378,6 +378,9 @@ class TtsManager {
   /// the chain, so finalized alone does not mean every sentence has been
   /// appended. Playback finishing a chunk in that window would otherwise end
   /// the session and the queued feed would drop the rest of the answer.
+  ///
+  /// Counts feeds of the session playing now. A feed that outlives its session
+  /// is left out of both ends, or the next session would wait on it.
   int _streamingFeedsPending = 0;
   bool _deviceWaitingForStreamingChunk = false;
   int _serverLastFetchScheduledIndex = -1;
@@ -599,6 +602,7 @@ class TtsManager {
     _streamingFedChunkCount = 0;
     _streamingSpokenText = '';
     _streamingFeedSerial = Future<void>.value();
+    _streamingFeedsPending = 0;
     _deviceWaitingForStreamingChunk = false;
     _serverLastFetchScheduledIndex = -1;
     _serverFetchingIndices.clear();
@@ -961,6 +965,13 @@ class TtsManager {
           ),
         )
         .whenComplete(() {
+          // A feed already inside the platform speak call when the next session
+          // starts outlives its own session. The counter was zeroed with that
+          // session, so decrementing here would take the new session's own feed
+          // off the count and end it early.
+          if (_activeSession?.id != session.id) {
+            return;
+          }
           _streamingFeedsPending--;
         });
     _streamingFeedSerial = queued.catchError((Object _) {});
@@ -1638,6 +1649,7 @@ class TtsManager {
     _streamingFedChunkCount = 0;
     _streamingSpokenText = '';
     _streamingFeedSerial = Future<void>.value();
+    _streamingFeedsPending = 0;
     _deviceWaitingForStreamingChunk = false;
     _serverLastFetchScheduledIndex = -1;
     _serverFetchingIndices.clear();

--- a/lib/features/chat/services/tts_manager.dart
+++ b/lib/features/chat/services/tts_manager.dart
@@ -332,6 +332,7 @@ class TtsManager {
   bool _streamingFinalized = false;
   int _streamingFedChunkCount = 0;
   String? _streamingLastFedChunk;
+  Future<void> _streamingFeedSerial = Future<void>.value();
   bool _deviceWaitingForStreamingChunk = false;
   int _serverLastFetchScheduledIndex = -1;
   final Set<int> _serverFetchingIndices = <int>{};
@@ -527,6 +528,7 @@ class TtsManager {
     _streamingFinalized = false;
     _streamingFedChunkCount = 0;
     _streamingLastFedChunk = null;
+    _streamingFeedSerial = Future<void>.value();
     _deviceWaitingForStreamingChunk = false;
     _serverLastFetchScheduledIndex = -1;
     _serverFetchingIndices.clear();
@@ -869,7 +871,26 @@ class TtsManager {
     return (bytes: result.bytes, mimeType: result.mimeType);
   }
 
+  /// Chains feeds so a second one cannot append its chunks in between the ones
+  /// an earlier feed is still handing to playback.
+  ///
+  /// Streamed text arrives faster than a chunk takes to reach the player, so
+  /// two feeds do overlap. Without the chain the later feed's sentences can
+  /// land first and the answer is spoken out of order.
   Future<void> _enqueueStreamingText(
+    TtsPlaybackSession session,
+    String accumulatedText, {
+    required bool finalized,
+  }) {
+    final queued = _streamingFeedSerial.then(
+      (_) =>
+          _feedStreamingChunks(session, accumulatedText, finalized: finalized),
+    );
+    _streamingFeedSerial = queued.catchError((Object _) {});
+    return queued;
+  }
+
+  Future<void> _feedStreamingChunks(
     TtsPlaybackSession session,
     String accumulatedText, {
     required bool finalized,
@@ -1537,6 +1558,7 @@ class TtsManager {
     _streamingFinalized = false;
     _streamingFedChunkCount = 0;
     _streamingLastFedChunk = null;
+    _streamingFeedSerial = Future<void>.value();
     _deviceWaitingForStreamingChunk = false;
     _serverLastFetchScheduledIndex = -1;
     _serverFetchingIndices.clear();

--- a/lib/features/chat/services/tts_manager.dart
+++ b/lib/features/chat/services/tts_manager.dart
@@ -10,6 +10,7 @@ import 'package:path_provider/path_provider.dart';
 import '../../../core/models/backend_config.dart';
 import '../../../core/services/api_service.dart';
 import '../../../core/services/background_streaming_handler.dart';
+import '../../../core/utils/semantic_details.dart';
 import '../../../shared/widgets/markdown/markdown_preprocessor.dart';
 import 'native_tts_service.dart';
 
@@ -86,6 +87,110 @@ class TtsPlaybackSession {
 
   /// Whether to use server TTS (true) or device TTS (false).
   final bool useServerTts;
+}
+
+/// The chunks a streaming feed made speakable, plus the cursor to resume from.
+class StreamingChunkAdvance {
+  const StreamingChunkAdvance({
+    required this.chunks,
+    required this.fedChunkCount,
+    required this.lastFedChunk,
+  });
+
+  /// Newly speakable chunks, trimmed, in playback order.
+  final List<String> chunks;
+
+  /// How many chunks of the current split have been consumed.
+  final int fedChunkCount;
+
+  /// The untrimmed chunk the cursor sits behind, used to re-anchor after a
+  /// re-split.
+  final String? lastFedChunk;
+}
+
+@visibleForTesting
+StreamingChunkAdvance advanceStreamingChunksForTesting({
+  required List<String> chunks,
+  required int fedChunkCount,
+  required String? lastFedChunk,
+  required bool finalized,
+}) {
+  return _advanceStreamingChunks(
+    chunks: chunks,
+    fedChunkCount: fedChunkCount,
+    lastFedChunk: lastFedChunk,
+    finalized: finalized,
+  );
+}
+
+StreamingChunkAdvance _advanceStreamingChunks({
+  required List<String> chunks,
+  required int fedChunkCount,
+  required String? lastFedChunk,
+  required bool finalized,
+}) {
+  // Hold the trailing chunk back until finalization: it is still growing.
+  final speakableCount = finalized
+      ? chunks.length
+      : (chunks.length <= 1 ? 0 : chunks.length - 1);
+
+  var cursor = _resolveStreamingCursor(
+    chunks: chunks,
+    fedChunkCount: fedChunkCount,
+    lastFedChunk: lastFedChunk,
+  );
+  final pending = <String>[];
+  var nextLastFedChunk = lastFedChunk;
+  while (cursor < speakableCount) {
+    final chunk = chunks[cursor];
+    cursor++;
+    final trimmed = chunk.trim();
+    if (trimmed.isEmpty) {
+      continue;
+    }
+    pending.add(trimmed);
+    nextLastFedChunk = chunk;
+  }
+
+  return StreamingChunkAdvance(
+    chunks: pending,
+    fedChunkCount: cursor,
+    lastFedChunk: nextLastFedChunk,
+  );
+}
+
+/// Re-anchors the feed cursor on the chunk text last handed to playback.
+///
+/// The split is re-derived from the whole accumulated response on every feed,
+/// so a `</details>` arriving late removes that block from the sanitized body
+/// and shifts every later chunk left. A bare index would then point past
+/// sentences nobody has spoken — typically the answer itself, which is what
+/// makes a response go silent after a tool call.
+int _resolveStreamingCursor({
+  required List<String> chunks,
+  required int fedChunkCount,
+  required String? lastFedChunk,
+}) {
+  if (lastFedChunk == null || fedChunkCount <= 0) {
+    return 0;
+  }
+  if (fedChunkCount <= chunks.length &&
+      chunks[fedChunkCount - 1] == lastFedChunk) {
+    return fedChunkCount;
+  }
+  // A re-split only ever collapses text away, so the anchor can only have
+  // moved earlier in the list.
+  final searchFrom = (fedChunkCount < chunks.length
+      ? fedChunkCount
+      : chunks.length);
+  for (var index = searchFrom - 1; index >= 0; index--) {
+    if (chunks[index] == lastFedChunk) {
+      return index + 1;
+    }
+  }
+  // The anchor is gone entirely (content rewritten upstream). Stay put rather
+  // than replay text that may already have been spoken.
+  return fedChunkCount < chunks.length ? fedChunkCount : chunks.length;
 }
 
 @visibleForTesting
@@ -226,6 +331,7 @@ class TtsManager {
   bool _isStreamingSession = false;
   bool _streamingFinalized = false;
   int _streamingFedChunkCount = 0;
+  String? _streamingLastFedChunk;
   bool _deviceWaitingForStreamingChunk = false;
   int _serverLastFetchScheduledIndex = -1;
   final Set<int> _serverFetchingIndices = <int>{};
@@ -420,6 +526,7 @@ class TtsManager {
     _isStreamingSession = true;
     _streamingFinalized = false;
     _streamingFedChunkCount = 0;
+    _streamingLastFedChunk = null;
     _deviceWaitingForStreamingChunk = false;
     _serverLastFetchScheduledIndex = -1;
     _serverFetchingIndices.clear();
@@ -667,10 +774,7 @@ class TtsManager {
     String content, {
     String splitOn = splitOnPunctuation,
   }) {
-    final sanitizedContent = content.replaceAll(
-      RegExp(r'<details[^>]*>[\s\S]*?<\/details>', caseSensitive: false),
-      '',
-    );
+    final sanitizedContent = _sanitizeForSpeech(content);
 
     switch (splitOn) {
       case splitOnParagraphs:
@@ -682,6 +786,24 @@ class TtsManager {
       default:
         return extractSentencesForAudio(sanitizedContent);
     }
+  }
+
+  /// Removes everything that must never be spoken: rendered semantic
+  /// `<details>` wrappers (reasoning, tool calls, code interpreter output) and
+  /// any other complete `<details>` block.
+  ///
+  /// A semantic wrapper that is still open — the common case while a response
+  /// streams — takes the rest of the body with it. Its contents would otherwise
+  /// be read aloud in the frames before `</details>` arrives to hide them.
+  static final RegExp _completeDetailsPattern = RegExp(
+    r'<details[^>]*>[\s\S]*?<\/details>',
+    caseSensitive: false,
+  );
+
+  String _sanitizeForSpeech(String content) {
+    final withoutCompleteBlocks = stripRenderedSemanticDetails(content)
+        .replaceAll(_completeDetailsPattern, '');
+    return dropUnterminatedSemanticDetails(withoutCompleteBlocks);
   }
 
   /// Gets available voices from the device TTS engine.
@@ -754,18 +876,20 @@ class TtsManager {
   }) async {
     if (_activeSession?.id != session.id) return;
 
-    final chunks = splitTextForSpeech(accumulatedText);
-    final speakableCount = finalized
-        ? chunks.length
-        : (chunks.length <= 1 ? 0 : chunks.length - 1);
+    final advance = _advanceStreamingChunks(
+      chunks: splitTextForSpeech(accumulatedText),
+      fedChunkCount: _streamingFedChunkCount,
+      lastFedChunk: _streamingLastFedChunk,
+      finalized: finalized,
+    );
+    // Move the cursor before awaiting: a concurrent feed must not re-enqueue
+    // the chunks this call is still handing to playback.
+    _streamingFedChunkCount = advance.fedChunkCount;
+    _streamingLastFedChunk = advance.lastFedChunk;
 
-    while (_streamingFedChunkCount < speakableCount) {
-      final chunk = chunks[_streamingFedChunkCount].trim();
-      _streamingFedChunkCount++;
-      if (chunk.isEmpty) {
-        continue;
-      }
+    for (final chunk in advance.chunks) {
       await _appendStreamingChunk(session, chunk);
+      if (_activeSession?.id != session.id) return;
     }
   }
 
@@ -1412,6 +1536,7 @@ class TtsManager {
     _isStreamingSession = false;
     _streamingFinalized = false;
     _streamingFedChunkCount = 0;
+    _streamingLastFedChunk = null;
     _deviceWaitingForStreamingChunk = false;
     _serverLastFetchScheduledIndex = -1;
     _serverFetchingIndices.clear();

--- a/lib/features/chat/services/tts_manager.dart
+++ b/lib/features/chat/services/tts_manager.dart
@@ -304,7 +304,7 @@ class TtsManager {
 
   bool _ttsInitialized = false;
   Completer<void>? _initCompleter;
-  final NativeTtsService _nativeTts = NativeTtsService();
+  NativeTtsService _nativeTts = NativeTtsService();
   StreamSubscription<NativeTtsEvent>? _nativeTtsSub;
   bool _nativeTtsAvailable = false;
 
@@ -326,6 +326,7 @@ class TtsManager {
   TtsConfig _config = const TtsConfig();
   bool _deviceEngineAvailable = false;
   bool _voiceConfigured = false;
+  bool _voiceCallActive = false;
 
   // Session management
   int _sessionCounter = 0;
@@ -380,6 +381,30 @@ class TtsManager {
   /// Sets the API service for server TTS.
   void setApiService(ApiService? api) {
     _apiService = api;
+  }
+
+  /// Swaps the device engine binding so tests can drive device playback
+  /// without a platform channel. Pass null to restore the real engine.
+  @visibleForTesting
+  Future<void> debugSetNativeTtsService(NativeTtsService? service) async {
+    await _nativeTtsSub?.cancel();
+    _nativeTtsSub = null;
+    _nativeTts = service ?? NativeTtsService();
+    _ttsInitialized = false;
+    _initCompleter = null;
+    _nativeTtsAvailable = false;
+    _deviceEngineAvailable = false;
+    _voiceConfigured = false;
+  }
+
+  /// Marks playback as belonging to a voice call.
+  ///
+  /// Device TTS then speaks on the voice-communication stream instead of the
+  /// media stream, which is what makes it follow the call route and keep
+  /// playing while the app is in the background. Read-aloud outside a call must
+  /// stay on the media stream or it lands on the earpiece at call volume.
+  void setVoiceCallActive(bool active) {
+    _voiceCallActive = active;
   }
 
   /// Updates the TTS configuration.
@@ -1110,6 +1135,7 @@ class TtsManager {
       rate: _config.speechRate,
       pitch: _config.pitch,
       volume: _config.volume,
+      voiceCall: _voiceCallActive,
     );
     if (!started) {
       throw StateError('Native TTS failed to start');

--- a/lib/features/chat/services/tts_manager.dart
+++ b/lib/features/chat/services/tts_manager.dart
@@ -94,7 +94,7 @@ class StreamingChunkAdvance {
   const StreamingChunkAdvance({
     required this.chunks,
     required this.fedChunkCount,
-    required this.lastFedChunk,
+    required this.spokenText,
   });
 
   /// Newly speakable chunks, trimmed, in playback order.
@@ -103,22 +103,22 @@ class StreamingChunkAdvance {
   /// How many chunks of the current split have been consumed.
   final int fedChunkCount;
 
-  /// The untrimmed chunk the cursor sits behind, used to re-anchor after a
-  /// re-split.
-  final String? lastFedChunk;
+  /// Everything handed to playback so far, concatenated. The cursor is
+  /// re-derived from this after a re-split.
+  final String spokenText;
 }
 
 @visibleForTesting
 StreamingChunkAdvance advanceStreamingChunksForTesting({
   required List<String> chunks,
   required int fedChunkCount,
-  required String? lastFedChunk,
+  required String spokenText,
   required bool finalized,
 }) {
   return _advanceStreamingChunks(
     chunks: chunks,
     fedChunkCount: fedChunkCount,
-    lastFedChunk: lastFedChunk,
+    spokenText: spokenText,
     finalized: finalized,
   );
 }
@@ -126,7 +126,7 @@ StreamingChunkAdvance advanceStreamingChunksForTesting({
 StreamingChunkAdvance _advanceStreamingChunks({
   required List<String> chunks,
   required int fedChunkCount,
-  required String? lastFedChunk,
+  required String spokenText,
   required bool finalized,
 }) {
   // Hold the trailing chunk back until finalization: it is still growing.
@@ -134,13 +134,14 @@ StreamingChunkAdvance _advanceStreamingChunks({
       ? chunks.length
       : (chunks.length <= 1 ? 0 : chunks.length - 1);
 
-  var cursor = _resolveStreamingCursor(
+  final resolved = _resolveStreamingCursor(
     chunks: chunks,
     fedChunkCount: fedChunkCount,
-    lastFedChunk: lastFedChunk,
+    spokenText: spokenText,
   );
+  var cursor = resolved.cursor;
+  final spoken = StringBuffer(resolved.spokenText);
   final pending = <String>[];
-  var nextLastFedChunk = lastFedChunk;
   while (cursor < speakableCount) {
     final chunk = chunks[cursor];
     cursor++;
@@ -149,48 +150,61 @@ StreamingChunkAdvance _advanceStreamingChunks({
       continue;
     }
     pending.add(trimmed);
-    nextLastFedChunk = chunk;
+    spoken.write(trimmed);
   }
 
   return StreamingChunkAdvance(
     chunks: pending,
     fedChunkCount: cursor,
-    lastFedChunk: nextLastFedChunk,
+    spokenText: spoken.toString(),
   );
 }
 
-/// Re-anchors the feed cursor on the chunk text last handed to playback.
+/// Where the feed cursor sits in a freshly derived split, and the text behind
+/// it.
+class _StreamingCursor {
+  const _StreamingCursor(this.cursor, this.spokenText);
+
+  final int cursor;
+  final String spokenText;
+}
+
+/// Re-derives the feed cursor by matching the split against the text already
+/// handed to playback.
 ///
 /// The split is re-derived from the whole accumulated response on every feed,
 /// so a `</details>` arriving late removes that block from the sanitized body
 /// and shifts every later chunk left. A bare index would then point past
-/// sentences nobody has spoken — typically the answer itself, which is what
-/// makes a response go silent after a tool call.
-int _resolveStreamingCursor({
+/// sentences nobody has spoken, typically the answer itself, which is what
+/// makes a response go silent after a tool call. Matching on running text
+/// instead of on a single chunk keeps the cursor exact even when the same
+/// sentence appears more than once, and a server rewrite mid-answer resumes at
+/// the point the two versions stop agreeing.
+_StreamingCursor _resolveStreamingCursor({
   required List<String> chunks,
   required int fedChunkCount,
-  required String? lastFedChunk,
+  required String spokenText,
 }) {
-  if (lastFedChunk == null || fedChunkCount <= 0) {
-    return 0;
+  if (spokenText.isEmpty || fedChunkCount <= 0) {
+    return const _StreamingCursor(0, '');
   }
-  if (fedChunkCount <= chunks.length &&
-      chunks[fedChunkCount - 1] == lastFedChunk) {
-    return fedChunkCount;
-  }
-  // A re-split only ever collapses text away, so the anchor can only have
-  // moved earlier in the list.
-  final searchFrom = (fedChunkCount < chunks.length
-      ? fedChunkCount
-      : chunks.length);
-  for (var index = searchFrom - 1; index >= 0; index--) {
-    if (chunks[index] == lastFedChunk) {
-      return index + 1;
+
+  final replayed = StringBuffer();
+  var cursor = 0;
+  var matched = '';
+  for (final chunk in chunks) {
+    replayed.write(chunk.trim());
+    final candidate = replayed.toString();
+    if (!spokenText.startsWith(candidate)) {
+      break;
+    }
+    cursor++;
+    matched = candidate;
+    if (candidate.length == spokenText.length) {
+      break;
     }
   }
-  // The anchor is gone entirely (content rewritten upstream). Stay put rather
-  // than replay text that may already have been spoken.
-  return fedChunkCount < chunks.length ? fedChunkCount : chunks.length;
+  return _StreamingCursor(cursor, matched);
 }
 
 @visibleForTesting
@@ -331,7 +345,7 @@ class TtsManager {
   bool _isStreamingSession = false;
   bool _streamingFinalized = false;
   int _streamingFedChunkCount = 0;
-  String? _streamingLastFedChunk;
+  String _streamingSpokenText = '';
   Future<void> _streamingFeedSerial = Future<void>.value();
   bool _deviceWaitingForStreamingChunk = false;
   int _serverLastFetchScheduledIndex = -1;
@@ -527,7 +541,7 @@ class TtsManager {
     _isStreamingSession = true;
     _streamingFinalized = false;
     _streamingFedChunkCount = 0;
-    _streamingLastFedChunk = null;
+    _streamingSpokenText = '';
     _streamingFeedSerial = Future<void>.value();
     _deviceWaitingForStreamingChunk = false;
     _serverLastFetchScheduledIndex = -1;
@@ -900,13 +914,13 @@ class TtsManager {
     final advance = _advanceStreamingChunks(
       chunks: splitTextForSpeech(accumulatedText),
       fedChunkCount: _streamingFedChunkCount,
-      lastFedChunk: _streamingLastFedChunk,
+      spokenText: _streamingSpokenText,
       finalized: finalized,
     );
     // Move the cursor before awaiting: a concurrent feed must not re-enqueue
     // the chunks this call is still handing to playback.
     _streamingFedChunkCount = advance.fedChunkCount;
-    _streamingLastFedChunk = advance.lastFedChunk;
+    _streamingSpokenText = advance.spokenText;
 
     for (final chunk in advance.chunks) {
       await _appendStreamingChunk(session, chunk);
@@ -1557,7 +1571,7 @@ class TtsManager {
     _isStreamingSession = false;
     _streamingFinalized = false;
     _streamingFedChunkCount = 0;
-    _streamingLastFedChunk = null;
+    _streamingSpokenText = '';
     _streamingFeedSerial = Future<void>.value();
     _deviceWaitingForStreamingChunk = false;
     _serverLastFetchScheduledIndex = -1;

--- a/lib/features/chat/services/tts_manager.dart
+++ b/lib/features/chat/services/tts_manager.dart
@@ -1053,7 +1053,11 @@ class TtsManager {
         _setBufferedServerChunk(index, chunk);
         await _enqueueBufferedServerChunks(session);
       } catch (error) {
-        _emitEvent(TtsError(error.toString()));
+        // A fetch for a session that is over has nobody to report to, and the
+        // listeners are all watching whatever is playing now.
+        if (_activeSession?.id == session.id) {
+          _emitEvent(TtsError(error.toString()));
+        }
       } finally {
         // The set was emptied when this session ended, so a fetch that outlived
         // it would take the next session's marker for the same index instead of

--- a/lib/features/chat/services/tts_manager.dart
+++ b/lib/features/chat/services/tts_manager.dart
@@ -142,6 +142,14 @@ StreamingChunkAdvance _advanceStreamingChunks({
   var cursor = resolved.cursor;
   final spoken = StringBuffer(resolved.spokenText);
   final pending = <String>[];
+
+  // The part of the old response that playback heard past the point the two
+  // versions stop agreeing. A rewrite usually touches one sentence and leaves
+  // the rest alone, so the sentences after it are still in here and must not be
+  // spoken twice.
+  final alreadyHeard = spokenText.substring(resolved.spokenText.length);
+  var heardCursor = 0;
+
   while (cursor < speakableCount) {
     final chunk = chunks[cursor];
     cursor++;
@@ -149,8 +157,17 @@ StreamingChunkAdvance _advanceStreamingChunks({
     if (trimmed.isEmpty) {
       continue;
     }
-    pending.add(trimmed);
     spoken.write(trimmed);
+    if (heardCursor < alreadyHeard.length) {
+      // Scan forward only, so a sentence that repeats later in the answer is
+      // still spoken once for each time the old version was heard.
+      final at = alreadyHeard.indexOf(trimmed, heardCursor);
+      if (at >= 0) {
+        heardCursor = at + trimmed.length;
+        continue;
+      }
+    }
+    pending.add(trimmed);
   }
 
   return StreamingChunkAdvance(

--- a/lib/features/chat/services/tts_manager.dart
+++ b/lib/features/chat/services/tts_manager.dart
@@ -365,6 +365,14 @@ class TtsManager {
   int _streamingFedChunkCount = 0;
   String _streamingSpokenText = '';
   Future<void> _streamingFeedSerial = Future<void>.value();
+
+  /// Feeds queued or running on [_streamingFeedSerial].
+  ///
+  /// `finishStreaming` marks the response finalized before its own feed reaches
+  /// the chain, so finalized alone does not mean every sentence has been
+  /// appended. Playback finishing a chunk in that window would otherwise end
+  /// the session and the queued feed would drop the rest of the answer.
+  int _streamingFeedsPending = 0;
   bool _deviceWaitingForStreamingChunk = false;
   int _serverLastFetchScheduledIndex = -1;
   final Set<int> _serverFetchingIndices = <int>{};
@@ -937,10 +945,18 @@ class TtsManager {
     String accumulatedText, {
     required bool finalized,
   }) {
-    final queued = _streamingFeedSerial.then(
-      (_) =>
-          _feedStreamingChunks(session, accumulatedText, finalized: finalized),
-    );
+    _streamingFeedsPending++;
+    final queued = _streamingFeedSerial
+        .then(
+          (_) => _feedStreamingChunks(
+            session,
+            accumulatedText,
+            finalized: finalized,
+          ),
+        )
+        .whenComplete(() {
+          _streamingFeedsPending--;
+        });
     _streamingFeedSerial = queued.catchError((Object _) {});
     return queued;
   }
@@ -1134,7 +1150,8 @@ class TtsManager {
 
     // Check if there are more chunks
     if (nextIndex >= session.chunks.length) {
-      if (_isStreamingSession && !_streamingFinalized) {
+      if (_isStreamingSession &&
+          (!_streamingFinalized || _streamingFeedsPending > 0)) {
         _deviceWaitingForStreamingChunk = true;
         return;
       }

--- a/lib/features/chat/services/tts_manager.dart
+++ b/lib/features/chat/services/tts_manager.dart
@@ -1055,11 +1055,14 @@ class TtsManager {
       } catch (error) {
         _emitEvent(TtsError(error.toString()));
       } finally {
-        _serverFetchingIndices.remove(index);
-        if (_streamingFinalized &&
-            _serverFetchingIndices.isEmpty &&
-            _activeSession?.id == session.id) {
-          _onServerAudioComplete();
+        // The set was emptied when this session ended, so a fetch that outlived
+        // it would take the next session's marker for the same index instead of
+        // its own.
+        if (_activeSession?.id == session.id) {
+          _serverFetchingIndices.remove(index);
+          if (_streamingFinalized && _serverFetchingIndices.isEmpty) {
+            _onServerAudioComplete();
+          }
         }
       }
     }());

--- a/lib/features/chat/voice_mode/chat_voice_audio_session_coordinator.dart
+++ b/lib/features/chat/voice_mode/chat_voice_audio_session_coordinator.dart
@@ -305,6 +305,10 @@ class ChatVoiceAudioSessionCoordinator {
       if (enabled == _speakerphoneEnabled) return;
 
       await _applySpeakerphoneRoute(enabled, phase: 'device-change');
+      // The button can be pressed, or the call can end, while the platform
+      // calls above are still going. Publishing then would leave the speaker
+      // control showing a route nobody chose.
+      if (_speakerphoneChosenByUser || _routeChangesStopped) return;
       if (!_speakerphoneRouteController.isClosed) {
         _speakerphoneRouteController.add(enabled);
       }

--- a/lib/features/chat/voice_mode/chat_voice_audio_session_coordinator.dart
+++ b/lib/features/chat/voice_mode/chat_voice_audio_session_coordinator.dart
@@ -66,6 +66,11 @@ class ChatVoiceAudioSessionCoordinator {
   /// How many speaker-button presses are queued or on the wire.
   int _pendingSpeakerphoneRequests = 0;
 
+  /// How many teardowns are part-way through. Hanging up and disposal can
+  /// overlap, and the first to finish must not lift the shutter while the other
+  /// is still putting the platform route back.
+  int _teardownsRunning = 0;
+
   /// Whether the hardware has lost its vote over the route.
   ///
   /// A press counts from the moment it is queued, so an automatic reroute
@@ -112,6 +117,7 @@ class ChatVoiceAudioSessionCoordinator {
   }
 
   Future<void> configureForListening() async {
+    final generation = _callGeneration;
     final session = await _ensureSession();
     await _configureSession(
       session,
@@ -134,11 +140,16 @@ class ChatVoiceAudioSessionCoordinator {
       'listening',
     );
     _confirmDefaultSpeakerphoneRoute(
-      await _activateVoiceRoute(session, phase: 'listening'),
+      await _activateVoiceRoute(
+        session,
+        phase: 'listening',
+        generation: generation,
+      ),
     );
   }
 
   Future<void> configureForSpeaking() async {
+    final generation = _callGeneration;
     final session = await _ensureSession();
     await _configureSession(
       session,
@@ -161,12 +172,17 @@ class ChatVoiceAudioSessionCoordinator {
       'speaking',
     );
     _confirmDefaultSpeakerphoneRoute(
-      await _activateVoiceRoute(session, phase: 'speaking'),
+      await _activateVoiceRoute(
+        session,
+        phase: 'speaking',
+        generation: generation,
+      ),
     );
     await _settleIosSpeakingRoute();
   }
 
   Future<void> configureForBargeInSpeaking() async {
+    final generation = _callGeneration;
     final session = await _ensureSession();
     await _configureSession(
       session,
@@ -189,7 +205,11 @@ class ChatVoiceAudioSessionCoordinator {
       'barge-in-speaking',
     );
     _confirmDefaultSpeakerphoneRoute(
-      await _activateVoiceRoute(session, phase: 'barge-in-speaking'),
+      await _activateVoiceRoute(
+        session,
+        phase: 'barge-in-speaking',
+        generation: generation,
+      ),
     );
     await _settleIosSpeakingRoute();
   }
@@ -205,12 +225,18 @@ class ChatVoiceAudioSessionCoordinator {
   /// Teardown drains the same queue, so queueing is also what stops a pass that
   /// started before the call ended from reactivating the session or putting the
   /// phone back into communication mode after the route was handed back.
+  ///
+  /// [generation] is the call this pass was started for, read before the
+  /// session configuration it follows. A teardown that both began and finished
+  /// during that configuration leaves the shutter up again, so the generation
+  /// is what tells this pass the call it belongs to is over.
   Future<bool> _activateVoiceRoute(
     AudioSession session, {
     required String phase,
+    required int generation,
   }) {
     return _serializeRouteChange(() async {
-      if (_routeChangesStopped) {
+      if (_routeChangesStopped || generation != _callGeneration) {
         return false;
       }
       await _setActive(session, active: true, phase: phase);
@@ -234,13 +260,15 @@ class ChatVoiceAudioSessionCoordinator {
 
   /// Hands the route back to whatever had it before the call.
   ///
-  /// Safe to run twice, and in either order: every step either restores state
-  /// it captured or clears state that is already clear.
+  /// Safe to run twice, in either order, and overlapping: every step either
+  /// restores state it captured or clears state that is already clear, and the
+  /// shutter stays down until the last teardown is done.
   Future<void> _tearDownRoute({required String phase}) async {
     assert(() {
       debugRouteTeardowns.add(phase);
       return true;
     }());
+    _teardownsRunning++;
     _callGeneration++;
     final session = _session;
     final devicesSub = _devicesSub;
@@ -262,7 +290,10 @@ class ChatVoiceAudioSessionCoordinator {
       _pendingSpeakerphoneRequests = 0;
       _accessoryAttached = null;
       _defaultRouteAwaitingConfirmation = false;
-      _routeChangesStopped = _disposed;
+      _teardownsRunning--;
+      if (_teardownsRunning == 0) {
+        _routeChangesStopped = _disposed;
+      }
     }
   }
 

--- a/lib/features/chat/voice_mode/chat_voice_audio_session_coordinator.dart
+++ b/lib/features/chat/voice_mode/chat_voice_audio_session_coordinator.dart
@@ -48,6 +48,8 @@ class ChatVoiceAudioSessionCoordinator {
   bool _speakerphoneEnabled = false;
   bool _speakerphoneChosenByUser = false;
   bool? _accessoryAttached;
+  bool _routeChangesStopped = false;
+  Future<void> _routeSerial = Future<void>.value();
   StreamSubscription<Set<AudioDevice>>? _devicesSub;
   final StreamController<bool> _speakerphoneRouteController =
       StreamController<bool>.broadcast();
@@ -155,8 +157,12 @@ class ChatVoiceAudioSessionCoordinator {
     final session = _session;
     final devicesSub = _devicesSub;
     _devicesSub = null;
+    _routeChangesStopped = true;
     try {
       await devicesSub?.cancel();
+      // Let any reroute already on the wire finish before tearing the route
+      // down, so the teardown is not the thing that gets interleaved.
+      await _routeSerial;
       await _clearIosVoiceRoute();
       if (session != null) {
         await _setActive(session, active: false, phase: 'deactivate');
@@ -166,13 +172,16 @@ class ChatVoiceAudioSessionCoordinator {
       _speakerphoneEnabled = false;
       _speakerphoneChosenByUser = false;
       _accessoryAttached = null;
+      _routeChangesStopped = false;
     }
   }
 
   Future<void> dispose() async {
     final devicesSub = _devicesSub;
     _devicesSub = null;
+    _routeChangesStopped = true;
     await devicesSub?.cancel();
+    await _routeSerial;
     await _speakerphoneRouteController.close();
   }
 
@@ -240,9 +249,9 @@ class ChatVoiceAudioSessionCoordinator {
       _handleAudioDevicesChanged(devices);
 
   Future<void> _handleAudioDevicesChanged(Set<AudioDevice> devices) async {
-    if (_speakerphoneChosenByUser) {
-      // Someone pressed the speaker button. Their choice outranks the default
-      // for the rest of the call, so stop second-guessing it.
+    if (_speakerphoneChosenByUser || _routeChangesStopped) {
+      // Someone pressed the speaker button, or the call is over. Either way the
+      // hardware no longer gets a vote.
       return;
     }
 
@@ -257,19 +266,43 @@ class ChatVoiceAudioSessionCoordinator {
     _accessoryAttached = attached;
 
     final enabled = !attached;
-    if (enabled == _speakerphoneEnabled) {
-      return;
-    }
 
     DebugLogger.info(
       'audio-accessory-changed',
       scope: 'chat/voice_audio',
       data: {'attached': attached, 'speakerphone': enabled},
     );
-    await _applySpeakerphoneRoute(enabled, phase: 'device-change');
-    if (!_speakerphoneRouteController.isClosed) {
-      _speakerphoneRouteController.add(enabled);
-    }
+    await _serializeRouteChange(() async {
+      // Re-read everything this reroute assumed: while it waited its turn the
+      // user may have pressed the speaker button, the call may have ended, or a
+      // later event may have already put the route where it belongs.
+      if (_speakerphoneChosenByUser || _routeChangesStopped) return;
+      if (_accessoryAttached != attached) return;
+      if (enabled == _speakerphoneEnabled) return;
+
+      await _applySpeakerphoneRoute(enabled, phase: 'device-change');
+      if (!_speakerphoneRouteController.isClosed) {
+        _speakerphoneRouteController.add(enabled);
+      }
+    });
+  }
+
+  /// Runs route changes one at a time.
+  ///
+  /// Rerouting is several platform calls deep, so two of them running together
+  /// interleave and the loser gets the last word. Queueing keeps the newest
+  /// decision the one that sticks.
+  Future<void> _serializeRouteChange(Future<void> Function() change) {
+    final queued = _routeSerial.then((_) => change());
+    _routeSerial = queued.catchError((Object error, StackTrace stackTrace) {
+      DebugLogger.error(
+        'audio-route-change-failed',
+        scope: 'chat/voice_audio',
+        error: error,
+        stackTrace: stackTrace,
+      );
+    });
+    return queued;
   }
 
   /// Whether an audio accessory is attached, or null when the scan failed.
@@ -301,9 +334,13 @@ class ChatVoiceAudioSessionCoordinator {
     }
   }
 
-  Future<void> setSpeakerphoneEnabled(bool enabled) async {
+  Future<void> setSpeakerphoneEnabled(bool enabled) {
+    // Set before queueing so an automatic reroute still waiting its turn sees
+    // the choice and stands down.
     _speakerphoneChosenByUser = true;
-    await _applySpeakerphoneRoute(enabled, phase: 'user-toggle');
+    return _serializeRouteChange(
+      () => _applySpeakerphoneRoute(enabled, phase: 'user-toggle'),
+    );
   }
 
   Future<void> _applySpeakerphoneRoute(
@@ -319,7 +356,7 @@ class ChatVoiceAudioSessionCoordinator {
       await _safeAndroidRouteCall(
         () => manager.clearCommunicationDevice(),
         operation: 'clear-communication-device',
-        phase: 'user-toggle',
+        phase: phase,
       );
       await _safeAndroidRouteCall(
         () async {
@@ -327,11 +364,11 @@ class ChatVoiceAudioSessionCoordinator {
           await manager.stopBluetoothSco();
         },
         operation: 'stop-bluetooth-sco',
-        phase: 'user-toggle',
+        phase: phase,
       );
-      await _configureAndroidVoiceRoute(phase: 'user-toggle');
+      await _configureAndroidVoiceRoute(phase: phase);
     }
-    await _setIosSpeakerphoneEnabled(enabled, phase: 'user-toggle');
+    await _setIosSpeakerphoneEnabled(enabled, phase: phase);
   }
 
   Future<void> _configureAndroidVoiceRoute({required String phase}) async {

--- a/lib/features/chat/voice_mode/chat_voice_audio_session_coordinator.dart
+++ b/lib/features/chat/voice_mode/chat_voice_audio_session_coordinator.dart
@@ -420,9 +420,12 @@ class ChatVoiceAudioSessionCoordinator {
       if (_manualRouteHeld || _routeChangesStopped) return;
       if (_accessoryAttached != attached) return;
       if (!applied) {
-        // Audio is still coming out of wherever it was. Saying otherwise would
-        // point the speaker button at a route nobody is hearing, and the flag
-        // is back where it was so the next device event gets another go.
+        // Audio is still coming out of wherever it was, so saying otherwise
+        // would point the speaker button at a route nobody is hearing. Drop the
+        // accessory snapshot claimed above as well: the hardware never moved,
+        // and leaving the claim standing would make the next notification about
+        // the same hardware look like old news and skip the retry.
+        _accessoryAttached = null;
         return;
       }
       if (!_speakerphoneRouteController.isClosed) {

--- a/lib/features/chat/voice_mode/chat_voice_audio_session_coordinator.dart
+++ b/lib/features/chat/voice_mode/chat_voice_audio_session_coordinator.dart
@@ -53,6 +53,11 @@ class ChatVoiceAudioSessionCoordinator {
   bool? _accessoryAttached;
   bool _routeChangesStopped = false;
 
+  /// Set once [applyDefaultSpeakerphoneRoute] has picked the loudspeaker but no
+  /// configure pass has tried to move the route there yet. Until one does,
+  /// nobody knows whether the platform will take it.
+  bool _defaultRouteAwaitingConfirmation = false;
+
   /// Bumped by every teardown so work started for an earlier call can tell that
   /// it came back too late.
   int _callGeneration = 0;
@@ -100,8 +105,9 @@ class ChatVoiceAudioSessionCoordinator {
       'listening',
     );
     await _setActive(session, active: true, phase: 'listening');
-    await _configureAndroidVoiceRoute(phase: 'listening');
-    await _configureIosVoiceRoute(phase: 'listening');
+    final androidRouted = await _configureAndroidVoiceRoute(phase: 'listening');
+    final iosRouted = await _configureIosVoiceRoute(phase: 'listening');
+    _confirmDefaultSpeakerphoneRoute(androidRouted && iosRouted);
   }
 
   Future<void> configureForSpeaking() async {
@@ -127,8 +133,9 @@ class ChatVoiceAudioSessionCoordinator {
       'speaking',
     );
     await _setActive(session, active: true, phase: 'speaking');
-    await _configureAndroidVoiceRoute(phase: 'speaking');
-    await _configureIosVoiceRoute(phase: 'speaking');
+    final androidRouted = await _configureAndroidVoiceRoute(phase: 'speaking');
+    final iosRouted = await _configureIosVoiceRoute(phase: 'speaking');
+    _confirmDefaultSpeakerphoneRoute(androidRouted && iosRouted);
     await _settleIosSpeakingRoute();
   }
 
@@ -155,8 +162,11 @@ class ChatVoiceAudioSessionCoordinator {
       'barge-in-speaking',
     );
     await _setActive(session, active: true, phase: 'barge-in-speaking');
-    await _configureAndroidVoiceRoute(phase: 'barge-in-speaking');
-    await _configureIosVoiceRoute(phase: 'barge-in-speaking');
+    final androidRouted = await _configureAndroidVoiceRoute(
+      phase: 'barge-in-speaking',
+    );
+    final iosRouted = await _configureIosVoiceRoute(phase: 'barge-in-speaking');
+    _confirmDefaultSpeakerphoneRoute(androidRouted && iosRouted);
     await _settleIosSpeakingRoute();
   }
 
@@ -180,6 +190,7 @@ class ChatVoiceAudioSessionCoordinator {
       _speakerphoneEnabled = false;
       _speakerphoneChosenByUser = false;
       _accessoryAttached = null;
+      _defaultRouteAwaitingConfirmation = false;
       _routeChangesStopped = false;
     }
   }
@@ -205,8 +216,7 @@ class ChatVoiceAudioSessionCoordinator {
   static bool isExternalAudioAccessory(AudioDeviceType type) =>
       _externalAudioAccessoryTypes.contains(type);
 
-  /// Picks the speakerphone for a call that has no accessory to play through,
-  /// and reports whether it did.
+  /// Picks the speakerphone for a call that has no accessory to play through.
   ///
   /// Voice calls run the session in communication mode, so a phone with
   /// nothing attached routes playback to the earpiece — audible only with the
@@ -215,11 +225,12 @@ class ChatVoiceAudioSessionCoordinator {
   /// hearing aid connected routed to it.
   ///
   /// Only the routing preference is set here; the `configureFor*` pass that
-  /// follows applies it. Call this before the first pass of a call, not after a
-  /// manual toggle, or it would overwrite the user's choice.
-  Future<bool> applyDefaultSpeakerphoneRoute() async {
+  /// follows applies it, and [speakerphoneRouteChanges] carries the answer once
+  /// it has. Call this before the first pass of a call, not after a manual
+  /// toggle, or it would overwrite the user's choice.
+  Future<void> applyDefaultSpeakerphoneRoute() async {
     if (!Platform.isAndroid && !Platform.isIOS) {
-      return false;
+      return;
     }
     final generation = _callGeneration;
     final attached = await _hasExternalAudioAccessory();
@@ -227,7 +238,7 @@ class ChatVoiceAudioSessionCoordinator {
       // The call ended, or the speaker button was pressed, while the scan was
       // out. Either way this answer is stale and must not resubscribe or move
       // the route.
-      return false;
+      return;
     }
 
     _accessoryAttached = attached;
@@ -239,10 +250,32 @@ class ChatVoiceAudioSessionCoordinator {
       // A failed scan says nothing about what is plugged in, and playing an
       // answer out of the loudspeaker over someone's headset is worse than
       // leaving the route alone.
-      return false;
+      return;
     }
     _speakerphoneEnabled = true;
-    return true;
+    _defaultRouteAwaitingConfirmation = true;
+  }
+
+  /// Reports the default route once a configure pass has tried to apply it.
+  ///
+  /// The session does not exist yet when the default is picked, so the route
+  /// only moves on the next `configureFor*` pass. Announcing the loudspeaker
+  /// before then would light the speaker button up for a route the platform
+  /// still had the chance to refuse.
+  void _confirmDefaultSpeakerphoneRoute(bool applied) {
+    if (!_defaultRouteAwaitingConfirmation) return;
+    _defaultRouteAwaitingConfirmation = false;
+    if (_speakerphoneChosenByUser || _routeChangesStopped) return;
+    if (!applied) {
+      // The call is still on the earpiece, so the preference set above never
+      // became a route. Putting the flag back lets the next device event try
+      // the move again.
+      _speakerphoneEnabled = false;
+      return;
+    }
+    if (!_speakerphoneRouteController.isClosed) {
+      _speakerphoneRouteController.add(true);
+    }
   }
 
   /// Keeps the default following the hardware for the rest of the call:
@@ -628,9 +661,10 @@ class ChatVoiceAudioSessionCoordinator {
     }
   }
 
-  Future<void> _configureIosVoiceRoute({required String phase}) async {
+  /// Puts the iOS session on the current route, and reports whether it took.
+  Future<bool> _configureIosVoiceRoute({required String phase}) async {
     if (!Platform.isIOS) {
-      return;
+      return true;
     }
 
     final payload = _speakerphoneEnabled
@@ -643,8 +677,7 @@ class ChatVoiceAudioSessionCoordinator {
             phase: phase,
           );
     if (payload == null) {
-      await _setIosSpeakerphoneEnabled(_speakerphoneEnabled, phase: phase);
-      return;
+      return _setIosSpeakerphoneEnabled(_speakerphoneEnabled, phase: phase);
     }
 
     final selected = payload['selected'] == true;
@@ -653,7 +686,7 @@ class ChatVoiceAudioSessionCoordinator {
       scope: 'chat/voice_audio',
       data: _iosRouteLogData(payload, phase: phase),
     );
-    await _setIosSpeakerphoneEnabled(_speakerphoneEnabled, phase: phase);
+    return _setIosSpeakerphoneEnabled(_speakerphoneEnabled, phase: phase);
   }
 
   /// Overrides the iOS output port, and reports whether the session took it.

--- a/lib/features/chat/voice_mode/chat_voice_audio_session_coordinator.dart
+++ b/lib/features/chat/voice_mode/chat_voice_audio_session_coordinator.dart
@@ -49,6 +49,10 @@ class ChatVoiceAudioSessionCoordinator {
   bool _speakerphoneChosenByUser = false;
   bool? _accessoryAttached;
   bool _routeChangesStopped = false;
+
+  /// Bumped by every teardown so work started for an earlier call can tell that
+  /// it came back too late.
+  int _callGeneration = 0;
   Future<void> _routeSerial = Future<void>.value();
   StreamSubscription<Set<AudioDevice>>? _devicesSub;
   final StreamController<bool> _speakerphoneRouteController =
@@ -154,6 +158,7 @@ class ChatVoiceAudioSessionCoordinator {
   }
 
   Future<void> deactivate() async {
+    _callGeneration++;
     final session = _session;
     final devicesSub = _devicesSub;
     _devicesSub = null;
@@ -177,6 +182,7 @@ class ChatVoiceAudioSessionCoordinator {
   }
 
   Future<void> dispose() async {
+    _callGeneration++;
     final devicesSub = _devicesSub;
     _devicesSub = null;
     _routeChangesStopped = true;
@@ -207,12 +213,21 @@ class ChatVoiceAudioSessionCoordinator {
     if (!Platform.isAndroid && !Platform.isIOS) {
       return false;
     }
-    _accessoryAttached = await _hasExternalAudioAccessory();
+    final generation = _callGeneration;
+    final attached = await _hasExternalAudioAccessory();
+    if (generation != _callGeneration || _speakerphoneChosenByUser) {
+      // The call ended, or the speaker button was pressed, while the scan was
+      // out. Either way this answer is stale and must not resubscribe or move
+      // the route.
+      return false;
+    }
+
+    _accessoryAttached = attached;
     // Subscribing re-reads the device list and delivers it, so anything plugged
     // in or pulled out during the scan above arrives as the first event and
     // corrects this snapshot.
     _watchAudioDevices();
-    if (_accessoryAttached != false) {
+    if (attached != false) {
       // A failed scan says nothing about what is plugged in, and playing an
       // answer out of the loudspeaker over someone's headset is worse than
       // leaving the route alone.

--- a/lib/features/chat/voice_mode/chat_voice_audio_session_coordinator.dart
+++ b/lib/features/chat/voice_mode/chat_voice_audio_session_coordinator.dart
@@ -535,11 +535,23 @@ class ChatVoiceAudioSessionCoordinator {
     // sees the press and stands down.
     _pendingSpeakerphoneRequests++;
     return _serializeRouteChange(() async {
-      bool applied;
+      var applied = false;
       try {
+        if (_routeChangesStopped) {
+          // Teardown started while this press waited its turn. The route is on
+          // its way back to whatever had it before the call, so moving it now
+          // is platform work for a call that is over.
+          return false;
+        }
         applied = await _applySpeakerphoneRoute(enabled, phase: 'user-toggle');
       } finally {
         _pendingSpeakerphoneRequests--;
+      }
+      if (_routeChangesStopped) {
+        // Same again, for a teardown that started while the platform calls were
+        // out. Answering `true` here would light the speaker button up as the
+        // call ends.
+        return false;
       }
       if (applied) {
         _speakerphoneChosenByUser = true;

--- a/lib/features/chat/voice_mode/chat_voice_audio_session_coordinator.dart
+++ b/lib/features/chat/voice_mode/chat_voice_audio_session_coordinator.dart
@@ -304,13 +304,22 @@ class ChatVoiceAudioSessionCoordinator {
       if (_accessoryAttached != attached) return;
       if (enabled == _speakerphoneEnabled) return;
 
-      await _applySpeakerphoneRoute(enabled, phase: 'device-change');
+      final applied = await _applySpeakerphoneRoute(
+        enabled,
+        phase: 'device-change',
+      );
       // The button can be pressed, the call can end, or the hardware can change
       // again while the platform calls above are still going. Publishing then
       // would leave the speaker control showing a route nobody chose; whoever
       // superseded this reroute gets to publish instead.
       if (_speakerphoneChosenByUser || _routeChangesStopped) return;
       if (_accessoryAttached != attached) return;
+      if (!applied) {
+        // Audio is still coming out of wherever it was. Saying otherwise would
+        // point the speaker button at a route nobody is hearing, and the flag
+        // is back where it was so the next device event gets another go.
+        return;
+      }
       if (!_speakerphoneRouteController.isClosed) {
         _speakerphoneRouteController.add(enabled);
       }
@@ -322,16 +331,19 @@ class ChatVoiceAudioSessionCoordinator {
   /// Rerouting is several platform calls deep, so two of them running together
   /// interleave and the loser gets the last word. Queueing keeps the newest
   /// decision the one that sticks.
-  Future<void> _serializeRouteChange(Future<void> Function() change) {
+  Future<T> _serializeRouteChange<T>(Future<T> Function() change) {
     final queued = _routeSerial.then((_) => change());
-    _routeSerial = queued.catchError((Object error, StackTrace stackTrace) {
-      DebugLogger.error(
-        'audio-route-change-failed',
-        scope: 'chat/voice_audio',
-        error: error,
-        stackTrace: stackTrace,
-      );
-    });
+    _routeSerial = queued.then<void>(
+      (_) {},
+      onError: (Object error, StackTrace stackTrace) {
+        DebugLogger.error(
+          'audio-route-change-failed',
+          scope: 'chat/voice_audio',
+          error: error,
+          stackTrace: stackTrace,
+        );
+      },
+    );
     return queued;
   }
 
@@ -364,11 +376,13 @@ class ChatVoiceAudioSessionCoordinator {
     }
   }
 
-  Future<void> setSpeakerphoneEnabled(bool enabled) {
+  /// Moves the call to [enabled] on the user's instruction and reports whether
+  /// the platform took it.
+  Future<bool> setSpeakerphoneEnabled(bool enabled) {
     if (_routeChangesStopped) {
       // The call is being torn down. Honouring a last-moment button press would
       // put communication mode back after the route was handed back.
-      return Future<void>.value();
+      return Future<bool>.value(false);
     }
     // Set before queueing so an automatic reroute still waiting its turn sees
     // the choice and stands down.
@@ -378,11 +392,22 @@ class ChatVoiceAudioSessionCoordinator {
     );
   }
 
-  Future<void> _applySpeakerphoneRoute(
+  /// Moves the call to [enabled] and reports whether the platform took it.
+  ///
+  /// Every route call here tolerates failure, so without an answer a refused
+  /// route is indistinguishable from an applied one: the flag would read
+  /// speaker while audio kept coming out of the earpiece, and the guard in
+  /// [_handleAudioDevicesChanged] would drop the next identical device event as
+  /// already handled rather than trying the move again.
+  Future<bool> _applySpeakerphoneRoute(
     bool enabled, {
     required String phase,
   }) async {
+    final previous = _speakerphoneEnabled;
+    // The route configuration below reads this to pick its branch, so it has to
+    // be set before the platform calls and put back if they refuse.
     _speakerphoneEnabled = enabled;
+    var applied = true;
     if (Platform.isAndroid) {
       final manager = _androidAudioManager ??= AndroidAudioManager();
       // Release the currently selected communication device before re-routing:
@@ -401,14 +426,22 @@ class ChatVoiceAudioSessionCoordinator {
         operation: 'stop-bluetooth-sco',
         phase: phase,
       );
-      await _configureAndroidVoiceRoute(phase: phase);
+      applied = await _configureAndroidVoiceRoute(phase: phase);
     }
-    await _setIosSpeakerphoneEnabled(enabled, phase: phase);
+    if (!await _setIosSpeakerphoneEnabled(enabled, phase: phase)) {
+      applied = false;
+    }
+    if (!applied) {
+      _speakerphoneEnabled = previous;
+    }
+    return applied;
   }
 
-  Future<void> _configureAndroidVoiceRoute({required String phase}) async {
+  /// Points the Android call at the route [_speakerphoneEnabled] asks for, and
+  /// reports whether it landed.
+  Future<bool> _configureAndroidVoiceRoute({required String phase}) async {
     if (!Platform.isAndroid) {
-      return;
+      return true;
     }
 
     final manager = _androidAudioManager ??= AndroidAudioManager();
@@ -424,7 +457,7 @@ class ChatVoiceAudioSessionCoordinator {
       phase: phase,
     );
 
-    await _safeAndroidRouteCall(
+    final modeSet = await _safeAndroidRouteAction(
       () => manager.setMode(AndroidAudioHardwareMode.inCommunication),
       operation: 'set-in-communication',
       phase: phase,
@@ -438,14 +471,15 @@ class ChatVoiceAudioSessionCoordinator {
         AndroidAudioDeviceType.builtInSpeaker,
         phase: phase,
       );
-      if (!routed) {
-        await _safeAndroidRouteCall(
-          () => manager.setSpeakerphoneOn(true),
-          operation: 'configure-speakerphone',
-          phase: phase,
-        );
+      if (routed) {
+        return modeSet;
       }
-      return;
+      final legacyRouted = await _safeAndroidRouteAction(
+        () => manager.setSpeakerphoneOn(true),
+        operation: 'configure-speakerphone',
+        phase: phase,
+      );
+      return modeSet && legacyRouted;
     }
 
     await _safeAndroidRouteCall(
@@ -454,13 +488,17 @@ class ChatVoiceAudioSessionCoordinator {
       phase: phase,
     );
 
+    // Off the loudspeaker, the communication device was already cleared above,
+    // so the system is sending the call to the headset or earpiece on its own.
+    // Grabbing SCO is a preference on top of that, and failing to get it (a
+    // wired headset, no Bluetooth at all) is not a failed reroute.
     final selected = await _selectAndroidCommunicationDevice(
       manager,
       AndroidAudioDeviceType.bluetoothSco,
       phase: phase,
     );
     if (selected) {
-      return;
+      return modeSet;
     }
 
     await _safeAndroidRouteCall(
@@ -471,6 +509,7 @@ class ChatVoiceAudioSessionCoordinator {
       operation: 'start-bluetooth-sco',
       phase: phase,
     );
+    return modeSet;
   }
 
   Future<bool> _selectAndroidCommunicationDevice(
@@ -551,6 +590,24 @@ class ChatVoiceAudioSessionCoordinator {
     _previousAndroidSpeakerphone = null;
   }
 
+  /// [_safeAndroidRouteCall] for calls that answer with nothing, where a null
+  /// result cannot tell a completed call from a failed one.
+  Future<bool> _safeAndroidRouteAction(
+    Future<void> Function() action, {
+    required String operation,
+    required String phase,
+  }) async {
+    final completed = await _safeAndroidRouteCall<bool>(
+      () async {
+        await action();
+        return true;
+      },
+      operation: operation,
+      phase: phase,
+    );
+    return completed ?? false;
+  }
+
   Future<T?> _safeAndroidRouteCall<T>(
     Future<T> Function() action, {
     required String operation,
@@ -599,12 +656,13 @@ class ChatVoiceAudioSessionCoordinator {
     await _setIosSpeakerphoneEnabled(_speakerphoneEnabled, phase: phase);
   }
 
-  Future<void> _setIosSpeakerphoneEnabled(
+  /// Overrides the iOS output port, and reports whether the session took it.
+  Future<bool> _setIosSpeakerphoneEnabled(
     bool enabled, {
     required String phase,
   }) async {
-    if (!Platform.isIOS) return;
-    await _safeIosRouteCall(
+    if (!Platform.isIOS) return true;
+    final payload = await _safeIosRouteCall(
       () => _iosVoiceAudioRouteChannel.invokeMapMethod<Object?, Object?>(
         'setSpeakerphoneEnabled',
         <String, Object?>{'enabled': enabled},
@@ -612,6 +670,10 @@ class ChatVoiceAudioSessionCoordinator {
       operation: 'set-speakerphone',
       phase: phase,
     );
+    // The handler always answers with the current route and only carries an
+    // `error` when overrideOutputAudioPort threw, so a missing payload means
+    // the channel itself never got there.
+    return payload != null && payload['error'] == null;
   }
 
   Future<void> _clearIosVoiceRoute() async {

--- a/lib/features/chat/voice_mode/chat_voice_audio_session_coordinator.dart
+++ b/lib/features/chat/voice_mode/chat_voice_audio_session_coordinator.dart
@@ -23,18 +23,21 @@ class ChatVoiceAudioSessionCoordinator {
 
   /// Device types that give a call somewhere to play other than the phone
   /// itself. Built-in earpiece, speaker and microphone are deliberately absent.
+  ///
+  /// So are A2DP and AirPlay. A voice call runs the session in communication
+  /// mode, which cannot route to either, so a device offering only those is not
+  /// somewhere the call can play. Headsets that also speak HFP still show up
+  /// here as [AudioDeviceType.bluetoothSco].
   static const Set<AudioDeviceType> _externalAudioAccessoryTypes = {
     AudioDeviceType.wiredHeadset,
     AudioDeviceType.wiredHeadphones,
     AudioDeviceType.headsetMic,
     AudioDeviceType.bluetoothSco,
-    AudioDeviceType.bluetoothA2dp,
     AudioDeviceType.bluetoothLe,
     AudioDeviceType.usbAudio,
     AudioDeviceType.hearingAid,
     AudioDeviceType.carAudio,
     AudioDeviceType.dock,
-    AudioDeviceType.airPlay,
     AudioDeviceType.lineAnalog,
     AudioDeviceType.lineDigital,
     AudioDeviceType.hdmi,
@@ -191,6 +194,11 @@ class ChatVoiceAudioSessionCoordinator {
     await _speakerphoneRouteController.close();
   }
 
+  /// Whether the call can play through [device] in preference to the phone's
+  /// own speaker. A plugged-in microphone is not somewhere to play.
+  static bool _isPlayableAccessory(AudioDevice device) =>
+      device.isOutput && _externalAudioAccessoryTypes.contains(device.type);
+
   /// Whether [type] is an accessory a call should play through in preference
   /// to the phone's own speaker.
   @visibleForTesting
@@ -273,9 +281,7 @@ class ChatVoiceAudioSessionCoordinator {
       return;
     }
 
-    final attached = devices.any(
-      (device) => _externalAudioAccessoryTypes.contains(device.type),
-    );
+    final attached = devices.any(_isPlayableAccessory);
     if (attached == _accessoryAttached) {
       return;
     }
@@ -329,7 +335,7 @@ class ChatVoiceAudioSessionCoordinator {
       final session = await _ensureSession();
       final devices = await session.getDevices();
       final accessories = devices
-          .where((device) => _externalAudioAccessoryTypes.contains(device.type))
+          .where(_isPlayableAccessory)
           .map((device) => device.type.name)
           .toSet();
       DebugLogger.info(
@@ -353,6 +359,11 @@ class ChatVoiceAudioSessionCoordinator {
   }
 
   Future<void> setSpeakerphoneEnabled(bool enabled) {
+    if (_routeChangesStopped) {
+      // The call is being torn down. Honouring a last-moment button press would
+      // put communication mode back after the route was handed back.
+      return Future<void>.value();
+    }
     // Set before queueing so an automatic reroute still waiting its turn sees
     // the choice and stands down.
     _speakerphoneChosenByUser = true;

--- a/lib/features/chat/voice_mode/chat_voice_audio_session_coordinator.dart
+++ b/lib/features/chat/voice_mode/chat_voice_audio_session_coordinator.dart
@@ -208,6 +208,9 @@ class ChatVoiceAudioSessionCoordinator {
       return false;
     }
     _accessoryAttached = await _hasExternalAudioAccessory();
+    // Subscribing re-reads the device list and delivers it, so anything plugged
+    // in or pulled out during the scan above arrives as the first event and
+    // corrects this snapshot.
     _watchAudioDevices();
     if (_accessoryAttached != false) {
       // A failed scan says nothing about what is plugged in, and playing an

--- a/lib/features/chat/voice_mode/chat_voice_audio_session_coordinator.dart
+++ b/lib/features/chat/voice_mode/chat_voice_audio_session_coordinator.dart
@@ -305,10 +305,12 @@ class ChatVoiceAudioSessionCoordinator {
       if (enabled == _speakerphoneEnabled) return;
 
       await _applySpeakerphoneRoute(enabled, phase: 'device-change');
-      // The button can be pressed, or the call can end, while the platform
-      // calls above are still going. Publishing then would leave the speaker
-      // control showing a route nobody chose.
+      // The button can be pressed, the call can end, or the hardware can change
+      // again while the platform calls above are still going. Publishing then
+      // would leave the speaker control showing a route nobody chose; whoever
+      // superseded this reroute gets to publish instead.
       if (_speakerphoneChosenByUser || _routeChangesStopped) return;
+      if (_accessoryAttached != attached) return;
       if (!_speakerphoneRouteController.isClosed) {
         _speakerphoneRouteController.add(enabled);
       }

--- a/lib/features/chat/voice_mode/chat_voice_audio_session_coordinator.dart
+++ b/lib/features/chat/voice_mode/chat_voice_audio_session_coordinator.dart
@@ -105,9 +105,9 @@ class ChatVoiceAudioSessionCoordinator {
       'listening',
     );
     await _setActive(session, active: true, phase: 'listening');
-    final androidRouted = await _configureAndroidVoiceRoute(phase: 'listening');
-    final iosRouted = await _configureIosVoiceRoute(phase: 'listening');
-    _confirmDefaultSpeakerphoneRoute(androidRouted && iosRouted);
+    _confirmDefaultSpeakerphoneRoute(
+      await _configureVoiceRoute(phase: 'listening'),
+    );
   }
 
   Future<void> configureForSpeaking() async {
@@ -133,9 +133,9 @@ class ChatVoiceAudioSessionCoordinator {
       'speaking',
     );
     await _setActive(session, active: true, phase: 'speaking');
-    final androidRouted = await _configureAndroidVoiceRoute(phase: 'speaking');
-    final iosRouted = await _configureIosVoiceRoute(phase: 'speaking');
-    _confirmDefaultSpeakerphoneRoute(androidRouted && iosRouted);
+    _confirmDefaultSpeakerphoneRoute(
+      await _configureVoiceRoute(phase: 'speaking'),
+    );
     await _settleIosSpeakingRoute();
   }
 
@@ -162,12 +162,25 @@ class ChatVoiceAudioSessionCoordinator {
       'barge-in-speaking',
     );
     await _setActive(session, active: true, phase: 'barge-in-speaking');
-    final androidRouted = await _configureAndroidVoiceRoute(
-      phase: 'barge-in-speaking',
+    _confirmDefaultSpeakerphoneRoute(
+      await _configureVoiceRoute(phase: 'barge-in-speaking'),
     );
-    final iosRouted = await _configureIosVoiceRoute(phase: 'barge-in-speaking');
-    _confirmDefaultSpeakerphoneRoute(androidRouted && iosRouted);
     await _settleIosSpeakingRoute();
+  }
+
+  /// Puts the call on the current route for a configure pass, and reports
+  /// whether both platforms took it.
+  ///
+  /// This queues behind the button and device-change reroutes because it makes
+  /// the same platform calls off the same [_speakerphoneEnabled] flag. Run
+  /// loose, a pass that started before a headset was pulled out can finish
+  /// after the reroute and put the call back on the route it just left.
+  Future<bool> _configureVoiceRoute({required String phase}) {
+    return _serializeRouteChange(() async {
+      final androidRouted = await _configureAndroidVoiceRoute(phase: phase);
+      final iosRouted = await _configureIosVoiceRoute(phase: phase);
+      return androidRouted && iosRouted;
+    });
   }
 
   Future<void> deactivate() async {
@@ -273,6 +286,10 @@ class ChatVoiceAudioSessionCoordinator {
       _speakerphoneEnabled = false;
       return;
     }
+    // A headset connected while the pass was on the wire has already moved the
+    // call off the loudspeaker and said so. Announcing the default now would
+    // talk over it.
+    if (!_speakerphoneEnabled) return;
     if (!_speakerphoneRouteController.isClosed) {
       _speakerphoneRouteController.add(true);
     }

--- a/lib/features/chat/voice_mode/chat_voice_audio_session_coordinator.dart
+++ b/lib/features/chat/voice_mode/chat_voice_audio_session_coordinator.dart
@@ -1,7 +1,13 @@
+// audio_session marks its device-enumeration API experimental; it is the only
+// way to see what is plugged in without a second native bridge.
+// ignore_for_file: experimental_member_use
+
+import 'dart:async';
 import 'dart:developer' as developer;
 import 'dart:io';
 
 import 'package:audio_session/audio_session.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
@@ -15,11 +21,42 @@ class ChatVoiceAudioSessionCoordinator {
     'app.cogwheel.conduit/voice_audio_route',
   );
 
+  /// Device types that give a call somewhere to play other than the phone
+  /// itself. Built-in earpiece, speaker and microphone are deliberately absent.
+  static const Set<AudioDeviceType> _externalAudioAccessoryTypes = {
+    AudioDeviceType.wiredHeadset,
+    AudioDeviceType.wiredHeadphones,
+    AudioDeviceType.headsetMic,
+    AudioDeviceType.bluetoothSco,
+    AudioDeviceType.bluetoothA2dp,
+    AudioDeviceType.bluetoothLe,
+    AudioDeviceType.usbAudio,
+    AudioDeviceType.hearingAid,
+    AudioDeviceType.carAudio,
+    AudioDeviceType.dock,
+    AudioDeviceType.airPlay,
+    AudioDeviceType.lineAnalog,
+    AudioDeviceType.lineDigital,
+    AudioDeviceType.hdmi,
+    AudioDeviceType.hdmiArc,
+  };
+
   AudioSession? _session;
   AndroidAudioManager? _androidAudioManager;
   AndroidAudioHardwareMode? _previousAndroidMode;
   bool? _previousAndroidSpeakerphone;
   bool _speakerphoneEnabled = false;
+  bool _speakerphoneChosenByUser = false;
+  bool? _accessoryAttached;
+  StreamSubscription<Set<AudioDevice>>? _devicesSub;
+  final StreamController<bool> _speakerphoneRouteController =
+      StreamController<bool>.broadcast();
+
+  /// Speakerphone changes this coordinator made on its own, so callers can keep
+  /// their own view of the route in step. Manual toggles are not reported: the
+  /// caller already knows about those.
+  Stream<bool> get speakerphoneRouteChanges =>
+      _speakerphoneRouteController.stream;
 
   Future<AudioSession> _ensureSession() async {
     final session = _session;
@@ -116,7 +153,10 @@ class ChatVoiceAudioSessionCoordinator {
 
   Future<void> deactivate() async {
     final session = _session;
+    final devicesSub = _devicesSub;
+    _devicesSub = null;
     try {
+      await devicesSub?.cancel();
       await _clearIosVoiceRoute();
       if (session != null) {
         await _setActive(session, active: false, phase: 'deactivate');
@@ -124,10 +164,152 @@ class ChatVoiceAudioSessionCoordinator {
     } finally {
       await _restoreAndroidVoiceRoute();
       _speakerphoneEnabled = false;
+      _speakerphoneChosenByUser = false;
+      _accessoryAttached = null;
+    }
+  }
+
+  Future<void> dispose() async {
+    final devicesSub = _devicesSub;
+    _devicesSub = null;
+    await devicesSub?.cancel();
+    await _speakerphoneRouteController.close();
+  }
+
+  /// Whether [type] is an accessory a call should play through in preference
+  /// to the phone's own speaker.
+  @visibleForTesting
+  static bool isExternalAudioAccessory(AudioDeviceType type) =>
+      _externalAudioAccessoryTypes.contains(type);
+
+  /// Picks the speakerphone for a call that has no accessory to play through,
+  /// and reports whether it did.
+  ///
+  /// Voice calls run the session in communication mode, so a phone with
+  /// nothing attached routes playback to the earpiece — audible only with the
+  /// handset against your head, which is not how this call is held. Start those
+  /// calls on the loudspeaker instead, and leave calls with a headset, car or
+  /// hearing aid connected routed to it.
+  ///
+  /// Only the routing preference is set here; the `configureFor*` pass that
+  /// follows applies it. Call this before the first pass of a call, not after a
+  /// manual toggle, or it would overwrite the user's choice.
+  Future<bool> applyDefaultSpeakerphoneRoute() async {
+    if (!Platform.isAndroid && !Platform.isIOS) {
+      return false;
+    }
+    _accessoryAttached = await _hasExternalAudioAccessory();
+    _watchAudioDevices();
+    if (_accessoryAttached != false) {
+      // A failed scan says nothing about what is plugged in, and playing an
+      // answer out of the loudspeaker over someone's headset is worse than
+      // leaving the route alone.
+      return false;
+    }
+    _speakerphoneEnabled = true;
+    return true;
+  }
+
+  /// Keeps the default following the hardware for the rest of the call:
+  /// headphones pulled out mid-answer should not drop the call back to the
+  /// earpiece, and a headset connected mid-call should take playback back off
+  /// the loudspeaker.
+  void _watchAudioDevices() {
+    if (_devicesSub != null) {
+      return;
+    }
+    final session = _session;
+    if (session == null) {
+      return;
+    }
+    _devicesSub = session.devicesStream.listen(
+      (devices) => unawaited(_handleAudioDevicesChanged(devices)),
+      onError: (Object error, StackTrace stackTrace) {
+        DebugLogger.error(
+          'audio-device-watch-failed',
+          scope: 'chat/voice_audio',
+          error: error,
+          stackTrace: stackTrace,
+        );
+      },
+    );
+  }
+
+  @visibleForTesting
+  Future<void> handleAudioDevicesChangedForTesting(Set<AudioDevice> devices) =>
+      _handleAudioDevicesChanged(devices);
+
+  Future<void> _handleAudioDevicesChanged(Set<AudioDevice> devices) async {
+    if (_speakerphoneChosenByUser) {
+      // Someone pressed the speaker button. Their choice outranks the default
+      // for the rest of the call, so stop second-guessing it.
+      return;
+    }
+
+    final attached = devices.any(
+      (device) => _externalAudioAccessoryTypes.contains(device.type),
+    );
+    if (attached == _accessoryAttached) {
+      return;
+    }
+    // Claim the transition before the first await so a burst of events (a
+    // headset announcing its A2DP and SCO ends separately) reroutes once.
+    _accessoryAttached = attached;
+
+    final enabled = !attached;
+    if (enabled == _speakerphoneEnabled) {
+      return;
+    }
+
+    DebugLogger.info(
+      'audio-accessory-changed',
+      scope: 'chat/voice_audio',
+      data: {'attached': attached, 'speakerphone': enabled},
+    );
+    await _applySpeakerphoneRoute(enabled, phase: 'device-change');
+    if (!_speakerphoneRouteController.isClosed) {
+      _speakerphoneRouteController.add(enabled);
+    }
+  }
+
+  /// Whether an audio accessory is attached, or null when the scan failed.
+  Future<bool?> _hasExternalAudioAccessory() async {
+    try {
+      final session = await _ensureSession();
+      final devices = await session.getDevices();
+      final accessories = devices
+          .where((device) => _externalAudioAccessoryTypes.contains(device.type))
+          .map((device) => device.type.name)
+          .toSet();
+      DebugLogger.info(
+        'audio-accessory-scan',
+        scope: 'chat/voice_audio',
+        data: {
+          'accessories': accessories.join(','),
+          'deviceCount': devices.length,
+        },
+      );
+      return accessories.isNotEmpty;
+    } catch (error, stackTrace) {
+      DebugLogger.error(
+        'audio-accessory-scan-failed',
+        scope: 'chat/voice_audio',
+        error: error,
+        stackTrace: stackTrace,
+      );
+      return null;
     }
   }
 
   Future<void> setSpeakerphoneEnabled(bool enabled) async {
+    _speakerphoneChosenByUser = true;
+    await _applySpeakerphoneRoute(enabled, phase: 'user-toggle');
+  }
+
+  Future<void> _applySpeakerphoneRoute(
+    bool enabled, {
+    required String phase,
+  }) async {
     _speakerphoneEnabled = enabled;
     if (Platform.isAndroid) {
       final manager = _androidAudioManager ??= AndroidAudioManager();
@@ -512,5 +694,7 @@ class ChatVoiceAudioSessionCoordinator {
 
 final chatVoiceAudioSessionCoordinatorProvider =
     Provider<ChatVoiceAudioSessionCoordinator>((ref) {
-      return ChatVoiceAudioSessionCoordinator();
+      final coordinator = ChatVoiceAudioSessionCoordinator();
+      ref.onDispose(() => unawaited(coordinator.dispose()));
+      return coordinator;
     });

--- a/lib/features/chat/voice_mode/chat_voice_audio_session_coordinator.dart
+++ b/lib/features/chat/voice_mode/chat_voice_audio_session_coordinator.dart
@@ -367,9 +367,17 @@ class ChatVoiceAudioSessionCoordinator {
     if (_manualRouteHeld || _routeChangesStopped) return;
     if (!applied) {
       // The call is still on the earpiece, so the preference set above never
-      // became a route. Putting the flag back lets the next device event try
-      // the move again.
+      // became a route. Put the flag back, and drop the "nothing attached"
+      // snapshot with it: a phone that stays bare repeats the same device list
+      // rather than sending a fresh transition, and the snapshot would make
+      // that repeat look like old news and skip the retry.
       _speakerphoneEnabled = false;
+      if (_accessoryAttached == false) {
+        // Still the snapshot this default was picked from. A headset that
+        // connected while the pass was on the wire owns it now, and its own
+        // reroute is what the next event has to compare against.
+        _accessoryAttached = null;
+      }
       return;
     }
     // A headset connected while the pass was on the wire has already moved the

--- a/lib/features/chat/voice_mode/chat_voice_audio_session_coordinator.dart
+++ b/lib/features/chat/voice_mode/chat_voice_audio_session_coordinator.dart
@@ -53,6 +53,11 @@ class ChatVoiceAudioSessionCoordinator {
   bool? _accessoryAttached;
   bool _routeChangesStopped = false;
 
+  /// Set once this coordinator has been disposed. There is no next call for it
+  /// to route after that, so a `deactivate` arriving late must not lift the
+  /// shutter [dispose] put down.
+  bool _disposed = false;
+
   /// Set once [applyDefaultSpeakerphoneRoute] has picked the loudspeaker but no
   /// configure pass has tried to move the route there yet. Until one does,
   /// nobody knows whether the platform will take it.
@@ -222,19 +227,16 @@ class ChatVoiceAudioSessionCoordinator {
     // controller that drives it, so disposal cannot assume `deactivate` has
     // already run. Running it again is cheap and leaves nothing behind; not
     // running it can leave the phone in communication mode after the call.
-    await _tearDownRoute(phase: 'dispose', finalizing: true);
+    _disposed = true;
+    await _tearDownRoute(phase: 'dispose');
     await _speakerphoneRouteController.close();
   }
 
   /// Hands the route back to whatever had it before the call.
   ///
-  /// Safe to run twice: every step either restores state it captured or clears
-  /// state that is already clear. Pass [finalizing] when there is no next call
-  /// to route, which keeps the shutter down for good.
-  Future<void> _tearDownRoute({
-    required String phase,
-    bool finalizing = false,
-  }) async {
+  /// Safe to run twice, and in either order: every step either restores state
+  /// it captured or clears state that is already clear.
+  Future<void> _tearDownRoute({required String phase}) async {
     assert(() {
       debugRouteTeardowns.add(phase);
       return true;
@@ -260,7 +262,7 @@ class ChatVoiceAudioSessionCoordinator {
       _pendingSpeakerphoneRequests = 0;
       _accessoryAttached = null;
       _defaultRouteAwaitingConfirmation = false;
-      _routeChangesStopped = finalizing;
+      _routeChangesStopped = _disposed;
     }
   }
 

--- a/lib/features/chat/voice_mode/chat_voice_audio_session_coordinator.dart
+++ b/lib/features/chat/voice_mode/chat_voice_audio_session_coordinator.dart
@@ -58,6 +58,24 @@ class ChatVoiceAudioSessionCoordinator {
   /// nobody knows whether the platform will take it.
   bool _defaultRouteAwaitingConfirmation = false;
 
+  /// How many speaker-button presses are queued or on the wire.
+  int _pendingSpeakerphoneRequests = 0;
+
+  /// Whether the hardware has lost its vote over the route.
+  ///
+  /// A press counts from the moment it is queued, so an automatic reroute
+  /// waiting behind it stands down rather than undoing it. It only becomes
+  /// permanent once the platform takes the move: a press that was refused
+  /// changed nothing, and should not leave the call deaf to headsets for the
+  /// rest of its life.
+  bool get _manualRouteHeld =>
+      _speakerphoneChosenByUser || _pendingSpeakerphoneRequests > 0;
+
+  /// Makes every route change report refusal. A test host has no platform to
+  /// turn a move down, and refusal is the interesting half of the behaviour.
+  @visibleForTesting
+  bool debugRefuseRouteChanges = false;
+
   /// Bumped by every teardown so work started for an earlier call can tell that
   /// it came back too late.
   int _callGeneration = 0;
@@ -202,6 +220,7 @@ class ChatVoiceAudioSessionCoordinator {
       await _restoreAndroidVoiceRoute();
       _speakerphoneEnabled = false;
       _speakerphoneChosenByUser = false;
+      _pendingSpeakerphoneRequests = 0;
       _accessoryAttached = null;
       _defaultRouteAwaitingConfirmation = false;
       _routeChangesStopped = false;
@@ -247,7 +266,7 @@ class ChatVoiceAudioSessionCoordinator {
     }
     final generation = _callGeneration;
     final attached = await _hasExternalAudioAccessory();
-    if (generation != _callGeneration || _speakerphoneChosenByUser) {
+    if (generation != _callGeneration || _manualRouteHeld) {
       // The call ended, or the speaker button was pressed, while the scan was
       // out. Either way this answer is stale and must not resubscribe or move
       // the route.
@@ -278,7 +297,7 @@ class ChatVoiceAudioSessionCoordinator {
   void _confirmDefaultSpeakerphoneRoute(bool applied) {
     if (!_defaultRouteAwaitingConfirmation) return;
     _defaultRouteAwaitingConfirmation = false;
-    if (_speakerphoneChosenByUser || _routeChangesStopped) return;
+    if (_manualRouteHeld || _routeChangesStopped) return;
     if (!applied) {
       // The call is still on the earpiece, so the preference set above never
       // became a route. Putting the flag back lets the next device event try
@@ -325,7 +344,7 @@ class ChatVoiceAudioSessionCoordinator {
       _handleAudioDevicesChanged(devices);
 
   Future<void> _handleAudioDevicesChanged(Set<AudioDevice> devices) async {
-    if (_speakerphoneChosenByUser || _routeChangesStopped) {
+    if (_manualRouteHeld || _routeChangesStopped) {
       // Someone pressed the speaker button, or the call is over. Either way the
       // hardware no longer gets a vote.
       return;
@@ -350,7 +369,7 @@ class ChatVoiceAudioSessionCoordinator {
       // Re-read everything this reroute assumed: while it waited its turn the
       // user may have pressed the speaker button, the call may have ended, or a
       // later event may have already put the route where it belongs.
-      if (_speakerphoneChosenByUser || _routeChangesStopped) return;
+      if (_manualRouteHeld || _routeChangesStopped) return;
       if (_accessoryAttached != attached) return;
       if (enabled == _speakerphoneEnabled) return;
 
@@ -362,7 +381,7 @@ class ChatVoiceAudioSessionCoordinator {
       // again while the platform calls above are still going. Publishing then
       // would leave the speaker control showing a route nobody chose; whoever
       // superseded this reroute gets to publish instead.
-      if (_speakerphoneChosenByUser || _routeChangesStopped) return;
+      if (_manualRouteHeld || _routeChangesStopped) return;
       if (_accessoryAttached != attached) return;
       if (!applied) {
         // Audio is still coming out of wherever it was. Saying otherwise would
@@ -434,12 +453,27 @@ class ChatVoiceAudioSessionCoordinator {
       // put communication mode back after the route was handed back.
       return Future<bool>.value(false);
     }
-    // Set before queueing so an automatic reroute still waiting its turn sees
-    // the choice and stands down.
-    _speakerphoneChosenByUser = true;
-    return _serializeRouteChange(
-      () => _applySpeakerphoneRoute(enabled, phase: 'user-toggle'),
-    );
+    // Counted before queueing so an automatic reroute still waiting its turn
+    // sees the press and stands down.
+    _pendingSpeakerphoneRequests++;
+    return _serializeRouteChange(() async {
+      bool applied;
+      try {
+        applied = await _applySpeakerphoneRoute(enabled, phase: 'user-toggle');
+      } finally {
+        _pendingSpeakerphoneRequests--;
+      }
+      if (applied) {
+        _speakerphoneChosenByUser = true;
+      } else {
+        // The press never became a route, so the hardware keeps its vote. The
+        // platform calls above may still have torn the old route down on the
+        // way, so drop the accessory snapshot and let the next device event
+        // work the route out from scratch.
+        _accessoryAttached = null;
+      }
+      return applied;
+    });
   }
 
   /// Moves the call to [enabled] and reports whether the platform took it.
@@ -479,6 +513,9 @@ class ChatVoiceAudioSessionCoordinator {
       applied = await _configureAndroidVoiceRoute(phase: phase);
     }
     if (!await _setIosSpeakerphoneEnabled(enabled, phase: phase)) {
+      applied = false;
+    }
+    if (debugRefuseRouteChanges) {
       applied = false;
     }
     if (!applied) {

--- a/lib/features/chat/voice_mode/chat_voice_audio_session_coordinator.dart
+++ b/lib/features/chat/voice_mode/chat_voice_audio_session_coordinator.dart
@@ -76,6 +76,12 @@ class ChatVoiceAudioSessionCoordinator {
   @visibleForTesting
   bool debugRefuseRouteChanges = false;
 
+  /// The phases teardown has run for, in order. A test host has no audio route
+  /// to watch come back, so this is the only trace teardown leaves behind.
+  /// Only filled in when asserts are on.
+  @visibleForTesting
+  final List<String> debugRouteTeardowns = <String>[];
+
   /// Bumped by every teardown so work started for an earlier call can tell that
   /// it came back too late.
   int _callGeneration = 0;
@@ -122,9 +128,8 @@ class ChatVoiceAudioSessionCoordinator {
       ),
       'listening',
     );
-    await _setActive(session, active: true, phase: 'listening');
     _confirmDefaultSpeakerphoneRoute(
-      await _configureVoiceRoute(phase: 'listening'),
+      await _activateVoiceRoute(session, phase: 'listening'),
     );
   }
 
@@ -150,9 +155,8 @@ class ChatVoiceAudioSessionCoordinator {
       ),
       'speaking',
     );
-    await _setActive(session, active: true, phase: 'speaking');
     _confirmDefaultSpeakerphoneRoute(
-      await _configureVoiceRoute(phase: 'speaking'),
+      await _activateVoiceRoute(session, phase: 'speaking'),
     );
     await _settleIosSpeakingRoute();
   }
@@ -179,29 +183,62 @@ class ChatVoiceAudioSessionCoordinator {
       ),
       'barge-in-speaking',
     );
-    await _setActive(session, active: true, phase: 'barge-in-speaking');
     _confirmDefaultSpeakerphoneRoute(
-      await _configureVoiceRoute(phase: 'barge-in-speaking'),
+      await _activateVoiceRoute(session, phase: 'barge-in-speaking'),
     );
     await _settleIosSpeakingRoute();
   }
 
-  /// Puts the call on the current route for a configure pass, and reports
+  /// Activates the session and puts the call on the current route, and reports
   /// whether both platforms took it.
   ///
-  /// This queues behind the button and device-change reroutes because it makes
-  /// the same platform calls off the same [_speakerphoneEnabled] flag. Run
-  /// loose, a pass that started before a headset was pulled out can finish
+  /// The whole step queues behind the button and device-change reroutes because
+  /// it makes the same platform calls off the same [_speakerphoneEnabled] flag.
+  /// Run loose, a pass that started before a headset was pulled out can finish
   /// after the reroute and put the call back on the route it just left.
-  Future<bool> _configureVoiceRoute({required String phase}) {
+  ///
+  /// Teardown drains the same queue, so queueing is also what stops a pass that
+  /// started before the call ended from reactivating the session or putting the
+  /// phone back into communication mode after the route was handed back.
+  Future<bool> _activateVoiceRoute(
+    AudioSession session, {
+    required String phase,
+  }) {
     return _serializeRouteChange(() async {
+      if (_routeChangesStopped) {
+        return false;
+      }
+      await _setActive(session, active: true, phase: phase);
       final androidRouted = await _configureAndroidVoiceRoute(phase: phase);
       final iosRouted = await _configureIosVoiceRoute(phase: phase);
       return androidRouted && iosRouted;
     });
   }
 
-  Future<void> deactivate() async {
+  Future<void> deactivate() => _tearDownRoute(phase: 'deactivate');
+
+  Future<void> dispose() async {
+    // Riverpod does not promise to dispose this coordinator after the
+    // controller that drives it, so disposal cannot assume `deactivate` has
+    // already run. Running it again is cheap and leaves nothing behind; not
+    // running it can leave the phone in communication mode after the call.
+    await _tearDownRoute(phase: 'dispose', finalizing: true);
+    await _speakerphoneRouteController.close();
+  }
+
+  /// Hands the route back to whatever had it before the call.
+  ///
+  /// Safe to run twice: every step either restores state it captured or clears
+  /// state that is already clear. Pass [finalizing] when there is no next call
+  /// to route, which keeps the shutter down for good.
+  Future<void> _tearDownRoute({
+    required String phase,
+    bool finalizing = false,
+  }) async {
+    assert(() {
+      debugRouteTeardowns.add(phase);
+      return true;
+    }());
     _callGeneration++;
     final session = _session;
     final devicesSub = _devicesSub;
@@ -214,7 +251,7 @@ class ChatVoiceAudioSessionCoordinator {
       await _routeSerial;
       await _clearIosVoiceRoute();
       if (session != null) {
-        await _setActive(session, active: false, phase: 'deactivate');
+        await _setActive(session, active: false, phase: phase);
       }
     } finally {
       await _restoreAndroidVoiceRoute();
@@ -223,18 +260,8 @@ class ChatVoiceAudioSessionCoordinator {
       _pendingSpeakerphoneRequests = 0;
       _accessoryAttached = null;
       _defaultRouteAwaitingConfirmation = false;
-      _routeChangesStopped = false;
+      _routeChangesStopped = finalizing;
     }
-  }
-
-  Future<void> dispose() async {
-    _callGeneration++;
-    final devicesSub = _devicesSub;
-    _devicesSub = null;
-    _routeChangesStopped = true;
-    await devicesSub?.cancel();
-    await _routeSerial;
-    await _speakerphoneRouteController.close();
   }
 
   /// Whether the call can play through [device] in preference to the phone's
@@ -264,9 +291,16 @@ class ChatVoiceAudioSessionCoordinator {
     if (!Platform.isAndroid && !Platform.isIOS) {
       return;
     }
+    if (_routeChangesStopped) {
+      // A teardown is part-way through. Its generation bump has already
+      // happened, so the check below would wave this scan through.
+      return;
+    }
     final generation = _callGeneration;
     final attached = await _hasExternalAudioAccessory();
-    if (generation != _callGeneration || _manualRouteHeld) {
+    if (generation != _callGeneration ||
+        _routeChangesStopped ||
+        _manualRouteHeld) {
       // The call ended, or the speaker button was pressed, while the scan was
       // out. Either way this answer is stale and must not resubscribe or move
       // the route.

--- a/lib/features/chat/voice_mode/chat_voice_mode_controller.dart
+++ b/lib/features/chat/voice_mode/chat_voice_mode_controller.dart
@@ -573,9 +573,11 @@ class ChatVoiceModeController extends Notifier<ChatVoiceModeSnapshot> {
     return result;
   }
 
-  /// Starts accessory-free calls on the loudspeaker so the snapshot and the
-  /// overlay's speaker button match the route the coordinator picked, and
-  /// follows the coordinator when hardware comes and goes mid-call.
+  /// Starts accessory-free calls on the loudspeaker, and follows the
+  /// coordinator when hardware comes and goes mid-call.
+  ///
+  /// The snapshot only ever moves on a route the coordinator confirms, so the
+  /// overlay's speaker button never lights up for a move the platform refused.
   Future<void> _applyDefaultSpeakerphoneRoute() async {
     final coordinator = _audioSessionCoordinator;
     if (coordinator == null) {
@@ -588,11 +590,7 @@ class ChatVoiceModeController extends Notifier<ChatVoiceModeSnapshot> {
       if (_disposed || !state.isActive) return;
       state = state.copyWith(isSpeakerphoneEnabled: enabled);
     });
-    final enabled = await coordinator.applyDefaultSpeakerphoneRoute();
-    if (_disposed || !enabled) {
-      return;
-    }
-    state = state.copyWith(isSpeakerphoneEnabled: true);
+    await coordinator.applyDefaultSpeakerphoneRoute();
   }
 
   Future<void> _requestAndroidVoiceRoutingPermission() async {

--- a/lib/features/chat/voice_mode/chat_voice_mode_controller.dart
+++ b/lib/features/chat/voice_mode/chat_voice_mode_controller.dart
@@ -1677,8 +1677,12 @@ class ChatVoiceModeController extends Notifier<ChatVoiceModeSnapshot> {
         await _runTeardownStep('tts-stop', () async {
           if (!replacementOwnsTts()) {
             await tts?.stop();
-            // Hand the shared engine back to read-aloud, which belongs on the
-            // media stream. A replacement session left it on the call route.
+          }
+        });
+        // Its own step: a stop that throws must not leave the shared engine on
+        // the call route, where read-aloud does not belong.
+        await _runTeardownStep('tts-call-route-release', () async {
+          if (!replacementOwnsTts()) {
             tts?.setVoiceCallActive(false);
           }
         });

--- a/lib/features/chat/voice_mode/chat_voice_mode_controller.dart
+++ b/lib/features/chat/voice_mode/chat_voice_mode_controller.dart
@@ -706,9 +706,14 @@ class ChatVoiceModeController extends Notifier<ChatVoiceModeSnapshot> {
   Future<void> toggleSpeakerphone() {
     return _enqueue(() async {
       if (!state.isActive) return;
+      final coordinator = _audioSessionCoordinator;
+      if (coordinator == null) return;
       final enabled = !state.isSpeakerphoneEnabled;
-      await _audioSessionCoordinator?.setSpeakerphoneEnabled(enabled);
+      final applied = await coordinator.setSpeakerphoneEnabled(enabled);
       if (_disposed) return;
+      // A route the platform refused leaves audio where it was, so the button
+      // stays where it was too rather than promising a route nobody is hearing.
+      if (!applied) return;
       state = state.copyWith(isSpeakerphoneEnabled: enabled);
     });
   }

--- a/lib/features/chat/voice_mode/chat_voice_mode_controller.dart
+++ b/lib/features/chat/voice_mode/chat_voice_mode_controller.dart
@@ -747,6 +747,7 @@ class ChatVoiceModeController extends Notifier<ChatVoiceModeSnapshot> {
   }
 
   Future<void> _initializeTts(TextToSpeechService tts, AppSettings settings) {
+    tts.setVoiceCallActive(true);
     return tts.initialize(
       deviceVoice: settings.ttsVoice,
       serverVoice: settings.ttsServerVoiceId,
@@ -1669,6 +1670,9 @@ class ChatVoiceModeController extends Notifier<ChatVoiceModeSnapshot> {
         await _runTeardownStep('tts-stop', () async {
           if (!replacementOwnsTts()) {
             await tts?.stop();
+            // Hand the shared engine back to read-aloud, which belongs on the
+            // media stream. A replacement session left it on the call route.
+            tts?.setVoiceCallActive(false);
           }
         });
         await _runTeardownStep('background-lease-stop', () async {

--- a/lib/features/chat/voice_mode/chat_voice_mode_controller.dart
+++ b/lib/features/chat/voice_mode/chat_voice_mode_controller.dart
@@ -354,6 +354,10 @@ class ChatVoiceModeController extends Notifier<ChatVoiceModeSnapshot> {
               await _stopVoiceInputAfterDispose(input);
               await _cancelSubscriptionAfterDispose(ttsSub);
               await _stopTtsAfterDispose(tts);
+              // The engine is shared with read-aloud, which belongs on the
+              // media stream. Nothing survives provider disposal to hand it
+              // back, so it happens here.
+              tts?.setVoiceCallActive(false);
               await _stopBackgroundVoiceLeaseAfterDispose(
                 backgroundCoordinator,
               );

--- a/lib/features/chat/voice_mode/chat_voice_mode_controller.dart
+++ b/lib/features/chat/voice_mode/chat_voice_mode_controller.dart
@@ -268,6 +268,7 @@ class ChatVoiceModeController extends Notifier<ChatVoiceModeSnapshot> {
   StreamSubscription<int>? _intensitySub;
   StreamSubscription<TtsEvent>? _ttsSub;
   StreamSubscription<CallEvent>? _callKitSub;
+  StreamSubscription<bool>? _speakerphoneRouteSub;
   Timer? _elapsedTimer;
   Timer? _backgroundKeepAliveTimer;
 
@@ -336,6 +337,8 @@ class ChatVoiceModeController extends Notifier<ChatVoiceModeSnapshot> {
       final intensitySub = _intensitySub;
       final ttsSub = _ttsSub;
       final callKitSub = _callKitSub;
+      final speakerphoneRouteSub = _speakerphoneRouteSub;
+      _speakerphoneRouteSub = null;
       final input = _voiceInput;
       final tts = _textToSpeech;
       final backgroundCoordinator = _backgroundCoordinator;
@@ -358,6 +361,7 @@ class ChatVoiceModeController extends Notifier<ChatVoiceModeSnapshot> {
                 audioSessionCoordinator,
               );
               await _cancelSubscriptionAfterDispose(callKitSub);
+              await _cancelSubscriptionAfterDispose(speakerphoneRouteSub);
               if (callId != null) {
                 await _endCallAfterDispose(callKit, callId);
               }
@@ -489,6 +493,9 @@ class ChatVoiceModeController extends Notifier<ChatVoiceModeSnapshot> {
           await _requestAndroidVoiceRoutingPermission();
           if (lostOwnership()) return;
           cancelIfRequested();
+          await _applyDefaultSpeakerphoneRoute();
+          if (lostOwnership()) return;
+          cancelIfRequested();
           await _initializeTts(tts, settings);
           if (lostOwnership()) return;
           cancelIfRequested();
@@ -560,6 +567,28 @@ class ChatVoiceModeController extends Notifier<ChatVoiceModeSnapshot> {
       }
     });
     return result;
+  }
+
+  /// Starts accessory-free calls on the loudspeaker so the snapshot and the
+  /// overlay's speaker button match the route the coordinator picked, and
+  /// follows the coordinator when hardware comes and goes mid-call.
+  Future<void> _applyDefaultSpeakerphoneRoute() async {
+    final coordinator = _audioSessionCoordinator;
+    if (coordinator == null) {
+      return;
+    }
+    unawaited(_speakerphoneRouteSub?.cancel());
+    _speakerphoneRouteSub = coordinator.speakerphoneRouteChanges.listen((
+      enabled,
+    ) {
+      if (_disposed || !state.isActive) return;
+      state = state.copyWith(isSpeakerphoneEnabled: enabled);
+    });
+    final enabled = await coordinator.applyDefaultSpeakerphoneRoute();
+    if (_disposed || !enabled) {
+      return;
+    }
+    state = state.copyWith(isSpeakerphoneEnabled: true);
   }
 
   Future<void> _requestAndroidVoiceRoutingPermission() async {
@@ -1578,6 +1607,7 @@ class ChatVoiceModeController extends Notifier<ChatVoiceModeSnapshot> {
     final intensitySub = _intensitySub;
     final ttsSub = _ttsSub;
     final callKitSub = _callKitSub;
+    final speakerphoneRouteSub = _speakerphoneRouteSub;
     final elapsedTimer = _elapsedTimer;
     final backgroundKeepAliveTimer = _backgroundKeepAliveTimer;
     final backgroundLeaseId = _backgroundLeaseId;
@@ -1594,6 +1624,7 @@ class ChatVoiceModeController extends Notifier<ChatVoiceModeSnapshot> {
     _intensitySub = null;
     _ttsSub = null;
     _callKitSub = null;
+    _speakerphoneRouteSub = null;
     _backgroundKeepAliveTimer = null;
     _backgroundLeaseId = null;
     _voiceInput = null;
@@ -1658,6 +1689,12 @@ class ChatVoiceModeController extends Notifier<ChatVoiceModeSnapshot> {
         await _runTeardownStep('callkit-subscription-cancel', () async {
           await callKitSub?.cancel();
         });
+        await _runTeardownStep(
+          'speakerphone-route-subscription-cancel',
+          () async {
+            await speakerphoneRouteSub?.cancel();
+          },
+        );
         if (endCallKit && callId != null) {
           await _runTeardownStep('callkit-end', () async {
             await callKit?.endCall(callId);

--- a/test/core/utils/semantic_details_test.dart
+++ b/test/core/utils/semantic_details_test.dart
@@ -1,3 +1,4 @@
+import 'package:checks/checks.dart';
 import 'package:conduit/core/utils/semantic_details.dart';
 import 'package:flutter_test/flutter_test.dart';
 
@@ -10,7 +11,7 @@ void main() {
         '> internal notes',
       );
 
-      expect(result, 'Checking that now.');
+      check(result).equals('Checking that now.');
     });
 
     test('drops the tail from an unterminated tool call opener', () {
@@ -20,19 +21,19 @@ void main() {
         '{"entities": []}',
       );
 
-      expect(result, 'One moment.');
+      check(result).equals('One moment.');
     });
 
     test('leaves content without semantic details untouched', () {
       const content = 'Plain answer with no wrappers at all.';
 
-      expect(dropUnterminatedSemanticDetails(content), content);
+      check(dropUnterminatedSemanticDetails(content)).equals(content);
     });
 
     test('leaves a non-semantic details opener untouched', () {
       const content = 'Answer. <details><summary>Extra</summary>notes';
 
-      expect(dropUnterminatedSemanticDetails(content), content);
+      check(dropUnterminatedSemanticDetails(content)).equals(content);
     });
 
     test('drops only the unterminated opener after complete blocks are '
@@ -49,7 +50,7 @@ void main() {
         stripRenderedSemanticDetails(content),
       );
 
-      expect(result, 'Answer body. More answer.');
+      check(result).equals('Answer body. More answer.');
     });
   });
 }

--- a/test/core/utils/semantic_details_test.dart
+++ b/test/core/utils/semantic_details_test.dart
@@ -108,6 +108,28 @@ void main() {
       check(stripDetailsForSpeech(content)).equals(content);
     });
 
+    test('withholds an open wrapper nested in an ordinary details', () {
+      // The ordinary opener stays, but the reasoning body inside it is still
+      // a reasoning body.
+      final result = stripDetailsForSpeech(
+        'Answer. <details><summary>Extra</summary>'
+        '<details type="reasoning" done="false">internal notes',
+      );
+
+      check(result).equals('Answer. <details><summary>Extra</summary>');
+    });
+
+    test('strips a closed wrapper nested in an ordinary details', () {
+      final result = stripDetailsForSpeech(
+        'Answer. <details><summary>Extra</summary>'
+        '<details type="reasoning" done="true">notes</details>'
+        'visible tail',
+      );
+
+      check(result)
+          .equals('Answer. <details><summary>Extra</summary>visible tail');
+    });
+
     test('leaves content without details untouched', () {
       const content = 'Plain answer with no wrappers at all.';
 

--- a/test/core/utils/semantic_details_test.dart
+++ b/test/core/utils/semantic_details_test.dart
@@ -24,6 +24,18 @@ void main() {
       check(result).equals('One moment.');
     });
 
+    test('drops an uppercase opener', () {
+      // Tag and attribute names are case-insensitive in HTML, and this is
+      // model output, so the wrapper does not have to arrive lowercase.
+      final result = dropUnterminatedSemanticDetails(
+        'Checking that now. '
+        '<DETAILS TYPE="reasoning" DONE="false"><SUMMARY>Thinking…</SUMMARY>'
+        '> internal notes',
+      );
+
+      check(result).equals('Checking that now.');
+    });
+
     test('leaves content without semantic details untouched', () {
       const content = 'Plain answer with no wrappers at all.';
 

--- a/test/core/utils/semantic_details_test.dart
+++ b/test/core/utils/semantic_details_test.dart
@@ -65,4 +65,61 @@ void main() {
       check(result).equals('Answer body. More answer.');
     });
   });
+
+  group('stripDetailsForSpeech', () {
+    test('removes a complete semantic block', () {
+      final result = stripDetailsForSpeech(
+        'Answer body. '
+        '<details type="reasoning" done="true"><summary>Thought</summary>'
+        'notes</details>'
+        'More answer.',
+      );
+
+      check(result).equals('Answer body. More answer.');
+    });
+
+    test('removes a nested block whole', () {
+      // A non-greedy pattern stops at the inner close tag and leaves the outer
+      // block's tail behind, which is content the reader never meant to hear.
+      final result = stripDetailsForSpeech(
+        '<details type="reasoning" done="true">'
+        '<details><summary>inner</summary>inner body</details>'
+        'outer body</details>'
+        'The answer.',
+      );
+
+      check(result).equals('The answer.');
+    });
+
+    test('withholds everything after an open semantic wrapper', () {
+      final result = stripDetailsForSpeech(
+        'Checking that now. '
+        '<details type="reasoning" done="false"><summary>Thinking</summary>'
+        '> internal notes',
+      );
+
+      check(result).equals('Checking that now.');
+    });
+
+    test('leaves an ordinary open details alone', () {
+      // Not a wrapper, so silencing the rest of the answer would be wrong.
+      const content = 'Answer. <details><summary>Extra</summary>notes';
+
+      check(stripDetailsForSpeech(content)).equals(content);
+    });
+
+    test('leaves content without details untouched', () {
+      const content = 'Plain answer with no wrappers at all.';
+
+      check(stripDetailsForSpeech(content)).equals(content);
+    });
+
+    test('handles an uppercase wrapper', () {
+      final result = stripDetailsForSpeech(
+        'Answer. <DETAILS TYPE="reasoning" DONE="true">notes</DETAILS> Rest.',
+      );
+
+      check(result).equals('Answer.  Rest.');
+    });
+  });
 }

--- a/test/core/utils/semantic_details_test.dart
+++ b/test/core/utils/semantic_details_test.dart
@@ -1,0 +1,55 @@
+import 'package:conduit/core/utils/semantic_details.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('dropUnterminatedSemanticDetails', () {
+    test('drops the tail from an unterminated reasoning opener', () {
+      final result = dropUnterminatedSemanticDetails(
+        'Checking that now. '
+        '<details type="reasoning" done="false"><summary>Thinking…</summary>'
+        '> internal notes',
+      );
+
+      expect(result, 'Checking that now.');
+    });
+
+    test('drops the tail from an unterminated tool call opener', () {
+      final result = dropUnterminatedSemanticDetails(
+        'One moment. '
+        '<details type="tool_calls" done="false" name="get_entities">'
+        '{"entities": []}',
+      );
+
+      expect(result, 'One moment.');
+    });
+
+    test('leaves content without semantic details untouched', () {
+      const content = 'Plain answer with no wrappers at all.';
+
+      expect(dropUnterminatedSemanticDetails(content), content);
+    });
+
+    test('leaves a non-semantic details opener untouched', () {
+      const content = 'Answer. <details><summary>Extra</summary>notes';
+
+      expect(dropUnterminatedSemanticDetails(content), content);
+    });
+
+    test('drops only the unterminated opener after complete blocks are '
+        'stripped', () {
+      const content =
+          'Answer body. '
+          '<details type="reasoning" done="true"><summary>Thought</summary>'
+          'first pass</details>'
+          'More answer. '
+          '<details type="reasoning" done="false"><summary>Thinking…</summary>'
+          'second pass';
+
+      final result = dropUnterminatedSemanticDetails(
+        stripRenderedSemanticDetails(content),
+      );
+
+      expect(result, 'Answer body. More answer.');
+    });
+  });
+}

--- a/test/features/chat/services/tts_manager_test.dart
+++ b/test/features/chat/services/tts_manager_test.dart
@@ -229,6 +229,32 @@ void main() {
 
       check(native.spokenTexts).deepEquals([first, second, third]);
     });
+
+    test('ends a session a stale feed was still running behind', () async {
+      final stuck = Completer<void>();
+      addTearDown(() {
+        if (!stuck.isCompleted) stuck.complete();
+      });
+      native.gateFirstSpeak = stuck;
+
+      await TtsManager.instance.startStreaming();
+      final stale = TtsManager.instance.feedStreamingText('$first $second ');
+      await pumpEventQueue();
+
+      // The next answer starts while that feed is still inside the engine's
+      // speak call, so it outlives the session it belongs to.
+      await TtsManager.instance.startStreaming();
+      await TtsManager.instance.finishStreaming(finalText: third);
+      native.emit('complete');
+      await pumpEventQueue();
+
+      // Counting the stale feed against this session leaves playback waiting
+      // for a chunk that is never coming.
+      check(TtsManager.instance.isPlaying).isFalse();
+
+      stuck.complete();
+      await stale;
+    });
   });
 
   group('TtsManager server voice resolution', () {

--- a/test/features/chat/services/tts_manager_test.dart
+++ b/test/features/chat/services/tts_manager_test.dart
@@ -65,6 +65,42 @@ void main() {
       expect(chunks, ['Hello  world.']);
     });
 
+    test('strips a completed reasoning block', () {
+      final chunks = TtsManager.instance.getMessageContentParts(
+        'Checking that now. '
+        '<details type="reasoning" done="true" duration="4">'
+        '<summary>Thought for 4 seconds</summary>'
+        '> The user wants the entity list, so call the tool.'
+        '</details>'
+        'The living room light is on.',
+      );
+
+      expect(chunks.join(' '), isNot(contains('entity list')));
+      expect(chunks.join(' '), contains('The living room light is on.'));
+    });
+
+    test('withholds the body of a reasoning block that is still open', () {
+      final chunks = TtsManager.instance.getMessageContentParts(
+        'Checking that now. '
+        '<details type="reasoning" done="false">'
+        '<summary>Thinking…</summary>'
+        '> The user wants the entity list, so call the tool.',
+      );
+
+      expect(chunks, ['Checking that now.']);
+    });
+
+    test('withholds the body of a tool call block that is still open', () {
+      final chunks = TtsManager.instance.getMessageContentParts(
+        'One moment. '
+        '<details type="tool_calls" done="false" name="get_entities">'
+        '<summary>Tool</summary>'
+        '{"entities": ["light.living_room", "light.kitchen"]}',
+      );
+
+      expect(chunks, ['One moment.']);
+    });
+
     test('cleans markdown internally without caller preprocessing', () {
       final chunks = TtsManager.instance.getMessageContentParts(
         '## **Hello**\n- world',
@@ -125,6 +161,129 @@ void main() {
       await TtsManager.instance.synthesizeChunk('Hello from the server');
 
       expect(api.lastVoice, 'shimmer');
+    });
+  });
+
+  group('TtsManager streaming chunk advance', () {
+    List<String> speakStream(List<String> frames) {
+      final spoken = <String>[];
+      var fedChunkCount = 0;
+      String? lastFedChunk;
+
+      for (var index = 0; index < frames.length; index++) {
+        final advance = advanceStreamingChunksForTesting(
+          chunks: TtsManager.instance.getMessageContentParts(frames[index]),
+          fedChunkCount: fedChunkCount,
+          lastFedChunk: lastFedChunk,
+          finalized: index == frames.length - 1,
+        );
+        spoken.addAll(advance.chunks);
+        fedChunkCount = advance.fedChunkCount;
+        lastFedChunk = advance.lastFedChunk;
+      }
+
+      return spoken;
+    }
+
+    test('never speaks a reasoning block and still speaks the answer', () {
+      const opening = 'Let me look that up for you right now. ';
+      const reasoning =
+          '<details type="reasoning" done="false">'
+          '<summary>Thinking…</summary>'
+          '> The user asked which lights are on. '
+          '> I should call the entity listing tool first.';
+      const closedReasoning =
+          '<details type="reasoning" done="true" duration="4">'
+          '<summary>Thought for 4 seconds</summary>'
+          '> The user asked which lights are on. '
+          '> I should call the entity listing tool first.'
+          '</details>';
+      const answer =
+          'The living room light is on and every other light is off. '
+          'Nothing else in the house is currently switched on.';
+
+      final spoken = speakStream([
+        opening,
+        '$opening<details type="reasoning" done="false"><summary>Thinking…</summary>',
+        '$opening$reasoning',
+        '$opening$closedReasoning',
+        '$opening${closedReasoning}The living room light is on and every '
+            'other light is off. ',
+        '$opening$closedReasoning$answer',
+      ]);
+
+      final transcript = spoken.join(' ');
+      expect(transcript, isNot(contains('entity listing tool')));
+      expect(transcript, isNot(contains('Thinking')));
+      expect(transcript, isNot(contains('Thought for 4 seconds')));
+      expect(
+        transcript,
+        contains('The living room light is on and every other light is off.'),
+      );
+      expect(
+        transcript,
+        contains('Nothing else in the house is currently switched on.'),
+      );
+    });
+
+    test('speaks every answer sentence exactly once', () {
+      final spoken = speakStream([
+        'The first sentence carries enough words to stand alone. ',
+        'The first sentence carries enough words to stand alone. '
+            'The second sentence also carries enough words to stand alone. ',
+        'The first sentence carries enough words to stand alone. '
+            'The second sentence also carries enough words to stand alone. '
+            'The third sentence closes out the response body.',
+      ]);
+
+      final transcript = spoken.join(' ');
+      for (final sentence in const [
+        'The first sentence carries enough words to stand alone.',
+        'The second sentence also carries enough words to stand alone.',
+        'The third sentence closes out the response body.',
+      ]) {
+        expect(sentence.allMatches(transcript).length, 1, reason: sentence);
+      }
+    });
+
+    test('re-anchors the cursor when a late re-split shifts chunks left', () {
+      // Chunks 1 and 2 dropped out of the split (a `</details>` landed and the
+      // block was stripped), so the answer moved from index 3 down to index 1.
+      final advance = advanceStreamingChunksForTesting(
+        chunks: const ['Opening line.', 'Answer one.', 'Answer two.'],
+        fedChunkCount: 3,
+        lastFedChunk: 'Opening line.',
+        finalized: true,
+      );
+
+      expect(advance.chunks, ['Answer one.', 'Answer two.']);
+      expect(advance.fedChunkCount, 3);
+      expect(advance.lastFedChunk, 'Answer two.');
+    });
+
+    test('holds the trailing chunk back until finalization', () {
+      final advance = advanceStreamingChunksForTesting(
+        chunks: const ['Answer one.', 'Answer two.'],
+        fedChunkCount: 0,
+        lastFedChunk: null,
+        finalized: false,
+      );
+
+      expect(advance.chunks, ['Answer one.']);
+      expect(advance.fedChunkCount, 1);
+      expect(advance.lastFedChunk, 'Answer one.');
+    });
+
+    test('stays put when the anchor is gone entirely', () {
+      final advance = advanceStreamingChunksForTesting(
+        chunks: const ['Rewritten one.', 'Rewritten two.', 'Rewritten three.'],
+        fedChunkCount: 2,
+        lastFedChunk: 'Original two.',
+        finalized: true,
+      );
+
+      expect(advance.chunks, ['Rewritten three.']);
+      expect(advance.fedChunkCount, 3);
     });
   });
 

--- a/test/features/chat/services/tts_manager_test.dart
+++ b/test/features/chat/services/tts_manager_test.dart
@@ -424,6 +424,34 @@ void main() {
           .equals('Opening line.Rewritten middle.Closing line.');
     });
 
+    test('remembers what was heard past the chunk it holds back', () {
+      // The rewrite arrives mid-stream, so the closing line sits behind the
+      // trailing chunk this pass holds back. Playback already heard it under the
+      // old wording of the middle.
+      const chunks = ['Opening line.', 'Rewritten middle.', 'Closing line.'];
+      final held = advanceStreamingChunksForTesting(
+        chunks: chunks,
+        fedChunkCount: 3,
+        spokenText: 'Opening line.Original middle.Closing line.',
+        finalized: false,
+      );
+
+      check(held.chunks).deepEquals(['Rewritten middle.']);
+      check(held.fedChunkCount).equals(2);
+
+      // Finalization releases the closing line. Forgetting that it was heard
+      // would speak it a second time.
+      final finalized = advanceStreamingChunksForTesting(
+        chunks: chunks,
+        fedChunkCount: held.fedChunkCount,
+        spokenText: held.spokenText,
+        finalized: true,
+      );
+
+      check(finalized.chunks).isEmpty();
+      check(finalized.fedChunkCount).equals(3);
+    });
+
     test('keeps its place when the answer repeats a sentence', () {
       // 'Right away.' appears twice and a `</details>` landing between them
       // shifted the split left, so the spoken copy is now at index 1. Anchoring

--- a/test/features/chat/services/tts_manager_test.dart
+++ b/test/features/chat/services/tts_manager_test.dart
@@ -155,6 +155,29 @@ void main() {
 
       expect(native.voiceCallFlags, [true, false]);
     });
+
+    test('returns to the media route after a reset', () async {
+      // Nothing hands the route back when the service is disposed out from
+      // under a live call, so read aloud would keep speaking at call volume.
+      TtsManager.instance.setVoiceCallActive(true);
+      await TtsManager.instance.speak('During the call.');
+
+      await TtsManager.instance.reset();
+      await TtsManager.instance.speak('After the call.');
+
+      expect(native.voiceCallFlags, [true, false]);
+    });
+
+    test('does not hand a session id back out after a reset', () async {
+      // A feed queued on the old chain only checks the active session's id, so
+      // a reused id lets it append its stale text to the next session.
+      final first = await TtsManager.instance.speak('During the call.');
+
+      await TtsManager.instance.reset();
+      final second = await TtsManager.instance.speak('After the call.');
+
+      expect(second!.id, greaterThan(first!.id));
+    });
   });
 
   group('TtsManager server voice resolution', () {

--- a/test/features/chat/services/tts_manager_test.dart
+++ b/test/features/chat/services/tts_manager_test.dart
@@ -357,6 +357,23 @@ void main() {
       check(advance.fedChunkCount).equals(3);
     });
 
+    test('does not repeat a sentence the rewrite left alone', () {
+      // The server replaced one sentence in the middle. The tail after it is
+      // unchanged and playback already heard it, so only the new sentence is
+      // speakable.
+      final advance = advanceStreamingChunksForTesting(
+        chunks: const ['Opening line.', 'Rewritten middle.', 'Closing line.'],
+        fedChunkCount: 3,
+        spokenText: 'Opening line.Original middle.Closing line.',
+        finalized: true,
+      );
+
+      check(advance.chunks).deepEquals(['Rewritten middle.']);
+      check(advance.fedChunkCount).equals(3);
+      check(advance.spokenText)
+          .equals('Opening line.Rewritten middle.Closing line.');
+    });
+
     test('keeps its place when the answer repeats a sentence', () {
       // 'Right away.' appears twice and a `</details>` landing between them
       // shifted the split left, so the spoken copy is now at index 1. Anchoring

--- a/test/features/chat/services/tts_manager_test.dart
+++ b/test/features/chat/services/tts_manager_test.dart
@@ -168,18 +168,18 @@ void main() {
     List<String> speakStream(List<String> frames) {
       final spoken = <String>[];
       var fedChunkCount = 0;
-      String? lastFedChunk;
+      var spokenText = '';
 
       for (var index = 0; index < frames.length; index++) {
         final advance = advanceStreamingChunksForTesting(
           chunks: TtsManager.instance.getMessageContentParts(frames[index]),
           fedChunkCount: fedChunkCount,
-          lastFedChunk: lastFedChunk,
+          spokenText: spokenText,
           finalized: index == frames.length - 1,
         );
         spoken.addAll(advance.chunks);
         fedChunkCount = advance.fedChunkCount;
-        lastFedChunk = advance.lastFedChunk;
+        spokenText = advance.spokenText;
       }
 
       return spoken;
@@ -252,38 +252,61 @@ void main() {
       final advance = advanceStreamingChunksForTesting(
         chunks: const ['Opening line.', 'Answer one.', 'Answer two.'],
         fedChunkCount: 3,
-        lastFedChunk: 'Opening line.',
+        spokenText: 'Opening line.',
         finalized: true,
       );
 
       expect(advance.chunks, ['Answer one.', 'Answer two.']);
       expect(advance.fedChunkCount, 3);
-      expect(advance.lastFedChunk, 'Answer two.');
     });
 
     test('holds the trailing chunk back until finalization', () {
       final advance = advanceStreamingChunksForTesting(
         chunks: const ['Answer one.', 'Answer two.'],
         fedChunkCount: 0,
-        lastFedChunk: null,
+        spokenText: '',
         finalized: false,
       );
 
       expect(advance.chunks, ['Answer one.']);
       expect(advance.fedChunkCount, 1);
-      expect(advance.lastFedChunk, 'Answer one.');
+      expect(advance.spokenText, 'Answer one.');
     });
 
-    test('stays put when the anchor is gone entirely', () {
+    test('resumes where a rewritten response stops agreeing', () {
+      // The server replaced the tail of the answer. Everything up to the point
+      // the two versions diverge has been spoken already.
       final advance = advanceStreamingChunksForTesting(
-        chunks: const ['Rewritten one.', 'Rewritten two.', 'Rewritten three.'],
+        chunks: const ['Original one.', 'Rewritten two.', 'Rewritten three.'],
         fedChunkCount: 2,
-        lastFedChunk: 'Original two.',
+        spokenText: 'Original one.Original two.',
         finalized: true,
       );
 
-      expect(advance.chunks, ['Rewritten three.']);
+      expect(advance.chunks, ['Rewritten two.', 'Rewritten three.']);
       expect(advance.fedChunkCount, 3);
+    });
+
+    test('keeps its place when the answer repeats a sentence', () {
+      // 'Right away.' appears twice and a `</details>` landing between them
+      // shifted the split left, so the spoken copy is now at index 1. Anchoring
+      // on the chunk's text alone would match the second copy and skip the two
+      // sentences in between.
+      final advance = advanceStreamingChunksForTesting(
+        chunks: const [
+          'Intro.',
+          'Right away.',
+          'Middle line.',
+          'Right away.',
+          'Tail.',
+        ],
+        fedChunkCount: 4,
+        spokenText: 'Intro.Right away.',
+        finalized: true,
+      );
+
+      expect(advance.chunks, ['Middle line.', 'Right away.', 'Tail.']);
+      expect(advance.fedChunkCount, 5);
     });
   });
 

--- a/test/features/chat/services/tts_manager_test.dart
+++ b/test/features/chat/services/tts_manager_test.dart
@@ -1,5 +1,6 @@
 import 'dart:typed_data';
 
+import 'package:checks/checks.dart';
 import 'package:conduit/core/models/backend_config.dart';
 import 'package:conduit/core/models/server_config.dart';
 import 'package:conduit/core/services/api_service.dart';
@@ -25,7 +26,7 @@ void main() {
 
       final chunks = TtsManager.instance.splitTextForSpeech(sampleText);
 
-      expect(chunks.length, 2);
+      check(chunks).length.equals(2);
     });
 
     test('keeps OpenWebUI-sized chunks for server mode', () async {
@@ -35,7 +36,7 @@ void main() {
 
       final chunks = TtsManager.instance.splitTextForSpeech(sampleText);
 
-      expect(chunks.length, 2);
+      check(chunks).length.equals(2);
     });
   });
 
@@ -46,7 +47,7 @@ void main() {
         splitOn: TtsManager.splitOnParagraphs,
       );
 
-      expect(chunks, ['First paragraph', 'Second paragraph']);
+      check(chunks).deepEquals(['First paragraph', 'Second paragraph']);
     });
 
     test('supports none mode like OpenWebUI', () {
@@ -55,7 +56,7 @@ void main() {
         splitOn: TtsManager.splitOnNone,
       );
 
-      expect(chunks, ['One.\nTwo.']);
+      check(chunks).deepEquals(['One.\nTwo.']);
     });
 
     test('strips details blocks before splitting', () {
@@ -63,7 +64,7 @@ void main() {
         'Hello <details><summary>Hidden</summary>ignored</details> world.',
       );
 
-      expect(chunks, ['Hello  world.']);
+      check(chunks).deepEquals(['Hello  world.']);
     });
 
     test('strips a completed reasoning block', () {
@@ -76,8 +77,8 @@ void main() {
         'The living room light is on.',
       );
 
-      expect(chunks.join(' '), isNot(contains('entity list')));
-      expect(chunks.join(' '), contains('The living room light is on.'));
+      check(chunks.join(' ')).not((it) => it.contains('entity list'));
+      check(chunks.join(' ')).contains('The living room light is on.');
     });
 
     test('withholds the body of a reasoning block that is still open', () {
@@ -88,7 +89,7 @@ void main() {
         '> The user wants the entity list, so call the tool.',
       );
 
-      expect(chunks, ['Checking that now.']);
+      check(chunks).deepEquals(['Checking that now.']);
     });
 
     test('withholds the body of a tool call block that is still open', () {
@@ -99,7 +100,7 @@ void main() {
         '{"entities": ["light.living_room", "light.kitchen"]}',
       );
 
-      expect(chunks, ['One moment.']);
+      check(chunks).deepEquals(['One moment.']);
     });
 
     test('cleans markdown internally without caller preprocessing', () {
@@ -108,7 +109,7 @@ void main() {
         splitOn: TtsManager.splitOnNone,
       );
 
-      expect(chunks, ['Hello\nworld']);
+      check(chunks).deepEquals(['Hello\nworld']);
     });
   });
 
@@ -137,13 +138,13 @@ void main() {
 
       await TtsManager.instance.speak('Hello there.');
 
-      expect(native.voiceCallFlags, [true]);
+      check(native.voiceCallFlags).deepEquals([true]);
     });
 
     test('speaks on the media route for read aloud', () async {
       await TtsManager.instance.speak('Hello there.');
 
-      expect(native.voiceCallFlags, [false]);
+      check(native.voiceCallFlags).deepEquals([false]);
     });
 
     test('returns to the media route after the call ends', () async {
@@ -153,7 +154,7 @@ void main() {
 
       await TtsManager.instance.speak('After the call.');
 
-      expect(native.voiceCallFlags, [true, false]);
+      check(native.voiceCallFlags).deepEquals([true, false]);
     });
 
     test('returns to the media route after a reset', () async {
@@ -165,7 +166,7 @@ void main() {
       await TtsManager.instance.reset();
       await TtsManager.instance.speak('After the call.');
 
-      expect(native.voiceCallFlags, [true, false]);
+      check(native.voiceCallFlags).deepEquals([true, false]);
     });
 
     test('does not hand a session id back out after a reset', () async {
@@ -176,7 +177,7 @@ void main() {
       await TtsManager.instance.reset();
       final second = await TtsManager.instance.speak('After the call.');
 
-      expect(second!.id, greaterThan(first!.id));
+      check(second!.id).isGreaterThan(first!.id);
     });
   });
 
@@ -205,7 +206,7 @@ void main() {
 
       await TtsManager.instance.synthesizeChunk('Hello from the server');
 
-      expect(api.lastVoice, isNull);
+      check(api.lastVoice).isNull();
     });
 
     test('uses backend default voice when available', () async {
@@ -215,7 +216,7 @@ void main() {
 
       await TtsManager.instance.synthesizeChunk('Hello from the server');
 
-      expect(api.lastVoice, 'nova');
+      check(api.lastVoice).equals('nova');
     });
 
     test('uses the explicitly selected server voice when present', () async {
@@ -229,7 +230,7 @@ void main() {
 
       await TtsManager.instance.synthesizeChunk('Hello from the server');
 
-      expect(api.lastVoice, 'shimmer');
+      check(api.lastVoice).equals('shimmer');
     });
   });
 
@@ -282,17 +283,14 @@ void main() {
       ]);
 
       final transcript = spoken.join(' ');
-      expect(transcript, isNot(contains('entity listing tool')));
-      expect(transcript, isNot(contains('Thinking')));
-      expect(transcript, isNot(contains('Thought for 4 seconds')));
-      expect(
+      check(transcript).not((it) => it.contains('entity listing tool'));
+      check(transcript).not((it) => it.contains('Thinking'));
+      check(transcript).not((it) => it.contains('Thought for 4 seconds'));
+      check(
         transcript,
-        contains('The living room light is on and every other light is off.'),
-      );
-      expect(
-        transcript,
-        contains('Nothing else in the house is currently switched on.'),
-      );
+      ).contains('The living room light is on and every other light is off.');
+      check(transcript)
+          .contains('Nothing else in the house is currently switched on.');
     });
 
     test('speaks every answer sentence exactly once', () {
@@ -311,7 +309,10 @@ void main() {
         'The second sentence also carries enough words to stand alone.',
         'The third sentence closes out the response body.',
       ]) {
-        expect(sentence.allMatches(transcript).length, 1, reason: sentence);
+        check(
+          because: sentence,
+          sentence.allMatches(transcript),
+        ).length.equals(1);
       }
     });
 
@@ -325,8 +326,8 @@ void main() {
         finalized: true,
       );
 
-      expect(advance.chunks, ['Answer one.', 'Answer two.']);
-      expect(advance.fedChunkCount, 3);
+      check(advance.chunks).deepEquals(['Answer one.', 'Answer two.']);
+      check(advance.fedChunkCount).equals(3);
     });
 
     test('holds the trailing chunk back until finalization', () {
@@ -337,9 +338,9 @@ void main() {
         finalized: false,
       );
 
-      expect(advance.chunks, ['Answer one.']);
-      expect(advance.fedChunkCount, 1);
-      expect(advance.spokenText, 'Answer one.');
+      check(advance.chunks).deepEquals(['Answer one.']);
+      check(advance.fedChunkCount).equals(1);
+      check(advance.spokenText).equals('Answer one.');
     });
 
     test('resumes where a rewritten response stops agreeing', () {
@@ -352,8 +353,8 @@ void main() {
         finalized: true,
       );
 
-      expect(advance.chunks, ['Rewritten two.', 'Rewritten three.']);
-      expect(advance.fedChunkCount, 3);
+      check(advance.chunks).deepEquals(['Rewritten two.', 'Rewritten three.']);
+      check(advance.fedChunkCount).equals(3);
     });
 
     test('keeps its place when the answer repeats a sentence', () {
@@ -374,8 +375,9 @@ void main() {
         finalized: true,
       );
 
-      expect(advance.chunks, ['Middle line.', 'Right away.', 'Tail.']);
-      expect(advance.fedChunkCount, 5);
+      check(advance.chunks)
+          .deepEquals(['Middle line.', 'Right away.', 'Tail.']);
+      check(advance.fedChunkCount).equals(5);
     });
   });
 
@@ -388,7 +390,7 @@ void main() {
         lastEnqueuedIndex: 2,
       );
 
-      expect(completed, isFalse);
+      check(completed).isFalse();
     });
 
     test('completes only after final chunk playback completes', () {
@@ -399,7 +401,7 @@ void main() {
         lastEnqueuedIndex: 2,
       );
 
-      expect(completed, isTrue);
+      check(completed).isTrue();
     });
   });
 }

--- a/test/features/chat/services/tts_manager_test.dart
+++ b/test/features/chat/services/tts_manager_test.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:typed_data';
 
 import 'package:checks/checks.dart';
@@ -178,6 +179,55 @@ void main() {
       final second = await TtsManager.instance.speak('After the call.');
 
       check(second!.id).isGreaterThan(first!.id);
+    });
+  });
+
+  group('TtsManager streaming finalization', () {
+    const first = 'The first sentence carries enough words to stand alone.';
+    const second =
+        'The second sentence also carries enough words to stand alone.';
+    const third = 'The third sentence closes out the response body.';
+
+    late _FakeNativeTtsService native;
+
+    setUp(() async {
+      native = _FakeNativeTtsService();
+      await TtsManager.instance.debugSetNativeTtsService(native);
+      await TtsManager.instance.updateConfig(
+        const TtsConfig(preferServer: false),
+      );
+    });
+
+    tearDown(() async {
+      await TtsManager.instance.reset();
+      await TtsManager.instance.debugSetNativeTtsService(null);
+      await native.dispose();
+    });
+
+    test('speaks the tail when a chunk completes mid-finalize', () async {
+      final speaking = Completer<void>();
+      native.gateFirstSpeak = speaking;
+
+      await TtsManager.instance.startStreaming();
+      final feeding = TtsManager.instance.feedStreamingText('$first $second ');
+      await pumpEventQueue();
+
+      // The response is finalized while the first feed is still handing chunk
+      // one to the engine, so the final feed is queued behind it with the rest
+      // of the answer still to append.
+      final finishing = TtsManager.instance.finishStreaming(
+        finalText: '$first $second $third',
+      );
+      native.emit('complete');
+      await pumpEventQueue();
+
+      speaking.complete();
+      await feeding;
+      await finishing;
+      native.emit('complete');
+      await pumpEventQueue();
+
+      check(native.spokenTexts).deepEquals([first, second, third]);
     });
   });
 
@@ -425,6 +475,17 @@ void main() {
 
 class _FakeNativeTtsService extends NativeTtsService {
   final List<bool> voiceCallFlags = <bool>[];
+  final List<String> spokenTexts = <String>[];
+  final StreamController<NativeTtsEvent> _events =
+      StreamController<NativeTtsEvent>.broadcast();
+
+  /// Holds the next utterance open, so a test can decide when the engine has
+  /// taken it.
+  Completer<void>? gateFirstSpeak;
+
+  void emit(String type) => _events.add(NativeTtsEvent(type: type));
+
+  Future<void> dispose() => _events.close();
 
   @override
   bool get isSupportedPlatform => true;
@@ -433,7 +494,7 @@ class _FakeNativeTtsService extends NativeTtsService {
   Future<bool> isAvailable() async => true;
 
   @override
-  Stream<NativeTtsEvent> get events => const Stream<NativeTtsEvent>.empty();
+  Stream<NativeTtsEvent> get events => _events.stream;
 
   @override
   Future<List<Map<String, dynamic>>> getVoices() async =>
@@ -449,6 +510,12 @@ class _FakeNativeTtsService extends NativeTtsService {
     bool voiceCall = false,
   }) async {
     voiceCallFlags.add(voiceCall);
+    spokenTexts.add(text);
+    final gate = gateFirstSpeak;
+    if (gate != null) {
+      gateFirstSpeak = null;
+      await gate.future;
+    }
     return true;
   }
 

--- a/test/features/chat/services/tts_manager_test.dart
+++ b/test/features/chat/services/tts_manager_test.dart
@@ -4,6 +4,7 @@ import 'package:conduit/core/models/backend_config.dart';
 import 'package:conduit/core/models/server_config.dart';
 import 'package:conduit/core/services/api_service.dart';
 import 'package:conduit/core/services/worker_manager.dart';
+import 'package:conduit/features/chat/services/native_tts_service.dart';
 import 'package:conduit/features/chat/services/tts_manager.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:just_audio/just_audio.dart';
@@ -108,6 +109,51 @@ void main() {
       );
 
       expect(chunks, ['Hello\nworld']);
+    });
+  });
+
+  group('TtsManager device audio route', () {
+    late _FakeNativeTtsService native;
+
+    setUp(() async {
+      native = _FakeNativeTtsService();
+      await TtsManager.instance.debugSetNativeTtsService(native);
+      await TtsManager.instance.updateConfig(
+        const TtsConfig(preferServer: false),
+      );
+    });
+
+    tearDown(() async {
+      TtsManager.instance.setVoiceCallActive(false);
+      await TtsManager.instance.reset();
+      await TtsManager.instance.debugSetNativeTtsService(null);
+    });
+
+    test('speaks on the call route during a voice call', () async {
+      // Android routes voice-communication and media output separately, so a
+      // media-stream utterance ignores the call's speakerphone choice and goes
+      // silent once the app is backgrounded mid-call.
+      TtsManager.instance.setVoiceCallActive(true);
+
+      await TtsManager.instance.speak('Hello there.');
+
+      expect(native.voiceCallFlags, [true]);
+    });
+
+    test('speaks on the media route for read aloud', () async {
+      await TtsManager.instance.speak('Hello there.');
+
+      expect(native.voiceCallFlags, [false]);
+    });
+
+    test('returns to the media route after the call ends', () async {
+      TtsManager.instance.setVoiceCallActive(true);
+      await TtsManager.instance.speak('During the call.');
+      TtsManager.instance.setVoiceCallActive(false);
+
+      await TtsManager.instance.speak('After the call.');
+
+      expect(native.voiceCallFlags, [true, false]);
     });
   });
 
@@ -333,6 +379,39 @@ void main() {
       expect(completed, isTrue);
     });
   });
+}
+
+class _FakeNativeTtsService extends NativeTtsService {
+  final List<bool> voiceCallFlags = <bool>[];
+
+  @override
+  bool get isSupportedPlatform => true;
+
+  @override
+  Future<bool> isAvailable() async => true;
+
+  @override
+  Stream<NativeTtsEvent> get events => const Stream<NativeTtsEvent>.empty();
+
+  @override
+  Future<List<Map<String, dynamic>>> getVoices() async =>
+      const <Map<String, dynamic>>[];
+
+  @override
+  Future<bool> speak({
+    required String text,
+    String? voiceIdentifier,
+    required double rate,
+    required double pitch,
+    required double volume,
+    bool voiceCall = false,
+  }) async {
+    voiceCallFlags.add(voiceCall);
+    return true;
+  }
+
+  @override
+  Future<bool> stop() async => true;
 }
 
 class _RecordingApiService extends ApiService {

--- a/test/features/chat/voice_mode/chat_voice_audio_session_coordinator_test.dart
+++ b/test/features/chat/voice_mode/chat_voice_audio_session_coordinator_test.dart
@@ -136,6 +136,20 @@ void main() {
       check(routeChanges).deepEquals(<bool>[true]);
     });
 
+    test('tries the same accessory again after a refused reroute', () async {
+      coordinator.debugRefuseRouteChanges = true;
+      await reportDevices(const [AudioDeviceType.builtInSpeaker]);
+      check(routeChanges).isEmpty();
+
+      // The hardware never moved, so the phone repeats itself rather than
+      // sending a fresh transition. The refused attempt must not have made this
+      // look like old news.
+      coordinator.debugRefuseRouteChanges = false;
+      await reportDevices(const [AudioDeviceType.builtInSpeaker]);
+
+      check(routeChanges).deepEquals(<bool>[true]);
+    });
+
     test('ignores a microphone with no output of its own', () async {
       await coordinator.handleAudioDevicesChangedForTesting({
         _outputDevice(AudioDeviceType.builtInSpeaker),

--- a/test/features/chat/voice_mode/chat_voice_audio_session_coordinator_test.dart
+++ b/test/features/chat/voice_mode/chat_voice_audio_session_coordinator_test.dart
@@ -217,6 +217,20 @@ void main() {
           .deepEquals(<String>['deactivate', 'dispose']);
     });
 
+    test('keeps the shutter down until the last teardown is done', () async {
+      final first = coordinator.deactivate();
+      final second = coordinator.deactivate();
+      await first;
+
+      // The second teardown is still putting the platform route back. A button
+      // press slipping in behind it would put communication mode back on a call
+      // that is already over.
+      final pressed = coordinator.setSpeakerphoneEnabled(true);
+      await second;
+
+      check(await pressed).isFalse();
+    });
+
     test('stays shut once disposed, however late hanging up is', () async {
       await coordinator.dispose();
       // Teardown normally lifts the shutter for the next call. A disposed

--- a/test/features/chat/voice_mode/chat_voice_audio_session_coordinator_test.dart
+++ b/test/features/chat/voice_mode/chat_voice_audio_session_coordinator_test.dart
@@ -1,0 +1,126 @@
+// ignore_for_file: experimental_member_use
+
+import 'package:audio_session/audio_session.dart';
+import 'package:checks/checks.dart';
+import 'package:conduit/features/chat/voice_mode/chat_voice_audio_session_coordinator.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('ChatVoiceAudioSessionCoordinator.isExternalAudioAccessory', () {
+    test('treats attached listening hardware as an accessory', () {
+      for (final type in const [
+        AudioDeviceType.wiredHeadset,
+        AudioDeviceType.wiredHeadphones,
+        AudioDeviceType.headsetMic,
+        AudioDeviceType.bluetoothSco,
+        AudioDeviceType.bluetoothA2dp,
+        AudioDeviceType.bluetoothLe,
+        AudioDeviceType.usbAudio,
+        AudioDeviceType.hearingAid,
+        AudioDeviceType.carAudio,
+        AudioDeviceType.airPlay,
+      ]) {
+        check(
+          because: '$type should keep the call off the loudspeaker',
+          ChatVoiceAudioSessionCoordinator.isExternalAudioAccessory(type),
+        ).isTrue();
+      }
+    });
+
+    test('does not count the phone itself as an accessory', () {
+      // A bare phone must fall through to the speakerphone default, so none of
+      // the always-present built-ins may look like something to route to.
+      for (final type in const [
+        AudioDeviceType.builtInEarpiece,
+        AudioDeviceType.builtInSpeaker,
+        AudioDeviceType.builtInSpeakerSafe,
+        AudioDeviceType.builtInMic,
+        AudioDeviceType.telephony,
+        AudioDeviceType.remoteSubmix,
+        AudioDeviceType.unknown,
+      ]) {
+        check(
+          because: '$type is part of the phone, not an accessory',
+          ChatVoiceAudioSessionCoordinator.isExternalAudioAccessory(type),
+        ).isFalse();
+      }
+    });
+  });
+
+  group('ChatVoiceAudioSessionCoordinator device changes', () {
+    late ChatVoiceAudioSessionCoordinator coordinator;
+    late List<bool> routeChanges;
+
+    setUp(() {
+      coordinator = ChatVoiceAudioSessionCoordinator();
+      routeChanges = <bool>[];
+      coordinator.speakerphoneRouteChanges.listen(routeChanges.add);
+      addTearDown(coordinator.dispose);
+    });
+
+    Future<void> reportDevices(List<AudioDeviceType> types) async {
+      var id = 0;
+      await coordinator.handleAudioDevicesChangedForTesting({
+        for (final type in types)
+          AudioDevice(
+            id: '${id++}',
+            name: type.name,
+            isInput: false,
+            isOutput: true,
+            type: type,
+          ),
+      });
+      await pumpEventQueue();
+    }
+
+    test('follows accessories plugged in and pulled out mid-call', () async {
+      await reportDevices(const [
+        AudioDeviceType.builtInEarpiece,
+        AudioDeviceType.builtInSpeaker,
+      ]);
+      check(routeChanges).deepEquals(<bool>[true]);
+
+      await reportDevices(const [
+        AudioDeviceType.builtInEarpiece,
+        AudioDeviceType.builtInSpeaker,
+        AudioDeviceType.wiredHeadphones,
+      ]);
+      check(routeChanges).deepEquals(<bool>[true, false]);
+
+      // Headphones pulled out: back to the loudspeaker rather than the earpiece.
+      await reportDevices(const [
+        AudioDeviceType.builtInEarpiece,
+        AudioDeviceType.builtInSpeaker,
+      ]);
+      check(routeChanges).deepEquals(<bool>[true, false, true]);
+    });
+
+    test('reroutes once when one accessory announces several ends', () async {
+      await reportDevices(const [AudioDeviceType.builtInSpeaker]);
+      check(routeChanges).deepEquals(<bool>[true]);
+
+      await reportDevices(const [
+        AudioDeviceType.builtInSpeaker,
+        AudioDeviceType.bluetoothA2dp,
+      ]);
+      await reportDevices(const [
+        AudioDeviceType.builtInSpeaker,
+        AudioDeviceType.bluetoothA2dp,
+        AudioDeviceType.bluetoothSco,
+      ]);
+
+      check(routeChanges).deepEquals(<bool>[true, false]);
+    });
+
+    test('stops second-guessing the route after a manual toggle', () async {
+      await coordinator.setSpeakerphoneEnabled(false);
+
+      await reportDevices(const [
+        AudioDeviceType.builtInEarpiece,
+        AudioDeviceType.builtInSpeaker,
+      ]);
+
+      check(routeChanges).isEmpty();
+    });
+  });
+}

--- a/test/features/chat/voice_mode/chat_voice_audio_session_coordinator_test.dart
+++ b/test/features/chat/voice_mode/chat_voice_audio_session_coordinator_test.dart
@@ -124,6 +124,18 @@ void main() {
       check(routeChanges).isEmpty();
     });
 
+    test('lets the hardware back in after a refused button press', () async {
+      coordinator.debugRefuseRouteChanges = true;
+      check(await coordinator.setSpeakerphoneEnabled(false)).isFalse();
+      coordinator.debugRefuseRouteChanges = false;
+
+      // The press moved nothing, so it must not cost the rest of the call its
+      // automatic routing.
+      await reportDevices(const [AudioDeviceType.builtInSpeaker]);
+
+      check(routeChanges).deepEquals(<bool>[true]);
+    });
+
     test('ignores a microphone with no output of its own', () async {
       await coordinator.handleAudioDevicesChangedForTesting({
         _outputDevice(AudioDeviceType.builtInSpeaker),

--- a/test/features/chat/voice_mode/chat_voice_audio_session_coordinator_test.dart
+++ b/test/features/chat/voice_mode/chat_voice_audio_session_coordinator_test.dart
@@ -13,12 +13,10 @@ void main() {
         AudioDeviceType.wiredHeadphones,
         AudioDeviceType.headsetMic,
         AudioDeviceType.bluetoothSco,
-        AudioDeviceType.bluetoothA2dp,
         AudioDeviceType.bluetoothLe,
         AudioDeviceType.usbAudio,
         AudioDeviceType.hearingAid,
         AudioDeviceType.carAudio,
-        AudioDeviceType.airPlay,
       ]) {
         check(
           because: '$type should keep the call off the loudspeaker',
@@ -27,7 +25,7 @@ void main() {
       }
     });
 
-    test('does not count the phone itself as an accessory', () {
+    test('does not count anything a call cannot play through', () {
       // A bare phone must fall through to the speakerphone default, so none of
       // the always-present built-ins may look like something to route to.
       for (final type in const [
@@ -38,9 +36,12 @@ void main() {
         AudioDeviceType.telephony,
         AudioDeviceType.remoteSubmix,
         AudioDeviceType.unknown,
+        // A call runs in communication mode, which cannot route to either.
+        AudioDeviceType.bluetoothA2dp,
+        AudioDeviceType.airPlay,
       ]) {
         check(
-          because: '$type is part of the phone, not an accessory',
+          because: '$type is not somewhere a call can play',
           ChatVoiceAudioSessionCoordinator.isExternalAudioAccessory(type),
         ).isFalse();
       }
@@ -101,12 +102,12 @@ void main() {
 
       await reportDevices(const [
         AudioDeviceType.builtInSpeaker,
-        AudioDeviceType.bluetoothA2dp,
+        AudioDeviceType.bluetoothSco,
       ]);
       await reportDevices(const [
         AudioDeviceType.builtInSpeaker,
-        AudioDeviceType.bluetoothA2dp,
         AudioDeviceType.bluetoothSco,
+        AudioDeviceType.wiredHeadphones,
       ]);
 
       check(routeChanges).deepEquals(<bool>[true, false]);
@@ -121,6 +122,35 @@ void main() {
       ]);
 
       check(routeChanges).isEmpty();
+    });
+
+    test('ignores a microphone with no output of its own', () async {
+      await coordinator.handleAudioDevicesChangedForTesting({
+        _outputDevice(AudioDeviceType.builtInSpeaker),
+        // A plugged-in mic is not somewhere to play the answer.
+        AudioDevice(
+          id: 'mic',
+          name: 'usb mic',
+          isInput: true,
+          isOutput: false,
+          type: AudioDeviceType.usbAudio,
+        ),
+      });
+      await pumpEventQueue();
+
+      check(routeChanges).deepEquals(<bool>[true]);
+    });
+
+    test('ignores the speaker button once the call is being torn down', () async {
+      final hangingUp = coordinator.deactivate();
+      await coordinator.setSpeakerphoneEnabled(true);
+      await hangingUp;
+
+      // The next call still gets its automatic default: the press was rejected
+      // outright rather than latched as a manual choice.
+      await reportDevices(const [AudioDeviceType.builtInSpeaker]);
+
+      check(routeChanges).deepEquals(<bool>[true]);
     });
 
     test('drops a reroute the speaker button overtakes', () async {

--- a/test/features/chat/voice_mode/chat_voice_audio_session_coordinator_test.dart
+++ b/test/features/chat/voice_mode/chat_voice_audio_session_coordinator_test.dart
@@ -203,6 +203,16 @@ void main() {
           .deepEquals(<String>['deactivate', 'dispose']);
     });
 
+    test('stays shut once disposed, however late hanging up is', () async {
+      await coordinator.dispose();
+      // Teardown normally lifts the shutter for the next call. A disposed
+      // coordinator has no next call, so this must not leave the button able to
+      // put the phone back into communication mode.
+      await coordinator.deactivate();
+
+      check(await coordinator.setSpeakerphoneEnabled(true)).isFalse();
+    });
+
     test('drops a reroute that hanging up overtakes', () async {
       final rerouting = reportDevices(const [AudioDeviceType.builtInEarpiece]);
       await coordinator.deactivate();

--- a/test/features/chat/voice_mode/chat_voice_audio_session_coordinator_test.dart
+++ b/test/features/chat/voice_mode/chat_voice_audio_session_coordinator_test.dart
@@ -241,6 +241,16 @@ void main() {
       check(await coordinator.setSpeakerphoneEnabled(true)).isFalse();
     });
 
+    test('drops a speaker press that hanging up overtakes', () async {
+      // The press is queued, not finished, when the call ends. Moving the route
+      // behind the teardown would be work for a call nobody is on, and the
+      // answer would light the speaker button up on the way out.
+      final pressed = coordinator.setSpeakerphoneEnabled(true);
+      await coordinator.deactivate();
+
+      check(await pressed).isFalse();
+    });
+
     test('drops a reroute that hanging up overtakes', () async {
       final rerouting = reportDevices(const [AudioDeviceType.builtInEarpiece]);
       await coordinator.deactivate();

--- a/test/features/chat/voice_mode/chat_voice_audio_session_coordinator_test.dart
+++ b/test/features/chat/voice_mode/chat_voice_audio_session_coordinator_test.dart
@@ -122,5 +122,66 @@ void main() {
 
       check(routeChanges).isEmpty();
     });
+
+    test('drops a reroute the speaker button overtakes', () async {
+      // The reroute is in flight, not finished, when the button is pressed.
+      final rerouting = reportDevices(const [AudioDeviceType.builtInEarpiece]);
+      await coordinator.setSpeakerphoneEnabled(false);
+      await rerouting;
+
+      check(
+        because: 'the button press is newer than the accessory scan',
+        routeChanges,
+      ).isEmpty();
+    });
+
+    test('drops a reroute that hanging up overtakes', () async {
+      final rerouting = reportDevices(const [AudioDeviceType.builtInEarpiece]);
+      await coordinator.deactivate();
+      await rerouting;
+
+      check(routeChanges).isEmpty();
+    });
+
+    test('reroutes once to the newest route when events overlap', () async {
+      // Start the call on a headset, so the loudspeaker is genuinely off.
+      await reportDevices(const [
+        AudioDeviceType.builtInSpeaker,
+        AudioDeviceType.wiredHeadphones,
+      ]);
+      check(routeChanges).isEmpty();
+
+      // A loose jack: out, in, out again, all before the first reroute has
+      // finished talking to the platform. Rerouting three times in a row would
+      // leave whichever call finished last owning the route, so the coordinator
+      // collapses the flapping into the one move that matches the hardware now.
+      final flapping = <Future<void>>[
+        coordinator.handleAudioDevicesChangedForTesting({
+          _outputDevice(AudioDeviceType.builtInSpeaker),
+        }),
+        coordinator.handleAudioDevicesChangedForTesting({
+          _outputDevice(AudioDeviceType.builtInSpeaker),
+          _outputDevice(AudioDeviceType.wiredHeadphones),
+        }),
+        coordinator.handleAudioDevicesChangedForTesting({
+          _outputDevice(AudioDeviceType.builtInSpeaker),
+        }),
+      ];
+      await Future.wait(flapping);
+      await pumpEventQueue();
+
+      check(
+        because: 'the headset is out, so the call belongs on the loudspeaker',
+        routeChanges,
+      ).deepEquals(<bool>[true]);
+    });
   });
 }
+
+AudioDevice _outputDevice(AudioDeviceType type) => AudioDevice(
+  id: type.name,
+  name: type.name,
+  isInput: false,
+  isOutput: true,
+  type: type,
+);

--- a/test/features/chat/voice_mode/chat_voice_audio_session_coordinator_test.dart
+++ b/test/features/chat/voice_mode/chat_voice_audio_session_coordinator_test.dart
@@ -177,6 +177,32 @@ void main() {
       ).isEmpty();
     });
 
+    test('tears the call down when disposal beats hanging up', () async {
+      await reportDevices(const [AudioDeviceType.builtInSpeaker]);
+      check(routeChanges).deepEquals(<bool>[true]);
+
+      // Riverpod gives no order to provider disposal, so the coordinator can go
+      // first and never see the controller's `deactivate`. Disposing has to
+      // hand the route back on its own.
+      await coordinator.dispose();
+
+      check(coordinator.debugRouteTeardowns).deepEquals(<String>['dispose']);
+      check(
+        because: 'a disposed coordinator has no call left to route',
+        await coordinator.setSpeakerphoneEnabled(true),
+      ).isFalse();
+      await reportDevices(const [AudioDeviceType.wiredHeadphones]);
+      check(routeChanges).deepEquals(<bool>[true]);
+    });
+
+    test('survives hanging up and disposal both arriving', () async {
+      await coordinator.deactivate();
+      await coordinator.dispose();
+
+      check(coordinator.debugRouteTeardowns)
+          .deepEquals(<String>['deactivate', 'dispose']);
+    });
+
     test('drops a reroute that hanging up overtakes', () async {
       final rerouting = reportDevices(const [AudioDeviceType.builtInEarpiece]);
       await coordinator.deactivate();

--- a/test/features/chat/voice_mode/chat_voice_mode_controller_test.dart
+++ b/test/features/chat/voice_mode/chat_voice_mode_controller_test.dart
@@ -1934,6 +1934,41 @@ void main() {
       check(uncaught).isEmpty();
     },
   );
+
+  test('provider disposal hands the tts engine back to read aloud', () async {
+    final tts = _FakeTextToSpeechService();
+    final container = ProviderContainer(
+      overrides: [
+        ...openWebUiStorageOpenOverrides(),
+        authNavigationStateProvider.overrideWithValue(
+          AuthNavigationState.authenticated,
+        ),
+        selectedModelProvider.overrideWithValue(_model),
+        appSettingsProvider.overrideWithValue(const AppSettings()),
+        reviewerModeProvider.overrideWithValue(true),
+        voiceInputServiceProvider.overrideWithValue(_FakeVoiceInputService()),
+        textToSpeechServiceProvider.overrideWithValue(tts),
+        callKitServiceProvider.overrideWithValue(_UnavailableCallKitService()),
+        chatVoiceModeBackgroundCoordinatorProvider.overrideWithValue(
+          _FakeChatVoiceBackgroundCoordinator(),
+        ),
+        chatVoiceAudioSessionCoordinatorProvider.overrideWithValue(
+          _FakeChatVoiceAudioSessionCoordinator(),
+        ),
+      ],
+    );
+
+    final controller = container.read(chatVoiceModeControllerProvider.notifier);
+    await controller.start(startNewConversation: false);
+    check(tts.voiceCallFlags).deepEquals(<bool>[true]);
+
+    container.dispose();
+    await pumpEventQueue();
+
+    // The engine is shared with read-aloud. Left on the call route it speaks
+    // out of the earpiece at call volume.
+    check(tts.voiceCallFlags).deepEquals(<bool>[true, false]);
+  });
 }
 
 const _usableHermesConfig = HermesConfig(
@@ -2250,6 +2285,7 @@ class _FakeTextToSpeechService extends TextToSpeechService {
   final _events = StreamController<TtsEvent>.broadcast();
   final fedTexts = <String>[];
   final finishedTexts = <String?>[];
+  final voiceCallFlags = <bool>[];
   bool startedStreaming = false;
   bool holdCompletion = false;
   int pauseCalls = 0;
@@ -2262,6 +2298,11 @@ class _FakeTextToSpeechService extends TextToSpeechService {
 
   @override
   Stream<TtsEvent> get events => _events.stream;
+
+  @override
+  void setVoiceCallActive(bool active) {
+    voiceCallFlags.add(active);
+  }
 
   @override
   List<String> splitTextForSpeech(String text) {

--- a/test/features/chat/voice_mode/chat_voice_mode_controller_test.dart
+++ b/test/features/chat/voice_mode/chat_voice_mode_controller_test.dart
@@ -1071,6 +1071,111 @@ void main() {
   });
 
   test(
+    'starts on the speakerphone when no audio accessory is attached',
+    () async {
+      final audioSession = _FakeChatVoiceAudioSessionCoordinator()
+        ..defaultsToSpeakerphone = true;
+      final container = ProviderContainer(
+        overrides: [
+          ...openWebUiStorageOpenOverrides(),
+          authNavigationStateProvider.overrideWithValue(
+            AuthNavigationState.authenticated,
+          ),
+          selectedModelProvider.overrideWithValue(_model),
+          appSettingsProvider.overrideWithValue(const AppSettings()),
+          reviewerModeProvider.overrideWithValue(true),
+          voiceInputServiceProvider.overrideWithValue(_FakeVoiceInputService()),
+          textToSpeechServiceProvider.overrideWithValue(
+            _FakeTextToSpeechService(),
+          ),
+          callKitServiceProvider.overrideWithValue(
+            _UnavailableCallKitService(),
+          ),
+          chatVoiceModeBackgroundCoordinatorProvider.overrideWithValue(
+            _FakeChatVoiceBackgroundCoordinator(),
+          ),
+          chatVoiceAudioSessionCoordinatorProvider.overrideWithValue(
+            audioSession,
+          ),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      final controller = container.read(
+        chatVoiceModeControllerProvider.notifier,
+      );
+      await controller.start(startNewConversation: false);
+
+      check(audioSession.defaultRouteCalls).equals(1);
+      check(
+        container.read(chatVoiceModeControllerProvider).isSpeakerphoneEnabled,
+      ).isTrue();
+
+      // The default is only a starting point: the button still turns it off.
+      await controller.toggleSpeakerphone();
+      check(
+        container.read(chatVoiceModeControllerProvider).isSpeakerphoneEnabled,
+      ).isFalse();
+      check(audioSession.speakerphoneCalls).deepEquals(<bool>[false]);
+
+      await controller.stop();
+    },
+  );
+
+  test('follows the audio route the coordinator picks mid-call', () async {
+    final audioSession = _FakeChatVoiceAudioSessionCoordinator()
+      ..defaultsToSpeakerphone = true;
+    final container = ProviderContainer(
+      overrides: [
+        ...openWebUiStorageOpenOverrides(),
+        authNavigationStateProvider.overrideWithValue(
+          AuthNavigationState.authenticated,
+        ),
+        selectedModelProvider.overrideWithValue(_model),
+        appSettingsProvider.overrideWithValue(const AppSettings()),
+        reviewerModeProvider.overrideWithValue(true),
+        voiceInputServiceProvider.overrideWithValue(_FakeVoiceInputService()),
+        textToSpeechServiceProvider.overrideWithValue(
+          _FakeTextToSpeechService(),
+        ),
+        callKitServiceProvider.overrideWithValue(_UnavailableCallKitService()),
+        chatVoiceModeBackgroundCoordinatorProvider.overrideWithValue(
+          _FakeChatVoiceBackgroundCoordinator(),
+        ),
+        chatVoiceAudioSessionCoordinatorProvider.overrideWithValue(
+          audioSession,
+        ),
+      ],
+    );
+    addTearDown(container.dispose);
+
+    final controller = container.read(chatVoiceModeControllerProvider.notifier);
+    await controller.start(startNewConversation: false);
+    check(container.read(chatVoiceModeControllerProvider).isSpeakerphoneEnabled)
+        .isTrue();
+
+    // A headset connected mid-call takes playback off the loudspeaker, and the
+    // overlay's speaker button has to say so.
+    audioSession.routeChanges.add(false);
+    await pumpEventQueue();
+    check(container.read(chatVoiceModeControllerProvider).isSpeakerphoneEnabled)
+        .isFalse();
+
+    audioSession.routeChanges.add(true);
+    await pumpEventQueue();
+    check(container.read(chatVoiceModeControllerProvider).isSpeakerphoneEnabled)
+        .isTrue();
+
+    await controller.stop();
+
+    // A late event from a torn-down call cannot revive the speaker state.
+    audioSession.routeChanges.add(true);
+    await pumpEventQueue();
+    check(container.read(chatVoiceModeControllerProvider).isSpeakerphoneEnabled)
+        .isFalse();
+  });
+
+  test(
     'speakerphone toggle drives the audio session on every platform',
     () async {
       final audioSession = _FakeChatVoiceAudioSessionCoordinator();
@@ -2303,8 +2408,20 @@ class _FakeChatVoiceAudioSessionCoordinator
   int listeningCalls = 0;
   int speakingCalls = 0;
   int deactivateCalls = 0;
+  int defaultRouteCalls = 0;
   bool throwOnDeactivate = false;
+  bool defaultsToSpeakerphone = false;
   final speakerphoneCalls = <bool>[];
+  final routeChanges = StreamController<bool>.broadcast();
+
+  @override
+  Stream<bool> get speakerphoneRouteChanges => routeChanges.stream;
+
+  @override
+  Future<bool> applyDefaultSpeakerphoneRoute() async {
+    defaultRouteCalls += 1;
+    return defaultsToSpeakerphone;
+  }
 
   @override
   Future<void> setSpeakerphoneEnabled(bool enabled) async {
@@ -2327,6 +2444,11 @@ class _FakeChatVoiceAudioSessionCoordinator
     if (throwOnDeactivate) {
       throw StateError('audio session deactivation failed');
     }
+  }
+
+  @override
+  Future<void> dispose() async {
+    await routeChanges.close();
   }
 }
 

--- a/test/features/chat/voice_mode/chat_voice_mode_controller_test.dart
+++ b/test/features/chat/voice_mode/chat_voice_mode_controller_test.dart
@@ -1105,6 +1105,7 @@ void main() {
         chatVoiceModeControllerProvider.notifier,
       );
       await controller.start(startNewConversation: false);
+      await pumpEventQueue();
 
       check(audioSession.defaultRouteCalls).equals(1);
       check(
@@ -1151,6 +1152,7 @@ void main() {
 
     final controller = container.read(chatVoiceModeControllerProvider.notifier);
     await controller.start(startNewConversation: false);
+    await pumpEventQueue();
     check(container.read(chatVoiceModeControllerProvider).isSpeakerphoneEnabled)
         .isTrue();
 
@@ -2500,9 +2502,8 @@ class _FakeChatVoiceAudioSessionCoordinator
   Stream<bool> get speakerphoneRouteChanges => routeChanges.stream;
 
   @override
-  Future<bool> applyDefaultSpeakerphoneRoute() async {
+  Future<void> applyDefaultSpeakerphoneRoute() async {
     defaultRouteCalls += 1;
-    return defaultsToSpeakerphone;
   }
 
   @override
@@ -2514,6 +2515,12 @@ class _FakeChatVoiceAudioSessionCoordinator
   @override
   Future<void> configureForListening() async {
     listeningCalls += 1;
+    // The real coordinator only announces the default once a configure pass has
+    // moved the route, so the fake announces it from the same place.
+    if (defaultsToSpeakerphone && !routeChanges.isClosed) {
+      defaultsToSpeakerphone = false;
+      routeChanges.add(true);
+    }
   }
 
   @override

--- a/test/features/chat/voice_mode/chat_voice_mode_controller_test.dart
+++ b/test/features/chat/voice_mode/chat_voice_mode_controller_test.dart
@@ -1227,6 +1227,46 @@ void main() {
     },
   );
 
+  test('speakerphone toggle stays put when the platform refuses', () async {
+    final audioSession = _FakeChatVoiceAudioSessionCoordinator()
+      ..speakerphoneRouteApplies = false;
+    final container = ProviderContainer(
+      overrides: [
+        ...openWebUiStorageOpenOverrides(),
+        authNavigationStateProvider.overrideWithValue(
+          AuthNavigationState.authenticated,
+        ),
+        selectedModelProvider.overrideWithValue(_model),
+        appSettingsProvider.overrideWithValue(const AppSettings()),
+        reviewerModeProvider.overrideWithValue(true),
+        voiceInputServiceProvider.overrideWithValue(_FakeVoiceInputService()),
+        textToSpeechServiceProvider.overrideWithValue(
+          _FakeTextToSpeechService(),
+        ),
+        callKitServiceProvider.overrideWithValue(_UnavailableCallKitService()),
+        chatVoiceModeBackgroundCoordinatorProvider.overrideWithValue(
+          _FakeChatVoiceBackgroundCoordinator(),
+        ),
+        chatVoiceAudioSessionCoordinatorProvider.overrideWithValue(
+          audioSession,
+        ),
+      ],
+    );
+    addTearDown(container.dispose);
+
+    final controller = container.read(chatVoiceModeControllerProvider.notifier);
+    await controller.start(startNewConversation: false);
+
+    await controller.toggleSpeakerphone();
+
+    // Audio is still coming out of the earpiece, so a button that flipped to
+    // speaker would be pointing at a route nobody is hearing.
+    check(container.read(chatVoiceModeControllerProvider).isSpeakerphoneEnabled)
+        .isFalse();
+    check(audioSession.speakerphoneCalls).deepEquals(<bool>[true]);
+    await controller.stop();
+  });
+
   test(
     'queues final transcripts that arrive while the previous final is sending',
     () async {
@@ -2412,6 +2452,7 @@ class _FakeChatVoiceAudioSessionCoordinator
   bool throwOnDeactivate = false;
   bool defaultsToSpeakerphone = false;
   final speakerphoneCalls = <bool>[];
+  bool speakerphoneRouteApplies = true;
   final routeChanges = StreamController<bool>.broadcast();
 
   @override
@@ -2424,8 +2465,9 @@ class _FakeChatVoiceAudioSessionCoordinator
   }
 
   @override
-  Future<void> setSpeakerphoneEnabled(bool enabled) async {
+  Future<bool> setSpeakerphoneEnabled(bool enabled) async {
     speakerphoneCalls.add(enabled);
+    return speakerphoneRouteApplies;
   }
 
   @override

--- a/test/features/chat/voice_mode/chat_voice_mode_controller_test.dart
+++ b/test/features/chat/voice_mode/chat_voice_mode_controller_test.dart
@@ -1591,7 +1591,9 @@ void main() {
     'stop completes every teardown step and ends CallKit after cleanup errors',
     () async {
       final input = _FakeVoiceInputService();
-      final tts = _FakeTextToSpeechService()..throwOnStopStreaming = true;
+      final tts = _FakeTextToSpeechService()
+        ..throwOnStopStreaming = true
+        ..throwOnStop = true;
       final callKit = _AvailableCallKitService()..throwOnEnd = true;
       final background = _FakeChatVoiceBackgroundCoordinator()
         ..throwOnStop = true;
@@ -1628,6 +1630,9 @@ void main() {
 
       check(tts.stopStreamingCalls).equals(1);
       check(tts.stopCalls).equals(1);
+      // A stop that throws must still hand the shared engine back to read
+      // aloud, which does not belong on the call route.
+      check(tts.voiceCallFlags).deepEquals(<bool>[true, false]);
       check(background.stopped).length.equals(1);
       check(background.externalAudioSessionOwners.last).isFalse();
       check(audioSession.deactivateCalls).equals(1);
@@ -2295,6 +2300,7 @@ class _FakeTextToSpeechService extends TextToSpeechService {
   int stopStreamingCalls = 0;
   int stopCalls = 0;
   bool throwOnStopStreaming = false;
+  bool throwOnStop = false;
   Completer<void>? firstStopStreamingGate;
   bool _didStart = false;
 
@@ -2379,6 +2385,9 @@ class _FakeTextToSpeechService extends TextToSpeechService {
   Future<void> stop() async {
     stopCalls += 1;
     startedStreaming = false;
+    if (throwOnStop) {
+      throw StateError('stop TTS failed');
+    }
   }
 
   void emitError(String message) {


### PR DESCRIPTION
Three things were wrong with voice calls in 4.1.0, all reported on #347.

## The assistant stopped reading its answer

Voice mode speaks assistant content as it streams. Since the streaming merge started preserving local `<details>` wrappers, `TtsManager` stripped only the blocks that had already closed, so an open reasoning or `tool_calls` wrapper was read aloud. Worse, once `</details>` arrived the whole block dropped out of the split and every later chunk shifted left, behind the monotonic chunk cursor. The cursor never went back, so the answer itself was never spoken. Any turn with reasoning or a tool call went silent after the preamble.

TTS now sanitizes through the shared `semantic_details` helpers and stops at an unterminated semantic opener, so the speakable text only grows and a partly written reasoning block is withheld until it closes. The streaming feed re-anchors on the text of the chunk it last handed to playback instead of trusting a bare index, which survives a re-split.

## Calls came out of the earpiece

A call configures the session for communication, so with nothing plugged in both platforms route playback to the earpiece. That is right for a phone against your ear and wrong for how this call is actually held.

The coordinator scans attached audio devices at call start and engages the loudspeaker only when there is nothing else to play through. Wired, Bluetooth, USB, hearing aid, car and AirPlay outputs all count as somewhere better. A failed scan leaves the route alone, since playing an answer out of the loudspeaker over someone's headset is worse than a quiet earpiece.

It keeps watching for the rest of the call. Pull headphones out mid answer and playback moves to the speaker instead of dropping to the earpiece, connect a headset and it moves back off. The speaker button still wins: press it once and automatic switching stops for that call. Device enumeration comes from `audio_session`, so no new native code on either platform.

A refused reroute used to be indistinguishable from an applied one. Every platform route call tolerates failure, and the coordinator returned normally either way, so the speaker button could point at a route nobody was hearing and the `enabled == _speakerphoneEnabled` guard would drop the next identical device event as already handled. The route calls now answer whether they landed, the flag rolls back when they did not, and nothing is published without a successful move.

## Device TTS went quiet in the background on Android

Android routes voice-communication and media output separately. The call holds focus as `USAGE_VOICE_COMMUNICATION` in `MODE_IN_COMMUNICATION`, but the device TTS engine spoke as `USAGE_MEDIA`, so `setCommunicationDevice()` never moved it to the call's speakerphone choice and the system silenced it as soon as the app went to the background mid-call.

The engine now gets voice-communication audio attributes while a call is up, plus the matching legacy stream param for engines that only read that, and returns to the media stream for read-aloud outside a call. Provider disposal and `TtsManager.reset()` both hand the engine back, so a call torn down from under the controller does not leave read-aloud speaking out of the earpiece at call volume. Server TTS was never affected: `just_audio` applies the session's Android attributes by default. iOS needs nothing here, since `AVSpeechSynthesizer` already shares the call's `AVAudioSession`.

## Testing

`flutter test` (5570 passed, 4 skipped), `flutter analyze`, `dart format`, `./gradlew :app:compileDebugKotlin`. New coverage for the unterminated `<details>` helper, TTS sanitizing and cursor re-anchoring, the accessory classification, mid call route changes, the controller following them, a refused route leaving the button alone, and device TTS picking the call route only during a call.

Refs #347

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Voice mode automatically routes audio when accessories connect or disconnect.
  - Speakerphone state follows audio-route changes while respecting manual selections.
  - Text-to-speech filters complete, nested, unfinished, and case-insensitive hidden detail blocks.
  - Streaming speech handles changing chunks, incomplete text, and duplicate content smoothly.
  - Voice-call playback uses appropriate audio routing.

- **Bug Fixes**
  - Improved audio-routing reliability during device changes, failures, and cleanup.
  - Prevented hidden or incomplete content from being spoken.

- **Tests**
  - Expanded coverage for speech filtering, streaming, and audio routing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix voice call speech routing and default new calls to speakerphone
> - Defaults new calls to loudspeaker when no external accessory is connected, and re-routes automatically on hardware plug/unplug events in [chat_voice_audio_session_coordinator.dart](https://github.com/cogwheel0/conduit/pull/650/files#diff-4ca2dcd69625fc7a6fb35b0b02ed9bc976874de651add7718b33afb673443a48)
> - Routes device TTS to the voice-communication stream on Android and iOS, and restores the media route on teardown in [NativeTtsBridge.kt](https://github.com/cogwheel0/conduit/pull/650/files#diff-d0f8e957752a40d2bca72d7ad8336662e012f81f464a2b9c1765a72e98784118) and [tts_manager.dart](https://github.com/cogwheel0/conduit/pull/650/files#diff-5579a6d387cc71a60da0f4773f32efc424d72e1618a6fcc1b4266717f22cbc75)
> - Fixes streaming TTS playback to advance deterministically without duplicating or skipping sentences after server rewrites
> - Strips all `<details>` blocks and truncates unterminated semantic tags before speaking content in [semantic_details.dart](https://github.com/cogwheel0/conduit/pull/650/files#diff-137a386772c28a139858edaf9689dadb8a259c32fa958a5dccdd4dd25b86a079)
> - Risk: `_configureAndroidVoiceRoute` and `_setIosSpeakerphoneEnabled` now return success and roll back internal state on failure; failed manual toggles will not update UI state
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 34b5631.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->







































<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This update strengthens voice-call audio routing and streamed speech continuity. It serializes accessory route changes, retries refused route changes, and keeps already-heard streamed text from being replayed after response revisions.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

No blocking failure remains.

No accepted blocking findings remain after reviewing the current routing ownership checks, route-retry handling, and streaming cursor behavior.
</details>


<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex attempted to run the existing focused tests for chat voice mode and the TTS manager, but the commands exited with code 127 because Flutter was not installed.
- T-Rex authored and attempted to run the deterministic regression harness for focused voice TTS, but it also exited with code 127 due to Flutter not being found.
- A tool availability check confirmed that both Flutter and the Dart SDK are missing from the environment.

<a href="https://app.greptile.com/trex/runs/20238768/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (19): Last reviewed commit: ["fix(tts): keep a dead session&#39;s fetch er..."](https://github.com/cogwheel0/conduit/commit/34b5631ce35c7c6e63858121e0fb8c1411a3db67) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55832679)</sub>

<!-- /greptile_comment -->