### PR TITLE
fix(markdown): align list bullet markers vertically with text

### DIFF
--- a/lib/shared/widgets/markdown/renderer/block_renderer.dart
+++ b/lib/shared/widgets/markdown/renderer/block_renderer.dart
@@ -940,9 +940,12 @@ class BlockRenderer {
       child: Row(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          SizedBox(
-            width: 24,
-            child: Text(marker, style: style.body, textAlign: TextAlign.center),
+          Padding(
+            padding: const EdgeInsets.only(top: 1.0),
+            child: SizedBox(
+              width: 24,
+              child: Text(marker, style: style.body, textAlign: TextAlign.center),
+            ),
           ),
           Expanded(child: content),
         ],


### PR DESCRIPTION
Исправлено вертикальное позиционирование маркеров списков по базовой линии текста.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix vertical alignment of list bullet markers in `BlockRenderer`
> Wraps the list item marker `SizedBox` (width 24) in a `Padding(top: 1.0)` in the `BlockRenderer` list-item renderer in [block_renderer.dart](https://github.com/cogwheel0/conduit/pull/660/files#diff-cd900651f73e7da261f7378626d3e5da3ad305c7ec5e24f87b39c4c899696b74). This shifts the marker down by 1 logical pixel so bullets and numbers line up with the first line of content text.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7fee9d2.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the vertical alignment of list item markers in rendered Markdown content.
  * Preserved consistent marker width and centered text layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This change adds one logical pixel of top padding around Markdown list markers while preserving their fixed width, typography, centering, and list-content layout.

## T-Rex validation blocked
The required Flutter tool is missing (`flutter: not found`), so the focused Markdown widget test could not render ordered or unordered lists to check marker alignment, clipping, or overflow. No defect was established from the available source comparison.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

No user-impacting defect was identified in the narrowly scoped list-marker layout change.

There are no final findings. Source comparison shows the change only adds one pixel of top padding while retaining the marker dimensions and text configuration; rendered verification could not run because Flutter is unavailable.

**Files Needing Attention:** No files require corrective changes. `lib/shared/widgets/markdown/renderer/block_renderer.dart` should receive a rendered Markdown list check once Flutter is available.
</details>


<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- The focused Flutter test command for test/shared/widgets/markdown/renderer/streaming\_markdown\_widget\_test.dart was attempted and exited with code 127 because the Flutter tool is not installed, blocking validation.
- The validation summary concluded the block is due to the missing Flutter SDK, and described the comparison between the parent and candidate layouts, including a small top padding addition, while noting no security impact in this narrow validation.
- Artifacts were gathered to support review, including the shell-script artifact showing the exact test invocation and two log artifacts with access URLs that document the blocked validation and the comparison notes.

<a href="https://app.greptile.com/trex/runs/20398986/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(markdown): align list bullet markers..."](https://github.com/cogwheel0/conduit/commit/7fee9d2bf2d7614127d0b30a8b1daf6530aaee16) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56302141)</sub>

<!-- /greptile_comment -->