### PR TITLE
fix(chat): add skill mention autocomplete

### DIFF
--- a/lib/features/chat/widgets/mention_text_controller.dart
+++ b/lib/features/chat/widgets/mention_text_controller.dart
@@ -133,7 +133,8 @@ class MentionTextEditingController extends TextEditingController {
 
     final List<MentionData> updated = <MentionData>[];
     for (final MentionData m in _mentionData) {
-      if (changeStart > m.range.end) {
+      if (changeStart > m.range.end ||
+          (changeStart == m.range.end && delta <= 0)) {
         // After this mention — keep as-is.
         updated.add(m);
       } else if (changeStart <= m.range.start) {

--- a/lib/features/chat/widgets/mention_text_controller.dart
+++ b/lib/features/chat/widgets/mention_text_controller.dart
@@ -1,5 +1,7 @@
 import 'package:material_ui/material_ui.dart';
 
+enum MentionKind { entity, skill }
+
 /// Metadata for a tracked mention (range + identity).
 class MentionData {
   MentionData({
@@ -7,6 +9,7 @@ class MentionData {
     required this.idType,
     required this.id,
     required this.label,
+    required this.kind,
   });
 
   TextRange range;
@@ -19,6 +22,8 @@ class MentionData {
 
   /// Display label (e.g. model name).
   final String label;
+
+  final MentionKind kind;
 }
 
 /// A [TextEditingController] that renders tracked `@mention` spans
@@ -53,6 +58,7 @@ class MentionTextEditingController extends TextEditingController {
     String idType = 'M',
     String id = '',
     String label = '',
+    MentionKind kind = MentionKind.entity,
   }) {
     _mentionData
       ..add(
@@ -61,6 +67,7 @@ class MentionTextEditingController extends TextEditingController {
           idType: idType,
           id: id,
           label: label,
+          kind: kind,
         ),
       )
       ..sort((a, b) => a.range.start.compareTo(b.range.start));
@@ -86,7 +93,11 @@ class MentionTextEditingController extends TextEditingController {
       if (start == end) continue;
 
       buf.write(plainText.substring(cursor, start));
-      buf.write('<@${m.idType}:${m.id}|${m.label}>');
+      buf.write(
+        m.kind == MentionKind.skill
+            ? '<\$${m.id}|${m.label}>'
+            : '<@${m.idType}:${m.id}|${m.label}>',
+      );
       cursor = end;
     }
 

--- a/lib/features/chat/widgets/mention_text_controller.dart
+++ b/lib/features/chat/widgets/mention_text_controller.dart
@@ -133,8 +133,13 @@ class MentionTextEditingController extends TextEditingController {
 
     final List<MentionData> updated = <MentionData>[];
     for (final MentionData m in _mentionData) {
+      final boundaryInsertionIsDelimiter =
+          changeStart == m.range.end &&
+          delta > 0 &&
+          newText.substring(changeStart, changeStart + delta).trim().isEmpty;
       if (changeStart > m.range.end ||
-          (changeStart == m.range.end && delta <= 0)) {
+          (changeStart == m.range.end &&
+              (delta <= 0 || boundaryInsertionIsDelimiter))) {
         // After this mention — keep as-is.
         updated.add(m);
       } else if (changeStart <= m.range.start) {

--- a/lib/features/chat/widgets/mention_text_controller.dart
+++ b/lib/features/chat/widgets/mention_text_controller.dart
@@ -133,7 +133,7 @@ class MentionTextEditingController extends TextEditingController {
 
     final List<MentionData> updated = <MentionData>[];
     for (final MentionData m in _mentionData) {
-      if (changeStart >= m.range.end) {
+      if (changeStart > m.range.end) {
         // After this mention — keep as-is.
         updated.add(m);
       } else if (changeStart <= m.range.start) {

--- a/lib/features/chat/widgets/modern_chat_input.dart
+++ b/lib/features/chat/widgets/modern_chat_input.dart
@@ -1453,7 +1453,10 @@ class _ModernChatInputState extends ConsumerState<ModernChatInput>
   ) async {
     final api = ref.read(apiServiceProvider);
     final token = ref.read(authTokenProvider3);
-    if (api == null || !_openWebUiSkillsAvailable) return;
+    if (api == null || !_openWebUiSkillsAvailable) {
+      if (mounted && !_isDeactivated) _hidePromptOverlay();
+      return;
+    }
 
     try {
       final response = await api.getWorkspaceSkills(
@@ -1464,7 +1467,10 @@ class _ModernChatInputState extends ConsumerState<ModernChatInput>
         return;
       }
       final skills = response.items
-          .where((skill) => skill.id.isNotEmpty && skill.name.isNotEmpty)
+          .where(
+            (skill) =>
+                skill.isActive && skill.id.isNotEmpty && skill.name.isNotEmpty,
+          )
           .toList(growable: false);
       setState(() {
         _skillSuggestions = AsyncData(skills);
@@ -2079,6 +2085,12 @@ class _ModernChatInputState extends ConsumerState<ModernChatInput>
     return !(model != null &&
         isHermesModel(model) &&
         _currentPromptCommand.startsWith('#'));
+  }
+
+  bool get _canConfirmPromptSelection {
+    if (!_shouldShowPromptOverlay) return false;
+    if (!_currentPromptCommand.startsWith('\$')) return true;
+    return _skillSuggestions.asData?.value.isNotEmpty ?? false;
   }
 
   Future<void> _openKnowledgePicker({String? initialBaseId}) async {
@@ -3739,7 +3751,7 @@ class _ModernChatInputState extends ConsumerState<ModernChatInput>
           actions: <Type, Action<Intent>>{
             SendMessageIntent: CallbackAction<SendMessageIntent>(
               onInvoke: (intent) {
-                if (_shouldShowPromptOverlay) {
+                if (_canConfirmPromptSelection) {
                   _confirmPromptSelection();
                   return null;
                 }

--- a/lib/features/chat/widgets/modern_chat_input.dart
+++ b/lib/features/chat/widgets/modern_chat_input.dart
@@ -35,6 +35,7 @@ import '../../hermes/models/hermes_config.dart';
 import '../../hermes/providers/hermes_providers.dart';
 import '../../hermes/services/hermes_local_document_service.dart';
 import '../../direct_connections/direct_connections.dart';
+import '../../workspace/models/workspace_resources.dart';
 import '../../../core/models/tool.dart';
 import '../../../core/models/model.dart';
 import '../../../core/models/prompt.dart';
@@ -70,6 +71,7 @@ import 'composer_overflow_menu.dart';
 import 'mention_text_controller.dart';
 import 'model_suggestion_overlay.dart';
 import 'prompt_suggestion_overlay.dart';
+import 'skill_suggestion_overlay.dart';
 
 /// Native platform views are recomposited for every animated cursor-opacity
 /// frame. Keep the normal animated caret everywhere else, but use a discrete
@@ -480,6 +482,7 @@ class _ModernChatInputState extends ConsumerState<ModernChatInput>
   VoiceInputService? _voiceService;
   StreamSubscription<String>? _textSub;
   Timer? _contextSuggestionDebounce;
+  Timer? _skillSuggestionDebounce;
   String _baseTextAtStart = '';
   bool _isDeactivated = false;
   int _lastHandledFocusTick = 0;
@@ -493,6 +496,10 @@ class _ModernChatInputState extends ConsumerState<ModernChatInput>
   List<_ComposerContextSuggestion> _contextSuggestions =
       const <_ComposerContextSuggestion>[];
   int _contextSuggestionRequestId = 0;
+  int _skillSuggestionRequestId = 0;
+  AsyncValue<List<WorkspaceSkillSummary>> _skillSuggestions = const AsyncData(
+    <WorkspaceSkillSummary>[],
+  );
   bool _isNativeAttachmentPanelVisible = false;
   bool _isFallbackAttachmentPanelVisible = false;
   bool _fallbackPanelReplacedKeyboard = false;
@@ -622,6 +629,7 @@ class _ModernChatInputState extends ConsumerState<ModernChatInput>
     _keyboardAttachmentSubscription?.cancel();
     _textSub?.cancel();
     _contextSuggestionDebounce?.cancel();
+    _skillSuggestionDebounce?.cancel();
     if (!kIsWeb && Platform.isIOS) {
       unawaited(IosKeyboardAttachmentBridge.instance.hide());
     }
@@ -1218,6 +1226,7 @@ class _ModernChatInputState extends ConsumerState<ModernChatInput>
       widget.enabled,
     );
     final bool isContextTrigger = match?.command.startsWith('#') ?? false;
+    final bool isSkillTrigger = match?.command.startsWith('\$') ?? false;
     final bool shouldShow = match != null;
     final bool wasShowing = _showPromptOverlay;
     final String previousCommand = _currentPromptCommand;
@@ -1262,8 +1271,12 @@ class _ModernChatInputState extends ConsumerState<ModernChatInput>
         if (!isContextTrigger) {
           _clearContextSuggestions();
         }
+        if (!isSkillTrigger) {
+          _clearSkillSuggestions();
+        }
       } else {
         _clearContextSuggestions();
+        _clearSkillSuggestions();
         _currentPromptCommand = '';
         _currentPromptRange = null;
         _promptSelectionIndex = 0;
@@ -1276,6 +1289,13 @@ class _ModernChatInputState extends ConsumerState<ModernChatInput>
     } else {
       _contextSuggestionDebounce?.cancel();
       _contextSuggestionDebounce = null;
+    }
+
+    if (isSkillTrigger) {
+      _scheduleSkillSuggestionSearch(match!.command);
+    } else {
+      _skillSuggestionDebounce?.cancel();
+      _skillSuggestionDebounce = null;
     }
 
     if (!wasShowing && shouldShow) {
@@ -1308,6 +1328,13 @@ class _ModernChatInputState extends ConsumerState<ModernChatInput>
       ? ref.read(hermesSkillPromptsProvider).value
       : ref.read(promptsListProvider).value;
 
+  bool get _openWebUiSkillsAvailable {
+    if (!ref.read(openWebUiAccountAvailableProvider)) return false;
+    final model = ref.read(selectedModelProvider);
+    return model == null ||
+        (!isHermesModel(model) && !isLocallyMintedDirectModel(model));
+  }
+
   PromptCommandMatch? _resolvePromptCommand(
     String text,
     TextSelection selection,
@@ -1333,7 +1360,12 @@ class _ModernChatInputState extends ConsumerState<ModernChatInput>
     if (candidate.isEmpty ||
         !(candidate.startsWith('/') ||
             candidate.startsWith('#') ||
-            candidate.startsWith('@'))) {
+            candidate.startsWith('@') ||
+            candidate.startsWith('\$'))) {
+      return null;
+    }
+
+    if (candidate.startsWith('\$') && !_openWebUiSkillsAvailable) {
       return null;
     }
 
@@ -1391,6 +1423,85 @@ class _ModernChatInputState extends ConsumerState<ModernChatInput>
               m.id.toLowerCase().contains(searchQuery),
         )
         .toList();
+  }
+
+  void _clearSkillSuggestions() {
+    _skillSuggestionDebounce?.cancel();
+    _skillSuggestionDebounce = null;
+    _skillSuggestionRequestId++;
+    _skillSuggestions = const AsyncData(<WorkspaceSkillSummary>[]);
+  }
+
+  void _scheduleSkillSuggestionSearch(String command) {
+    _skillSuggestionDebounce?.cancel();
+    final requestId = ++_skillSuggestionRequestId;
+    setState(() {
+      _skillSuggestions = const AsyncLoading();
+      _promptSelectionIndex = 0;
+    });
+
+    final query = command.length > 1 ? command.substring(1).trim() : '';
+    _skillSuggestionDebounce = Timer(_contextSuggestionDelay, () {
+      unawaited(_loadSkillSuggestions(command, query, requestId));
+    });
+  }
+
+  Future<void> _loadSkillSuggestions(
+    String command,
+    String query,
+    int requestId,
+  ) async {
+    final api = ref.read(apiServiceProvider);
+    final token = ref.read(authTokenProvider3);
+    if (api == null || !_openWebUiSkillsAvailable) return;
+
+    try {
+      final response = await api.getWorkspaceSkills(
+        query: query.isEmpty ? null : query,
+        page: 1,
+      );
+      if (!_skillSuggestionRequestIsCurrent(command, requestId, api, token)) {
+        return;
+      }
+      final skills = response.items
+          .where((skill) => skill.id.isNotEmpty && skill.name.isNotEmpty)
+          .toList(growable: false);
+      setState(() {
+        _skillSuggestions = AsyncData(skills);
+        _promptSelectionIndex = skills.isEmpty
+            ? 0
+            : _promptSelectionIndex.clamp(0, skills.length - 1);
+      });
+    } catch (error, stackTrace) {
+      if (!_skillSuggestionRequestIsCurrent(command, requestId, api, token)) {
+        return;
+      }
+      DebugLogger.warning(
+        'skill suggestion search failed',
+        scope: 'chat/skills',
+        data: {'errorType': error.runtimeType.toString()},
+      );
+      setState(() {
+        _skillSuggestions = AsyncError(error, stackTrace);
+        _promptSelectionIndex = 0;
+      });
+    }
+  }
+
+  bool _skillSuggestionRequestIsCurrent(
+    String command,
+    int requestId,
+    Object api,
+    String? token,
+  ) {
+    return mounted &&
+        !_isDeactivated &&
+        requestId == _skillSuggestionRequestId &&
+        _currentPromptCommand == command &&
+        _currentPromptCommand.startsWith('\$') &&
+        identical(ref.read(apiServiceProvider), api) &&
+        ref.read(authTokenProvider3) == token &&
+        _openWebUiSkillsAvailable;
   }
 
   void _clearContextSuggestions() {
@@ -1704,6 +1815,40 @@ class _ModernChatInputState extends ConsumerState<ModernChatInput>
     });
   }
 
+  void _applySkill(WorkspaceSkillSummary skill) {
+    final range = _currentPromptRange;
+    if (range == null) return;
+
+    final text = _controller.text;
+    final before = text.substring(0, range.start);
+    final after = text.substring(range.end);
+    final mention = '\$${skill.name} ';
+    final newText = '$before$mention$after';
+    final newCursor = before.length + mention.length;
+
+    _controller.value = TextEditingValue(
+      text: newText,
+      selection: TextSelection.collapsed(offset: newCursor),
+    );
+    _controller.addMention(
+      range.start,
+      range.start + mention.trimRight().length,
+      id: skill.id,
+      label: skill.name,
+      kind: MentionKind.skill,
+    );
+
+    setState(() {
+      _hasText = newText.trim().isNotEmpty;
+      _clearSkillSuggestions();
+      _showPromptOverlay = false;
+      _currentPromptCommand = '';
+      _currentPromptRange = null;
+      _promptSelectionIndex = 0;
+    });
+    _ensureFocusedIfEnabled();
+  }
+
   void _movePromptSelection(int delta) {
     if (_currentPromptCommand.startsWith('#')) {
       final int itemCount = _contextSuggestions.length;
@@ -1725,7 +1870,9 @@ class _ModernChatInputState extends ConsumerState<ModernChatInput>
 
     // Determine filtered list length based on trigger type.
     final int filteredLength;
-    if (_currentPromptCommand.startsWith('@')) {
+    if (_currentPromptCommand.startsWith('\$')) {
+      filteredLength = _skillSuggestions.asData?.value.length ?? 0;
+    } else if (_currentPromptCommand.startsWith('@')) {
       final List<Model>? models = ref.read(modelsProvider).value;
       if (models == null || models.isEmpty) return;
       filteredLength = _filterModels(models).length;
@@ -1771,6 +1918,15 @@ class _ModernChatInputState extends ConsumerState<ModernChatInput>
       if (filtered.isEmpty) return;
       int index = _promptSelectionIndex.clamp(0, filtered.length - 1);
       _applyModel(filtered[index]);
+      return;
+    }
+
+    if (_currentPromptCommand.startsWith('\$')) {
+      final skills =
+          _skillSuggestions.asData?.value ?? const <WorkspaceSkillSummary>[];
+      if (skills.isEmpty) return;
+      final index = _promptSelectionIndex.clamp(0, skills.length - 1);
+      _applySkill(skills[index]);
       return;
     }
 
@@ -1906,6 +2062,7 @@ class _ModernChatInputState extends ConsumerState<ModernChatInput>
     if (!_showPromptOverlay) return;
     setState(() {
       _clearContextSuggestions();
+      _clearSkillSuggestions();
       _showPromptOverlay = false;
       _currentPromptCommand = '';
       _currentPromptRange = null;
@@ -1915,6 +2072,9 @@ class _ModernChatInputState extends ConsumerState<ModernChatInput>
 
   bool get _shouldShowPromptOverlay {
     if (!_showPromptOverlay) return false;
+    if (_currentPromptCommand.startsWith('\$')) {
+      return _openWebUiSkillsAvailable;
+    }
     final model = ref.read(selectedModelProvider);
     return !(model != null &&
         isHermesModel(model) &&
@@ -2180,6 +2340,13 @@ class _ModernChatInputState extends ConsumerState<ModernChatInput>
         filteredModels: _filterModels,
         selectionIndex: _promptSelectionIndex,
         onModelSelected: _applyModel,
+      );
+    }
+    if (_currentPromptCommand.startsWith('\$')) {
+      return SkillSuggestionOverlay(
+        skills: _skillSuggestions,
+        selectionIndex: _promptSelectionIndex,
+        onSkillSelected: _applySkill,
       );
     }
     return PromptSuggestionOverlay(

--- a/lib/features/chat/widgets/skill_suggestion_overlay.dart
+++ b/lib/features/chat/widgets/skill_suggestion_overlay.dart
@@ -1,0 +1,178 @@
+import 'package:conduit/features/workspace/models/workspace_resources.dart';
+import 'package:conduit/l10n/app_localizations.dart';
+import 'package:conduit/shared/theme/theme_extensions.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:material_ui/material_ui.dart';
+
+class SkillSuggestionOverlay extends StatelessWidget {
+  const SkillSuggestionOverlay({
+    required this.skills,
+    required this.selectionIndex,
+    required this.onSkillSelected,
+    super.key,
+  });
+
+  final AsyncValue<List<WorkspaceSkillSummary>> skills;
+  final int selectionIndex;
+  final ValueChanged<WorkspaceSkillSummary> onSkillSelected;
+
+  @override
+  Widget build(BuildContext context) {
+    final brightness = Theme.of(context).brightness;
+    final borderColor = context.conduitTheme.cardBorder.withValues(
+      alpha: brightness == Brightness.dark ? 0.6 : 0.4,
+    );
+
+    return Container(
+      decoration: BoxDecoration(
+        color: context.conduitTheme.cardBackground,
+        borderRadius: BorderRadius.circular(AppBorderRadius.card),
+        border: Border.all(color: borderColor, width: BorderWidth.thin),
+        boxShadow: [
+          BoxShadow(
+            color: context.conduitTheme.cardShadow.withValues(
+              alpha: brightness == Brightness.dark ? 0.28 : 0.16,
+            ),
+            blurRadius: 22,
+            offset: const Offset(0, 8),
+            spreadRadius: -4,
+          ),
+        ],
+      ),
+      child: skills.when(
+        data: (items) {
+          if (items.isEmpty) {
+            return _SkillOverlayPlaceholder(
+              leading: Icon(
+                Icons.inbox_outlined,
+                size: IconSize.medium,
+                color: context.conduitTheme.textSecondary.withValues(
+                  alpha: Alpha.medium,
+                ),
+              ),
+              message: AppLocalizations.of(context)!.noResults,
+            );
+          }
+
+          final activeIndex = selectionIndex.clamp(0, items.length - 1);
+          return ConstrainedBox(
+            constraints: const BoxConstraints(maxHeight: 240),
+            child: ListView.separated(
+              padding: const EdgeInsets.symmetric(vertical: Spacing.xs),
+              shrinkWrap: true,
+              physics: const ClampingScrollPhysics(),
+              itemCount: items.length,
+              separatorBuilder: (_, _) => const SizedBox(height: Spacing.xxs),
+              itemBuilder: (context, index) {
+                final skill = items[index];
+                final selected = index == activeIndex;
+                return Semantics(
+                  button: true,
+                  selected: selected,
+                  label: '${skill.name}, ${skill.id}',
+                  child: GestureDetector(
+                    key: ValueKey('skill-suggestion-${skill.id}'),
+                    behavior: HitTestBehavior.opaque,
+                    onTap: () => onSkillSelected(skill),
+                    child: Container(
+                      decoration: BoxDecoration(
+                        color: selected
+                            ? context.conduitTheme.navigationSelectedBackground
+                                  .withValues(alpha: 0.4)
+                            : Colors.transparent,
+                        borderRadius: BorderRadius.circular(
+                          AppBorderRadius.card,
+                        ),
+                      ),
+                      padding: const EdgeInsets.symmetric(
+                        horizontal: Spacing.sm,
+                        vertical: Spacing.xs,
+                      ),
+                      child: Row(
+                        children: [
+                          Expanded(
+                            child: Text(
+                              skill.name,
+                              maxLines: 1,
+                              overflow: TextOverflow.ellipsis,
+                              style: Theme.of(context).textTheme.bodyMedium
+                                  ?.copyWith(
+                                    fontWeight: FontWeight.w600,
+                                    color: context.conduitTheme.textPrimary,
+                                  ),
+                            ),
+                          ),
+                          const SizedBox(width: Spacing.sm),
+                          Flexible(
+                            child: Text(
+                              skill.id,
+                              maxLines: 1,
+                              overflow: TextOverflow.ellipsis,
+                              style: Theme.of(context).textTheme.bodySmall
+                                  ?.copyWith(
+                                    color: context.conduitTheme.textSecondary,
+                                  ),
+                            ),
+                          ),
+                        ],
+                      ),
+                    ),
+                  ),
+                );
+              },
+            ),
+          );
+        },
+        loading: () => _SkillOverlayPlaceholder(
+          leading: SizedBox.square(
+            dimension: IconSize.large,
+            child: CircularProgressIndicator(
+              strokeWidth: BorderWidth.regular,
+              color: context.conduitTheme.loadingIndicator,
+            ),
+          ),
+        ),
+        error: (_, _) => _SkillOverlayPlaceholder(
+          leading: Icon(
+            Icons.error_outline,
+            size: IconSize.medium,
+            color: context.conduitTheme.error,
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _SkillOverlayPlaceholder extends StatelessWidget {
+  const _SkillOverlayPlaceholder({required this.leading, this.message});
+
+  final Widget leading;
+  final String? message;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(
+        horizontal: Spacing.sm,
+        vertical: Spacing.md,
+      ),
+      child: Row(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          leading,
+          if (message != null) ...[
+            const SizedBox(width: Spacing.sm),
+            Flexible(
+              child: Text(
+                message!,
+                style: Theme.of(context).textTheme.bodySmall
+                    ?.copyWith(color: context.conduitTheme.textSecondary),
+              ),
+            ),
+          ],
+        ],
+      ),
+    );
+  }
+}

--- a/test/features/chat/widgets/modern_chat_input_skill_test.dart
+++ b/test/features/chat/widgets/modern_chat_input_skill_test.dart
@@ -125,6 +125,28 @@ void main() {
     expect(find.text('Disabled Skill'), findsNothing);
   });
 
+  testWidgets('editing the end of a skill name removes its identity', (
+    tester,
+  ) async {
+    final api = _SkillApi((_) async => _skills(_codeReview));
+    final sent = <String>[];
+    await _pumpComposer(tester, api: api, onSend: sent.add);
+
+    await tester.enterText(find.byType(TextField), '\$code');
+    await tester.pump(const Duration(milliseconds: 300));
+    await tester.pump();
+    await tester.tap(
+      find.byKey(const ValueKey('skill-suggestion-code-review')),
+    );
+    await tester.pump();
+
+    await tester.enterText(find.byType(TextField), '\$Code ReviewX ');
+    await tester.tap(find.byKey(const ValueKey('primary-btn-send')));
+    await tester.pump();
+
+    expect(sent, ['\$Code ReviewX']);
+  });
+
   testWidgets('Enter sends while skill suggestions are still loading', (
     tester,
   ) async {

--- a/test/features/chat/widgets/modern_chat_input_skill_test.dart
+++ b/test/features/chat/widgets/modern_chat_input_skill_test.dart
@@ -147,6 +147,28 @@ void main() {
     expect(sent, ['\$Code ReviewX']);
   });
 
+  testWidgets('deleting the skill delimiter preserves its identity', (
+    tester,
+  ) async {
+    final api = _SkillApi((_) async => _skills(_codeReview));
+    final sent = <String>[];
+    await _pumpComposer(tester, api: api, onSend: sent.add);
+
+    await tester.enterText(find.byType(TextField), '\$code');
+    await tester.pump(const Duration(milliseconds: 300));
+    await tester.pump();
+    await tester.tap(
+      find.byKey(const ValueKey('skill-suggestion-code-review')),
+    );
+    await tester.pump();
+
+    await tester.enterText(find.byType(TextField), '\$Code Review');
+    await tester.tap(find.byKey(const ValueKey('primary-btn-send')));
+    await tester.pump();
+
+    expect(sent, ['<\$code-review|Code Review>']);
+  });
+
   testWidgets('Enter sends while skill suggestions are still loading', (
     tester,
   ) async {

--- a/test/features/chat/widgets/modern_chat_input_skill_test.dart
+++ b/test/features/chat/widgets/modern_chat_input_skill_test.dart
@@ -100,6 +100,84 @@ void main() {
     expect(find.text('First Skill'), findsNothing);
   });
 
+  testWidgets('inactive skills are not selectable', (tester) async {
+    final api = _SkillApi(
+      (_) async => const WorkspacePagedResponse(
+        items: [
+          _codeReview,
+          WorkspaceSkillSummary(
+            id: 'disabled',
+            name: 'Disabled Skill',
+            userId: 'user',
+            isActive: false,
+          ),
+        ],
+        total: 2,
+      ),
+    );
+    await _pumpComposer(tester, api: api);
+
+    await tester.enterText(find.byType(TextField), '\$');
+    await tester.pump(const Duration(milliseconds: 300));
+    await tester.pump();
+
+    expect(find.text('Code Review'), findsOneWidget);
+    expect(find.text('Disabled Skill'), findsNothing);
+  });
+
+  testWidgets('Enter sends while skill suggestions are still loading', (
+    tester,
+  ) async {
+    final pending = Completer<WorkspacePagedResponse<WorkspaceSkillSummary>>();
+    final api = _SkillApi((_) => pending.future);
+    final sent = <String>[];
+    await _pumpComposer(tester, api: api, onSend: sent.add);
+
+    await tester.enterText(find.byType(TextField), '\$code');
+    await tester.pump(const Duration(milliseconds: 300));
+    await tester.sendKeyEvent(LogicalKeyboardKey.enter);
+    await tester.pump();
+
+    expect(sent, ['\$code']);
+    pending.complete(_skills(_codeReview));
+    await tester.pump();
+  });
+
+  testWidgets('model changes during debounce clear the skill overlay', (
+    tester,
+  ) async {
+    final registry = DirectModelRegistry();
+    final directModel = registry.replaceProfileModels(
+      DirectConnectionProfile(
+        id: 'direct',
+        name: 'Direct',
+        adapterKey: kOllamaAdapterKey,
+        baseUrl: 'http://localhost:11434',
+      ),
+      [DirectRemoteModel(id: 'llama3')],
+    ).single;
+    const serverModel = Model(id: 'server-model', name: 'Server Model');
+    final api = _SkillApi((_) async => _skills(_codeReview));
+    await _pumpComposer(
+      tester,
+      api: api,
+      model: serverModel,
+      directRegistry: registry,
+    );
+
+    await tester.enterText(find.byType(TextField), '\$code');
+    final container = ProviderScope.containerOf(
+      tester.element(find.byType(ModernChatInput)),
+    );
+    container.read(selectedModelProvider.notifier).set(directModel);
+    await tester.pump(const Duration(milliseconds: 300));
+    container.read(selectedModelProvider.notifier).set(serverModel);
+    await tester.pump();
+
+    expect(api.queries, isEmpty);
+    expect(find.byKey(const ValueKey('prompt-overlay')), findsNothing);
+  });
+
   testWidgets('direct chats suppress OpenWebUI skill suggestions', (
     tester,
   ) async {
@@ -185,7 +263,7 @@ Future<void> _pumpComposer(
   await tester.pumpWidget(
     ProviderScope(
       overrides: [
-        selectedModelProvider.overrideWithValue(model),
+        selectedModelProvider.overrideWith(() => _SeededSelectedModel(model)),
         apiServiceProvider.overrideWithValue(api),
         authTokenProvider3.overrideWithValue('token'),
         isAuthenticatedProvider2.overrideWithValue(authenticated),
@@ -215,6 +293,15 @@ Future<void> _pumpComposer(
 final class _SendOnEnterSettings extends AppSettingsNotifier {
   @override
   AppSettings build() => const AppSettings(sendOnEnter: true);
+}
+
+final class _SeededSelectedModel extends SelectedModel {
+  _SeededSelectedModel(this.model);
+
+  final Model model;
+
+  @override
+  Model build() => model;
 }
 
 final class _FixedDiscovery extends DirectModelDiscoveryController {

--- a/test/features/chat/widgets/modern_chat_input_skill_test.dart
+++ b/test/features/chat/widgets/modern_chat_input_skill_test.dart
@@ -169,6 +169,29 @@ void main() {
     expect(sent, ['<\$code-review|Code Review>']);
   });
 
+  testWidgets('retyping the skill delimiter preserves its identity', (
+    tester,
+  ) async {
+    final api = _SkillApi((_) async => _skills(_codeReview));
+    final sent = <String>[];
+    await _pumpComposer(tester, api: api, onSend: sent.add);
+
+    await tester.enterText(find.byType(TextField), '\$code');
+    await tester.pump(const Duration(milliseconds: 300));
+    await tester.pump();
+    await tester.tap(
+      find.byKey(const ValueKey('skill-suggestion-code-review')),
+    );
+    await tester.pump();
+
+    await tester.enterText(find.byType(TextField), '\$Code Review');
+    await tester.enterText(find.byType(TextField), '\$Code Review ');
+    await tester.tap(find.byKey(const ValueKey('primary-btn-send')));
+    await tester.pump();
+
+    expect(sent, ['<\$code-review|Code Review>']);
+  });
+
   testWidgets('Enter sends while skill suggestions are still loading', (
     tester,
   ) async {

--- a/test/features/chat/widgets/modern_chat_input_skill_test.dart
+++ b/test/features/chat/widgets/modern_chat_input_skill_test.dart
@@ -1,0 +1,256 @@
+import 'dart:async';
+
+import 'package:conduit/core/models/model.dart';
+import 'package:conduit/core/models/server_config.dart';
+import 'package:conduit/core/providers/app_providers.dart';
+import 'package:conduit/core/services/api_service.dart';
+import 'package:conduit/core/services/settings_service.dart';
+import 'package:conduit/core/services/worker_manager.dart';
+import 'package:conduit/features/auth/providers/unified_auth_providers.dart';
+import 'package:conduit/features/chat/providers/chat_providers.dart';
+import 'package:conduit/features/chat/widgets/modern_chat_input.dart';
+import 'package:conduit/features/direct_connections/direct_connections.dart';
+import 'package:conduit/features/hermes/models/hermes_capabilities.dart';
+import 'package:conduit/features/hermes/models/hermes_model.dart';
+import 'package:conduit/features/hermes/providers/hermes_providers.dart';
+import 'package:conduit/features/workspace/models/workspace_common.dart';
+import 'package:conduit/features/workspace/models/workspace_resources.dart';
+import 'package:conduit/l10n/app_localizations.dart';
+import 'package:conduit/l10n/conduit_localizations.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:material_ui/material_ui.dart';
+
+void main() {
+  testWidgets('skill suggestions insert and send the OpenWebUI mention token', (
+    tester,
+  ) async {
+    final api = _SkillApi((_) async => _skills(_codeReview));
+    final sent = <String>[];
+    await _pumpComposer(tester, api: api, onSend: sent.add);
+
+    await tester.enterText(find.byType(TextField), '\$code');
+    await tester.pump(const Duration(milliseconds: 300));
+    await tester.pump();
+
+    expect(api.queries, ['code']);
+    expect(find.text('Code Review'), findsOneWidget);
+    expect(find.text('code-review'), findsOneWidget);
+
+    await tester.tap(
+      find.byKey(const ValueKey('skill-suggestion-code-review')),
+    );
+    await tester.pump();
+    expect(_composerText(tester), '\$Code Review ');
+
+    await tester.enterText(find.byType(TextField), '\$Code Review check this');
+    await tester.tap(find.byKey(const ValueKey('primary-btn-send')));
+    await tester.pump();
+
+    expect(sent, ['<\$code-review|Code Review> check this']);
+
+    await tester.enterText(find.byType(TextField), '\$');
+    await tester.pump(const Duration(milliseconds: 300));
+    await tester.pump();
+    await tester.sendKeyEvent(LogicalKeyboardKey.enter);
+    await tester.pump();
+
+    expect(_composerText(tester), '\$Code Review ');
+  });
+
+  testWidgets('newer skill searches win when responses finish out of order', (
+    tester,
+  ) async {
+    final first = Completer<WorkspacePagedResponse<WorkspaceSkillSummary>>();
+    final second = Completer<WorkspacePagedResponse<WorkspaceSkillSummary>>();
+    final api = _SkillApi(
+      (query) => query == 'first' ? first.future : second.future,
+    );
+    await _pumpComposer(tester, api: api);
+
+    await tester.enterText(find.byType(TextField), '\$first');
+    await tester.pump(const Duration(milliseconds: 300));
+    await tester.enterText(find.byType(TextField), '\$second');
+    await tester.pump(const Duration(milliseconds: 300));
+
+    second.complete(
+      _skills(
+        const WorkspaceSkillSummary(
+          id: 'second',
+          name: 'Second Skill',
+          userId: 'user',
+        ),
+      ),
+    );
+    await tester.pump();
+    expect(find.text('Second Skill'), findsOneWidget);
+
+    first.complete(
+      _skills(
+        const WorkspaceSkillSummary(
+          id: 'first',
+          name: 'First Skill',
+          userId: 'user',
+        ),
+      ),
+    );
+    await tester.pump();
+    expect(find.text('Second Skill'), findsOneWidget);
+    expect(find.text('First Skill'), findsNothing);
+  });
+
+  testWidgets('direct chats suppress OpenWebUI skill suggestions', (
+    tester,
+  ) async {
+    final registry = DirectModelRegistry();
+    final model = registry.replaceProfileModels(
+      DirectConnectionProfile(
+        id: 'direct',
+        name: 'Direct',
+        adapterKey: kOllamaAdapterKey,
+        baseUrl: 'http://localhost:11434',
+      ),
+      [DirectRemoteModel(id: 'llama3')],
+    ).single;
+    final api = _SkillApi((_) async => _skills(_codeReview));
+
+    await _pumpComposer(
+      tester,
+      api: api,
+      model: model,
+      directRegistry: registry,
+    );
+    await tester.enterText(find.byType(TextField), '\$code');
+    await tester.pump(const Duration(milliseconds: 300));
+
+    expect(api.queries, isEmpty);
+    expect(find.byKey(const ValueKey('prompt-overlay')), findsNothing);
+  });
+
+  testWidgets('signed-out chats suppress OpenWebUI skill suggestions', (
+    tester,
+  ) async {
+    final api = _SkillApi((_) async => _skills(_codeReview));
+    await _pumpComposer(tester, api: api, authenticated: false);
+
+    await tester.enterText(find.byType(TextField), '\$code');
+    await tester.pump(const Duration(milliseconds: 300));
+
+    expect(api.queries, isEmpty);
+    expect(find.byKey(const ValueKey('prompt-overlay')), findsNothing);
+  });
+
+  testWidgets('Hermes chats suppress OpenWebUI skill suggestions', (
+    tester,
+  ) async {
+    final api = _SkillApi((_) async => _skills(_codeReview));
+    await _pumpComposer(
+      tester,
+      api: api,
+      model: hermesSyntheticModel(),
+      hermes: true,
+    );
+
+    await tester.enterText(find.byType(TextField), '\$code');
+    await tester.pump(const Duration(milliseconds: 300));
+
+    expect(api.queries, isEmpty);
+    expect(find.byKey(const ValueKey('prompt-overlay')), findsNothing);
+  });
+}
+
+const _codeReview = WorkspaceSkillSummary(
+  id: 'code-review',
+  name: 'Code Review',
+  userId: 'user',
+);
+
+WorkspacePagedResponse<WorkspaceSkillSummary> _skills(
+  WorkspaceSkillSummary skill,
+) => WorkspacePagedResponse(items: [skill], total: 1);
+
+String _composerText(WidgetTester tester) =>
+    tester.widget<TextField>(find.byType(TextField)).controller!.text;
+
+Future<void> _pumpComposer(
+  WidgetTester tester, {
+  required _SkillApi api,
+  Model model = const Model(id: 'server-model', name: 'Server Model'),
+  ValueChanged<String>? onSend,
+  DirectModelRegistry? directRegistry,
+  bool hermes = false,
+  bool authenticated = true,
+}) async {
+  await tester.pumpWidget(
+    ProviderScope(
+      overrides: [
+        selectedModelProvider.overrideWithValue(model),
+        apiServiceProvider.overrideWithValue(api),
+        authTokenProvider3.overrideWithValue('token'),
+        isAuthenticatedProvider2.overrideWithValue(authenticated),
+        appSettingsProvider.overrideWith(_SendOnEnterSettings.new),
+        isChatStreamingProvider.overrideWithValue(false),
+        webSearchAvailableProvider.overrideWithValue(false),
+        imageGenerationAvailableProvider.overrideWithValue(false),
+        if (directRegistry != null) ...[
+          directModelRegistryProvider.overrideWithValue(directRegistry),
+          directModelDiscoveryProvider.overrideWith(_FixedDiscovery.new),
+        ],
+        if (hermes)
+          hermesCapabilitiesProvider.overrideWith(
+            (_) async => const HermesCapabilities(skills: true),
+          ),
+      ],
+      child: MaterialApp(
+        localizationsDelegates: conduitLocalizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+        home: Scaffold(body: ModernChatInput(onSendMessage: onSend ?? (_) {})),
+      ),
+    ),
+  );
+  await tester.pump();
+}
+
+final class _SendOnEnterSettings extends AppSettingsNotifier {
+  @override
+  AppSettings build() => const AppSettings(sendOnEnter: true);
+}
+
+final class _FixedDiscovery extends DirectModelDiscoveryController {
+  @override
+  Future<DirectModelDiscoveryState> build() async =>
+      DirectModelDiscoveryState();
+}
+
+final class _SkillApi extends ApiService {
+  _SkillApi(this.search)
+    : super(
+        serverConfig: const ServerConfig(
+          id: 'server',
+          name: 'Server',
+          url: 'https://example.com',
+        ),
+        workerManager: WorkerManager(),
+      );
+
+  final Future<WorkspacePagedResponse<WorkspaceSkillSummary>> Function(
+    String? query,
+  )
+  search;
+  final queries = <String?>[];
+
+  @override
+  Future<Map<String, dynamic>> getUserSettings({Object? authSnapshot}) async =>
+      const <String, dynamic>{};
+
+  @override
+  Future<WorkspacePagedResponse<WorkspaceSkillSummary>> getWorkspaceSkills({
+    String? query,
+    String? viewOption,
+    int page = 1,
+  }) {
+    queries.add(query);
+    return search(query);
+  }
+}


### PR DESCRIPTION
## Summary

- add `$` skill autocomplete to authenticated Open WebUI chats
- support debounced search, stale-response protection, and tap or keyboard selection
- keep `$Skill Name` visible while sending `<$skill-id|Skill Name>` to Open WebUI
- suppress Open WebUI skills for signed-out, Direct, and Hermes chats

Fixes #645

## Verification

- `flutter analyze`
- `flutter test test/features/chat/widgets/modern_chat_input_skill_test.dart test/features/chat/widgets/modern_chat_input_direct_test.dart test/features/chat/widgets/modern_chat_input_hermes_test.dart test/features/workspace/providers/workspace_providers_test.dart` (66 passed)
- `flutter test` (5,637 passed, 4 skipped, 3 unrelated failures; the FTS append budget and streaming recovery failures reproduced in isolation, while the read-path timeout passed in isolation)

Live iOS verification was not run because no disposable authenticated Open WebUI server with a readable skill was available.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `$` skill mention autocomplete to chat composer
> - Adds a `MentionKind` enum to [mention_text_controller.dart](https://github.com/cogwheel0/conduit/pull/664/files#diff-d3de24b97d91268b20bc9d8d4760ae716ba84905f860986713f14aaef159f6c5) so mentions carry an `entity` or `skill` kind; `addMention` defaults to `entity` for existing callers
> - Skill mentions serialize as `<$id|label>` instead of the `<@idType:id|label>` format used for entities
> - Introduces `$` as a prompt trigger in [_ModernChatInputState](https://github.com/cogwheel0/conduit/pull/664/files#diff-c6dc1bffeaea79facaf47a17818417883c068df43c545c18e8c48e8ce7a1ce63), gated by `_openWebUiSkillsAvailable` (excludes Hermes and locally minted direct models). Typing `$query` debounces a backend search via `api.getWorkspaceSkills`, renders results in the new [SkillSuggestionOverlay](https://github.com/cogwheel0/conduit/pull/664/files#diff-96cc64605c6b87d4ddf18452d4590f04c3d680de55f3c02eb50d564c811c30ba), and inserts a `$Name ` mention on selection
> - Keyboard navigation and Enter-to-confirm now cover the `$` results list alongside existing `@` and `/` overlays
> - Behavioral Change: inserting non-whitespace immediately after a mention now invalidates it; deleting or typing only whitespace at the trailing boundary preserves it. Reviewers should check the mention-range condition in `MentionTextEditingController`'s editing handler and the out-of-order and boundary-edit tests in [modern_chat_input_skill_test.dart](https://github.com/cogwheel0/conduit/pull/664/files#diff-ca140991a9ac2005d117859c0e3b567aa26df7e60b3fa0e08fe0e41455f3f40a).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized df8a2d9.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added skill autocomplete for chat commands beginning with `$`.
  - View, search, and select available skills from a suggestion overlay.
  - Insert selected skills as mentions in the message composer.
  - Added loading, empty, error, keyboard navigation, and stale-result handling.

- **Bug Fixes**
  - Improved mention behavior when inserting or deleting text at mention boundaries.

- **Tests**
  - Added coverage for skill search, selection, editing, filtering, cancellation, and unsupported chat scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This change adds Open WebUI skill autocomplete to the chat composer, preserves selected skill identity while users edit surrounding text, and serializes selected skills into the required message token. The delimiter-deletion behavior reported earlier is corrected: removing only the generated trailing space retains the selected skill, while inserting text at the skill boundary invalidates the selection as intended.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

No blocking failure remains.

The exercised mention-editing paths preserve skill serialization after delimiter deletion and remove identity after a label-boundary edit.
</details>


<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- The PR-parent delimiter-deletion reproduction source shows that deleting only the trailing delimiter produces plain $Code Review.
- The HEAD delimiter and exact-boundary reproduction source shows that deleting the boundary serializes as \<$code-review|Code Review\>, and inserting X at the exact end yields plain $Code ReviewX.
- A focused-widget test attempt was made but exited with an error due to missing generated symbols, while the broader reproductions completed.
- The before/after command results confirmed the expected parent behavior and boundary handling, as reflected in the reproduction artifacts.

<a href="https://app.greptile.com/trex/runs/20554710/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (5): Last reviewed commit: ["fix(chat): preserve mentions across deli..."](https://github.com/cogwheel0/conduit/commit/df8a2d971f0d3e6e81bc266caa63f7e28ddc3b2f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56584974)</sub>

<!-- /greptile_comment -->