### PR TITLE
fix(notes): prevent metadata bar overlap and wrap chips on compact sc…

### DIFF
--- a/lib/features/notes/views/note_editor_page.dart
+++ b/lib/features/notes/views/note_editor_page.dart
@@ -1599,13 +1599,16 @@ class _NoteEditorPageState extends ConsumerState<NoteEditorPage> {
             if (!_isLoading && _note != null)
               Positioned(
                 top:
-                    MediaQuery.of(context).padding.top +
-                    conduitAdaptiveToolbarHeightOf(context),
-                left: 0,
-                right: 0,
-                child: Padding(
-                  padding: const EdgeInsets.only(bottom: Spacing.xs),
-                  child: Center(child: _buildFloatingMetadataBar(context)),
+                    MediaQuery.paddingOf(context).top +
+                    conduitAdaptiveToolbarHeightOf(context) +
+                    Spacing.xs,
+                left: Spacing.md,
+                right: Spacing.md,
+                child: Center(
+                  child: ConstrainedBox(
+                    constraints: const BoxConstraints(maxWidth: 600),
+                    child: _buildFloatingMetadataBar(context),
+                  ),
                 ),
               ),
             if (!_isLoading && _note != null && !_contentFocusNode.hasFocus)
@@ -2078,9 +2081,10 @@ class _NoteEditorPageState extends ConsumerState<NoteEditorPage> {
   }
 
   Widget _buildEditor(BuildContext context) {
-    final topPadding = MediaQuery.of(context).padding.top;
-    // Adaptive app bar height + metadata bar (~40).
-    final appBarHeight = conduitAdaptiveToolbarHeightOf(context) + 40;
+    final topPadding = MediaQuery.paddingOf(context).top;
+    // Adaptive app bar height + top spacing + metadata bar (~36).
+    final appBarHeight =
+        conduitAdaptiveToolbarHeightOf(context) + Spacing.xs + 36;
 
     // Get attached files
     final files = _note?.data.files ?? [];
@@ -2100,7 +2104,7 @@ class _NoteEditorPageState extends ConsumerState<NoteEditorPage> {
             Spacing.inputPadding,
             topPadding +
                 appBarHeight +
-                Spacing.sm, // Space for floating app bar
+                Spacing.sm, // Space for floating app bar and metadata bar
             Spacing.inputPadding,
             120, // Extra padding for floating buttons
           ),


### PR DESCRIPTION
Устранены наложения плавающей плашки метаданных заметок на заголовок и контент на компактных экранах.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix metadata bar overlap and constrain width to 600 in note editor
> - Adjusts the floating metadata bar in [note_editor_page.dart](https://github.com/cogwheel0/conduit/pull/661/files#diff-78854ea1159ecb3432e03346b97a0fe608a7e37275f5685601fc69ec944c11f4) with horizontal insets (`Spacing.md`), a `ConstrainedBox` (max width 600), and a lower top position (`Spacing.xs`).
> - Recalculates editor content top padding using `MediaQuery.paddingOf(context).top` and `appBarHeight` (toolbar height + `Spacing.xs` + 36 instead of +40).
> - Behavioral Change: The content start position and pull-to-refresh `edgeOffset` shift slightly downward due to the updated padding formula.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d39e4dc.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Improved the note metadata bar layout with centered, wrapping content.
  * Added balanced top spacing and horizontal insets while constraining content to a maximum width.
  * Updated editor spacing to accommodate the metadata bar.
  * Refined pull-to-refresh and content padding for better visual alignment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->



<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The floating note metadata surface is constrained on compact screens, but its date, word-count, and character-count chips remain in a single non-wrapping row. This can make metadata overflow or become unreadable when a narrow device, larger accessibility text, or longer localized labels reduce the available width.

### T-Rex validation blocked
The Flutter tool is missing from the environment, so the focused metadata layout checks could not render the note editor.

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The note editor can present unreadable metadata on compact layouts because the constrained metadata surface does not allow its chip row to wrap.

One user-visible layout failure remains in the note editor.

**Files Needing Attention:** lib/features/notes/views/note_editor_page.dart
</details>


<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex attempted the Flutter layout checks for baseline and compact 320px, 2× text-scale, and long-label configurations but could not start because the flutter tool was not installed or not on PATH, and the command exited with code 127 before any widget tree could render.
- T-Rex completed the requested verification run, but local artifact references were not uploaded, leaving artifacts unavailable for review.

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (2)</h3></summary>

1. General comment 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Wrapping metadata bar can cover the note's first content**

   - **Bug**
     - At compact width with enlarged text, the wrapping metadata surface grows beyond the 40px height used to position the scroll content, so its positioned overlay covers the first content/title region.
   - **Cause**
     - The metadata bar uses an unconstrained-height `Wrap` (`1959-1995`), but `_buildEditor` assumes a constant metadata height of 40px when calculating the scroll view's top padding (`2083-2109`).
   - **Fix**
     - Measure or otherwise share the metadata bar's actual height with the editor padding (for example through layout measurement/state), or constrain the metadata to a guaranteed bounded single-line presentation that matches the reserved height.

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>

2. `lib/features/notes/views/note_editor_page.dart`, line 1967-1994 ([link](https://github.com/cogwheel0/conduit/blob/d39e4dc998d2cd7c548d32212ab8eb4b9bc0f900/lib/features/notes/views/note_editor_page.dart#L1967-L1994)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Metadata row cannot adapt to available width**

   When a compact viewport, enlarged text, or longer localized labels makes the metadata wider than the constrained surface, this non-wrapping `Row` cannot create another run. The result is a horizontal RenderFlex overflow and clipped or unreadable note metadata.

</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (2): Last reviewed commit: ["fix(notes): resolve floating metadata ba..."](https://github.com/cogwheel0/conduit/commit/d39e4dc998d2cd7c548d32212ab8eb4b9bc0f900) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56302196)</sub>

<!-- /greptile_comment -->