### PR TITLE
Fix citation links, note checklists, and Hermes PDF input

### DIFF
--- a/ios/Runner/NativeSheetBridge.swift
+++ b/ios/Runner/NativeSheetBridge.swift
@@ -2,6 +2,7 @@ import CryptoKit
 import Flutter
 import ImageIO
 import PhotosUI
+import SafariServices
 import StoreKit
 import UIKit
 import UniformTypeIdentifiers
@@ -1601,6 +1602,11 @@ final class NativeSheetBridge: NativeSheetHostApi {
         }
 
         if let url = item.url {
+            if item.kind == "source",
+               let presenter = activeNavigationController?.visibleViewController {
+                presenter.present(SFSafariViewController(url: url), animated: true)
+                return
+            }
             UIApplication.shared.open(url)
             return
         }

--- a/lib/core/services/media_upload_controller.dart
+++ b/lib/core/services/media_upload_controller.dart
@@ -1721,9 +1721,17 @@ class MediaUploadController {
       final desktop =
           _ref.read(hermesConfigProvider).mode ==
           HermesBackendMode.desktopGateway;
-      if (!desktop && !isHermesLocalDocumentFileNameSupported(fileName)) {
+      final responsesPdf =
+          !desktop &&
+          hermesCapabilitiesNow(_ref).inputFiles &&
+          isHermesResponsesPdfFileNameSupported(fileName);
+      if (!desktop &&
+          !responsesPdf &&
+          !isHermesLocalDocumentFileNameSupported(fileName)) {
         throw HermesChatInputException(
-          'Hermes supports local UTF-8 text and DOCX documents.',
+          isHermesResponsesPdfFileNameSupported(fileName)
+              ? 'This Hermes server does not advertise Responses file input.'
+              : 'Hermes supports local UTF-8 text and DOCX documents.',
         );
       }
       final documentPaths = <String>{

--- a/lib/features/chat/providers/chat_providers.dart
+++ b/lib/features/chat/providers/chat_providers.dart
@@ -8625,9 +8625,13 @@ Future<void> _regenerateHermesMessage(
     }
   }
 
-  if (replayedFiles.any((file) => file['source'] == 'hermes_desktop_file')) {
+  if (replayedFiles.any(
+    (file) =>
+        file['source'] == 'hermes_desktop_file' ||
+        file['source'] == 'hermes_responses_file',
+  )) {
     const error = HermesAttachmentsUnsupportedException(
-      'Desktop file attachments cannot be regenerated. Send the file again.',
+      'File attachments cannot be regenerated. Send the file again.',
     );
     installAssistant(
       assistantMessage(

--- a/lib/features/chat/providers/chat_providers.dart
+++ b/lib/features/chat/providers/chat_providers.dart
@@ -7903,10 +7903,27 @@ Future<_PreparedHermesTurn> _prepareHermesTurn(
       (ref.read(hermesConfigProvider) as HermesConfig).mode ==
       HermesBackendMode.desktopGateway;
   AsyncValue<HermesCapabilities>? capabilities;
+  final requestedAttachmentIds = attachmentIds ?? const <String>[];
+  final responsesPdfRequested =
+      !desktop &&
+      requestedAttachmentIds.any((attachmentId) {
+        final state = stateById[attachmentId];
+        return state != null &&
+            state.isImage != true &&
+            isHermesResponsesPdfFileNameSupported(state.fileName);
+      });
+  if (responsesPdfRequested) {
+    capabilities = ref.read(hermesCapabilitiesProvider);
+    if (capabilities?.asData == null) {
+      capabilities = await AsyncValue.guard(
+        () => ref.read(hermesCapabilitiesProvider.future),
+      );
+    }
+  }
   var decodedImageBytes = 0;
   var inputFileBytes = 0;
 
-  for (final attachmentId in attachmentIds ?? const <String>[]) {
+  for (final attachmentId in requestedAttachmentIds) {
     if (attachmentId.startsWith('data:image/')) {
       capabilities ??= ref.read(hermesCapabilitiesProvider);
       if (capabilities?.asData?.value.inputImages != true) {
@@ -7945,11 +7962,6 @@ Future<_PreparedHermesTurn> _prepareHermesTurn(
     }
     final responsesPdf =
         !desktop && isHermesResponsesPdfFileNameSupported(state.fileName);
-    if (responsesPdf && capabilities == null) {
-      capabilities = await AsyncValue.guard(
-        () => ref.read(hermesCapabilitiesProvider.future),
-      );
-    }
     if (responsesPdf && capabilities?.asData?.value.inputFiles != true) {
       throw const HermesChatInputException(
         'This Hermes server does not advertise Responses file input.',

--- a/lib/features/chat/providers/chat_providers.dart
+++ b/lib/features/chat/providers/chat_providers.dart
@@ -7945,7 +7945,11 @@ Future<_PreparedHermesTurn> _prepareHermesTurn(
     }
     final responsesPdf =
         !desktop && isHermesResponsesPdfFileNameSupported(state.fileName);
-    if (responsesPdf) capabilities ??= ref.read(hermesCapabilitiesProvider);
+    if (responsesPdf && capabilities == null) {
+      capabilities = await AsyncValue.guard(
+        () => ref.read(hermesCapabilitiesProvider.future),
+      );
+    }
     if (responsesPdf && capabilities?.asData?.value.inputFiles != true) {
       throw const HermesChatInputException(
         'This Hermes server does not advertise Responses file input.',

--- a/lib/features/chat/providers/chat_providers.dart
+++ b/lib/features/chat/providers/chat_providers.dart
@@ -8002,6 +8002,12 @@ Future<_PreparedHermesTurn> _prepareHermesTurn(
           totalCharacters: 0,
         )
       : await documentService.prepareAll(documentSources);
+  if (documents.totalSourceBytes + inputFileBytes >
+      kHermesMaxAggregateLocalDocumentBytes) {
+    throw const HermesChatInputException(
+      'Hermes files exceed the 16 MB aggregate limit.',
+    );
+  }
   final promptText = documents.documents.isEmpty
       ? text
       : '$text\n\n${documents.renderForPrompt()}';

--- a/lib/features/chat/providers/chat_providers.dart
+++ b/lib/features/chat/providers/chat_providers.dart
@@ -7898,20 +7898,18 @@ Future<_PreparedHermesTurn> _prepareHermesTurn(
   final images = <String>[];
   final seenImages = <String>{};
   final documentSources = <HermesLocalDocumentSource>[];
-  final desktopFiles = <HermesInputFilePart>[];
+  final inputFiles = <HermesInputFilePart>[];
   final desktop =
       (ref.read(hermesConfigProvider) as HermesConfig).mode ==
       HermesBackendMode.desktopGateway;
+  AsyncValue<HermesCapabilities>? capabilities;
   var decodedImageBytes = 0;
-  var desktopFileBytes = 0;
+  var inputFileBytes = 0;
 
   for (final attachmentId in attachmentIds ?? const <String>[]) {
     if (attachmentId.startsWith('data:image/')) {
-      final AsyncValue<HermesCapabilities> capabilities = ref.read(
-        hermesCapabilitiesProvider,
-      );
-      final inputImages = capabilities.asData?.value.inputImages == true;
-      if (!inputImages) {
+      capabilities ??= ref.read(hermesCapabilitiesProvider);
+      if (capabilities?.asData?.value.inputImages != true) {
         throw const HermesChatInputException(
           'This Hermes server does not advertise image input support.',
         );
@@ -7945,10 +7943,17 @@ Future<_PreparedHermesTurn> _prepareHermesTurn(
     if (state == null || state.isImage == true) {
       throw const HermesAttachmentsUnsupportedException();
     }
-    if (desktop) {
-      final remaining =
-          kHermesMaxAggregateLocalDocumentBytes - desktopFileBytes;
-      final bytes = await _readBoundedHermesDesktopFile(
+    final responsesPdf =
+        !desktop && isHermesResponsesPdfFileNameSupported(state.fileName);
+    if (responsesPdf) capabilities ??= ref.read(hermesCapabilitiesProvider);
+    if (responsesPdf && capabilities?.asData?.value.inputFiles != true) {
+      throw const HermesChatInputException(
+        'This Hermes server does not advertise Responses file input.',
+      );
+    }
+    if (desktop || responsesPdf) {
+      final remaining = kHermesMaxAggregateLocalDocumentBytes - inputFileBytes;
+      final bytes = await _readBoundedHermesFile(
         state.file,
         maxBytes: math.min(kHermesMaxLocalDocumentBytes, remaining),
       );
@@ -7957,8 +7962,8 @@ Future<_PreparedHermesTurn> _prepareHermesTurn(
           'Hermes attachments cannot be empty.',
         );
       }
-      desktopFileBytes += bytes.length;
-      final mediaType = _hermesDesktopFileMediaType(state.fileName);
+      inputFileBytes += bytes.length;
+      final mediaType = _hermesFileMediaType(state.fileName);
       if (mediaType == 'application/pdf' &&
           (bytes.length < 5 ||
               bytes[0] != 0x25 ||
@@ -7970,7 +7975,7 @@ Future<_PreparedHermesTurn> _prepareHermesTurn(
           'This attachment is not a valid PDF document.',
         );
       }
-      desktopFiles.add(
+      inputFiles.add(
         HermesInputFilePart(
           filename: state.fileName,
           mediaType: mediaType,
@@ -8001,13 +8006,13 @@ Future<_PreparedHermesTurn> _prepareHermesTurn(
       ? text
       : '$text\n\n${documents.renderForPrompt()}';
   final HermesChatInput input;
-  if (images.isEmpty && desktopFiles.isEmpty) {
+  if (images.isEmpty && inputFiles.isEmpty) {
     input = HermesChatInput.text(promptText);
   } else {
     input = HermesChatInput.multimodal(<HermesChatContentPart>[
       if (promptText.trim().isNotEmpty) HermesInputTextPart(promptText),
       for (final image in images) HermesInputImagePart(image),
-      ...desktopFiles,
+      ...inputFiles,
     ]);
   }
 
@@ -8020,10 +8025,10 @@ Future<_PreparedHermesTurn> _prepareHermesTurn(
       },
     for (final document in documents.documents)
       _hermesLocalDocumentDescriptor(document),
-    for (final file in desktopFiles)
+    for (final file in inputFiles)
       <String, dynamic>{
         'type': 'file',
-        'source': 'hermes_desktop_file',
+        'source': desktop ? 'hermes_desktop_file' : 'hermes_responses_file',
         'name': file.filename,
         'content_type': file.mediaType,
       },
@@ -8039,7 +8044,7 @@ Future<_PreparedHermesTurn> _prepareHermesTurn(
   );
 }
 
-Future<Uint8List> _readBoundedHermesDesktopFile(
+Future<Uint8List> _readBoundedHermesFile(
   File file, {
   required int maxBytes,
 }) async {
@@ -8062,7 +8067,7 @@ Future<Uint8List> _readBoundedHermesDesktopFile(
   return builder.takeBytes();
 }
 
-String _hermesDesktopFileMediaType(String filename) {
+String _hermesFileMediaType(String filename) {
   final extension = filename.toLowerCase().split('.').last;
   return switch (extension) {
     'pdf' => 'application/pdf',

--- a/lib/features/chat/views/chat_page.dart
+++ b/lib/features/chat/views/chat_page.dart
@@ -341,9 +341,11 @@ class _HermesBotActivityDotState extends State<_HermesBotActivityDot>
 List<String>? chatLocalFilePickerExtensions(
   Model? selectedModel, {
   bool desktopHermes = false,
+  bool hermesResponsesFiles = false,
 }) => localFilePickerExtensionsForModel(
   selectedModel,
   desktopHermes: desktopHermes,
+  hermesResponsesFiles: hermesResponsesFiles,
 );
 
 @visibleForTesting
@@ -1444,6 +1446,9 @@ class _ChatPageState extends ConsumerState<ChatPage> {
           desktopHermes:
               ref.read(hermesConfigProvider).mode ==
               HermesBackendMode.desktopGateway,
+          hermesResponsesFiles:
+              ref.read(hermesCapabilitiesProvider).asData?.value.inputFiles ==
+              true,
         ),
       );
       if (attachments.isEmpty) return;

--- a/lib/features/chat/widgets/modern_chat_input.dart
+++ b/lib/features/chat/widgets/modern_chat_input.dart
@@ -136,10 +136,14 @@ bool directModelAcceptsImageInput(Model? model, DirectModelRegistry registry) {
 List<String>? localFilePickerExtensionsForModel(
   Model? selectedModel, {
   bool desktopHermes = false,
+  bool hermesResponsesFiles = false,
 }) {
   if (selectedModel == null) return null;
   if (isHermesModel(selectedModel)) {
-    return desktopHermes ? null : kHermesLocalDocumentPickerExtensions;
+    if (desktopHermes) return null;
+    final extensions = <String>{...kHermesLocalDocumentPickerExtensions};
+    if (hermesResponsesFiles) extensions.add('pdf');
+    return extensions.toList(growable: false)..sort();
   }
   if (hasReservedDirectIdentity(selectedModel)) {
     final extensions = <String>{...kDirectLocalDocumentPickerExtensions};

--- a/lib/features/hermes/models/hermes_capabilities.dart
+++ b/lib/features/hermes/models/hermes_capabilities.dart
@@ -1,8 +1,8 @@
 /// Parsed `/v1/capabilities` feature flags.
 ///
 /// Existing management features are optimistic for compatibility with older
-/// servers. Image input is fail-closed: the client only enables it when the
-/// server advertises a compatible endpoint.
+/// servers. Image and file input are fail-closed: the client only enables them
+/// when the server advertises a compatible endpoint.
 class HermesCapabilities {
   const HermesCapabilities({
     this.runApproval = true,
@@ -12,6 +12,7 @@ class HermesCapabilities {
     this.jobsAdmin = true,
     this.sessions = true,
     this.inputImages = false,
+    this.inputFiles = false,
   });
 
   final bool runApproval;
@@ -34,6 +35,9 @@ class HermesCapabilities {
   /// remains false when discovery is unavailable or ambiguous.
   final bool inputImages;
 
+  /// Whether the server advertises the streaming Responses path used for files.
+  final bool inputFiles;
+
   /// The compatibility default used while loading or when discovery fails.
   static const HermesCapabilities enabledByDefault = HermesCapabilities();
 
@@ -45,6 +49,7 @@ class HermesCapabilities {
   );
 
   factory HermesCapabilities.fromJson(Map<String, dynamic> json) {
+    final responsesInput = _resolveResponsesInput(json);
     return HermesCapabilities(
       runApproval: _resolve(json, const [
         'run_approval_response',
@@ -63,7 +68,8 @@ class HermesCapabilities {
         'sessions',
         'session_key_header',
       ]),
-      inputImages: _resolveResponsesImageInput(json),
+      inputImages: json['desktop_uploads'] == true || responsesInput,
+      inputFiles: responsesInput,
     );
   }
 
@@ -85,9 +91,7 @@ class HermesCapabilities {
     return true;
   }
 
-  /// Accepts either the Responses image contract or Desktop upload contract.
-  static bool _resolveResponsesImageInput(Map<String, dynamic> json) {
-    if (json['desktop_uploads'] == true) return true;
+  static bool _resolveResponsesInput(Map<String, dynamic> json) {
     final topLevelApi = json['responses_api'];
     final topLevelStreaming = json['responses_streaming'];
     final features = json['features'];

--- a/lib/features/hermes/models/hermes_chat_input.dart
+++ b/lib/features/hermes/models/hermes_chat_input.dart
@@ -18,8 +18,8 @@ final class HermesChatInputException implements Exception {
 /// Typed input for Hermes's multimodal HTTP endpoints.
 ///
 /// Text-only turns deliberately serialize as the legacy scalar string. Turns
-/// containing images serialize as the OpenAI Responses-style content list
-/// accepted by Hermes's OpenAI-compatible Responses endpoint.
+/// containing images or files serialize as the OpenAI Responses-style content
+/// list accepted by Hermes's OpenAI-compatible Responses endpoint.
 sealed class HermesChatInput {
   const HermesChatInput();
 
@@ -154,7 +154,7 @@ final class HermesInputImagePart extends HermesChatContentPart {
   );
 }
 
-/// Ephemeral local file bytes used by the Desktop Gateway upload RPCs.
+/// Ephemeral local file bytes used by Responses and Desktop Gateway requests.
 /// Conduit never persists this data URL in chat metadata.
 final class HermesInputFilePart extends HermesChatContentPart {
   HermesInputFilePart({

--- a/lib/features/hermes/services/hermes_local_document_service.dart
+++ b/lib/features/hermes/services/hermes_local_document_service.dart
@@ -24,6 +24,7 @@ const List<String> kHermesLocalDocumentPickerExtensions =
 bool isHermesLocalDocumentFileNameSupported(String name) =>
     isLocalDocumentFileNameSupported(name);
 
+/// Whether [name] is a PDF eligible for Hermes Responses file input.
 bool isHermesResponsesPdfFileNameSupported(String name) =>
     name.toLowerCase().endsWith('.pdf');
 

--- a/lib/features/hermes/services/hermes_local_document_service.dart
+++ b/lib/features/hermes/services/hermes_local_document_service.dart
@@ -24,6 +24,9 @@ const List<String> kHermesLocalDocumentPickerExtensions =
 bool isHermesLocalDocumentFileNameSupported(String name) =>
     isLocalDocumentFileNameSupported(name);
 
+bool isHermesResponsesPdfFileNameSupported(String name) =>
+    name.toLowerCase().endsWith('.pdf');
+
 String sanitizeHermesDocumentFilename(String input) =>
     sanitizeLocalDocumentFilename(input);
 

--- a/lib/features/navigation/views/folder_page.dart
+++ b/lib/features/navigation/views/folder_page.dart
@@ -606,6 +606,9 @@ class _FolderPageState extends ConsumerState<FolderPage> {
           desktopHermes:
               ref.read(hermesConfigProvider).mode ==
               HermesBackendMode.desktopGateway,
+          hermesResponsesFiles:
+              ref.read(hermesCapabilitiesProvider).asData?.value.inputFiles ==
+              true,
         ),
       );
       if (attachments.isEmpty) {

--- a/lib/features/notes/utils/note_document_codec.dart
+++ b/lib/features/notes/utils/note_document_codec.dart
@@ -7,9 +7,9 @@ import '../../../core/utils/debug_logger.dart';
 /// interchange format shared with the Open WebUI web client) and the
 /// [ParchmentDocument] model edited by Fleather.
 ///
-/// Markdown stays the source of truth: notes are stored as `content.md` (+ a
-/// derived `content.html`) and `content.json` is left null so notes authored or
-/// edited on the web (TipTap) remain fully compatible. These helpers wrap the
+/// Markdown stays the source of truth: notes are stored as `content.md` while
+/// `content.html` is left empty and `content.json` is left null so notes authored
+/// or edited on the web (TipTap) remain fully compatible. These helpers wrap the
 /// `parchment` codecs and centralise the best-effort failure handling, since
 /// decoding is lossy and may choke on markdown constructs the codec does not
 /// model (e.g. web-authored content or AI-enhanced output).
@@ -47,24 +47,6 @@ String markdownFromDocument(ParchmentDocument document) {
       stackTrace: st,
     );
     return document.toPlainText();
-  }
-}
-
-/// Encodes [document] to HTML for `content.html`.
-///
-/// Returns an empty string on failure; `content.md` remains the source of truth,
-/// so a missing HTML representation is non-fatal.
-String htmlFromDocument(ParchmentDocument document) {
-  try {
-    return parchmentHtml.encode(document);
-  } catch (e, st) {
-    DebugLogger.error(
-      'Failed to encode note document to HTML',
-      scope: 'notes/codec',
-      error: e,
-      stackTrace: st,
-    );
-    return '';
   }
 }
 

--- a/lib/features/notes/views/note_editor_page.dart
+++ b/lib/features/notes/views/note_editor_page.dart
@@ -162,6 +162,7 @@ class NoteEditorPage extends ConsumerStatefulWidget {
 class _NoteEditorPageState extends ConsumerState<NoteEditorPage> {
   final TextEditingController _titleController = TextEditingController();
   FleatherController? _contentController;
+  StreamSubscription<ParchmentChange>? _contentChangesSubscription;
   final FocusNode _titleFocusNode = FocusNode(debugLabel: 'note_title');
   final FocusNode _contentFocusNode = FocusNode(debugLabel: 'note_content');
   final ScrollController _scrollController = ScrollController();
@@ -304,9 +305,11 @@ class _NoteEditorPageState extends ConsumerState<NoteEditorPage> {
   void _installContentDocument(ParchmentDocument document) {
     final previous = _contentController;
     final controller = FleatherController(document: document);
-    controller.addListener(_onContentChanged);
+    _contentChangesSubscription?.cancel();
+    _contentChangesSubscription = document.changes.listen(
+      (_) => _onContentChanged(),
+    );
     _contentController = controller;
-    previous?.removeListener(_onContentChanged);
     previous?.dispose();
   }
 
@@ -319,6 +322,7 @@ class _NoteEditorPageState extends ConsumerState<NoteEditorPage> {
     _activeAudioCancelToken?.cancel('Note editor disposed.');
     _voiceService?.stopListening();
     _titleController.dispose();
+    _contentChangesSubscription?.cancel();
     _contentController?.dispose();
     _titleFocusNode.removeListener(_onTitleFocusChanged);
     _titleFocusNode.dispose();
@@ -480,16 +484,13 @@ class _NoteEditorPageState extends ConsumerState<NoteEditorPage> {
   }) {
     final data = <String, dynamic>{};
     if (includeContent) {
-      final document = _contentController?.document;
-      final markdown = document != null ? markdownFromDocument(document) : '';
-      final html = document != null ? htmlFromDocument(document) : '';
-      // `json` (TipTap) is intentionally left null: markdown stays the
-      // canonical interchange format so notes remain editable on the Open
-      // WebUI web client.
+      // Open WebUI prefers HTML when it is non-empty. Parchment's checklist
+      // HTML is not TipTap-compatible, so leave it empty and let Open WebUI
+      // derive its editor document from the canonical markdown.
       data['content'] = <String, dynamic>{
         'json': null,
-        'html': html,
-        'md': markdown,
+        'html': '',
+        'md': _contentMarkdown,
       };
     }
     if (files != null) {

--- a/test/core/services/media_upload_controller_test.dart
+++ b/test/core/services/media_upload_controller_test.dart
@@ -3209,7 +3209,7 @@ void main() {
       expect(queue.queue, isEmpty);
     });
 
-    test('PDF is rejected before local attachment preparation', () async {
+    test('PDF is rejected without Responses file input', () async {
       final directory = await Directory.systemTemp.createTemp(
         'conduit_hermes_media_',
       );
@@ -3239,7 +3239,7 @@ void main() {
           isA<HermesChatInputException>().having(
             (error) => error.message,
             'message',
-            allOf(contains('UTF-8 text'), isNot(contains('PDF'))),
+            contains('Responses file input'),
           ),
         ),
       );
@@ -3250,6 +3250,40 @@ void main() {
         container.read(attachedFilesProvider).single.status,
         FileUploadStatus.failed,
       );
+    });
+
+    test('Responses-capable Hermes accepts PDF without uploading it', () async {
+      final directory = await Directory.systemTemp.createTemp(
+        'conduit_hermes_media_',
+      );
+      addTearDown(() => directory.delete(recursive: true));
+      final document = File('${directory.path}/private-notes.pdf');
+      await document.writeAsBytes(utf8.encode('%PDF-1.4'));
+      var uploadCalls = 0;
+      final queue = await _recordingUploadQueue(onUpload: () => uploadCalls++);
+      addTearDown(queue.dispose);
+      final container = await _hermesContainer(
+        capabilities: const HermesCapabilities(inputFiles: true),
+        attachments: [_pendingDocument(document, reportedBytes: 1)],
+        encoder: (file) async => throw StateError('not an image'),
+        uploadQueue: queue,
+      );
+      addTearDown(container.dispose);
+
+      await container
+          .read(mediaUploadControllerProvider)
+          .upload(
+            filePath: document.path,
+            fileName: 'private-notes.pdf',
+            fileSize: 1,
+          );
+
+      final stored = container.read(attachedFilesProvider).single;
+      expect(stored.status, FileUploadStatus.completed);
+      expect(stored.fileId, startsWith(kHermesLocalDocumentIdPrefix));
+      expect(stored.base64DataUrl, isNull);
+      expect(uploadCalls, 0);
+      expect(queue.queue, isEmpty);
     });
 
     test('oversized local document is rejected before preparation', () async {

--- a/test/features/chat/chat_model_dropdown_test.dart
+++ b/test/features/chat/chat_model_dropdown_test.dart
@@ -170,6 +170,15 @@ void main() {
       check(extensions).not((it) => it.contains('pdf'));
     });
 
+    test('offers PDF when Hermes advertises Responses file input', () {
+      final extensions = chatLocalFilePickerExtensions(
+        hermesSyntheticModel(),
+        hermesResponsesFiles: true,
+      )!;
+
+      check(extensions).contains('pdf');
+    });
+
     test('leaves Desktop Hermes picker unrestricted', () {
       check(
         chatLocalFilePickerExtensions(

--- a/test/features/chat/providers/chat_messages_notifier_streaming_seams_test.dart
+++ b/test/features/chat/providers/chat_messages_notifier_streaming_seams_test.dart
@@ -2598,6 +2598,87 @@ void main() {
       check(user.files!.single.containsKey('hermes_extracted_text')).isFalse();
     });
 
+    test('Hermes mixed files share one aggregate byte budget', () async {
+      final directory = await Directory.systemTemp.createTemp(
+        'conduit_hermes_mixed_budget_',
+      );
+      addTearDown(() => directory.delete(recursive: true));
+      final attachments = <FileUploadState>[];
+      for (var index = 0; index < 2; index++) {
+        final pdf = File('${directory.path}/schedule-$index.pdf');
+        final handle = await pdf.open(mode: FileMode.write);
+        await handle.writeString('%PDF-1.4\n');
+        await handle.truncate(kHermesMaxLocalDocumentBytes);
+        await handle.close();
+        attachments.add(
+          FileUploadState(
+            file: pdf,
+            fileName: 'schedule-$index.pdf',
+            fileSize: kHermesMaxLocalDocumentBytes,
+            progress: 1,
+            status: FileUploadStatus.completed,
+            fileId: 'hermes-local:composer-pdf-$index',
+            isImage: false,
+          ),
+        );
+      }
+      final text = File('${directory.path}/notes.txt');
+      await text.writeAsString('x');
+      attachments.add(
+        FileUploadState(
+          file: text,
+          fileName: 'notes.txt',
+          fileSize: 1,
+          progress: 1,
+          status: FileUploadStatus.completed,
+          fileId: 'hermes-local:composer-text',
+          isImage: false,
+        ),
+      );
+      final service = _ResponsesHermesApi();
+      final container = _testContainer(
+        overrides: [
+          activeConversationProvider.overrideWith(
+            () => _TestActiveConversationNotifier(),
+          ),
+          reviewerModeProvider.overrideWithValue(false),
+          apiServiceProvider.overrideWithValue(null),
+          socketServiceProvider.overrideWithValue(null),
+          hermesConfigProvider.overrideWith(
+            () => _FixedHermesConfigController(),
+          ),
+          hermesApiServiceProvider.overrideWithValue(service),
+          hermesCapabilitiesProvider.overrideWith(
+            (ref) async => const HermesCapabilities(inputFiles: true),
+          ),
+          attachedFilesProvider.overrideWith(
+            () => _SeededAttachedFiles(attachments),
+          ),
+        ],
+      );
+      addTearDown(container.dispose);
+      await container.read(hermesCapabilitiesProvider.future);
+      container
+          .read(selectedModelProvider.notifier)
+          .set(hermesSyntheticModel());
+
+      await expectLater(
+        sendMessageWithContainer(
+          container,
+          'Read the schedules and notes',
+          attachments.map((attachment) => attachment.fileId!).toList(),
+        ),
+        throwsA(
+          isA<HermesChatInputException>().having(
+            (error) => error.message,
+            'message',
+            contains('16 MB aggregate limit'),
+          ),
+        ),
+      );
+      check(service.inputs).isEmpty();
+    });
+
     test(
       'server switch during document extraction cannot route local text',
       () async {

--- a/test/features/chat/providers/chat_messages_notifier_streaming_seams_test.dart
+++ b/test/features/chat/providers/chat_messages_notifier_streaming_seams_test.dart
@@ -2531,6 +2531,73 @@ void main() {
       },
     );
 
+    test('Hermes Responses sends PDFs as input_file content', () async {
+      final directory = await Directory.systemTemp.createTemp(
+        'conduit_hermes_pdf_send_',
+      );
+      addTearDown(() => directory.delete(recursive: true));
+      final document = File('${directory.path}/schedule.pdf');
+      final bytes = utf8.encode('%PDF-1.4\nschedule');
+      await document.writeAsBytes(bytes);
+      final attachment = FileUploadState(
+        file: document,
+        fileName: 'schedule.pdf',
+        fileSize: bytes.length,
+        progress: 1,
+        status: FileUploadStatus.completed,
+        fileId: 'hermes-local:composer-pdf',
+        isImage: false,
+      );
+      final service = _ResponsesHermesApi();
+      final container = _testContainer(
+        overrides: [
+          activeConversationProvider.overrideWith(
+            () => _TestActiveConversationNotifier(),
+          ),
+          reviewerModeProvider.overrideWithValue(false),
+          apiServiceProvider.overrideWithValue(null),
+          socketServiceProvider.overrideWithValue(null),
+          hermesConfigProvider.overrideWith(
+            () => _FixedHermesConfigController(),
+          ),
+          hermesApiServiceProvider.overrideWithValue(service),
+          hermesCapabilitiesProvider.overrideWith(
+            (ref) async => const HermesCapabilities(inputFiles: true),
+          ),
+          attachedFilesProvider.overrideWith(
+            () => _SeededAttachedFiles([attachment]),
+          ),
+        ],
+      );
+      addTearDown(container.dispose);
+      await container.read(hermesCapabilitiesProvider.future);
+      container
+          .read(selectedModelProvider.notifier)
+          .set(hermesSyntheticModel());
+
+      await sendMessageWithContainer(container, 'Read the schedule', [
+        attachment.fileId!,
+      ]);
+
+      check(service.inputs.single.toResponsesJson() as List).deepEquals([
+        {
+          'type': 'message',
+          'role': 'user',
+          'content': [
+            {'type': 'input_text', 'text': 'Read the schedule'},
+            {
+              'type': 'input_file',
+              'file_data': 'data:application/pdf;base64,${base64Encode(bytes)}',
+              'filename': 'schedule.pdf',
+            },
+          ],
+        },
+      ]);
+      final user = container.read(chatMessagesProvider).first;
+      check(user.files!.single['source']).equals('hermes_responses_file');
+      check(user.files!.single.containsKey('hermes_extracted_text')).isFalse();
+    });
+
     test(
       'server switch during document extraction cannot route local text',
       () async {
@@ -2538,11 +2605,11 @@ void main() {
           'conduit_hermes_admission_',
         );
         addTearDown(() => directory.delete(recursive: true));
-        final document = File('${directory.path}/notes.pdf');
+        final document = File('${directory.path}/notes.txt');
         await document.writeAsBytes(const <int>[0x25, 0x50, 0x44, 0x46]);
         final attachment = FileUploadState(
           file: document,
-          fileName: 'notes.pdf',
+          fileName: 'notes.txt',
           fileSize: await document.length(),
           progress: 1,
           status: FileUploadStatus.completed,

--- a/test/features/chat/providers/chat_messages_notifier_streaming_seams_test.dart
+++ b/test/features/chat/providers/chat_messages_notifier_streaming_seams_test.dart
@@ -2549,6 +2549,8 @@ void main() {
         isImage: false,
       );
       final service = _ResponsesHermesApi();
+      final capabilities = Completer<HermesCapabilities>();
+      final capabilitiesRequested = Completer<void>();
       final container = _testContainer(
         overrides: [
           activeConversationProvider.overrideWith(
@@ -2561,23 +2563,29 @@ void main() {
             () => _FixedHermesConfigController(),
           ),
           hermesApiServiceProvider.overrideWithValue(service),
-          hermesCapabilitiesProvider.overrideWith(
-            (ref) async => const HermesCapabilities(inputFiles: true),
-          ),
+          hermesCapabilitiesProvider.overrideWith((ref) {
+            if (!capabilitiesRequested.isCompleted) {
+              capabilitiesRequested.complete();
+            }
+            return capabilities.future;
+          }),
           attachedFilesProvider.overrideWith(
             () => _SeededAttachedFiles([attachment]),
           ),
         ],
       );
       addTearDown(container.dispose);
-      await container.read(hermesCapabilitiesProvider.future);
       container
           .read(selectedModelProvider.notifier)
           .set(hermesSyntheticModel());
 
-      await sendMessageWithContainer(container, 'Read the schedule', [
+      final send = sendMessageWithContainer(container, 'Read the schedule', [
         attachment.fileId!,
       ]);
+      await capabilitiesRequested.future.timeout(const Duration(seconds: 1));
+      check(service.inputs).isEmpty();
+      capabilities.complete(const HermesCapabilities(inputFiles: true));
+      await send;
 
       check(service.inputs.single.toResponsesJson() as List).deepEquals([
         {

--- a/test/features/chat/providers/chat_messages_notifier_streaming_seams_test.dart
+++ b/test/features/chat/providers/chat_messages_notifier_streaming_seams_test.dart
@@ -4913,7 +4913,7 @@ void main() {
       },
     );
 
-    test('Hermes file regeneration leaves a failed assistant bubble', () async {
+    test('Hermes PDF regeneration leaves a failed assistant bubble', () async {
       final user = ChatMessage(
         id: 'user-file',
         role: 'user',
@@ -4921,8 +4921,8 @@ void main() {
         timestamp: DateTime(2024, 1, 1),
         files: const <Map<String, dynamic>>[
           <String, dynamic>{
-            'source': 'hermes_desktop_file',
-            'name': 'archive.zip',
+            'source': 'hermes_responses_file',
+            'name': 'schedule.pdf',
           },
         ],
       );

--- a/test/features/chat/providers/chat_messages_notifier_streaming_seams_test.dart
+++ b/test/features/chat/providers/chat_messages_notifier_streaming_seams_test.dart
@@ -2539,6 +2539,7 @@ void main() {
       final document = File('${directory.path}/schedule.pdf');
       final bytes = utf8.encode('%PDF-1.4\nschedule');
       await document.writeAsBytes(bytes);
+      const image = 'data:image/png;base64,AQID';
       final attachment = FileUploadState(
         file: document,
         fileName: 'schedule.pdf',
@@ -2580,11 +2581,14 @@ void main() {
           .set(hermesSyntheticModel());
 
       final send = sendMessageWithContainer(container, 'Read the schedule', [
+        image,
         attachment.fileId!,
       ]);
       await capabilitiesRequested.future.timeout(const Duration(seconds: 1));
       check(service.inputs).isEmpty();
-      capabilities.complete(const HermesCapabilities(inputFiles: true));
+      capabilities.complete(
+        const HermesCapabilities(inputImages: true, inputFiles: true),
+      );
       await send;
 
       check(service.inputs.single.toResponsesJson() as List).deepEquals([
@@ -2593,6 +2597,7 @@ void main() {
           'role': 'user',
           'content': [
             {'type': 'input_text', 'text': 'Read the schedule'},
+            {'type': 'input_image', 'image_url': image},
             {
               'type': 'input_file',
               'file_data': 'data:application/pdf;base64,${base64Encode(bytes)}',
@@ -2602,8 +2607,8 @@ void main() {
         },
       ]);
       final user = container.read(chatMessagesProvider).first;
-      check(user.files!.single['source']).equals('hermes_responses_file');
-      check(user.files!.single.containsKey('hermes_extracted_text')).isFalse();
+      check(user.files!.last['source']).equals('hermes_responses_file');
+      check(user.files!.last.containsKey('hermes_extracted_text')).isFalse();
     });
 
     test('Hermes mixed files share one aggregate byte budget', () async {

--- a/test/features/hermes/hermes_chat_input_test.dart
+++ b/test/features/hermes/hermes_chat_input_test.dart
@@ -50,6 +50,32 @@ void main() {
         .deepEquals(input.toResponsesJson() as List<Object?>);
   });
 
+  test('file input uses the Responses input_file wire shape', () {
+    final input = HermesChatInput.multimodal([
+      HermesInputTextPart('Read this'),
+      HermesInputFilePart(
+        filename: 'schedule.pdf',
+        mediaType: 'application/pdf',
+        base64Data: 'JVBERi0xLjQ=',
+      ),
+    ]);
+
+    check(input.toResponsesJson() as List).deepEquals([
+      {
+        'type': 'message',
+        'role': 'user',
+        'content': [
+          {'type': 'input_text', 'text': 'Read this'},
+          {
+            'type': 'input_file',
+            'file_data': 'data:application/pdf;base64,JVBERi0xLjQ=',
+            'filename': 'schedule.pdf',
+          },
+        ],
+      },
+    ]);
+  });
+
   test('rejects empty turns and unsupported image references', () {
     check(() => HermesChatInput.text('  ')).throws<ArgumentError>();
     check(() => HermesChatInput.multimodal(const [])).throws<ArgumentError>();

--- a/test/features/hermes/hermes_real_payloads_test.dart
+++ b/test/features/hermes/hermes_real_payloads_test.dart
@@ -39,6 +39,7 @@ void main() {
     check(caps.jobs).isTrue(); // list surface shown
     check(caps.jobsAdmin).isFalse(); // writes disabled
     check(caps.inputImages).isTrue();
+    check(caps.inputFiles).isTrue();
   });
 
   test('toolsets: real payload parses tools', () {

--- a/test/features/hermes/hermes_tier1_test.dart
+++ b/test/features/hermes/hermes_tier1_test.dart
@@ -58,6 +58,7 @@ void main() {
       check(caps.runApproval).isTrue();
       check(caps.toolsets).isTrue();
       check(caps.inputImages).isFalse();
+      check(caps.inputFiles).isFalse();
     });
 
     test('null feature values remain optimistic', () {
@@ -98,7 +99,10 @@ void main() {
 
       check(viaFeature.inputImages).isTrue();
       check(viaEndpoint.inputImages).isTrue();
+      check(viaFeature.inputFiles).isTrue();
+      check(viaEndpoint.inputFiles).isTrue();
       check(disabled.inputImages).isFalse();
+      check(disabled.inputFiles).isFalse();
       check(conflictingFlags.inputImages).isFalse();
       check(oldSessionOnly.inputImages).isFalse();
     });

--- a/test/features/notes/providers/notes_providers_test.dart
+++ b/test/features/notes/providers/notes_providers_test.dart
@@ -25,6 +25,7 @@ import 'package:dio/dio.dart';
 import 'package:drift/native.dart';
 import 'package:fleather/fleather.dart';
 import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart' as flutter;
 import 'package:material_ui/material_ui.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter/services.dart';
@@ -113,7 +114,9 @@ Widget _noteEditorHarness({
   required SyncEngine syncEngine,
   bool withBackRoute = false,
   TargetPlatform platform = TargetPlatform.android,
+  Map<String, dynamic>? noteJson,
 }) {
+  final initialNote = noteJson ?? _deletedNoteJson();
   return ProviderScope(
     overrides: [
       appDatabaseProvider.overrideWith((ref) => db),
@@ -125,12 +128,15 @@ Widget _noteEditorHarness({
       syncEngineProvider.overrideWith(() => syncEngine),
       notesFeatureEnabledProvider.overrideWith(_EnabledNotesFeature.new),
       noteByIdProvider('deleted-note')
-          .overrideWith((ref) async => Note.fromJson(_deletedNoteJson())),
+          .overrideWith((ref) async => Note.fromJson(initialNote)),
     ],
     child: MaterialApp(
       theme: AppTheme.light(TweakcnThemes.conduit).copyWith(platform: platform),
       localizationsDelegates: conduitLocalizationsDelegates,
       supportedLocales: AppLocalizations.supportedLocales,
+      builder: noteJson == null
+          ? null
+          : (context, child) => flutter.Material(child: child),
       initialRoute: withBackRoute ? '/editor' : null,
       home: withBackRoute ? null : const NoteEditorPage(noteId: 'deleted-note'),
       routes: withBackRoute
@@ -226,6 +232,42 @@ void main() {
         TargetPlatform.iOS,
       }),
     );
+
+    testWidgets('checkbox toggles autosave canonical markdown', (tester) async {
+      await tester.binding.setSurfaceSize(const Size(1200, 900));
+      addTearDown(() => tester.binding.setSurfaceSize(null));
+      final noteJson = <String, dynamic>{
+        ..._deletedNoteJson(),
+        'data': {
+          'content': {
+            'md': '- [ ] Task',
+            'html': '<div class="checklist">Task</div>',
+          },
+        },
+      };
+      await db.into(db.notes).insertOnConflictUpdate(serverToNoteRow(noteJson));
+      await tester.pumpWidget(
+        _noteEditorHarness(
+          db: db,
+          syncEngine: _NoDrainSyncEngine(),
+          noteJson: noteJson,
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      final checkbox = find.byWidgetPredicate(
+        (widget) => widget.runtimeType.toString() == 'FleatherCheckbox',
+      );
+      check(checkbox.evaluate()).length.equals(1);
+      await tester.tap(checkbox);
+      await tester.pump(const Duration(milliseconds: 900));
+      await tester.pumpAndSettle();
+
+      final row = await db.notesDao.getNote('deleted-note');
+      final content = decodeNoteData(row!.data)['content'] as Map;
+      check(content['md'] as String).contains('[X] Task');
+      check(content['html']).equals('');
+    });
 
     test('renders cached Drift notes when the API is unavailable', () async {
       await db

--- a/test/features/notes/utils/note_document_codec_test.dart
+++ b/test/features/notes/utils/note_document_codec_test.dart
@@ -64,20 +64,4 @@ void main() {
           .contains('[docs](https://example.com)');
     });
   });
-
-  group('htmlFromDocument', () {
-    test('emits HTML tags for formatted content', () {
-      final html = htmlFromDocument(documentFromMarkdown('# Title'));
-      check(html.toLowerCase()).contains('<h1');
-    });
-
-    test('emits paragraph markup for plain text', () {
-      final html = htmlFromDocument(documentFromMarkdown('hello world'));
-      check(html.toLowerCase()).contains('hello world');
-    });
-
-    test('returns a string for empty documents', () {
-      check(htmlFromDocument(documentFromMarkdown(''))).isA<String>();
-    });
-  });
 }


### PR DESCRIPTION
## Summary

- open citation sources from the native iOS Sources sheet in SFSafariViewController
- persist Fleather checklist toggles through document changes and keep Markdown canonical for Open WebUI notes
- accept PDFs for Responses-capable Hermes servers and send them as input_file content parts

Closes #662
Closes #653
Closes #649

## Test plan

- flutter analyze
- focused citation, note checklist, Hermes capability, picker, upload, and Responses payload tests
- flutter test: 5,637 passed; the FTS append microbenchmark missed its 10 ms budget under aggregate load and passed when rerun alone
- flutter build ios --simulator --debug
- launch app.cogwheel.conduit.debug on a fresh iPhone 17 Pro simulator and verify onboarding renders

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix in-app citation links, note checklist persistence, and Hermes PDF input
> - Citation menu items of kind "source" now open in an in-app `SFSafariViewController` instead of leaving the app.
> - Hermes turns can include PDF files as Responses `input_file` parts when the server advertises `inputFiles` capability. File pickers dynamically include PDF extensions, and the aggregate 16 MB limit applies across local documents and input files.
> - Note editor now subscribes to `ParchmentDocument.changes` stream instead of a controller listener, and notes persist only markdown with `html` always set to an empty string.
> - Risk: `note_document_codec.dart` removes `htmlFromDocument`; any caller relying on HTML generation must persist markdown only. Regenerating a Hermes message with any file attachment now produces a failed assistant bubble with an error instead of proceeding.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f52d290.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Hermes Responses conversations can now accept PDF attachments when file input is supported.
  - Attachment pickers dynamically show supported file types, including PDF when available.
  - Source links can open in an in-app Safari view when available.

- **Bug Fixes**
  - Unsupported PDF uploads now provide a capability-specific message.
  - PDF and text attachments share local size-limit handling.

- **Notes**
  - Notes use Markdown as the canonical format, with checklist changes autosaved correctly.
  - Stored HTML content remains empty for notes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->







<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This update improves citation navigation on iOS, preserves notes as canonical Markdown for checklist edits, and adds capability-gated PDF attachments for Hermes Responses servers. No blocking failure remains.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

No blocking failure remains.

No accepted P0 or P1 findings remain, so the confidence score is 5.
</details>

<sub>Reviews (4): Last reviewed commit: ["Reject replaying Hermes PDF attachments"](https://github.com/cogwheel0/conduit/commit/f52d29066193b7e7073c9acaed74dd1721179a19) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56591177)</sub>

<!-- /greptile_comment -->