### PR TITLE
Improve chat transcript scrolling performance

### DIFF
--- a/lib/features/chat/views/chat_page.dart
+++ b/lib/features/chat/views/chat_page.dart
@@ -478,10 +478,9 @@ class _ChatPageState extends ConsumerState<ChatPage> {
   int? _timelineTailMetadataDesyncLogGeneration;
   final LinkedHashMap<String, ChatScrollAnchor> _savedScrollAnchors =
       LinkedHashMap<String, ChatScrollAnchor>();
-  Timer? _markdownPrewarmTimer;
-  int _markdownPrewarmGeneration = 0;
+  final MarkdownPrewarmThrottle _markdownPrewarmThrottle =
+      MarkdownPrewarmThrottle();
   String? _lastMarkdownPrewarmSignature;
-  List<String> _pendingMarkdownPrewarmContents = const <String>[];
   bool _hasPrewarmedAttachedViewport = false;
   Set<String> _lastVisibleMessageIds = const <String>{};
   double? _lastBottomInset;
@@ -1004,7 +1003,7 @@ class _ChatPageState extends ConsumerState<ChatPage> {
     _hermesTranscriptSub?.close();
     _hermesStreamingSub?.close();
     _hermesTranscriptRefreshGeneration++;
-    _markdownPrewarmTimer?.cancel();
+    _markdownPrewarmThrottle.cancel();
     _screenContextRetryTimer?.cancel();
     _cancelExplicitLatestNavigation();
     _cancelPendingViewportNavigation();
@@ -2323,11 +2322,8 @@ class _ChatPageState extends ConsumerState<ChatPage> {
 
     _lastConversationId = conversationId;
     _cancelPendingViewportNavigation();
-    _markdownPrewarmTimer?.cancel();
-    _markdownPrewarmTimer = null;
-    _markdownPrewarmGeneration++;
+    _markdownPrewarmThrottle.cancel();
     _lastMarkdownPrewarmSignature = null;
-    _pendingMarkdownPrewarmContents = const <String>[];
     _hasPrewarmedAttachedViewport = false;
     _lastVisibleMessageIds = const <String>{};
     _clearPinToTopAnchor();
@@ -3392,10 +3388,8 @@ class _ChatPageState extends ConsumerState<ChatPage> {
     }
 
     if (filteredCandidateIndices.isEmpty) {
-      _markdownPrewarmTimer?.cancel();
-      _markdownPrewarmTimer = null;
+      _markdownPrewarmThrottle.cancel();
       _lastMarkdownPrewarmSignature = null;
-      _pendingMarkdownPrewarmContents = const <String>[];
       return;
     }
 
@@ -3408,22 +3402,8 @@ class _ChatPageState extends ConsumerState<ChatPage> {
         .map((index) => messages[index].content.trim())
         .toList(growable: false);
     _lastMarkdownPrewarmSignature = signature;
-    _pendingMarkdownPrewarmContents = rawContents;
-    if (!debugShouldStartMarkdownPrewarmTimerForTesting(
-      timerActive: _markdownPrewarmTimer?.isActive ?? false,
-    )) {
-      return;
-    }
-    _markdownPrewarmGeneration += 1;
-    final generation = _markdownPrewarmGeneration;
-    _markdownPrewarmTimer = Timer(const Duration(milliseconds: 220), () {
-      _markdownPrewarmTimer = null;
-      if (!mounted || generation != _markdownPrewarmGeneration) {
-        return;
-      }
-      final pendingContents = _pendingMarkdownPrewarmContents;
-      _pendingMarkdownPrewarmContents = const <String>[];
-      if (pendingContents.isEmpty) return;
+    _markdownPrewarmThrottle.schedule(rawContents, (pendingContents) {
+      if (!mounted) return;
       unawaited(
         ref
             .read(markdownCompileServiceProvider)
@@ -5421,9 +5401,30 @@ bool _visibleMessageIdsGained({
 }
 
 @visibleForTesting
-bool debugShouldStartMarkdownPrewarmTimerForTesting({
-  required bool timerActive,
-}) => !timerActive;
+class MarkdownPrewarmThrottle {
+  MarkdownPrewarmThrottle({this.delay = const Duration(milliseconds: 220)});
+
+  final Duration delay;
+  Timer? _timer;
+  List<String> _pendingContents = const <String>[];
+
+  void schedule(List<String> contents, ValueChanged<List<String>> onReady) {
+    _pendingContents = contents;
+    if (_timer?.isActive ?? false) return;
+    _timer = Timer(delay, () {
+      _timer = null;
+      final pendingContents = _pendingContents;
+      _pendingContents = const <String>[];
+      if (pendingContents.isNotEmpty) onReady(pendingContents);
+    });
+  }
+
+  void cancel() {
+    _timer?.cancel();
+    _timer = null;
+    _pendingContents = const <String>[];
+  }
+}
 
 @visibleForTesting
 List<int> debugSelectMarkdownPrewarmCandidateIndicesForTesting(

--- a/lib/features/chat/views/chat_page.dart
+++ b/lib/features/chat/views/chat_page.dart
@@ -7,6 +7,7 @@ import '../../../shared/theme/theme_extensions.dart';
 import '../../../shared/utils/platform_scroll_physics.dart';
 
 import 'package:flutter/services.dart';
+import 'package:flutter/foundation.dart' show listEquals;
 import 'package:conduit/core/services/haptic_service.dart';
 import 'package:cupertino_ui/cupertino_ui.dart';
 import 'package:flutter/rendering.dart' show ScrollCacheExtent;
@@ -480,7 +481,9 @@ class _ChatPageState extends ConsumerState<ChatPage> {
   Timer? _markdownPrewarmTimer;
   int _markdownPrewarmGeneration = 0;
   String? _lastMarkdownPrewarmSignature;
+  List<String> _pendingMarkdownPrewarmContents = const <String>[];
   bool _hasPrewarmedAttachedViewport = false;
+  Set<String> _lastVisibleMessageIds = const <String>{};
   double? _lastBottomInset;
   String? _activeScrollProfileTaskKey;
   // Pin-to-top: scroll user message to top of viewport when sending
@@ -510,6 +513,7 @@ class _ChatPageState extends ConsumerState<ChatPage> {
   _ChatListStableLayoutMetadata? _rowBuilderLayout;
   bool _rowBuilderSuppressHaptics = false;
   ChatTimelineRowBuilder? _rowBuilderMemo;
+  List<Object?> _rowRebuildKeysMemo = const <Object?>[];
   String? _cachedGreetingName;
   bool _greetingReady = false;
   ProviderSubscription<String?>? _screenContextSub;
@@ -604,8 +608,15 @@ class _ChatPageState extends ConsumerState<ChatPage> {
         metrics.distanceFromLatest > _scrollButtonHideThreshold) {
       _bottomAnchorController.detachByUser();
     }
+    final visibleMessageIds = metrics.visibleMessageIds.toSet();
     final shouldPrewarm =
-        !_hasPrewarmedAttachedViewport && metrics.visibleMessageIds.isNotEmpty;
+        visibleMessageIds.isNotEmpty &&
+        (!_hasPrewarmedAttachedViewport ||
+            _visibleMessageIdsGained(
+              previous: _lastVisibleMessageIds,
+              current: visibleMessageIds,
+            ));
+    _lastVisibleMessageIds = visibleMessageIds;
     if (shouldPrewarm) _hasPrewarmedAttachedViewport = true;
     _scheduleScrollToBottomVisibilitySync(prewarm: shouldPrewarm);
   }
@@ -2316,7 +2327,9 @@ class _ChatPageState extends ConsumerState<ChatPage> {
     _markdownPrewarmTimer = null;
     _markdownPrewarmGeneration++;
     _lastMarkdownPrewarmSignature = null;
+    _pendingMarkdownPrewarmContents = const <String>[];
     _hasPrewarmedAttachedViewport = false;
+    _lastVisibleMessageIds = const <String>{};
     _clearPinToTopAnchor();
     _invalidateChatListStableLayoutMetadata();
     _hasUserScrolled = false;
@@ -2351,6 +2364,7 @@ class _ChatPageState extends ConsumerState<ChatPage> {
     _savedScrollAnchors.clear();
     _initialScrollAnchor = null;
     _hasPrewarmedAttachedViewport = false;
+    _lastVisibleMessageIds = const <String>{};
     _conversationOwnerGeneration += 1;
     _cancelExplicitLatestNavigation();
     _cancelPendingViewportNavigation();
@@ -2874,6 +2888,11 @@ class _ChatPageState extends ConsumerState<ChatPage> {
     }
 
     final messageIds = timeline.messageIds;
+    final rowBuilder = _resolveTimelineRowBuilder(
+      timeline: timeline,
+      layoutMetadata: layoutMetadata,
+      suppressStreamingHaptics: suppressAssistantStreamingHaptics,
+    );
     final hideForInitialPin = debugShouldHideTranscriptForInitialPinForTesting(
       settleImmediately: _pinShouldSettleImmediately,
       positionSettled: _pinToTopPositionSettled,
@@ -2883,6 +2902,7 @@ class _ChatPageState extends ConsumerState<ChatPage> {
       controller: _timelineViewportController,
       ownerGeneration: _conversationOwnerGeneration,
       messageIds: messageIds,
+      rowRebuildKeys: _rowRebuildKeysMemo,
       initialAnchor: _initialScrollAnchor,
       pinnedUserMessageId: _wantsPinToTop ? _pinnedUserMessageId : null,
       liveFooter: timeline.runningFooterHost == null
@@ -2962,11 +2982,7 @@ class _ChatPageState extends ConsumerState<ChatPage> {
       onOldestThresholdReached: _maybeLoadOlderMessages,
       onTrailingRefresh: _refreshActiveConversation,
       onNativeScrollToTop: _handleNativeScrollToTop,
-      rowBuilder: _resolveTimelineRowBuilder(
-        timeline: timeline,
-        layoutMetadata: layoutMetadata,
-        suppressStreamingHaptics: suppressAssistantStreamingHaptics,
-      ),
+      rowBuilder: rowBuilder,
     );
   }
 
@@ -3049,6 +3065,19 @@ class _ChatPageState extends ConsumerState<ChatPage> {
     _rowBuilderTimeline = timeline;
     _rowBuilderLayout = layoutMetadata;
     _rowBuilderSuppressHaptics = suppressStreamingHaptics;
+    _rowRebuildKeysMemo = List<Object?>.unmodifiable([
+      for (var renderIndex = 0; renderIndex < messageIds.length; renderIndex++)
+        if (timeline.sourceIndexAtRenderIndex(renderIndex) case final index?)
+          (
+            layout: index < layoutMetadata.rows.length
+                ? layoutMetadata.rows[index]
+                : null,
+            isTail: timeline.tailAssistantRenderIndex == renderIndex,
+            suppressStreamingHaptics: suppressStreamingHaptics,
+          )
+        else
+          null,
+    ]);
     return _rowBuilderMemo = rowBuilder;
   }
 
@@ -3366,6 +3395,7 @@ class _ChatPageState extends ConsumerState<ChatPage> {
       _markdownPrewarmTimer?.cancel();
       _markdownPrewarmTimer = null;
       _lastMarkdownPrewarmSignature = null;
+      _pendingMarkdownPrewarmContents = const <String>[];
       return;
     }
 
@@ -3378,17 +3408,26 @@ class _ChatPageState extends ConsumerState<ChatPage> {
         .map((index) => messages[index].content.trim())
         .toList(growable: false);
     _lastMarkdownPrewarmSignature = signature;
+    _pendingMarkdownPrewarmContents = rawContents;
+    if (!debugShouldStartMarkdownPrewarmTimerForTesting(
+      timerActive: _markdownPrewarmTimer?.isActive ?? false,
+    )) {
+      return;
+    }
     _markdownPrewarmGeneration += 1;
     final generation = _markdownPrewarmGeneration;
-    _markdownPrewarmTimer?.cancel();
     _markdownPrewarmTimer = Timer(const Duration(milliseconds: 220), () {
+      _markdownPrewarmTimer = null;
       if (!mounted || generation != _markdownPrewarmGeneration) {
         return;
       }
+      final pendingContents = _pendingMarkdownPrewarmContents;
+      _pendingMarkdownPrewarmContents = const <String>[];
+      if (pendingContents.isEmpty) return;
       unawaited(
         ref
             .read(markdownCompileServiceProvider)
-            .prewarmContents(rawContents, streaming: false),
+            .prewarmContents(pendingContents, streaming: false),
       );
     });
   }
@@ -4656,6 +4695,37 @@ class _ChatRowLayoutMetadata {
   /// A single-element list for an ungrouped row, and empty for a row that owns
   /// no response of its own (user turns, archived variants, decision cards).
   final List<String> groupMessageIds;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is _ChatRowLayoutMetadata &&
+          messageId == other.messageId &&
+          displayModelName == other.displayModelName &&
+          modelIconUrl == other.modelIconUrl &&
+          listEquals(versionModelNames, other.versionModelNames) &&
+          listEquals(versionModelIconUrls, other.versionModelIconUrls) &&
+          isArchivedVariant == other.isArchivedVariant &&
+          replacesArchivedAssistant == other.replacesArchivedAssistant &&
+          showFollowUps == other.showFollowUps &&
+          showModelHeader == other.showModelHeader &&
+          showActionBar == other.showActionBar &&
+          listEquals(groupMessageIds, other.groupMessageIds);
+
+  @override
+  int get hashCode => Object.hash(
+    messageId,
+    displayModelName,
+    modelIconUrl,
+    Object.hashAll(versionModelNames),
+    Object.hashAll(versionModelIconUrls),
+    isArchivedVariant,
+    replacesArchivedAssistant,
+    showFollowUps,
+    showModelHeader,
+    showActionBar,
+    Object.hashAll(groupMessageIds),
+  );
 }
 
 @immutable
@@ -5335,6 +5405,25 @@ bool debugShouldKeepConversationBottomAnchoredOnContentSizeChangeForTesting({
     wantsPinToTop: wantsPinToTop,
   );
 }
+
+@visibleForTesting
+bool debugVisibleMessageIdsGainedForTesting({
+  required Iterable<String> previous,
+  required Iterable<String> current,
+}) => _visibleMessageIdsGained(previous: previous, current: current);
+
+bool _visibleMessageIdsGained({
+  required Iterable<String> previous,
+  required Iterable<String> current,
+}) {
+  final previousSet = previous is Set<String> ? previous : previous.toSet();
+  return current.any((id) => !previousSet.contains(id));
+}
+
+@visibleForTesting
+bool debugShouldStartMarkdownPrewarmTimerForTesting({
+  required bool timerActive,
+}) => !timerActive;
 
 @visibleForTesting
 List<int> debugSelectMarkdownPrewarmCandidateIndicesForTesting(

--- a/lib/features/chat/widgets/chat_timeline_viewport.dart
+++ b/lib/features/chat/widgets/chat_timeline_viewport.dart
@@ -439,11 +439,15 @@ class _ChatTimelineViewportState extends State<ChatTimelineViewport>
       oldWidget.messageIds,
       widget.messageIds,
     );
+    final rowBuilderChanged = !identical(
+      oldWidget.rowBuilder,
+      widget.rowBuilder,
+    );
     final entryConfigurationChanged =
         messageIdsChanged ||
         !identical(oldWidget.rowRebuildKeys, widget.rowRebuildKeys) ||
-        (widget.rowRebuildKeys.isEmpty &&
-            !identical(oldWidget.rowBuilder, widget.rowBuilder));
+        rowBuilderChanged;
+    if (rowBuilderChanged) _rowWidgetCache.clear();
     if ((oldWidget.maintainVisibleAnchor || widget.maintainVisibleAnchor) &&
         (_freeAnchor == null || _rowRect(_freeAnchor!.messageId) == null)) {
       // Capture before the new child configuration is laid out. This is the
@@ -1806,7 +1810,9 @@ class _ChatTimelineViewportState extends State<ChatTimelineViewport>
       onUnmounted: _unregisterMountedRow,
       child: IndexedSemantics(
         index: chronologicalIndex,
-        child: widget.rowBuilder(context, entry.sourceIndex),
+        child: Builder(
+          builder: (context) => widget.rowBuilder(context, entry.sourceIndex),
+        ),
       ),
     );
     final builtRow = KeyedSubtree(key: _TimelineRowKey(id), child: row);

--- a/lib/features/chat/widgets/chat_timeline_viewport.dart
+++ b/lib/features/chat/widgets/chat_timeline_viewport.dart
@@ -4,7 +4,12 @@ import 'dart:math' as math;
 import 'package:flutter/foundation.dart' show listEquals, visibleForTesting;
 import 'package:material_ui/material_ui.dart';
 import 'package:flutter/rendering.dart'
-    show RenderBox, RenderObject, ScrollCacheExtent, ScrollDirection;
+    show
+        MatrixUtils,
+        RenderBox,
+        RenderObject,
+        ScrollCacheExtent,
+        ScrollDirection;
 
 import '../../../core/database/models/chat_transcript_window.dart';
 import '../../../core/utils/debug_logger.dart';
@@ -275,8 +280,14 @@ class ChatTimelineViewport extends StatefulWidget {
     this.liveFooter,
     this.trailingContent,
     this.hideUntilSettled = false,
+    this.rowRebuildKeys = const <Object?>[],
     super.key,
   }) : assert(
+         rowRebuildKeys.length == 0 ||
+             rowRebuildKeys.length == messageIds.length,
+         'Row rebuild keys must be empty or match the message count.',
+       ),
+       assert(
          !maintainVisibleAnchor || !followLatest,
          'Visible-anchor maintenance and latest-follow are exclusive.',
        );
@@ -284,6 +295,7 @@ class ChatTimelineViewport extends StatefulWidget {
   final ChatTimelineViewportController controller;
   final int ownerGeneration;
   final List<String> messageIds;
+  final List<Object?> rowRebuildKeys;
   final ChatScrollAnchor? initialAnchor;
   final ChatTimelineRowBuilder rowBuilder;
   final String? pinnedUserMessageId;
@@ -349,6 +361,8 @@ class _ChatTimelineViewportState extends State<ChatTimelineViewport>
   final ValueNotifier<double> _pinSupportSpace = ValueNotifier<double>(0);
   final Map<String, GlobalKey> _rowKeys = <String, GlobalKey>{};
   final Map<String, int> _mountedRowCounts = <String, int>{};
+  final Map<String, ({int sourceIndex, Object? rebuildKey, Widget widget})>
+  _rowWidgetCache = {};
   Map<String, Rect>? _cachedFrameRowRects;
   int? _cachedRowRectFrameStamp;
   int _rowRectFrameStamp = 0;
@@ -356,7 +370,8 @@ class _ChatTimelineViewportState extends State<ChatTimelineViewport>
   bool _geometryUnavailable = false;
   bool _geometryRecoveryCallbackScheduled = false;
 
-  late List<({String id, int sourceIndex})> _timelineEntries;
+  late List<({String id, int sourceIndex, Object? rebuildKey})>
+  _timelineEntries;
   late List<String> _messageIds;
   late Set<String> _messageIdSet;
   late Map<String, int> _messageIndexById;
@@ -424,6 +439,11 @@ class _ChatTimelineViewportState extends State<ChatTimelineViewport>
       oldWidget.messageIds,
       widget.messageIds,
     );
+    final entryConfigurationChanged =
+        messageIdsChanged ||
+        !identical(oldWidget.rowRebuildKeys, widget.rowRebuildKeys) ||
+        (widget.rowRebuildKeys.isEmpty &&
+            !identical(oldWidget.rowBuilder, widget.rowBuilder));
     if ((oldWidget.maintainVisibleAnchor || widget.maintainVisibleAnchor) &&
         (_freeAnchor == null || _rowRect(_freeAnchor!.messageId) == null)) {
       // Capture before the new child configuration is laid out. This is the
@@ -434,8 +454,10 @@ class _ChatTimelineViewportState extends State<ChatTimelineViewport>
       // complete render tree is measurable again.
       if (capturedAnchor != null) _freeAnchor = capturedAnchor;
     }
-    if (messageIdsChanged) {
+    if (entryConfigurationChanged) {
       _syncTimelineEntries();
+    }
+    if (messageIdsChanged) {
       _refreshCenterIndex();
     }
     if (!identical(oldWidget.controller, widget.controller)) {
@@ -482,6 +504,7 @@ class _ChatTimelineViewportState extends State<ChatTimelineViewport>
     _centerRecoveryPending = false;
     _metricsSnapshot = null;
     _lastReportedMetrics = null;
+    _rowWidgetCache.clear();
     _anchorCorrectionAttempts = 0;
     _initialPositionResolved = false;
     _initialEmptyFallbackVisible = false;
@@ -612,10 +635,18 @@ class _ChatTimelineViewportState extends State<ChatTimelineViewport>
 
   void _syncTimelineEntries() {
     final seen = <String>{};
-    final entries = <({String id, int sourceIndex})>[];
+    final entries = <({String id, int sourceIndex, Object? rebuildKey})>[];
     for (var index = 0; index < widget.messageIds.length; index += 1) {
       final id = widget.messageIds[index];
-      if (seen.add(id)) entries.add((id: id, sourceIndex: index));
+      if (seen.add(id)) {
+        entries.add((
+          id: id,
+          sourceIndex: index,
+          rebuildKey: widget.rowRebuildKeys.isEmpty
+              ? widget.rowBuilder
+              : widget.rowRebuildKeys[index],
+        ));
+      }
     }
     _timelineEntries = List.unmodifiable(entries);
     _messageIds = List.unmodifiable(entries.map((entry) => entry.id));
@@ -624,6 +655,7 @@ class _ChatTimelineViewportState extends State<ChatTimelineViewport>
       for (var index = 0; index < entries.length; index += 1)
         entries[index].id: index,
     });
+    _rowWidgetCache.removeWhere((id, _) => !seen.contains(id));
   }
 
   void _syncRowKeys() {
@@ -708,12 +740,22 @@ class _ChatTimelineViewportState extends State<ChatTimelineViewport>
   }
 
   Map<String, Rect> _mountedRowRectSnapshot() {
+    final viewport = _renderBoxFor(_viewportKey);
+    final viewportRect = _viewportRect;
+    if (viewport == null || viewportRect == null) {
+      return const <String, Rect>{};
+    }
+    final viewportToGlobal = viewport.getTransformTo(null);
     final rects = <String, Rect>{};
     for (final id in _mountedRowCounts.keys) {
       final key = _rowKeys[id];
       if (key == null || key.currentContext == null) continue;
-      final rect = _globalRectFor(key);
-      if (rect != null) rects[id] = rect;
+      final box = _renderBoxFor(key);
+      if (box == null || !identical(box.owner, viewport.owner)) continue;
+      final transform = viewportToGlobal.clone()
+        ..multiply(box.getTransformTo(viewport));
+      final rect = MatrixUtils.transformRect(transform, Offset.zero & box.size);
+      if (rect.isFinite) rects[id] = rect;
     }
     return Map<String, Rect>.unmodifiable(rects);
   }
@@ -900,6 +942,15 @@ class _ChatTimelineViewportState extends State<ChatTimelineViewport>
     // Per-tick consumers use only these lightweight pixel/extent values; the
     // scheduled callback refreshes row geometry exactly once per frame.
     final previous = _metricsSnapshot;
+    final position = _dimensionedPosition;
+    if (position == null) return;
+    if (previous != null &&
+        previous.pixels == position.pixels &&
+        previous.minScrollExtent == position.minScrollExtent &&
+        previous.maxScrollExtent == position.maxScrollExtent &&
+        previous.viewportDimension == position.viewportDimension) {
+      return;
+    }
     _metricsSnapshot =
         _metricsForCurrentPosition(
           visibleMessageIds: previous?.visibleMessageIds ?? const <String>[],
@@ -1742,6 +1793,12 @@ class _ChatTimelineViewportState extends State<ChatTimelineViewport>
   Widget _buildRow(BuildContext context, int chronologicalIndex) {
     final entry = _timelineEntries[chronologicalIndex];
     final id = entry.id;
+    final cached = _rowWidgetCache[id];
+    if (cached != null &&
+        cached.sourceIndex == entry.sourceIndex &&
+        cached.rebuildKey == entry.rebuildKey) {
+      return cached.widget;
+    }
     final row = _MountedTimelineRow(
       key: _rowKeys[id],
       messageId: id,
@@ -1752,7 +1809,13 @@ class _ChatTimelineViewportState extends State<ChatTimelineViewport>
         child: widget.rowBuilder(context, entry.sourceIndex),
       ),
     );
-    return KeyedSubtree(key: _TimelineRowKey(id), child: row);
+    final builtRow = KeyedSubtree(key: _TimelineRowKey(id), child: row);
+    _rowWidgetCache[id] = (
+      sourceIndex: entry.sourceIndex,
+      rebuildKey: entry.rebuildKey,
+      widget: builtRow,
+    );
+    return builtRow;
   }
 
   int? _olderChildIndexForKey(Key key, int centerIndex) {
@@ -2004,7 +2067,7 @@ class _TimelineRowDelegate extends SliverChildBuilderDelegate {
   }) : super(addSemanticIndexes: false);
 
   final ChatTimelineRowBuilder rowBuilder;
-  final List<({String id, int sourceIndex})> entries;
+  final List<({String id, int sourceIndex, Object? rebuildKey})> entries;
   final int centerIndex;
 
   @override

--- a/lib/shared/widgets/markdown/renderer/block_renderer.dart
+++ b/lib/shared/widgets/markdown/renderer/block_renderer.dart
@@ -1038,14 +1038,18 @@ class BlockRenderer {
 
   Widget _renderTable(CompiledMarkdownElement element) {
     final columns = <DataColumn>[];
-    final rows = <DataRow>[];
+    final rows = <CompiledMarkdownElement>[];
 
     for (final section in element.children) {
       if (section is! CompiledMarkdownElement) continue;
       if (section.tag == 'thead') {
         _parseTableHead(section, columns);
       } else if (section.tag == 'tbody') {
-        _parseTableBody(section, rows, columns.length);
+        rows.addAll(
+          section.children.whereType<CompiledMarkdownElement>().where(
+            (row) => row.tag == 'tr',
+          ),
+        );
       }
     }
 
@@ -1053,21 +1057,11 @@ class BlockRenderer {
 
     return Padding(
       padding: EdgeInsets.symmetric(vertical: style.tableSpacing),
-      child: HorizontalScrollGestureBoundary(
-        child: SingleChildScrollView(
-          scrollDirection: Axis.horizontal,
-          child: DataTable(
-            headingRowColor: WidgetStatePropertyAll(
-              style.tableHeaderBackground,
-            ),
-            border: TableBorder.all(
-              color: style.tableBorderColor,
-              borderRadius: BorderRadius.circular(style.tableRadius),
-            ),
-            columns: columns,
-            rows: rows,
-          ),
-        ),
+      child: _ExpandableMarkdownTable(
+        columns: columns,
+        rows: rows,
+        rowBuilder: (row) => _buildTableRow(row, columns.length),
+        style: style,
       ),
     );
   }
@@ -1098,43 +1092,30 @@ class BlockRenderer {
     }
   }
 
-  void _parseTableBody(
-    CompiledMarkdownElement tbody,
-    List<DataRow> rows,
-    int columnCount,
-  ) {
-    for (final row in tbody.children) {
-      if (row is! CompiledMarkdownElement || row.tag != 'tr') continue;
-      final cells = <DataCell>[];
-      for (final cell in row.children) {
-        if (cell is! CompiledMarkdownElement) continue;
-        if (cell.tag != 'td' && cell.tag != 'th') continue;
-        final children = cell.children;
-        cells.add(
-          DataCell(
-            children.isNotEmpty
-                ? Text.rich(
-                    inlineRenderer.render(
-                      children,
-                      parentStyle: style.tableCell,
-                    ),
-                  )
-                : Text(cell.textContent, style: style.tableCell),
-          ),
-        );
-      }
-      // Truncate extra cells if row is longer than
-      // header to avoid DataTable assertion errors.
-      if (cells.length > columnCount) {
-        cells.removeRange(columnCount, cells.length);
-      }
-      // Pad with empty cells if row is shorter than
-      // header.
-      while (cells.length < columnCount) {
-        cells.add(const DataCell(SizedBox.shrink()));
-      }
-      rows.add(DataRow(cells: cells));
+  DataRow _buildTableRow(CompiledMarkdownElement row, int columnCount) {
+    final cells = <DataCell>[];
+    for (final cell in row.children) {
+      if (cell is! CompiledMarkdownElement) continue;
+      if (cell.tag != 'td' && cell.tag != 'th') continue;
+      final children = cell.children;
+      cells.add(
+        DataCell(
+          children.isNotEmpty
+              ? Text.rich(
+                  inlineRenderer.render(children, parentStyle: style.tableCell),
+                )
+              : Text(cell.textContent, style: style.tableCell),
+        ),
+      );
     }
+    // Keep malformed rows compatible with DataTable's fixed column count.
+    if (cells.length > columnCount) {
+      cells.removeRange(columnCount, cells.length);
+    }
+    while (cells.length < columnCount) {
+      cells.add(const DataCell(SizedBox.shrink()));
+    }
+    return DataRow(cells: cells);
   }
 
   // -- Horizontal rule --
@@ -1536,6 +1517,76 @@ class BlockRenderer {
     final text = element.textContent.trim();
     if (text.isEmpty) return null;
     return Text.rich(inlineRenderer.render([element]));
+  }
+}
+
+class _ExpandableMarkdownTable extends StatefulWidget {
+  const _ExpandableMarkdownTable({
+    required this.columns,
+    required this.rows,
+    required this.rowBuilder,
+    required this.style,
+  });
+
+  static const previewRowCount = 20;
+
+  final List<DataColumn> columns;
+  final List<CompiledMarkdownElement> rows;
+  final DataRow Function(CompiledMarkdownElement row) rowBuilder;
+  final ConduitMarkdownStyle style;
+
+  @override
+  State<_ExpandableMarkdownTable> createState() =>
+      _ExpandableMarkdownTableState();
+}
+
+class _ExpandableMarkdownTableState extends State<_ExpandableMarkdownTable> {
+  bool _expanded = false;
+
+  @override
+  Widget build(BuildContext context) {
+    final collapsible =
+        widget.rows.length > _ExpandableMarkdownTable.previewRowCount;
+    final visibleRows = _expanded
+        ? widget.rows
+        : widget.rows.take(_ExpandableMarkdownTable.previewRowCount);
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        HorizontalScrollGestureBoundary(
+          child: SingleChildScrollView(
+            scrollDirection: Axis.horizontal,
+            child: DataTable(
+              headingRowColor: WidgetStatePropertyAll(
+                widget.style.tableHeaderBackground,
+              ),
+              border: TableBorder.all(
+                color: widget.style.tableBorderColor,
+                borderRadius: BorderRadius.circular(widget.style.tableRadius),
+              ),
+              columns: widget.columns,
+              rows: visibleRows.map(widget.rowBuilder).toList(growable: false),
+            ),
+          ),
+        ),
+        if (collapsible)
+          TextButton.icon(
+            onPressed: () => setState(() => _expanded = !_expanded),
+            icon: Icon(
+              _expanded ? Icons.expand_less_rounded : Icons.expand_more_rounded,
+            ),
+            label: Text(
+              _expanded
+                  ? AppLocalizations.of(context)!.markdownShowLess
+                  : AppLocalizations.of(context)!.markdownShowMoreLines(
+                      widget.rows.length -
+                          _ExpandableMarkdownTable.previewRowCount,
+                    ),
+            ),
+          ),
+      ],
+    );
   }
 }
 

--- a/lib/shared/widgets/markdown/renderer/block_renderer.dart
+++ b/lib/shared/widgets/markdown/renderer/block_renderer.dart
@@ -1054,12 +1054,23 @@ class BlockRenderer {
     }
 
     if (columns.isEmpty) return const SizedBox.shrink();
+    final previewRows = rows
+        .take(_ExpandableMarkdownTable.previewRowCount)
+        .map((row) => _buildTableRow(row, columns.length))
+        .toList(growable: false);
+    final remainingRows = rows
+        .skip(_ExpandableMarkdownTable.previewRowCount)
+        .toList(growable: false);
+    for (final row in remainingRows) {
+      inlineRenderer.advanceVisibleTextOffset(row.textContent.length);
+    }
 
     return Padding(
       padding: EdgeInsets.symmetric(vertical: style.tableSpacing),
       child: _ExpandableMarkdownTable(
         columns: columns,
-        rows: rows,
+        previewRows: previewRows,
+        remainingRows: remainingRows,
         rowBuilder: (row) => _buildTableRow(row, columns.length),
         style: style,
       ),
@@ -1523,7 +1534,8 @@ class BlockRenderer {
 class _ExpandableMarkdownTable extends StatefulWidget {
   const _ExpandableMarkdownTable({
     required this.columns,
-    required this.rows,
+    required this.previewRows,
+    required this.remainingRows,
     required this.rowBuilder,
     required this.style,
   });
@@ -1531,7 +1543,8 @@ class _ExpandableMarkdownTable extends StatefulWidget {
   static const previewRowCount = 20;
 
   final List<DataColumn> columns;
-  final List<CompiledMarkdownElement> rows;
+  final List<DataRow> previewRows;
+  final List<CompiledMarkdownElement> remainingRows;
   final DataRow Function(CompiledMarkdownElement row) rowBuilder;
   final ConduitMarkdownStyle style;
 
@@ -1545,11 +1558,13 @@ class _ExpandableMarkdownTableState extends State<_ExpandableMarkdownTable> {
 
   @override
   Widget build(BuildContext context) {
-    final collapsible =
-        widget.rows.length > _ExpandableMarkdownTable.previewRowCount;
+    final collapsible = widget.remainingRows.isNotEmpty;
     final visibleRows = _expanded
-        ? widget.rows
-        : widget.rows.take(_ExpandableMarkdownTable.previewRowCount);
+        ? <DataRow>[
+            ...widget.previewRows,
+            ...widget.remainingRows.map(widget.rowBuilder),
+          ]
+        : widget.previewRows;
 
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
@@ -1566,7 +1581,7 @@ class _ExpandableMarkdownTableState extends State<_ExpandableMarkdownTable> {
                 borderRadius: BorderRadius.circular(widget.style.tableRadius),
               ),
               columns: widget.columns,
-              rows: visibleRows.map(widget.rowBuilder).toList(growable: false),
+              rows: visibleRows,
             ),
           ),
         ),
@@ -1579,10 +1594,8 @@ class _ExpandableMarkdownTableState extends State<_ExpandableMarkdownTable> {
             label: Text(
               _expanded
                   ? AppLocalizations.of(context)!.markdownShowLess
-                  : AppLocalizations.of(context)!.markdownShowMoreLines(
-                      widget.rows.length -
-                          _ExpandableMarkdownTable.previewRowCount,
-                    ),
+                  : AppLocalizations.of(context)!
+                        .markdownShowMoreLines(widget.remainingRows.length),
             ),
           ),
       ],

--- a/test/features/chat/views/chat_page_layout_metadata_test.dart
+++ b/test/features/chat/views/chat_page_layout_metadata_test.dart
@@ -1164,6 +1164,30 @@ void main() {
     expect(indices, isEmpty);
   });
 
+  test('markdown prewarm retriggers when a new row enters the viewport', () {
+    expect(
+      debugVisibleMessageIdsGainedForTesting(
+        previous: const ['assistant-2', 'assistant-3'],
+        current: const ['assistant-3', 'assistant-4'],
+      ),
+      isTrue,
+    );
+    expect(
+      debugVisibleMessageIdsGainedForTesting(
+        previous: const ['assistant-2', 'assistant-3'],
+        current: const ['assistant-3'],
+      ),
+      isFalse,
+    );
+  });
+
+  test('markdown prewarm keeps its active timer while scrolling', () {
+    check(debugShouldStartMarkdownPrewarmTimerForTesting(timerActive: false))
+        .isTrue();
+    check(debugShouldStartMarkdownPrewarmTimerForTesting(timerActive: true))
+        .isFalse();
+  });
+
   test('markdown prewarm skips still-streaming assistant messages', () {
     final messages = <ChatMessage>[
       ChatMessage(

--- a/test/features/chat/views/chat_page_layout_metadata_test.dart
+++ b/test/features/chat/views/chat_page_layout_metadata_test.dart
@@ -16,6 +16,7 @@ import 'package:conduit/features/direct_connections/models/direct_connection_pro
 import 'package:conduit/features/direct_connections/models/direct_remote_model.dart';
 import 'package:conduit/features/direct_connections/services/direct_model_registry.dart';
 import 'package:conduit/features/hermes/services/hermes_session_provenance.dart';
+import 'package:fake_async/fake_async.dart';
 import 'package:material_ui/material_ui.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -1181,11 +1182,20 @@ void main() {
     );
   });
 
-  test('markdown prewarm keeps its active timer while scrolling', () {
-    check(debugShouldStartMarkdownPrewarmTimerForTesting(timerActive: false))
-        .isTrue();
-    check(debugShouldStartMarkdownPrewarmTimerForTesting(timerActive: true))
-        .isFalse();
+  test('markdown prewarm uses the latest batch queued during its throttle', () {
+    fakeAsync((async) {
+      final batches = <List<String>>[];
+      final throttle = MarkdownPrewarmThrottle();
+
+      throttle.schedule(const ['first'], batches.add);
+      throttle.schedule(const ['latest'], batches.add);
+      async.elapse(const Duration(milliseconds: 220));
+
+      check(batches).deepEquals([
+        ['latest'],
+      ]);
+      throttle.cancel();
+    });
   });
 
   test('markdown prewarm skips still-streaming assistant messages', () {

--- a/test/features/chat/widgets/chat_timeline_viewport_test.dart
+++ b/test/features/chat/widgets/chat_timeline_viewport_test.dart
@@ -623,6 +623,61 @@ void main() {
     },
   );
 
+  _viewportTest('timeline mutations rebuild only changed mounted rows', (
+    tester,
+  ) async {
+    final controller = _controller(tester);
+    var ids = List<String>.generate(18, (index) => 'message-$index');
+    var rowRebuildKeys = List<Object?>.of(ids);
+    final buildCounts = <String, int>{};
+    late StateSetter rebuild;
+
+    await tester.pumpWidget(
+      _viewportHost(
+        StatefulBuilder(
+          builder: (context, setState) {
+            rebuild = setState;
+            return _viewport(
+              controller: controller,
+              ids: ids,
+              rowRebuildKeys: rowRebuildKeys,
+              rowBuilder: (context, index) {
+                final id = ids[index];
+                buildCounts.update(id, (count) => count + 1, ifAbsent: () => 1);
+                return SizedBox(height: 52, child: Text(id));
+              },
+            );
+          },
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+    final initialCounts = Map<String, int>.of(buildCounts);
+
+    rebuild(() {
+      ids = [...ids, 'message-18'];
+      rowRebuildKeys = [...rowRebuildKeys, 'message-18'];
+    });
+    await tester.pumpAndSettle();
+
+    for (final entry in initialCounts.entries) {
+      check(buildCounts[entry.key]).equals(entry.value);
+    }
+    check(buildCounts['message-18']).equals(1);
+
+    final beforeVersionChange = Map<String, int>.of(buildCounts);
+    rebuild(() {
+      rowRebuildKeys = [...rowRebuildKeys]..[17] = 'message-17-v2';
+    });
+    await tester.pump();
+
+    check(buildCounts['message-17'])
+        .equals(beforeVersionChange['message-17']! + 1);
+    for (final id in ids.where((id) => id != 'message-17')) {
+      check(buildCounts[id]).equals(beforeVersionChange[id]);
+    }
+  });
+
   _viewportTest('viewport movement does not alter a free-scroll anchor', (
     tester,
   ) async {
@@ -2411,6 +2466,7 @@ Widget _viewport({
   bool hideUntilSettled = false,
   double Function(String id)? rowHeight,
   ChatTimelineRowBuilder? rowBuilder,
+  List<Object?> rowRebuildKeys = const <Object?>[],
   ValueChanged<ChatTimelineViewportMetrics>? onMetricsChanged,
   ValueChanged<double>? onPinEndSpaceChanged,
   VoidCallback? onOldestThresholdReached,
@@ -2424,6 +2480,7 @@ Widget _viewport({
     controller: controller,
     ownerGeneration: ownerGeneration,
     messageIds: ids,
+    rowRebuildKeys: rowRebuildKeys,
     initialAnchor: initialAnchor,
     pinnedUserMessageId: pinnedUserMessageId,
     liveFooter: liveFooter,

--- a/test/features/chat/widgets/chat_timeline_viewport_test.dart
+++ b/test/features/chat/widgets/chat_timeline_viewport_test.dart
@@ -631,6 +631,12 @@ void main() {
     var rowRebuildKeys = List<Object?>.of(ids);
     final buildCounts = <String, int>{};
     late StateSetter rebuild;
+    late final ChatTimelineRowBuilder rowBuilder;
+    rowBuilder = (context, index) {
+      final id = ids[index];
+      buildCounts.update(id, (count) => count + 1, ifAbsent: () => 1);
+      return SizedBox(height: 52, child: Text(id));
+    };
 
     await tester.pumpWidget(
       _viewportHost(
@@ -641,11 +647,7 @@ void main() {
               controller: controller,
               ids: ids,
               rowRebuildKeys: rowRebuildKeys,
-              rowBuilder: (context, index) {
-                final id = ids[index];
-                buildCounts.update(id, (count) => count + 1, ifAbsent: () => 1);
-                return SizedBox(height: 52, child: Text(id));
-              },
+              rowBuilder: rowBuilder,
             );
           },
         ),
@@ -676,6 +678,74 @@ void main() {
     for (final id in ids.where((id) => id != 'message-17')) {
       check(buildCounts[id]).equals(beforeVersionChange[id]);
     }
+  });
+
+  _viewportTest('row builder changes invalidate cached rows', (tester) async {
+    final controller = _controller(tester);
+    const ids = ['message-0'];
+    late StateSetter rebuild;
+    ChatTimelineRowBuilder rowBuilder = (context, index) =>
+        const SizedBox(height: 52, child: Text('version-1'));
+
+    await tester.pumpWidget(
+      _viewportHost(
+        StatefulBuilder(
+          builder: (context, setState) {
+            rebuild = setState;
+            return _viewport(
+              controller: controller,
+              ids: ids,
+              rowRebuildKeys: ids,
+              rowBuilder: rowBuilder,
+            );
+          },
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    check(find.text('version-1').evaluate()).length.equals(1);
+    rebuild(() {
+      rowBuilder = (context, index) =>
+          const SizedBox(height: 52, child: Text('version-2'));
+    });
+    await tester.pump();
+
+    check(find.text('version-1').evaluate()).isEmpty();
+    check(find.text('version-2').evaluate()).length.equals(1);
+  });
+
+  _viewportTest('cached rows update inherited theme values', (tester) async {
+    final controller = _controller(tester);
+    const ids = ['message-0'];
+    Widget rowBuilder(BuildContext context, int index) => SizedBox(
+      height: 52,
+      child: Text(
+        'themed-row',
+        style: TextStyle(color: Theme.of(context).colorScheme.primary),
+      ),
+    );
+
+    Widget host(Color primary) => _viewportHost(
+      _viewport(
+        controller: controller,
+        ids: ids,
+        rowRebuildKeys: ids,
+        rowBuilder: rowBuilder,
+      ),
+      theme: ThemeData(colorScheme: ColorScheme.light(primary: primary)),
+    );
+
+    await tester.pumpWidget(host(Colors.red));
+    await tester.pumpAndSettle();
+    check(tester.widget<Text>(find.text('themed-row')).style?.color)
+        .equals(Colors.red);
+
+    await tester.pumpWidget(host(Colors.blue));
+    await tester.pumpAndSettle();
+
+    check(tester.widget<Text>(find.text('themed-row')).style?.color)
+        .equals(Colors.blue);
   });
 
   _viewportTest('viewport movement does not alter a free-scroll anchor', (

--- a/test/shared/widgets/markdown/renderer/streaming_markdown_widget_test.dart
+++ b/test/shared/widgets/markdown/renderer/streaming_markdown_widget_test.dart
@@ -1064,6 +1064,32 @@ void main() {
     );
   }
 
+  testWidgets('large markdown tables render a bounded preview', (tester) async {
+    final content = <String>[
+      '| A | B |',
+      '| --- | --- |',
+      ...List<String>.generate(35, (index) => '| $index | value $index |'),
+    ].join('\n');
+
+    await tester.pumpWidget(buildHarness(content));
+    await tester.pumpAndSettle();
+
+    DataTable table() => tester.widget<DataTable>(find.byType(DataTable));
+    expect(table().rows, hasLength(20));
+
+    final showMore = find.text('Show 15 more lines');
+    await tester.ensureVisible(showMore);
+    await tester.tap(showMore);
+    await tester.pump();
+    expect(table().rows, hasLength(35));
+
+    final showLess = find.text('Show less');
+    await tester.ensureVisible(showLess);
+    await tester.tap(showLess);
+    await tester.pump();
+    expect(table().rows, hasLength(20));
+  });
+
   testWidgets('renders correctly when a streaming display part is dropped', (
     tester,
   ) async {

--- a/test/shared/widgets/markdown/renderer/streaming_markdown_widget_test.dart
+++ b/test/shared/widgets/markdown/renderer/streaming_markdown_widget_test.dart
@@ -1075,19 +1075,19 @@ void main() {
     await tester.pumpAndSettle();
 
     DataTable table() => tester.widget<DataTable>(find.byType(DataTable));
-    expect(table().rows, hasLength(20));
+    check(table().rows).length.equals(20);
 
     final showMore = find.text('Show 15 more lines');
     await tester.ensureVisible(showMore);
     await tester.tap(showMore);
     await tester.pump();
-    expect(table().rows, hasLength(35));
+    check(table().rows).length.equals(35);
 
     final showLess = find.text('Show less');
     await tester.ensureVisible(showLess);
     await tester.tap(showLess);
     await tester.pump();
-    expect(table().rows, hasLength(20));
+    check(table().rows).length.equals(20);
   });
 
   testWidgets('renders correctly when a streaming display part is dropped', (
@@ -1980,6 +1980,46 @@ graph TD
     await tester.pump(const Duration(milliseconds: 360));
     final settled = _textSpanLeaves(tailText().textSpan!).toList();
     expect(settled.every((span) => (span.style?.color?.a ?? 1) == 1), isTrue);
+  });
+
+  testWidgets('faded suffix begins after a collapsed table', (tester) async {
+    final table = <String>[
+      '| A | B |',
+      '| --- | --- |',
+      ...List<String>.generate(25, (index) => '| $index | value $index |'),
+    ].join('\n');
+    final prefix = '$table\n\nTail';
+
+    await tester.pumpWidget(
+      buildHarness(prefix, isStreaming: true, enableStreamingTextFade: true),
+    );
+    await tester.pump();
+    await tester.pumpWidget(
+      buildHarness(
+        '$prefix appended',
+        isStreaming: true,
+        enableStreamingTextFade: true,
+      ),
+    );
+    await tester.pump();
+
+    Text tailText() => tester.widget<Text>(
+      find.byWidgetPredicate(
+        (widget) =>
+            widget is Text &&
+            (widget.textSpan?.toPlainText() ?? '') == 'Tail appended',
+      ),
+    );
+
+    final leaves = _textSpanLeaves(tailText().textSpan!).toList();
+    final stable = leaves.where((span) => span.text == 'Tail');
+    final faded = leaves.where((span) => (span.style?.color?.a ?? 1) < 1);
+    check(stable.every((span) => (span.style?.color?.a ?? 1) == 1)).isTrue();
+    check(faded.map((span) => span.text).join()).contains('appended');
+
+    await tester.pump(const Duration(milliseconds: 360));
+    final settled = _textSpanLeaves(tailText().textSpan!).toList();
+    check(settled.every((span) => (span.style?.color?.a ?? 1) == 1)).isTrue();
   });
 
   testWidgets('surrogate-pair boundary never splits mid-emoji while fading', (


### PR DESCRIPTION
## Summary

- prewarm settled Markdown as new rows enter the viewport without starving the timer during continuous scrolling
- avoid redundant viewport geometry work and mounted-row rebuilds
- cap large Markdown tables behind an accessible expand control

## Verification

- iOS Simulator: 510-message performance transcript, 12 settled history flings without a repeated slow-frame pattern
- `flutter test`: 5,559 passed, 4 skipped
- focused chat and Markdown tests: 216 passed
- changed-file analysis: clean
- `git diff --check`: clean

## Known baseline issue

Full `flutter analyze` still reports the existing missing `package:pigeon` dependency in `tool/pigeon_codegen/bin/generate.dart`; none of the changed files report diagnostics.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Improve chat transcript scrolling with row rebuild caching, throttled markdown prewarm, and expandable tables
> - Adds per-row rebuild keys to `ChatTimelineViewport` so mounted rows are cached and only rebuilt when their `sourceIndex` or `rebuildKey` changes; inherited widgets still update via a `Builder` wrapper.
> - Replaces timer-based markdown prewarm with a `MarkdownPrewarmThrottle` (220ms) that coalesces batches and retriggers only when newly visible message IDs appear.
> - Renders large markdown tables with a 20-row preview and expand/collapse toggle via `_ExpandableMarkdownTable`; streaming fade accounts for collapsed rows.
> - Hardens `_mountedRowRectSnapshot` to use `MatrixUtils` transforms in viewport coordinate space and skips redundant metrics callbacks when extents are unchanged.
> - Behavioral Change: `_ChatTimelineViewportState._rowWidgetCache` is cleared on `rowBuilder` identity or owner generation change; stale cached rows across conversation switches are pruned via `_syncTimelineEntries`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 70ed7b1.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Large Markdown tables now show a compact 20-row preview with controls to expand or collapse additional rows.
- **Performance**
  - Chat timelines update more efficiently by rebuilding only rows whose content or configuration changed.
  - Newly visible chat messages are prewarmed automatically for smoother Markdown rendering.
- **Bug Fixes**
  - Prevented overlapping Markdown prewarm timers and ensured pending updates are retained correctly.
  - Improved timeline row reuse and removed stale cached content.
- **Tests**
  - Added coverage for timeline updates, prewarming behavior, and expandable Markdown tables.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->



<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This update improves long-transcript responsiveness by preserving mounted timeline rows when their layout is unchanged, coalescing Markdown prewarming for newly visible messages, and rendering large Markdown tables as expandable previews.

No blocking product failure remains. The change is safe to merge.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

No blocking failure remains.

No accepted blocking findings remain.
</details>


<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Reviewed the chat live-update path by inspecting chat\_timeline\_viewport.dart and chat\_page.dart to verify how history content updates and how a cached row is returned when source index and rebuild key match.
- Reviewed markdown renderer coverage and how the 20-row preview, the fade offset, and the Show more/Show less controls are implemented in the renderer source.
- Attempted to run the markdown-table-regression-harness flutter test; observed flutter: command not found and exit code 127.
- Prepared artifacts from both review streams to support review, aggregating the relevant code excerpts and test run logs for verification.

<a href="https://app.greptile.com/trex/runs/20230190/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (2): Last reviewed commit: ["fix: address scrolling review feedback"](https://github.com/cogwheel0/conduit/commit/70ed7b15d06d7f201fed87459a6e2e96c29579ff) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55972370)</sub>

<!-- /greptile_comment -->