### PR TITLE
fix(hermes): reconcile completed runs after idle stream timeout

### DIFF
--- a/lib/features/hermes/services/hermes_api_service.dart
+++ b/lib/features/hermes/services/hermes_api_service.dart
@@ -184,9 +184,20 @@ const int _carriageReturn = 0x0D;
 
 /// A fixed, provider-independent stream failure that is safe to show in UI.
 final class HermesStreamGuardException implements Exception {
-  const HermesStreamGuardException(this.message);
+  const HermesStreamGuardException(
+    this.message, {
+    this.allowsCheckpointRecovery = false,
+  });
 
   final String message;
+
+  /// Whether a caller with a separately pollable run identifier may replace
+  /// this failed SSE transport with a bounded checkpoint lookup.
+  ///
+  /// Resource, shape, and absolute-duration failures remain fail-closed. Only
+  /// an otherwise well-formed stream that stopped producing typed progress is
+  /// eligible, and the recovery request must enforce its own limits.
+  final bool allowsCheckpointRecovery;
 
   @override
   String toString() => 'HermesStreamGuardException: $message';
@@ -232,6 +243,7 @@ Stream<HermesRunEvent> guardHermesEventStream(
         }
         throw const HermesStreamGuardException(
           'The Hermes stream was idle for too long.',
+          allowsCheckpointRecovery: true,
         );
       }
       if (!hasNext) {

--- a/lib/features/hermes/services/hermes_run_transport.dart
+++ b/lib/features/hermes/services/hermes_run_transport.dart
@@ -513,6 +513,18 @@ Future<void> dispatchHermesRun({
     return;
   }
 
+  // The event request has narrower ownership than the durable run. A local
+  // SSE guard must be able to tear down its socket without poisoning the
+  // caller-owned token that also cancels bounded checkpoint recovery.
+  final eventCancelToken = CancelToken();
+  unawaited(
+    runCancelToken.whenCancel.then<void>((_) {
+      if (!eventCancelToken.isCancelled) {
+        eventCancelToken.cancel('Hermes run stopped');
+      }
+    }),
+  );
+
   // Record transport metadata so the stop path can find this run.
   updateMessage((m) {
     final meta = Map<String, dynamic>.from(m.metadata ?? const {});
@@ -529,7 +541,7 @@ Future<void> dispatchHermesRun({
 
   late final StreamSubscription<HermesRunEvent> sub;
   sub = service
-      .runEvents(runId, sessionId: sessionId, cancelToken: runCancelToken)
+      .runEvents(runId, sessionId: sessionId, cancelToken: eventCancelToken)
       .listen(
         (event) {
           // A queued run.cancelled/run.stopped frame may race Conduit's own
@@ -609,22 +621,31 @@ Future<void> dispatchHermesRun({
     }
 
     // The events stream ended without a terminal event and the user didn't
-    // stop — it likely dropped (network blip / app backgrounded). Reconcile the
-    // final result by polling the run instead of leaving the message hung.
+    // stop. Ordinary drops use bounded polling; a semantic idle timeout gets
+    // one authoritative checkpoint lookup before its error is shown.
     if (!sawTerminal &&
         (!runCancelToken.isCancelled ||
             _isActiveHermesProtocolFailure(streamError, runCancelToken))) {
       try {
         final guardedError = streamError;
-        if (_isHermesProtocolFailure(guardedError)) throw guardedError!;
+        final allowsCheckpointRecovery = _allowsHermesCheckpointRecovery(
+          guardedError,
+        );
+        if (_isHermesProtocolFailure(guardedError) &&
+            !allowsCheckpointRecovery) {
+          throw guardedError!;
+        }
         final recovered = await _recoverRunOutput(
           service,
           runId,
           cancelToken: runCancelToken,
-          maxPolls: maxRecoveryPolls,
-          pollInterval: recoveryPollInterval,
+          maxPolls: allowsCheckpointRecovery ? 1 : maxRecoveryPolls,
+          pollInterval: allowsCheckpointRecovery
+              ? Duration.zero
+              : recoveryPollInterval,
         );
         if (recovered == null) return;
+        if (runCancelToken.isCancelled) return;
         if (recovered.text.isNotEmpty) {
           _appendAuthoritativeOutput(
             recovered.text,
@@ -662,6 +683,7 @@ Future<void> dispatchHermesRun({
       }
     }
   } finally {
+    _signalHermesTransportCancellation(eventCancelToken);
     _signalHermesTransportCancellation(runCancelToken);
     _cancelHermesTransportSubscription(
       sub,
@@ -1604,6 +1626,9 @@ String _friendlyError(Object e) {
 
 bool _isHermesProtocolFailure(Object? error) =>
     error is HermesStreamGuardException || error is FormatException;
+
+bool _allowsHermesCheckpointRecovery(Object? error) =>
+    error is HermesStreamGuardException && error.allowsCheckpointRecovery;
 
 bool _isActiveHermesProtocolFailure(Object? error, CancelToken cancelToken) =>
     _isHermesProtocolFailure(error) &&

--- a/test/features/hermes/hermes_api_service_test.dart
+++ b/test/features/hermes/hermes_api_service_test.dart
@@ -733,11 +733,13 @@ void main() {
               cancelToken,
             ).timeout(const Duration(seconds: 1)),
             throwsA(
-              isA<HermesStreamGuardException>().having(
-                (error) => error.message,
-                'message',
-                contains('idle'),
-              ),
+              isA<HermesStreamGuardException>()
+                  .having((error) => error.message, 'message', contains('idle'))
+                  .having(
+                    (error) => error.allowsCheckpointRecovery,
+                    'allowsCheckpointRecovery',
+                    isTrue,
+                  ),
             ),
           );
 

--- a/test/features/hermes/hermes_run_transport_test.dart
+++ b/test/features/hermes/hermes_run_transport_test.dart
@@ -98,6 +98,7 @@ class _FakeHermesApiService extends HermesApiService {
   List<Map<String, dynamic>>? lastResponseConversationHistory;
   String? lastResponseInstructions;
   CancelToken? lastResponseCancelToken;
+  CancelToken? lastRunEventsCancelToken;
   List<Map<String, dynamic>>? lastRunConversationHistory;
 
   @override
@@ -128,6 +129,7 @@ class _FakeHermesApiService extends HermesApiService {
     String? sessionId,
     CancelToken? cancelToken,
   }) {
+    lastRunEventsCancelToken = cancelToken;
     final streamError = runStreamError;
     final source = streamError == null
         ? (eventsOverride ?? Stream<HermesRunEvent>.fromIterable(events))
@@ -2112,6 +2114,136 @@ void main() {
           .equals('Hermes returned an invalid response.');
     },
   );
+
+  test('recovers a completed run after the event stream idles', () async {
+    final events = StreamController<HermesRunEvent>();
+    addTearDown(events.close);
+    events.add(const HermesTokenDelta('Recovered'));
+    final runCancelToken = CancelToken();
+    final fake = _FakeHermesApiService(
+      const [],
+      eventsOverride: events.stream,
+      eventStreamLimits: const HermesStreamLimits(
+        idleTimeout: Duration(milliseconds: 10),
+        maxDuration: Duration(seconds: 1),
+      ),
+      runResult: const {'status': 'completed', 'output': 'Recovered answer'},
+    );
+    final content = StringBuffer();
+    var message = ChatMessage(
+      id: 'm',
+      role: 'assistant',
+      content: '',
+      timestamp: DateTime.fromMillisecondsSinceEpoch(0),
+    );
+
+    await dispatchHermesRun(
+      service: fake,
+      registry: HermesRunRegistry(),
+      assistantMessageId: message.id,
+      input: 'hello',
+      cancelToken: runCancelToken,
+      recoveryPollInterval: Duration.zero,
+      appendContent: content.write,
+      appendStatus: (_) {},
+      updateMessage: (updater) => message = updater(message),
+      finishStreaming: () {},
+      completeStreamingUi: () {},
+    );
+
+    check(fake.getRunCalls).equals(1);
+    check(content.toString()).equals('Recovered answer');
+    check(message.error).isNull();
+    check(fake.lastRunEventsCancelToken).isNotNull();
+    check(identical(fake.lastRunEventsCancelToken, runCancelToken)).isFalse();
+  });
+
+  test('retains the idle error when the run is still active', () async {
+    final events = StreamController<HermesRunEvent>();
+    addTearDown(events.close);
+    final fake = _FakeHermesApiService(
+      const [],
+      eventsOverride: events.stream,
+      eventStreamLimits: const HermesStreamLimits(
+        idleTimeout: Duration(milliseconds: 10),
+        maxDuration: Duration(seconds: 1),
+      ),
+      runResult: const {'status': 'running', 'output': ''},
+    );
+    var message = ChatMessage(
+      id: 'm',
+      role: 'assistant',
+      content: '',
+      timestamp: DateTime.fromMillisecondsSinceEpoch(0),
+    );
+
+    await dispatchHermesRun(
+      service: fake,
+      registry: HermesRunRegistry(),
+      assistantMessageId: message.id,
+      input: 'hello',
+      recoveryPollInterval: Duration.zero,
+      appendContent: (_) {},
+      appendStatus: (_) {},
+      updateMessage: (updater) => message = updater(message),
+      finishStreaming: () {},
+      completeStreamingUi: () {},
+    );
+
+    check(fake.getRunCalls).equals(1);
+    check(message.error?.content)
+        .equals('The Hermes stream was idle for too long.');
+  });
+
+  test('Stop wins while an idle stream recovery is in flight', () async {
+    final events = StreamController<HermesRunEvent>();
+    addTearDown(events.close);
+    final getRunGate = Completer<Map<String, dynamic>>();
+    final registry = HermesRunRegistry();
+    final fake = _FakeHermesApiService(
+      const [],
+      eventsOverride: events.stream,
+      eventStreamLimits: const HermesStreamLimits(
+        idleTimeout: Duration(milliseconds: 10),
+        maxDuration: Duration(seconds: 1),
+      ),
+      getRunGate: getRunGate,
+    );
+    final content = StringBuffer();
+    var message = ChatMessage(
+      id: 'm',
+      role: 'assistant',
+      content: '',
+      timestamp: DateTime.fromMillisecondsSinceEpoch(0),
+    );
+    final dispatch = dispatchHermesRun(
+      service: fake,
+      registry: registry,
+      assistantMessageId: message.id,
+      input: 'hello',
+      recoveryPollInterval: Duration.zero,
+      appendContent: content.write,
+      appendStatus: (_) {},
+      updateMessage: (updater) => message = updater(message),
+      finishStreaming: () {},
+      completeStreamingUi: () {},
+    );
+    while (fake.getRunCalls == 0) {
+      await Future<void>.delayed(Duration.zero);
+    }
+
+    final stop = registry.cancel(legacyHermesRunKey(message.id));
+    check(stop).isNotNull();
+    getRunGate.complete(const {
+      'status': 'completed',
+      'output': 'Stale answer',
+    });
+    await stop;
+    await dispatch;
+
+    check(content.toString()).isEmpty();
+    check(message.error).isNull();
+  });
 
   test('local run cancellation wins over queued provider failures', () async {
     final listened = Completer<void>();


### PR DESCRIPTION
## Summary

- distinguish recoverable typed-event inactivity from hard Hermes stream guard failures
- use a separate SSE cancellation token so one bounded run-status lookup remains available after idle
- reconcile a completed run from `GET /v1/runs/{id}` without duplicating streamed output
- preserve the idle error when the run is still active, and keep protocol and resource failures fail-closed

## Why

A Hermes run can complete server-side while Conduit misses the terminal SSE event, for example during a mobile lifecycle transition or stream cleanup. Conduit currently classifies its five-minute parsed-event idle guard as a hard protocol failure. The result can be a completed response followed by `The Hermes stream was idle for too long.`

This keeps the existing five-minute liveness boundary and all resource guards. After idle, Conduit performs one bounded `GET /v1/runs/{id}` checkpoint lookup. A completed run reconciles authoritative output. A run that remains active preserves the original idle error. Stop and run supersession remain authoritative.

## Tests

- `flutter test test/features/hermes/hermes_api_service_test.dart test/features/hermes/hermes_run_transport_test.dart` (127 passed)
- `flutter analyze` (no issues)
- `flutter test` (5,563 passed, 4 skipped, 2 failed)

The two full-suite failures also reproduce on unchanged `main`:

- `OpenWebUI auth epoch change aborts gated direct attachment preflight` times out waiting for an unrelated condition
- `note rows show last-edited metadata instead of descriptions` expects Jan 1 but formats Dec 31 in the local timezone


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix Hermes to reconcile completed runs after idle stream timeout via checkpoint recovery
> - Adds `allowsCheckpointRecovery` flag to `HermesStreamGuardException`, set to `true` when the idle timeout fires in [hermes_api_service.dart](https://github.com/cogwheel0/conduit/pull/663/files#diff-6a6551548824d6af121e195ad6e7262cdb81daf2bef071a10b550af7b7b1d064)
> - Introduces a dedicated `eventCancelToken` in `dispatchHermesRun` ([hermes_run_transport.dart](https://github.com/cogwheel0/conduit/pull/663/files#diff-f9f0d711187d92fc6a6fe7b5c45b0fb845eb75896caa6ae2628259cc4b38b397)) so the SSE socket can be torn down independently of the durable run token
> - On idle timeout, performs a single immediate checkpoint lookup (`_recoverRunOutput` with `maxPolls=1`, `Duration.zero`) instead of the normal bounded polling; protocol failures that disallow recovery are rethrown
> - Risk: the new `_allowsHermesCheckpointRecovery` helper gates recovery on the exception flag — if a future throw site forgets to set `allowsCheckpointRecovery`, idle drops will fall back to bounded polling rather than the single-checkpoint fast path
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2bf6b39.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved recovery when a run’s event stream becomes idle by checking for a completed run.
  * Preserved the original error when the run remains active or recovery is not allowed.
  * Ensured a user-initiated stop takes precedence during recovery.
  * Improved cancellation handling for event-stream subscriptions and recovery checks.

* **Tests**
  * Added coverage for successful idle-stream recovery, active runs, and stop behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This change separates the SSE request cancellation token from the durable run token so an idle event stream can be reconciled through a bounded checkpoint lookup. It restores completed output from that checkpoint, retains the idle-timeout error when the run is still active, and prevents a stopped run from publishing late recovery output.

### T-Rex validation blocked
The focused Flutter transport tests could not execute because the required Flutter/Dart tools (`flutter`, `dart`, and `fvm`) are missing and required Git submodules are uninitialized. The attempted test command exited with status 127 because `flutter` is not installed, so no runtime behavior was observed.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

No defect is reported from the reviewed Hermes recovery changes.

The changed code and focused test cases align around separate cancellation ownership, one checkpoint lookup after idle timeout, authoritative output reconciliation, and stop-race suppression. Runtime confirmation was unavailable because the Flutter/Dart tools are not installed.

**Files Needing Attention:** Runtime coverage remains most important for lib/features/hermes/services/hermes_run_transport.dart and test/features/hermes/hermes_run_transport_test.dart once a Flutter SDK and the required submodules are available.
</details>


<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- The environment prerequisite check and the focused idle-recovery command were run, and the run exited with status 127 because flutter is not installed and related submodules are uninitialized.
- The before-state log and the exact validation script were identified, and the subsequent after-state run failed with exit 127 due to flutter not found.

<a href="https://app.greptile.com/trex/runs/20447306/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(hermes): recover completed runs afte..."](https://github.com/cogwheel0/conduit/commit/2bf6b3927e2a811ef1fa451e424e8c648ad03dbc) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56394162)</sub>

<!-- /greptile_comment -->