### PR TITLE
feat(openwebui): support v0.11.1

### DIFF
--- a/lib/core/models/openwebui_chat_prompt.dart
+++ b/lib/core/models/openwebui_chat_prompt.dart
@@ -174,7 +174,7 @@ OpenWebUiPendingToolPrompt? findPendingOpenWebUiToolPrompt(
       for (final item in message.output!)
         if (item['type']?.toString() == 'function_call_output' &&
             (item['call_id']?.toString().isNotEmpty ?? false))
-          item['call_id'].toString(),
+          item['call_id'].toString().trim(),
     };
     for (final item in message.output!) {
       if (item['type']?.toString() != 'function_call') continue;

--- a/lib/core/models/openwebui_chat_prompt.dart
+++ b/lib/core/models/openwebui_chat_prompt.dart
@@ -67,7 +67,7 @@ class OpenWebUiPendingToolPrompt {
   final OpenWebUiComposerPrompt prompt;
 }
 
-String _boundedString(Object? value, int maxLength) {
+String boundedOpenWebUiString(Object? value, int maxLength) {
   final normalized = value?.toString().trim() ?? '';
   if (normalized.length <= maxLength) return normalized;
   var end = maxLength;
@@ -122,15 +122,15 @@ OpenWebUiComposerPrompt? parseOpenWebUiAskUserPrompt(
       return null;
     }
 
-    final id = _boundedString(rawQuestion['id'], 64);
-    final question = _boundedString(rawQuestion['question'], 500);
+    final id = boundedOpenWebUiString(rawQuestion['id'], 64);
+    final question = boundedOpenWebUiString(rawQuestion['question'], 500);
     if (id.isEmpty || question.isEmpty || !seenIds.add(id)) return null;
 
     final options = <OpenWebUiPromptOption>[];
     for (final rawOption in rawOptions) {
       final option = _stringMap(rawOption);
-      final label = _boundedString(option?['label'], 80);
-      final description = _boundedString(option?['description'], 240);
+      final label = boundedOpenWebUiString(option?['label'], 80);
+      final description = boundedOpenWebUiString(option?['description'], 240);
       if (option == null || label.isEmpty || description.isEmpty) return null;
       options.add(
         OpenWebUiPromptOption(label: label, description: description),
@@ -140,9 +140,9 @@ OpenWebUiComposerPrompt? parseOpenWebUiAskUserPrompt(
     questions.add(
       OpenWebUiPromptQuestion(
         id: id,
-        header: _boundedString(rawQuestion['header'], 48).isEmpty
+        header: boundedOpenWebUiString(rawQuestion['header'], 48).isEmpty
             ? 'Question ${index + 1}'
-            : _boundedString(rawQuestion['header'], 48),
+            : boundedOpenWebUiString(rawQuestion['header'], 48),
         question: question,
         options: List<OpenWebUiPromptOption>.unmodifiable(options),
         allowOther: rawQuestion['allow_other'] is bool
@@ -192,7 +192,7 @@ OpenWebUiPendingToolPrompt? findPendingOpenWebUiToolPrompt(
         continue;
       }
 
-      final name = _boundedString(item['name'], 80);
+      final name = boundedOpenWebUiString(item['name'], 80);
       if (name == 'ask_user') {
         final arguments = _decodeArguments(item['arguments']);
         final prompt = parseOpenWebUiAskUserPrompt(
@@ -240,7 +240,7 @@ String formatOpenWebUiToolArguments(Object? value) {
   } catch (_) {
     text = normalized.toString();
   }
-  return _boundedString(text, 2000);
+  return boundedOpenWebUiString(text, 2000);
 }
 
 List<Map<String, dynamic>> applyOpenWebUiToolCallResolution({
@@ -249,13 +249,16 @@ List<Map<String, dynamic>> applyOpenWebUiToolCallResolution({
   required String action,
   Map<String, dynamic>? answers,
 }) {
+  final normalizedCallId = callId.trim();
+  if (normalizedCallId.isEmpty) return output;
   final next = output
       .map((item) => Map<String, dynamic>.from(item))
       .toList(growable: true);
   final callIndex = next.indexWhere(
     (item) =>
         item['type']?.toString() == 'function_call' &&
-        (item['call_id']?.toString() ?? item['id']?.toString()) == callId,
+        (item['call_id']?.toString().trim() ?? item['id']?.toString().trim()) ==
+            normalizedCallId,
   );
   if (callIndex == -1) return output;
 

--- a/lib/core/models/openwebui_chat_prompt.dart
+++ b/lib/core/models/openwebui_chat_prompt.dart
@@ -1,0 +1,300 @@
+import 'dart:convert';
+
+import 'package:flutter/foundation.dart';
+
+import 'chat_message.dart';
+
+enum OpenWebUiComposerPromptKind { askUser, toolApproval, confirmation }
+
+enum OpenWebUiToolCallAction { approve, reject, answer }
+
+@immutable
+class OpenWebUiPromptOption {
+  const OpenWebUiPromptOption({required this.label, required this.description});
+
+  final String label;
+  final String description;
+}
+
+@immutable
+class OpenWebUiPromptQuestion {
+  const OpenWebUiPromptQuestion({
+    required this.id,
+    required this.header,
+    required this.question,
+    required this.options,
+    required this.allowOther,
+  });
+
+  final String id;
+  final String header;
+  final String question;
+  final List<OpenWebUiPromptOption> options;
+  final bool allowOther;
+}
+
+@immutable
+class OpenWebUiComposerPrompt {
+  const OpenWebUiComposerPrompt({
+    required this.identity,
+    required this.kind,
+    this.title = '',
+    this.message = '',
+    this.questions = const <OpenWebUiPromptQuestion>[],
+    this.timeout = const Duration(minutes: 2),
+  });
+
+  final String identity;
+  final OpenWebUiComposerPromptKind kind;
+  final String title;
+  final String message;
+  final List<OpenWebUiPromptQuestion> questions;
+  final Duration timeout;
+}
+
+@immutable
+class OpenWebUiPendingToolPrompt {
+  const OpenWebUiPendingToolPrompt({
+    required this.messageId,
+    required this.callId,
+    required this.toolName,
+    required this.prompt,
+  });
+
+  final String messageId;
+  final String callId;
+  final String toolName;
+  final OpenWebUiComposerPrompt prompt;
+}
+
+String _boundedString(Object? value, int maxLength) {
+  final normalized = value?.toString().trim() ?? '';
+  if (normalized.length <= maxLength) return normalized;
+  var end = maxLength;
+  final last = normalized.codeUnitAt(end - 1);
+  if (last >= 0xD800 && last <= 0xDBFF) end--;
+  return normalized.substring(0, end);
+}
+
+Map<String, dynamic>? _stringMap(Object? value) {
+  if (value is Map<String, dynamic>) return value;
+  if (value is Map) {
+    return value.map((key, item) => MapEntry(key.toString(), item));
+  }
+  return null;
+}
+
+Map<String, dynamic>? _decodeArguments(Object? value) {
+  Object? current = value;
+  for (var attempt = 0; attempt < 3 && current is String; attempt++) {
+    try {
+      current = jsonDecode(current);
+    } catch (_) {
+      return null;
+    }
+  }
+  return _stringMap(current);
+}
+
+OpenWebUiComposerPrompt? parseOpenWebUiAskUserPrompt(
+  Object? value, {
+  required String identity,
+}) {
+  final data = _stringMap(value);
+  final rawQuestions = data?['questions'];
+  if (data == null || rawQuestions is! List || rawQuestions.length > 3) {
+    return null;
+  }
+  if (rawQuestions.isEmpty) return null;
+
+  final defaultAllowOther = data['allow_other'] is bool
+      ? data['allow_other'] as bool
+      : true;
+  final seenIds = <String>{};
+  final questions = <OpenWebUiPromptQuestion>[];
+  for (var index = 0; index < rawQuestions.length; index++) {
+    final rawQuestion = _stringMap(rawQuestions[index]);
+    final rawOptions = rawQuestion?['options'];
+    if (rawQuestion == null ||
+        rawOptions is! List ||
+        rawOptions.length < 2 ||
+        rawOptions.length > 3) {
+      return null;
+    }
+
+    final id = _boundedString(rawQuestion['id'], 64);
+    final question = _boundedString(rawQuestion['question'], 500);
+    if (id.isEmpty || question.isEmpty || !seenIds.add(id)) return null;
+
+    final options = <OpenWebUiPromptOption>[];
+    for (final rawOption in rawOptions) {
+      final option = _stringMap(rawOption);
+      final label = _boundedString(option?['label'], 80);
+      final description = _boundedString(option?['description'], 240);
+      if (option == null || label.isEmpty || description.isEmpty) return null;
+      options.add(
+        OpenWebUiPromptOption(label: label, description: description),
+      );
+    }
+
+    questions.add(
+      OpenWebUiPromptQuestion(
+        id: id,
+        header: _boundedString(rawQuestion['header'], 48).isEmpty
+            ? 'Question ${index + 1}'
+            : _boundedString(rawQuestion['header'], 48),
+        question: question,
+        options: List<OpenWebUiPromptOption>.unmodifiable(options),
+        allowOther: rawQuestion['allow_other'] is bool
+            ? rawQuestion['allow_other'] as bool
+            : defaultAllowOther,
+      ),
+    );
+  }
+
+  final rawTimeout = data['timeout_ms'];
+  final timeoutMs =
+      rawTimeout is int && rawTimeout >= 60000 && rawTimeout <= 240000
+      ? rawTimeout
+      : 120000;
+  return OpenWebUiComposerPrompt(
+    identity: identity,
+    kind: OpenWebUiComposerPromptKind.askUser,
+    questions: List<OpenWebUiPromptQuestion>.unmodifiable(questions),
+    timeout: Duration(milliseconds: timeoutMs),
+  );
+}
+
+OpenWebUiPendingToolPrompt? findPendingOpenWebUiToolPrompt(
+  List<ChatMessage> messages,
+) {
+  for (final message in messages.reversed) {
+    if (message.role != 'assistant' || message.output == null) continue;
+    final resultCallIds = <String>{
+      for (final item in message.output!)
+        if (item['type']?.toString() == 'function_call_output' &&
+            (item['call_id']?.toString().isNotEmpty ?? false))
+          item['call_id'].toString(),
+    };
+    for (final item in message.output!) {
+      if (item['type']?.toString() != 'function_call') continue;
+      final callId =
+          item['call_id']?.toString().trim() ??
+          item['id']?.toString().trim() ??
+          '';
+      final status = item['status']?.toString();
+      if (callId.isEmpty ||
+          resultCallIds.contains(callId) ||
+          (status != 'pending' &&
+              status != 'queued' &&
+              status != 'requires_approval') ||
+          (status == 'queued' && item['approved'] == true)) {
+        continue;
+      }
+
+      final name = _boundedString(item['name'], 80);
+      if (name == 'ask_user') {
+        final arguments = _decodeArguments(item['arguments']);
+        final prompt = parseOpenWebUiAskUserPrompt(
+          arguments,
+          identity: 'saved:${message.id}:$callId',
+        );
+        if (prompt == null) continue;
+        return OpenWebUiPendingToolPrompt(
+          messageId: message.id,
+          callId: callId,
+          toolName: name,
+          prompt: prompt,
+        );
+      }
+
+      final arguments = formatOpenWebUiToolArguments(item['arguments']);
+      return OpenWebUiPendingToolPrompt(
+        messageId: message.id,
+        callId: callId,
+        toolName: name.isEmpty ? 'Tool' : name,
+        prompt: OpenWebUiComposerPrompt(
+          identity: 'saved:${message.id}:$callId',
+          kind: OpenWebUiComposerPromptKind.toolApproval,
+          title: name.isEmpty ? 'Tool' : name,
+          message: arguments,
+        ),
+      );
+    }
+  }
+  return null;
+}
+
+String formatOpenWebUiToolArguments(Object? value) {
+  Object? normalized = value;
+  if (value is String) {
+    try {
+      normalized = jsonDecode(value);
+    } catch (_) {}
+  }
+  String text;
+  try {
+    text = normalized is Map || normalized is List
+        ? const JsonEncoder.withIndent('  ').convert(normalized)
+        : normalized?.toString() ?? '';
+  } catch (_) {
+    text = normalized.toString();
+  }
+  return _boundedString(text, 2000);
+}
+
+List<Map<String, dynamic>> applyOpenWebUiToolCallResolution({
+  required List<Map<String, dynamic>> output,
+  required String callId,
+  required String action,
+  Map<String, dynamic>? answers,
+}) {
+  final next = output
+      .map((item) => Map<String, dynamic>.from(item))
+      .toList(growable: true);
+  final callIndex = next.indexWhere(
+    (item) =>
+        item['type']?.toString() == 'function_call' &&
+        (item['call_id']?.toString() ?? item['id']?.toString()) == callId,
+  );
+  if (callIndex == -1) return output;
+
+  final call = next[callIndex];
+  switch (action) {
+    case 'approve':
+      call['status'] = 'queued';
+      call['approved'] = true;
+      break;
+    case 'reject':
+      call['status'] = 'rejected';
+      next.add({
+        'type': 'function_call_output',
+        'id': 'fco_$callId',
+        'call_id': callId,
+        'output': const [
+          {'type': 'input_text', 'text': 'Error: tool call rejected by user.'},
+        ],
+        'status': 'rejected',
+      });
+      break;
+    case 'answer':
+      call['status'] = 'completed';
+      next.add({
+        'type': 'function_call_output',
+        'id': 'fco_$callId',
+        'call_id': callId,
+        'output': [
+          {
+            'type': 'input_text',
+            'text': jsonEncode({
+              'status': 'answered',
+              'answers': answers ?? const <String, dynamic>{},
+            }),
+          },
+        ],
+        'status': 'completed',
+      });
+      break;
+  }
+  return List<Map<String, dynamic>>.unmodifiable(next);
+}

--- a/lib/core/providers/app_providers.dart
+++ b/lib/core/providers/app_providers.dart
@@ -6017,6 +6017,7 @@ class AccountProfile extends _$AccountProfile {
       password: password,
       newPassword: newPassword,
     );
+    await ref.read(authStateManagerProvider.notifier).logout();
   }
 
   Future<AccountMetadata?> _loadProfile() async {

--- a/lib/core/providers/app_providers.dart
+++ b/lib/core/providers/app_providers.dart
@@ -6013,10 +6013,16 @@ class AccountProfile extends _$AccountProfile {
     if (api == null) {
       throw StateError('No API service available');
     }
+    final authenticationEpoch = api.authenticationEpoch;
     await api.updateAccountPassword(
       password: password,
       newPassword: newPassword,
     );
+    if (!ref.mounted ||
+        !identical(api, ref.read(apiServiceProvider)) ||
+        api.authenticationEpoch != authenticationEpoch) {
+      return;
+    }
     await ref.read(authStateManagerProvider.notifier).logout();
   }
 

--- a/lib/core/services/api_service.dart
+++ b/lib/core/services/api_service.dart
@@ -18,6 +18,7 @@ import '../models/file_info.dart';
 import '../models/knowledge_base.dart';
 import '../models/knowledge_base_file.dart';
 import '../models/model.dart';
+import '../models/openwebui_chat_prompt.dart';
 import '../models/prompt.dart';
 import '../models/server_about_info.dart';
 import '../models/server_config.dart';
@@ -8216,6 +8217,36 @@ class ApiService {
     } catch (e) {
       rethrow;
     }
+  }
+
+  Future<List<String>> resolveChatMessageToolCall({
+    required String chatId,
+    required String messageId,
+    required String callId,
+    required OpenWebUiToolCallAction action,
+    Map<String, dynamic>? answers,
+  }) async {
+    final response = await _dio.post(
+      '/api/v1/chats/${Uri.encodeComponent(chatId)}/messages/'
+      '${Uri.encodeComponent(messageId)}/resolve',
+      data: <String, dynamic>{
+        'call_id': callId,
+        'action': action.name,
+        if (action == OpenWebUiToolCallAction.answer) 'answers': answers,
+      },
+    );
+    final data = response.data;
+    if (data is! Map) return const <String>[];
+    final rawTaskIds = data['task_ids'];
+    final taskIds = rawTaskIds is List
+        ? rawTaskIds
+              .map((value) => value?.toString().trim() ?? '')
+              .where((value) => value.isNotEmpty)
+        : data['task_id'] == null
+        ? const Iterable<String>.empty()
+        : <String>[data['task_id'].toString().trim()]
+              .where((value) => value.isNotEmpty);
+    return taskIds.toSet().toList(growable: false);
   }
 
   /// Set once the bulk active-chats endpoint returns 404 or 405. Open WebUI

--- a/lib/core/services/streaming_helper.dart
+++ b/lib/core/services/streaming_helper.dart
@@ -508,6 +508,12 @@ ActiveChatStream attachUnifiedChunkedStreaming({
   void Function(String newTitle)? onChatTitleUpdated,
   void Function()? onChatTagsUpdated,
   void Function(String path)? onTerminalDisplayFile,
+  void Function(
+    String type,
+    Map<String, dynamic> data,
+    void Function(dynamic response) acknowledge,
+  )?
+  onInteractivePrompt,
 
   /// Called when a `chat:active` event is received, indicating a background
   /// task has started (active=true) or completed (active=false).
@@ -3490,6 +3496,24 @@ ActiveChatStream attachUnifiedChunkedStreaming({
           final content = map['content']?.toString() ?? '';
           _showSocketNotification(notifType, content);
         }
+      } else if (type == 'request:user_input' && payload != null) {
+        if (!matchesCurrentStreamSession(incomingSessionId)) {
+          return;
+        }
+        if (ack != null) {
+          final map = _asStringMap(payload);
+          if (map == null) {
+            ack(const <String, dynamic>{
+              'error': 'Invalid user input request.',
+            });
+          } else if (onInteractivePrompt != null) {
+            onInteractivePrompt(type.toString(), map, ack);
+          } else {
+            ack(const <String, dynamic>{
+              'error': 'User input is not available.',
+            });
+          }
+        }
       } else if (type == 'confirmation' && payload != null) {
         if (!matchesCurrentStreamSession(incomingSessionId)) {
           return;
@@ -3497,12 +3521,16 @@ ActiveChatStream attachUnifiedChunkedStreaming({
         if (ack != null) {
           final map = _asStringMap(payload);
           if (map != null) {
-            () async {
-              final confirmed = await _showConfirmationDialog(map);
-              try {
-                ack(confirmed);
-              } catch (_) {}
-            }();
+            if (onInteractivePrompt != null) {
+              onInteractivePrompt(type.toString(), map, ack);
+            } else {
+              () async {
+                final confirmed = await _showConfirmationDialog(map);
+                try {
+                  ack(confirmed);
+                } catch (_) {}
+              }();
+            }
           } else {
             ack(false);
           }

--- a/lib/core/utils/server_version_compat.dart
+++ b/lib/core/utils/server_version_compat.dart
@@ -17,10 +17,10 @@ class ServerVersionCompat {
   /// Servers reporting a `/api/config` `version` strictly greater than this are
   /// shown a compatibility warning. Bump this (and re-verify against
   /// `openwebui-src/`) whenever a newer server release is validated.
-  static const String maxSupportedVersion = '0.11.0';
+  static const String maxSupportedVersion = '0.11.1';
 
   /// Parsed [maxSupportedVersion] components: `[major, minor, patch]`.
-  static const List<int> _maxSupported = [0, 11, 0];
+  static const List<int> _maxSupported = [0, 11, 1];
 
   /// Whether [rawVersion] is within the supported range (<= [maxSupportedVersion]).
   ///

--- a/lib/features/chat/providers/chat_providers.dart
+++ b/lib/features/chat/providers/chat_providers.dart
@@ -1572,7 +1572,7 @@ class ChatMessagesNotifier extends Notifier<List<ChatMessage>>
   Timer? _passiveConversationRefreshTimer;
   bool _taskStatusCheckInFlight = false;
   int _taskStatusGeneration = 0;
-  int _nonTailToolTaskGeneration = 0;
+  final Set<Object> _nonTailToolTaskMonitors = <Object>{};
   bool _observedRemoteTask = false;
   // Feature C: number of consecutive polls that saw `tasksDone` while a socket
   // resume stream still held protection. The poll's force-adoption is deferred
@@ -4633,7 +4633,7 @@ class ChatMessagesNotifier extends Notifier<List<ChatMessage>>
   }
 
   void _stopNonTailToolTaskMonitor() {
-    _nonTailToolTaskGeneration++;
+    _nonTailToolTaskMonitors.clear();
   }
 
   void _monitorNonTailToolTask({
@@ -4642,7 +4642,8 @@ class ChatMessagesNotifier extends Notifier<List<ChatMessage>>
     required String messageId,
     required List<String> taskIds,
   }) {
-    final generation = ++_nonTailToolTaskGeneration;
+    final monitor = Object();
+    _nonTailToolTaskMonitors.add(monitor);
     final owner = captureOpenWebUiCompletionOwner(
       ref,
       chatId: conversation.id,
@@ -4654,74 +4655,85 @@ class ChatMessagesNotifier extends Notifier<List<ChatMessage>>
     final activationToken = activeChats.activationToken(conversation.id);
 
     unawaited(() async {
-      var fastPollsRemaining = _remoteTaskFastPollCount;
-      var consecutiveFailures = 0;
-      var hasActiveTask = true;
+      try {
+        var fastPollsRemaining = _remoteTaskFastPollCount;
+        var consecutiveFailures = 0;
+        var hasActiveTask = true;
 
-      while (!_disposed && generation == _nonTailToolTaskGeneration) {
-        if (!_isAppForeground) {
-          await Future<void>.delayed(const Duration(seconds: 3));
-          continue;
-        }
-
-        try {
-          final activeChatId = activeOpenWebUiChatIdForMutation(ref, owner);
-          if (activeChatId == null) return;
-          final activeTaskIds = await api.getTaskIdsByChat(activeChatId);
-          if (_disposed || generation != _nonTailToolTaskGeneration) return;
-          if (activeOpenWebUiChatIdForMutation(ref, owner) != activeChatId) {
-            return;
+        while (!_disposed && _nonTailToolTaskMonitors.contains(monitor)) {
+          if (!_isAppForeground) {
+            await Future<void>.delayed(const Duration(seconds: 3));
+            continue;
           }
-          hasActiveTask = activeTaskIds.any(expectedTaskIds.contains);
 
-          final serverConversation = await api.getConversation(activeChatId);
-          if (_disposed || generation != _nonTailToolTaskGeneration) return;
-          if (activeOpenWebUiChatIdForMutation(ref, owner) != activeChatId) {
-            return;
-          }
-          _adoptServerMessages(
-            serverConversation.messages,
-            source: 'non-tail tool task poll',
-          );
-          if (hasActiveTask) {
-            updateMessageById(messageId, (message) {
-              return message.copyWith(
-                isStreaming: false,
-                metadata: <String, dynamic>{
-                  ...?message.metadata,
-                  'taskId': taskIds.first,
-                  'taskConversationId': activeChatId,
-                },
-              );
-            });
-          } else {
-            if (activeTaskIds.isEmpty) {
-              activeChats.setInactiveIfUnchanged(activeChatId, activationToken);
+          try {
+            final activeChatId = activeOpenWebUiChatIdForMutation(ref, owner);
+            if (activeChatId == null) return;
+            final activeTaskIds = await api.getTaskIdsByChat(activeChatId);
+            if (_disposed || !_nonTailToolTaskMonitors.contains(monitor)) {
+              return;
             }
-            schedulePullChatNow(ref, activeChatId);
-            return;
+            if (activeOpenWebUiChatIdForMutation(ref, owner) != activeChatId) {
+              return;
+            }
+            hasActiveTask = activeTaskIds.any(expectedTaskIds.contains);
+
+            final serverConversation = await api.getConversation(activeChatId);
+            if (_disposed || !_nonTailToolTaskMonitors.contains(monitor)) {
+              return;
+            }
+            if (activeOpenWebUiChatIdForMutation(ref, owner) != activeChatId) {
+              return;
+            }
+            _adoptServerMessages(
+              serverConversation.messages,
+              source: 'non-tail tool task poll',
+            );
+            if (hasActiveTask) {
+              updateMessageById(messageId, (message) {
+                return message.copyWith(
+                  isStreaming: false,
+                  metadata: <String, dynamic>{
+                    ...?message.metadata,
+                    'taskId': taskIds.first,
+                    'taskConversationId': activeChatId,
+                  },
+                );
+              });
+            } else {
+              if (activeTaskIds.isEmpty) {
+                activeChats.setInactiveIfUnchanged(
+                  activeChatId,
+                  activationToken,
+                );
+              }
+              schedulePullChatNow(ref, activeChatId);
+              return;
+            }
+
+            consecutiveFailures = 0;
+            if (fastPollsRemaining > 0) fastPollsRemaining--;
+          } catch (error, stack) {
+            consecutiveFailures++;
+            DebugLogger.error(
+              'non-tail-tool-task-poll-failed',
+              scope: 'chat/resume',
+              error: error,
+              stackTrace: stack,
+            );
           }
 
-          consecutiveFailures = 0;
-          if (fastPollsRemaining > 0) fastPollsRemaining--;
-        } catch (error, stack) {
-          consecutiveFailures++;
-          DebugLogger.error(
-            'non-tail-tool-task-poll-failed',
-            scope: 'chat/resume',
-            error: error,
-            stackTrace: stack,
+          await Future<void>.delayed(
+            debugRemoteTaskPollDelayForTesting(
+              fastPollsRemaining: fastPollsRemaining,
+              consecutiveFailures: consecutiveFailures,
+              consecutiveCompletionMisses: 0,
+              hasActiveTask: hasActiveTask,
+            ),
           );
         }
-
-        await Future<void>.delayed(
-          debugRemoteTaskPollDelayForTesting(
-            fastPollsRemaining: fastPollsRemaining,
-            consecutiveFailures: consecutiveFailures,
-            consecutiveCompletionMisses: 0,
-            hasActiveTask: hasActiveTask,
-          ),
-        );
+      } finally {
+        _nonTailToolTaskMonitors.remove(monitor);
       }
     }());
   }

--- a/lib/features/chat/providers/chat_providers.dart
+++ b/lib/features/chat/providers/chat_providers.dart
@@ -4697,7 +4697,6 @@ class ChatMessagesNotifier extends Notifier<List<ChatMessage>>
         var fastPollsRemaining = _remoteTaskFastPollCount;
         var consecutiveFailures = 0;
         var hasActiveTask = true;
-        var observedExpectedTask = false;
 
         while (!_disposed && _nonTailToolTaskMonitors.contains(monitor)) {
           if (!_isAppForeground) {
@@ -4716,9 +4715,6 @@ class ChatMessagesNotifier extends Notifier<List<ChatMessage>>
               return;
             }
             hasActiveTask = activeTaskIds.any(expectedTaskIds.contains);
-            if (hasActiveTask) {
-              observedExpectedTask = true;
-            }
 
             final serverConversation = await api.getConversation(activeChatId);
             if (_disposed || !_nonTailToolTaskMonitors.contains(monitor)) {
@@ -4728,17 +4724,17 @@ class ChatMessagesNotifier extends Notifier<List<ChatMessage>>
               return;
             }
             // A returned task ID can remain absent from the registry for more
-            // than one poll. Until the task is observed, only an authoritative
-            // terminal call result proves that monitoring can stop.
-            final awaitingRegistration =
+            // than one poll, and multiple returned tasks can register in
+            // sequence. Only an authoritative terminal call result proves
+            // that monitoring can stop while none of them is active.
+            final awaitingTaskOrTerminal =
                 !hasActiveTask &&
-                !observedExpectedTask &&
                 !_serverToolCallIsTerminal(
                   serverConversation,
                   messageId: messageId,
                   callId: callId,
                 );
-            if (!awaitingRegistration) {
+            if (!awaitingTaskOrTerminal) {
               _adoptServerMessages(
                 serverConversation.messages,
                 source: 'non-tail tool task poll',
@@ -4755,7 +4751,7 @@ class ChatMessagesNotifier extends Notifier<List<ChatMessage>>
                   },
                 );
               });
-            } else if (!awaitingRegistration) {
+            } else if (!awaitingTaskOrTerminal) {
               if (activeTaskIds.isEmpty) {
                 activeChats.setInactiveIfUnchanged(
                   activeChatId,

--- a/lib/features/chat/providers/chat_providers.dart
+++ b/lib/features/chat/providers/chat_providers.dart
@@ -5249,12 +5249,11 @@ class ChatMessagesNotifier extends Notifier<List<ChatMessage>>
         state.indexWhere((message) => message.id == messageId) == -1) {
       return;
     }
-    if (taskIds.isNotEmpty &&
-        (state.isEmpty ||
-            state.last.id != messageId ||
-            state.last.role != 'assistant')) {
-      return;
-    }
+    final resumeTailOwnsTask =
+        taskIds.isNotEmpty &&
+        state.isNotEmpty &&
+        state.last.id == messageId &&
+        state.last.role == 'assistant';
 
     updateMessageById(messageId, (message) {
       final output = message.output;
@@ -5267,16 +5266,20 @@ class ChatMessagesNotifier extends Notifier<List<ChatMessage>>
           action: action.name,
           answers: answers,
         ),
-        isStreaming: taskIds.isNotEmpty,
-        metadata: taskIds.isEmpty
-            ? metadata
-            : <String, dynamic>{
+        isStreaming: resumeTailOwnsTask,
+        metadata: resumeTailOwnsTask
+            ? <String, dynamic>{
                 ...?metadata,
                 'taskId': taskIds.first,
                 'taskConversationId': conversation.id,
-              },
+              }
+            : taskIds.isEmpty
+            ? metadata
+            : message.metadata,
       );
     });
+
+    if (taskIds.isNotEmpty && !resumeTailOwnsTask) return;
 
     if (taskIds.isEmpty) {
       try {

--- a/lib/features/chat/providers/chat_providers.dart
+++ b/lib/features/chat/providers/chat_providers.dart
@@ -5249,6 +5249,12 @@ class ChatMessagesNotifier extends Notifier<List<ChatMessage>>
         state.indexWhere((message) => message.id == messageId) == -1) {
       return;
     }
+    if (taskIds.isNotEmpty &&
+        (state.isEmpty ||
+            state.last.id != messageId ||
+            state.last.role != 'assistant')) {
+      return;
+    }
 
     updateMessageById(messageId, (message) {
       final output = message.output;
@@ -5286,11 +5292,6 @@ class ChatMessagesNotifier extends Notifier<List<ChatMessage>>
       return;
     }
 
-    if (state.isEmpty ||
-        state.last.id != messageId ||
-        state.last.role != 'assistant') {
-      return;
-    }
     _reopenedStreamingMessageId = messageId;
     _observedRemoteTask = true;
     ref.read(activeChatIdsProvider.notifier).setActive(conversation.id);

--- a/lib/features/chat/providers/chat_providers.dart
+++ b/lib/features/chat/providers/chat_providers.dart
@@ -1586,7 +1586,7 @@ class ChatMessagesNotifier extends Notifier<List<ChatMessage>>
   // task lookup previously failed. Requiring a second empty observation keeps
   // a temporarily unregistered server task from being finalized immediately.
   int _unobservedReopenedEmptyPolls = 0;
-  static const int _unobservedReopenedEmptyPollGrace = 1;
+  static const int _unobservedTaskEmptyPollGrace = 1;
   bool _passiveConversationRefreshInFlight = false;
   int _passiveConversationGeneration = 0;
   int? _queuedPassiveConversationGeneration;
@@ -4659,6 +4659,8 @@ class ChatMessagesNotifier extends Notifier<List<ChatMessage>>
         var fastPollsRemaining = _remoteTaskFastPollCount;
         var consecutiveFailures = 0;
         var hasActiveTask = true;
+        var observedExpectedTask = false;
+        var unobservedEmptyPolls = 0;
 
         while (!_disposed && _nonTailToolTaskMonitors.contains(monitor)) {
           if (!_isAppForeground) {
@@ -4677,6 +4679,19 @@ class ChatMessagesNotifier extends Notifier<List<ChatMessage>>
               return;
             }
             hasActiveTask = activeTaskIds.any(expectedTaskIds.contains);
+            if (hasActiveTask) {
+              observedExpectedTask = true;
+              unobservedEmptyPolls = 0;
+            } else if (!observedExpectedTask) {
+              unobservedEmptyPolls++;
+            }
+            // The resolve endpoint can return a task ID just before the task
+            // registry exposes it. Keep the locally resolved prompt and poll
+            // once more instead of adopting a stale transcript and exiting.
+            final registrationGraceActive =
+                !hasActiveTask &&
+                !observedExpectedTask &&
+                unobservedEmptyPolls <= _unobservedTaskEmptyPollGrace;
 
             final serverConversation = await api.getConversation(activeChatId);
             if (_disposed || !_nonTailToolTaskMonitors.contains(monitor)) {
@@ -4685,10 +4700,12 @@ class ChatMessagesNotifier extends Notifier<List<ChatMessage>>
             if (activeOpenWebUiChatIdForMutation(ref, owner) != activeChatId) {
               return;
             }
-            _adoptServerMessages(
-              serverConversation.messages,
-              source: 'non-tail tool task poll',
-            );
+            if (!registrationGraceActive) {
+              _adoptServerMessages(
+                serverConversation.messages,
+                source: 'non-tail tool task poll',
+              );
+            }
             if (hasActiveTask) {
               updateMessageById(messageId, (message) {
                 return message.copyWith(
@@ -4700,7 +4717,7 @@ class ChatMessagesNotifier extends Notifier<List<ChatMessage>>
                   },
                 );
               });
-            } else {
+            } else if (!registrationGraceActive) {
               if (activeTaskIds.isEmpty) {
                 activeChats.setInactiveIfUnchanged(
                   activeChatId,
@@ -4795,7 +4812,7 @@ class ChatMessagesNotifier extends Notifier<List<ChatMessage>>
           (_observedRemoteTask ||
               (reopenedTail &&
                   _unobservedReopenedEmptyPolls >
-                      _unobservedReopenedEmptyPollGrace));
+                      _unobservedTaskEmptyPollGrace));
       DebugLogger.log(
         'Remote task recovery status',
         scope: 'chat/resume',

--- a/lib/features/chat/providers/chat_providers.dart
+++ b/lib/features/chat/providers/chat_providers.dart
@@ -1572,6 +1572,7 @@ class ChatMessagesNotifier extends Notifier<List<ChatMessage>>
   Timer? _passiveConversationRefreshTimer;
   bool _taskStatusCheckInFlight = false;
   int _taskStatusGeneration = 0;
+  int _nonTailToolTaskGeneration = 0;
   bool _observedRemoteTask = false;
   // Feature C: number of consecutive polls that saw `tasksDone` while a socket
   // resume stream still held protection. The poll's force-adoption is deferred
@@ -1677,6 +1678,7 @@ class ChatMessagesNotifier extends Notifier<List<ChatMessage>>
           _modelRebindGeneration += 1;
           _cancelMessageStream();
           _stopRemoteTaskMonitor();
+          _stopNonTailToolTaskMonitor();
           _teardownPassiveConversationSync();
           _cancelDbMessagesWatch();
           state = const <ChatMessage>[];
@@ -1735,6 +1737,7 @@ class ChatMessagesNotifier extends Notifier<List<ChatMessage>>
         // Cancel any existing message stream when switching conversations
         _cancelMessageStream();
         _stopRemoteTaskMonitor();
+        _stopNonTailToolTaskMonitor();
         _cancelColdHermesRecovery();
 
         if (next != null) {
@@ -1802,6 +1805,7 @@ class ChatMessagesNotifier extends Notifier<List<ChatMessage>>
         _cancelDbMessagesWatch();
         _cancelMessageStream(clearStreamingContent: false);
         _stopRemoteTaskMonitor();
+        _stopNonTailToolTaskMonitor();
         _cancelColdHermesRecovery();
         _streamingSyncTimer?.cancel();
         _streamingSyncTimer = null;
@@ -1928,6 +1932,7 @@ class ChatMessagesNotifier extends Notifier<List<ChatMessage>>
     // so equal raw ids cannot retain A's stream, DB watch, or socket callback.
     _cancelMessageStream();
     _stopRemoteTaskMonitor();
+    _stopNonTailToolTaskMonitor();
     _teardownPassiveConversationSync();
     _cancelDbMessagesWatch();
     state = const <ChatMessage>[];
@@ -4627,6 +4632,100 @@ class ChatMessagesNotifier extends Notifier<List<ChatMessage>>
     _clearBoundRemoteMessageId(ownedByMessageId: retiringMessageId);
   }
 
+  void _stopNonTailToolTaskMonitor() {
+    _nonTailToolTaskGeneration++;
+  }
+
+  void _monitorNonTailToolTask({
+    required ApiService api,
+    required Conversation conversation,
+    required String messageId,
+    required List<String> taskIds,
+  }) {
+    final generation = ++_nonTailToolTaskGeneration;
+    final owner = captureOpenWebUiCompletionOwner(
+      ref,
+      chatId: conversation.id,
+      api: api,
+    );
+    final expectedTaskIds = taskIds.toSet();
+    final activeChats = ref.read(activeChatIdsProvider.notifier);
+    activeChats.setActive(conversation.id);
+    final activationToken = activeChats.activationToken(conversation.id);
+
+    unawaited(() async {
+      var fastPollsRemaining = _remoteTaskFastPollCount;
+      var consecutiveFailures = 0;
+      var hasActiveTask = true;
+
+      while (!_disposed && generation == _nonTailToolTaskGeneration) {
+        if (!_isAppForeground) {
+          await Future<void>.delayed(const Duration(seconds: 3));
+          continue;
+        }
+
+        try {
+          final activeChatId = activeOpenWebUiChatIdForMutation(ref, owner);
+          if (activeChatId == null) return;
+          final activeTaskIds = await api.getTaskIdsByChat(activeChatId);
+          if (_disposed || generation != _nonTailToolTaskGeneration) return;
+          if (activeOpenWebUiChatIdForMutation(ref, owner) != activeChatId) {
+            return;
+          }
+          hasActiveTask = activeTaskIds.any(expectedTaskIds.contains);
+
+          final serverConversation = await api.getConversation(activeChatId);
+          if (_disposed || generation != _nonTailToolTaskGeneration) return;
+          if (activeOpenWebUiChatIdForMutation(ref, owner) != activeChatId) {
+            return;
+          }
+          _adoptServerMessages(
+            serverConversation.messages,
+            source: 'non-tail tool task poll',
+          );
+          if (hasActiveTask) {
+            updateMessageById(messageId, (message) {
+              return message.copyWith(
+                isStreaming: false,
+                metadata: <String, dynamic>{
+                  ...?message.metadata,
+                  'taskId': taskIds.first,
+                  'taskConversationId': activeChatId,
+                },
+              );
+            });
+          } else {
+            if (activeTaskIds.isEmpty) {
+              activeChats.setInactiveIfUnchanged(activeChatId, activationToken);
+            }
+            schedulePullChatNow(ref, activeChatId);
+            return;
+          }
+
+          consecutiveFailures = 0;
+          if (fastPollsRemaining > 0) fastPollsRemaining--;
+        } catch (error, stack) {
+          consecutiveFailures++;
+          DebugLogger.error(
+            'non-tail-tool-task-poll-failed',
+            scope: 'chat/resume',
+            error: error,
+            stackTrace: stack,
+          );
+        }
+
+        await Future<void>.delayed(
+          debugRemoteTaskPollDelayForTesting(
+            fastPollsRemaining: fastPollsRemaining,
+            consecutiveFailures: consecutiveFailures,
+            consecutiveCompletionMisses: 0,
+            hasActiveTask: hasActiveTask,
+          ),
+        );
+      }
+    }());
+  }
+
   Future<void> _syncRemoteTaskStatus({bool scheduleNext = true}) async {
     if (_taskStatusCheckInFlight) {
       return;
@@ -5267,19 +5366,28 @@ class ChatMessagesNotifier extends Notifier<List<ChatMessage>>
           answers: answers,
         ),
         isStreaming: resumeTailOwnsTask,
-        metadata: resumeTailOwnsTask
+        metadata: taskIds.isNotEmpty
             ? <String, dynamic>{
                 ...?metadata,
                 'taskId': taskIds.first,
                 'taskConversationId': conversation.id,
               }
-            : taskIds.isEmpty
-            ? metadata
-            : message.metadata,
+            : metadata,
       );
     });
 
-    if (taskIds.isNotEmpty && !resumeTailOwnsTask) return;
+    if (taskIds.isNotEmpty && !resumeTailOwnsTask) {
+      final api = ref.read(apiServiceProvider);
+      if (api != null) {
+        _monitorNonTailToolTask(
+          api: api,
+          conversation: conversation,
+          messageId: messageId,
+          taskIds: taskIds,
+        );
+      }
+      return;
+    }
 
     if (taskIds.isEmpty) {
       try {

--- a/lib/features/chat/providers/chat_providers.dart
+++ b/lib/features/chat/providers/chat_providers.dart
@@ -21,6 +21,7 @@ import '../../../core/auth/api_auth_interceptor.dart';
 import '../../../core/auth/openwebui_account_owner_marker.dart';
 import '../../../core/models/chat_message.dart';
 import '../../../core/models/model.dart';
+import '../../../core/models/openwebui_chat_prompt.dart';
 import '../../../core/models/conversation.dart';
 import '../../../core/models/file_info.dart';
 import '../../../core/models/server_config.dart';
@@ -5232,6 +5233,80 @@ class ChatMessagesNotifier extends Notifier<List<ChatMessage>>
     final next = [...state];
     next[index] = updated;
     state = next;
+  }
+
+  Future<void> resumeAfterOpenWebUiToolCall({
+    required String messageId,
+    required String callId,
+    required OpenWebUiToolCallAction action,
+    required List<String> taskIds,
+    Map<String, dynamic>? answers,
+  }) async {
+    final conversation = ref.read(activeConversationProvider);
+    if (_disposed ||
+        conversation == null ||
+        isTemporaryChat(conversation.id) ||
+        state.indexWhere((message) => message.id == messageId) == -1) {
+      return;
+    }
+
+    updateMessageById(messageId, (message) {
+      final output = message.output;
+      if (output == null) return message;
+      final metadata = _metadataWithoutResponseDone(message.metadata);
+      return message.copyWith(
+        output: applyOpenWebUiToolCallResolution(
+          output: output,
+          callId: callId,
+          action: action.name,
+          answers: answers,
+        ),
+        isStreaming: taskIds.isNotEmpty,
+        metadata: taskIds.isEmpty
+            ? metadata
+            : <String, dynamic>{
+                ...?metadata,
+                'taskId': taskIds.first,
+                'taskConversationId': conversation.id,
+              },
+      );
+    });
+
+    if (taskIds.isEmpty) {
+      try {
+        final pulled = await ref
+            .read(syncEngineProvider.notifier)
+            .pullChatNow(conversation.id);
+        if (!_disposed &&
+            ref.read(activeConversationProvider)?.id == conversation.id &&
+            pulled != null) {
+          _adoptServerMessages(pulled.messages, source: 'tool-call resolution');
+        }
+      } catch (_) {}
+      return;
+    }
+
+    if (state.isEmpty ||
+        state.last.id != messageId ||
+        state.last.role != 'assistant') {
+      return;
+    }
+    _reopenedStreamingMessageId = messageId;
+    _observedRemoteTask = true;
+    ref.read(activeChatIdsProvider.notifier).setActive(conversation.id);
+    _engageReopenedTailMonitor(messageId);
+    await _attachResumeSocketStream(
+      conversation,
+      state.last,
+      taskId: taskIds.first,
+    );
+    if (!_disposed &&
+        ref.read(activeConversationProvider)?.id == conversation.id &&
+        state.isNotEmpty &&
+        state.last.id == messageId &&
+        state.last.isStreaming) {
+      _engageReopenedTailMonitor(messageId);
+    }
   }
 
   Map<String, dynamic>? _metadataWithoutResponseDone(

--- a/lib/features/chat/providers/chat_providers.dart
+++ b/lib/features/chat/providers/chat_providers.dart
@@ -1586,7 +1586,7 @@ class ChatMessagesNotifier extends Notifier<List<ChatMessage>>
   // task lookup previously failed. Requiring a second empty observation keeps
   // a temporarily unregistered server task from being finalized immediately.
   int _unobservedReopenedEmptyPolls = 0;
-  static const int _unobservedTaskEmptyPollGrace = 1;
+  static const int _unobservedReopenedEmptyPollGrace = 1;
   bool _passiveConversationRefreshInFlight = false;
   int _passiveConversationGeneration = 0;
   int? _queuedPassiveConversationGeneration;
@@ -4636,10 +4636,48 @@ class ChatMessagesNotifier extends Notifier<List<ChatMessage>>
     _nonTailToolTaskMonitors.clear();
   }
 
+  bool _serverToolCallIsTerminal(
+    Conversation conversation, {
+    required String messageId,
+    required String callId,
+  }) {
+    final message = conversation.messages
+        .where((candidate) => candidate.id == messageId)
+        .firstOrNull;
+    final output = message?.output;
+    if (output == null) return false;
+    if (output.any(
+      (item) =>
+          item['type']?.toString() == 'function_call_output' &&
+          item['call_id']?.toString().trim() == callId,
+    )) {
+      return true;
+    }
+    final call = output
+        .where(
+          (item) =>
+              item['type']?.toString() == 'function_call' &&
+              (item['call_id']?.toString().trim() ??
+                      item['id']?.toString().trim()) ==
+                  callId,
+        )
+        .firstOrNull;
+    return const {
+      'completed',
+      'rejected',
+      'failed',
+      'cancelled',
+      'canceled',
+      'denied',
+      'done',
+    }.contains(call?['status']?.toString());
+  }
+
   void _monitorNonTailToolTask({
     required ApiService api,
     required Conversation conversation,
     required String messageId,
+    required String callId,
     required List<String> taskIds,
   }) {
     final monitor = Object();
@@ -4660,7 +4698,6 @@ class ChatMessagesNotifier extends Notifier<List<ChatMessage>>
         var consecutiveFailures = 0;
         var hasActiveTask = true;
         var observedExpectedTask = false;
-        var unobservedEmptyPolls = 0;
 
         while (!_disposed && _nonTailToolTaskMonitors.contains(monitor)) {
           if (!_isAppForeground) {
@@ -4681,17 +4718,7 @@ class ChatMessagesNotifier extends Notifier<List<ChatMessage>>
             hasActiveTask = activeTaskIds.any(expectedTaskIds.contains);
             if (hasActiveTask) {
               observedExpectedTask = true;
-              unobservedEmptyPolls = 0;
-            } else if (!observedExpectedTask) {
-              unobservedEmptyPolls++;
             }
-            // The resolve endpoint can return a task ID just before the task
-            // registry exposes it. Keep the locally resolved prompt and poll
-            // once more instead of adopting a stale transcript and exiting.
-            final registrationGraceActive =
-                !hasActiveTask &&
-                !observedExpectedTask &&
-                unobservedEmptyPolls <= _unobservedTaskEmptyPollGrace;
 
             final serverConversation = await api.getConversation(activeChatId);
             if (_disposed || !_nonTailToolTaskMonitors.contains(monitor)) {
@@ -4700,7 +4727,18 @@ class ChatMessagesNotifier extends Notifier<List<ChatMessage>>
             if (activeOpenWebUiChatIdForMutation(ref, owner) != activeChatId) {
               return;
             }
-            if (!registrationGraceActive) {
+            // A returned task ID can remain absent from the registry for more
+            // than one poll. Until the task is observed, only an authoritative
+            // terminal call result proves that monitoring can stop.
+            final awaitingRegistration =
+                !hasActiveTask &&
+                !observedExpectedTask &&
+                !_serverToolCallIsTerminal(
+                  serverConversation,
+                  messageId: messageId,
+                  callId: callId,
+                );
+            if (!awaitingRegistration) {
               _adoptServerMessages(
                 serverConversation.messages,
                 source: 'non-tail tool task poll',
@@ -4717,7 +4755,7 @@ class ChatMessagesNotifier extends Notifier<List<ChatMessage>>
                   },
                 );
               });
-            } else if (!registrationGraceActive) {
+            } else if (!awaitingRegistration) {
               if (activeTaskIds.isEmpty) {
                 activeChats.setInactiveIfUnchanged(
                   activeChatId,
@@ -4812,7 +4850,7 @@ class ChatMessagesNotifier extends Notifier<List<ChatMessage>>
           (_observedRemoteTask ||
               (reopenedTail &&
                   _unobservedReopenedEmptyPolls >
-                      _unobservedTaskEmptyPollGrace));
+                      _unobservedReopenedEmptyPollGrace));
       DebugLogger.log(
         'Remote task recovery status',
         scope: 'chat/resume',
@@ -5412,6 +5450,7 @@ class ChatMessagesNotifier extends Notifier<List<ChatMessage>>
           api: api,
           conversation: conversation,
           messageId: messageId,
+          callId: callId,
           taskIds: taskIds,
         );
       }

--- a/lib/features/chat/providers/openwebui_chat_prompt_provider.dart
+++ b/lib/features/chat/providers/openwebui_chat_prompt_provider.dart
@@ -1,0 +1,156 @@
+import 'dart:async';
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../core/models/openwebui_chat_prompt.dart';
+
+@visibleForTesting
+Duration? debugOpenWebUiPromptTimeoutOverride;
+
+@immutable
+class OpenWebUiLivePromptState {
+  const OpenWebUiLivePromptState({
+    required this.conversationId,
+    required this.prompt,
+  });
+
+  final String conversationId;
+  final OpenWebUiComposerPrompt prompt;
+}
+
+final openWebUiLivePromptProvider =
+    NotifierProvider<OpenWebUiLivePromptNotifier, OpenWebUiLivePromptState?>(
+      OpenWebUiLivePromptNotifier.new,
+    );
+
+class OpenWebUiLivePromptNotifier extends Notifier<OpenWebUiLivePromptState?> {
+  Timer? _timeout;
+  void Function(dynamic response)? _acknowledge;
+
+  @override
+  OpenWebUiLivePromptState? build() {
+    ref.onDispose(() {
+      _timeout?.cancel();
+      _respondToAbandonedPrompt();
+    });
+    return null;
+  }
+
+  void handleSocketRequest({
+    required String conversationId,
+    required String type,
+    required Map<String, dynamic> data,
+    required void Function(dynamic response) acknowledge,
+  }) {
+    cancel();
+    if (type == 'request:user_input') {
+      final prompt = parseOpenWebUiAskUserPrompt(
+        data,
+        identity: 'live:${DateTime.now().microsecondsSinceEpoch}',
+      );
+      if (prompt == null) {
+        _safeAcknowledge(acknowledge, const <String, dynamic>{
+          'error': 'Invalid user input request.',
+        });
+        return;
+      }
+      _acknowledge = acknowledge;
+      state = OpenWebUiLivePromptState(
+        conversationId: conversationId,
+        prompt: prompt,
+      );
+      _timeout = Timer(
+        debugOpenWebUiPromptTimeoutOverride ?? prompt.timeout,
+        cancel,
+      );
+      return;
+    }
+
+    if (type == 'confirmation') {
+      final title = _bounded(data['title'], 120);
+      final message = _bounded(data['message'], 2000);
+      _acknowledge = acknowledge;
+      state = OpenWebUiLivePromptState(
+        conversationId: conversationId,
+        prompt: OpenWebUiComposerPrompt(
+          identity: 'live:${DateTime.now().microsecondsSinceEpoch}',
+          kind: OpenWebUiComposerPromptKind.confirmation,
+          title: title,
+          message: message,
+        ),
+      );
+      return;
+    }
+
+    _safeAcknowledge(acknowledge, const <String, dynamic>{
+      'error': 'Unsupported input request.',
+    });
+  }
+
+  void answer(String promptIdentity, Map<String, dynamic> answers) {
+    final current = state;
+    if (current == null || current.prompt.identity != promptIdentity) return;
+    _settle(<String, dynamic>{'status': 'answered', 'answers': answers});
+  }
+
+  void decide(String promptIdentity, bool approved) {
+    final current = state;
+    if (current == null ||
+        current.prompt.identity != promptIdentity ||
+        current.prompt.kind != OpenWebUiComposerPromptKind.confirmation) {
+      return;
+    }
+    _settle(approved);
+  }
+
+  void cancelForConversation(String? conversationId) {
+    if (conversationId != null && state?.conversationId == conversationId) {
+      cancel();
+    }
+  }
+
+  void cancel() {
+    if (state == null && _acknowledge == null) return;
+    final kind = state?.prompt.kind;
+    _settle(
+      kind == OpenWebUiComposerPromptKind.confirmation
+          ? false
+          : const <String, dynamic>{'status': 'cancelled', 'answers': {}},
+    );
+  }
+
+  void _settle(dynamic response) {
+    final acknowledge = _acknowledge;
+    _acknowledge = null;
+    _timeout?.cancel();
+    _timeout = null;
+    state = null;
+    if (acknowledge != null) _safeAcknowledge(acknowledge, response);
+  }
+
+  void _respondToAbandonedPrompt() {
+    final acknowledge = _acknowledge;
+    if (acknowledge == null) return;
+    _acknowledge = null;
+    final response =
+        state?.prompt.kind == OpenWebUiComposerPromptKind.confirmation
+        ? false
+        : const <String, dynamic>{'status': 'cancelled', 'answers': {}};
+    _safeAcknowledge(acknowledge, response);
+  }
+
+  void _safeAcknowledge(
+    void Function(dynamic response) acknowledge,
+    dynamic response,
+  ) {
+    try {
+      acknowledge(response);
+    } catch (_) {}
+  }
+
+  String _bounded(Object? value, int maxLength) {
+    final text = value?.toString().trim() ?? '';
+    return text.length <= maxLength ? text : text.substring(0, maxLength);
+  }
+}

--- a/lib/features/chat/providers/openwebui_chat_prompt_provider.dart
+++ b/lib/features/chat/providers/openwebui_chat_prompt_provider.dart
@@ -68,17 +68,20 @@ class OpenWebUiLivePromptNotifier extends Notifier<OpenWebUiLivePromptState?> {
     }
 
     if (type == 'confirmation') {
-      final title = _bounded(data['title'], 120);
-      final message = _bounded(data['message'], 2000);
+      final prompt = OpenWebUiComposerPrompt(
+        identity: 'live:${DateTime.now().microsecondsSinceEpoch}',
+        kind: OpenWebUiComposerPromptKind.confirmation,
+        title: boundedOpenWebUiString(data['title'], 120),
+        message: boundedOpenWebUiString(data['message'], 2000),
+      );
       _acknowledge = acknowledge;
       state = OpenWebUiLivePromptState(
         conversationId: conversationId,
-        prompt: OpenWebUiComposerPrompt(
-          identity: 'live:${DateTime.now().microsecondsSinceEpoch}',
-          kind: OpenWebUiComposerPromptKind.confirmation,
-          title: title,
-          message: message,
-        ),
+        prompt: prompt,
+      );
+      _timeout = Timer(
+        debugOpenWebUiPromptTimeoutOverride ?? prompt.timeout,
+        cancel,
       );
       return;
     }
@@ -147,10 +150,5 @@ class OpenWebUiLivePromptNotifier extends Notifier<OpenWebUiLivePromptState?> {
     try {
       acknowledge(response);
     } catch (_) {}
-  }
-
-  String _bounded(Object? value, int maxLength) {
-    final text = value?.toString().trim() ?? '';
-    return text.length <= maxLength ? text : text.substring(0, maxLength);
   }
 }

--- a/lib/features/chat/services/chat_transport_dispatch.dart
+++ b/lib/features/chat/services/chat_transport_dispatch.dart
@@ -17,6 +17,7 @@ import '../../../core/sync/sync_engine.dart';
 import '../../../core/services/worker_manager.dart';
 import '../../../core/utils/debug_logger.dart';
 import '../providers/chat_providers.dart';
+import '../providers/openwebui_chat_prompt_provider.dart';
 import '../../navigation/models/sidebar_navigation_model.dart';
 import '../../navigation/providers/sidebar_providers.dart';
 import '../../terminal/models/terminal_models.dart';
@@ -415,6 +416,27 @@ Future<bool> dispatchChatTransport({
           .read(terminalSidebarPanelProvider.notifier)
           .setPanel(TerminalSidebarPanel.files);
       ref.read(terminalDisplayFileProvider.notifier).show(path);
+    },
+    onInteractivePrompt: (type, data, acknowledge) {
+      final conversationId = activeConversationId;
+      if (!ownsConversation() ||
+          conversationId == null ||
+          conversationId.isEmpty) {
+        acknowledge(
+          type == 'confirmation'
+              ? false
+              : const <String, dynamic>{'status': 'cancelled', 'answers': {}},
+        );
+        return;
+      }
+      ref
+          .read(openWebUiLivePromptProvider.notifier)
+          .handleSocketRequest(
+            conversationId: conversationId,
+            type: type,
+            data: data,
+            acknowledge: acknowledge,
+          );
     },
     onRemoteMessageBound: (remoteMessageId) {
       if (!ownsConversation()) return;

--- a/lib/features/chat/views/chat_page.dart
+++ b/lib/features/chat/views/chat_page.dart
@@ -37,6 +37,7 @@ import '../../auth/providers/unified_auth_providers.dart';
 import '../../direct_connections/providers/direct_connection_providers.dart';
 import '../../direct_connections/services/direct_model_registry.dart';
 import '../providers/chat_providers.dart';
+import '../providers/openwebui_chat_prompt_provider.dart';
 import '../../hermes/models/hermes_model.dart';
 import '../../hermes/models/hermes_bot.dart';
 import '../../hermes/models/hermes_config.dart';
@@ -76,6 +77,7 @@ import '../../../core/models/chat_message.dart';
 import '../../../core/models/conversation.dart';
 import '../../../core/models/folder.dart';
 import '../../../core/models/model.dart';
+import '../../../core/models/openwebui_chat_prompt.dart';
 import '../providers/context_attachments_provider.dart';
 import '../../../shared/utils/adaptive_glass.dart';
 import '../../../shared/widgets/themed_dialogs.dart';
@@ -90,6 +92,7 @@ import 'chat_bottom_anchor_controller.dart';
 import 'chat_timeline_render_model.dart';
 import 'chat_turn_render_state.dart';
 import '../widgets/streaming_turn_footer.dart';
+import '../widgets/openwebui_prompt_overlay.dart';
 import '../widgets/chat_timeline_viewport.dart';
 
 /// Keeps the assistant row's element ancestry identical while it moves from
@@ -530,6 +533,7 @@ class _ChatPageState extends ConsumerState<ChatPage> {
   ProviderSubscription<AppDatabase?>? _databaseOwnerSub;
   ProviderSubscription<AsyncValue<String>>? _hermesTranscriptSub;
   ProviderSubscription<bool>? _hermesStreamingSub;
+  late final OpenWebUiLivePromptNotifier _livePromptNotifier;
   String? _pendingHermesTranscriptRefresh;
   int _hermesTranscriptRefreshGeneration = 0;
   bool _viewportOwnerChangeScheduled = false;
@@ -900,6 +904,7 @@ class _ChatPageState extends ConsumerState<ChatPage> {
   @override
   void initState() {
     super.initState();
+    _livePromptNotifier = ref.read(openWebUiLivePromptProvider.notifier);
 
     _screenContextSub = ref.listenManual(screenContextProvider, (_, next) {
       if (next == null || next.isEmpty) {
@@ -943,11 +948,13 @@ class _ChatPageState extends ConsumerState<ChatPage> {
       next,
     ) {
       if (!identical(previous, next)) {
+        _livePromptNotifier.cancel();
         _scheduleViewportOwnerChanged();
       }
     });
     _apiOwnerSub = ref.listenManual(apiServiceProvider, (previous, next) {
       if (!identical(previous, next)) {
+        _livePromptNotifier.cancel();
         _scheduleViewportOwnerChanged();
       }
     });
@@ -999,6 +1006,7 @@ class _ChatPageState extends ConsumerState<ChatPage> {
   @override
   void dispose() {
     markConversationRead(ref, _lastConversationId);
+    _livePromptNotifier.cancel();
     _screenContextSub?.close();
     _conversationLoadingSub?.close();
     _reviewerModeSub?.close();
@@ -2331,6 +2339,10 @@ class _ChatPageState extends ConsumerState<ChatPage> {
       markConversationRead(ref, conversationId);
       return;
     }
+
+    ref
+        .read(openWebUiLivePromptProvider.notifier)
+        .cancelForConversation(outgoingId);
 
     _conversationOwnerGeneration += 1;
     markConversationRead(ref, outgoingId);
@@ -3762,6 +3774,36 @@ class _ChatPageState extends ConsumerState<ChatPage> {
                   final isLoadingConversation = composerRef.watch(
                     isLoadingConversationProvider,
                   );
+                  final activeConversation = composerRef.watch(
+                    activeConversationProvider,
+                  );
+                  final pendingPromptIdentity = composerRef.watch(
+                    chatMessagesProvider.select(
+                      (messages) =>
+                          findPendingOpenWebUiToolPrompt(messages)
+                              ?.prompt
+                              .identity,
+                    ),
+                  );
+                  final persistedPrompt =
+                      pendingPromptIdentity != null &&
+                          conversationUsesOpenWebUiStorage(
+                            activeConversation,
+                          ) &&
+                          !isTemporaryChat(activeConversation?.id)
+                      ? findPendingOpenWebUiToolPrompt(
+                          composerRef.read(chatMessagesProvider),
+                        )
+                      : null;
+                  final livePrompt = composerRef.watch(
+                    openWebUiLivePromptProvider,
+                  );
+                  final activeConversationId = activeConversation?.id;
+                  final matchingLivePrompt =
+                      livePrompt != null &&
+                          livePrompt.conversationId == activeConversationId
+                      ? livePrompt
+                      : null;
                   return ModernChatInput(
                     onSendMessage: _handleMessageSend,
                     enabled: debugCanSubmitChatMessageForTesting(
@@ -3773,6 +3815,55 @@ class _ChatPageState extends ConsumerState<ChatPage> {
                     managesSystemKeyboardInset: Platform.isAndroid,
                     composerTextInsertionTargetId:
                         chatComposerTextInsertionTargetId,
+                    attachedOverlay: persistedPrompt != null
+                        ? OpenWebUiPromptOverlay(
+                            key: ValueKey(persistedPrompt.prompt.identity),
+                            prompt: persistedPrompt.prompt,
+                            onAnswer: (answers) =>
+                                _resolvePersistedOpenWebUiPrompt(
+                                  persistedPrompt,
+                                  OpenWebUiToolCallAction.answer,
+                                  answers: answers,
+                                ),
+                            onDecision: (approved) =>
+                                _resolvePersistedOpenWebUiPrompt(
+                                  persistedPrompt,
+                                  persistedPrompt.prompt.kind ==
+                                          OpenWebUiComposerPromptKind.askUser
+                                      ? OpenWebUiToolCallAction.reject
+                                      : approved
+                                      ? OpenWebUiToolCallAction.approve
+                                      : OpenWebUiToolCallAction.reject,
+                                ),
+                          )
+                        : matchingLivePrompt == null
+                        ? null
+                        : OpenWebUiPromptOverlay(
+                            key: ValueKey(matchingLivePrompt.prompt.identity),
+                            prompt: matchingLivePrompt.prompt,
+                            onAnswer: (answers) {
+                              composerRef
+                                  .read(openWebUiLivePromptProvider.notifier)
+                                  .answer(
+                                    matchingLivePrompt.prompt.identity,
+                                    answers,
+                                  );
+                            },
+                            onDecision: (approved) {
+                              final notifier = composerRef.read(
+                                openWebUiLivePromptProvider.notifier,
+                              );
+                              if (matchingLivePrompt.prompt.kind ==
+                                  OpenWebUiComposerPromptKind.confirmation) {
+                                notifier.decide(
+                                  matchingLivePrompt.prompt.identity,
+                                  approved,
+                                );
+                              } else {
+                                notifier.cancel();
+                              }
+                            },
+                          ),
                     onVoiceInput: null,
                     onVoiceCall: _handleVoiceCall,
                     onFileAttachment: _handleFileAttachment,
@@ -3790,6 +3881,45 @@ class _ChatPageState extends ConsumerState<ChatPage> {
         ),
       ),
     );
+  }
+
+  Future<void> _resolvePersistedOpenWebUiPrompt(
+    OpenWebUiPendingToolPrompt pending,
+    OpenWebUiToolCallAction action, {
+    Map<String, dynamic>? answers,
+  }) async {
+    final api = ref.read(apiServiceProvider);
+    final conversation = ref.read(activeConversationProvider);
+    if (api == null ||
+        conversation == null ||
+        !conversationUsesOpenWebUiStorage(conversation) ||
+        isTemporaryChat(conversation.id)) {
+      throw StateError('Open WebUI chat is unavailable.');
+    }
+    final chatId = conversation.id;
+    final authEpoch = ref.read(openWebUiAuthSessionEpochProvider);
+    final taskIds = await api.resolveChatMessageToolCall(
+      chatId: chatId,
+      messageId: pending.messageId,
+      callId: pending.callId,
+      action: action,
+      answers: answers,
+    );
+    if (!mounted ||
+        !identical(api, ref.read(apiServiceProvider)) ||
+        !identical(authEpoch, ref.read(openWebUiAuthSessionEpochProvider)) ||
+        ref.read(activeConversationProvider)?.id != chatId) {
+      return;
+    }
+    await ref
+        .read(chatMessagesProvider.notifier)
+        .resumeAfterOpenWebUiToolCall(
+          messageId: pending.messageId,
+          callId: pending.callId,
+          action: action,
+          taskIds: taskIds,
+          answers: answers,
+        );
   }
 
   @override

--- a/lib/features/chat/views/chat_page.dart
+++ b/lib/features/chat/views/chat_page.dart
@@ -49,6 +49,7 @@ import '../../hermes/services/hermes_message_mapper.dart';
 import '../../hermes/services/hermes_pending_decision_store.dart';
 import '../../hermes/services/hermes_session_provenance.dart';
 import '../../hermes/widgets/hermes_bot_avatar.dart';
+import '../../hermes/widgets/hermes_message_interactions.dart';
 import '../../../core/utils/debug_logger.dart';
 import '../../../core/utils/message_tree_utils.dart' as message_tree;
 import '../../../core/utils/user_display_name.dart';
@@ -3804,6 +3805,68 @@ class _ChatPageState extends ConsumerState<ChatPage> {
                           livePrompt.conversationId == activeConversationId
                       ? livePrompt
                       : null;
+                  final pendingHermesPrompt = composerRef.watch(
+                    chatMessagesProvider.select(
+                      findPendingHermesComposerPrompt,
+                    ),
+                  );
+                  final Widget? attachedOverlay;
+                  if (persistedPrompt != null) {
+                    attachedOverlay = OpenWebUiPromptOverlay(
+                      key: ValueKey(persistedPrompt.prompt.identity),
+                      prompt: persistedPrompt.prompt,
+                      onAnswer: (answers) => _resolvePersistedOpenWebUiPrompt(
+                        persistedPrompt,
+                        OpenWebUiToolCallAction.answer,
+                        answers: answers,
+                      ),
+                      onDecision: (approved) =>
+                          _resolvePersistedOpenWebUiPrompt(
+                            persistedPrompt,
+                            persistedPrompt.prompt.kind ==
+                                    OpenWebUiComposerPromptKind.askUser
+                                ? OpenWebUiToolCallAction.reject
+                                : approved
+                                ? OpenWebUiToolCallAction.approve
+                                : OpenWebUiToolCallAction.reject,
+                          ),
+                    );
+                  } else if (matchingLivePrompt != null) {
+                    attachedOverlay = OpenWebUiPromptOverlay(
+                      key: ValueKey(matchingLivePrompt.prompt.identity),
+                      prompt: matchingLivePrompt.prompt,
+                      onAnswer: (answers) {
+                        composerRef
+                            .read(openWebUiLivePromptProvider.notifier)
+                            .answer(
+                              matchingLivePrompt.prompt.identity,
+                              answers,
+                            );
+                      },
+                      onDecision: (approved) {
+                        final notifier = composerRef.read(
+                          openWebUiLivePromptProvider.notifier,
+                        );
+                        if (matchingLivePrompt.prompt.kind ==
+                            OpenWebUiComposerPromptKind.confirmation) {
+                          notifier.decide(
+                            matchingLivePrompt.prompt.identity,
+                            approved,
+                          );
+                        } else {
+                          notifier.cancel();
+                        }
+                      },
+                    );
+                  } else if (pendingHermesPrompt != null &&
+                      isNativeHermesConversation(activeConversation)) {
+                    attachedOverlay = HermesComposerPromptOverlay(
+                      key: ValueKey(pendingHermesPrompt.id),
+                      message: pendingHermesPrompt,
+                    );
+                  } else {
+                    attachedOverlay = null;
+                  }
                   return ModernChatInput(
                     onSendMessage: _handleMessageSend,
                     enabled: debugCanSubmitChatMessageForTesting(
@@ -3815,55 +3878,7 @@ class _ChatPageState extends ConsumerState<ChatPage> {
                     managesSystemKeyboardInset: Platform.isAndroid,
                     composerTextInsertionTargetId:
                         chatComposerTextInsertionTargetId,
-                    attachedOverlay: persistedPrompt != null
-                        ? OpenWebUiPromptOverlay(
-                            key: ValueKey(persistedPrompt.prompt.identity),
-                            prompt: persistedPrompt.prompt,
-                            onAnswer: (answers) =>
-                                _resolvePersistedOpenWebUiPrompt(
-                                  persistedPrompt,
-                                  OpenWebUiToolCallAction.answer,
-                                  answers: answers,
-                                ),
-                            onDecision: (approved) =>
-                                _resolvePersistedOpenWebUiPrompt(
-                                  persistedPrompt,
-                                  persistedPrompt.prompt.kind ==
-                                          OpenWebUiComposerPromptKind.askUser
-                                      ? OpenWebUiToolCallAction.reject
-                                      : approved
-                                      ? OpenWebUiToolCallAction.approve
-                                      : OpenWebUiToolCallAction.reject,
-                                ),
-                          )
-                        : matchingLivePrompt == null
-                        ? null
-                        : OpenWebUiPromptOverlay(
-                            key: ValueKey(matchingLivePrompt.prompt.identity),
-                            prompt: matchingLivePrompt.prompt,
-                            onAnswer: (answers) {
-                              composerRef
-                                  .read(openWebUiLivePromptProvider.notifier)
-                                  .answer(
-                                    matchingLivePrompt.prompt.identity,
-                                    answers,
-                                  );
-                            },
-                            onDecision: (approved) {
-                              final notifier = composerRef.read(
-                                openWebUiLivePromptProvider.notifier,
-                              );
-                              if (matchingLivePrompt.prompt.kind ==
-                                  OpenWebUiComposerPromptKind.confirmation) {
-                                notifier.decide(
-                                  matchingLivePrompt.prompt.identity,
-                                  approved,
-                                );
-                              } else {
-                                notifier.cancel();
-                              }
-                            },
-                          ),
+                    attachedOverlay: attachedOverlay,
                     onVoiceInput: null,
                     onVoiceCall: _handleVoiceCall,
                     onFileAttachment: _handleFileAttachment,
@@ -4768,7 +4783,6 @@ bool debugCanCollapseGroupedAssistantRowForTesting(
   required bool showModelHeader,
   required bool showActionBar,
 }) {
-  final metadata = message.metadata;
   return !showModelHeader &&
       !showActionBar &&
       message.content.trim().isEmpty &&
@@ -4780,9 +4794,7 @@ bool debugCanCollapseGroupedAssistantRowForTesting(
       message.followUps.isEmpty &&
       message.codeExecutions.isEmpty &&
       message.sources.isEmpty &&
-      message.error == null &&
-      metadata?['hermesApproval'] == null &&
-      metadata?['hermesDecision'] == null;
+      message.error == null;
 }
 
 @immutable

--- a/lib/features/chat/views/chat_page.dart
+++ b/lib/features/chat/views/chat_page.dart
@@ -3858,8 +3858,7 @@ class _ChatPageState extends ConsumerState<ChatPage> {
                         }
                       },
                     );
-                  } else if (pendingHermesPrompt != null &&
-                      isNativeHermesConversation(activeConversation)) {
+                  } else if (pendingHermesPrompt != null) {
                     attachedOverlay = HermesComposerPromptOverlay(
                       key: ValueKey(pendingHermesPrompt.id),
                       message: pendingHermesPrompt,

--- a/lib/features/chat/views/chat_page.dart
+++ b/lib/features/chat/views/chat_page.dart
@@ -3778,6 +3778,7 @@ class _ChatPageState extends ConsumerState<ChatPage> {
                   final activeConversation = composerRef.watch(
                     activeConversationProvider,
                   );
+                  final activeConversationId = activeConversation?.id;
                   final pendingPromptIdentity = composerRef.watch(
                     chatMessagesProvider.select(
                       (messages) =>
@@ -3788,6 +3789,11 @@ class _ChatPageState extends ConsumerState<ChatPage> {
                   );
                   final persistedPrompt =
                       pendingPromptIdentity != null &&
+                          debugCanUsePersistedOpenWebUiPromptForTesting(
+                            isLoadingConversation: isLoadingConversation,
+                            ownerConversationId: activeConversationId,
+                            activeConversationId: activeConversationId,
+                          ) &&
                           conversationUsesOpenWebUiStorage(
                             activeConversation,
                           ) &&
@@ -3799,7 +3805,6 @@ class _ChatPageState extends ConsumerState<ChatPage> {
                   final livePrompt = composerRef.watch(
                     openWebUiLivePromptProvider,
                   );
-                  final activeConversationId = activeConversation?.id;
                   final matchingLivePrompt =
                       livePrompt != null &&
                           livePrompt.conversationId == activeConversationId
@@ -3816,12 +3821,14 @@ class _ChatPageState extends ConsumerState<ChatPage> {
                       key: ValueKey(persistedPrompt.prompt.identity),
                       prompt: persistedPrompt.prompt,
                       onAnswer: (answers) => _resolvePersistedOpenWebUiPrompt(
+                        activeConversationId!,
                         persistedPrompt,
                         OpenWebUiToolCallAction.answer,
                         answers: answers,
                       ),
                       onDecision: (approved) =>
                           _resolvePersistedOpenWebUiPrompt(
+                            activeConversationId!,
                             persistedPrompt,
                             persistedPrompt.prompt.kind ==
                                     OpenWebUiComposerPromptKind.askUser
@@ -3898,6 +3905,7 @@ class _ChatPageState extends ConsumerState<ChatPage> {
   }
 
   Future<void> _resolvePersistedOpenWebUiPrompt(
+    String ownerConversationId,
     OpenWebUiPendingToolPrompt pending,
     OpenWebUiToolCallAction action, {
     Map<String, dynamic>? answers,
@@ -3906,11 +3914,16 @@ class _ChatPageState extends ConsumerState<ChatPage> {
     final conversation = ref.read(activeConversationProvider);
     if (api == null ||
         conversation == null ||
+        !debugCanUsePersistedOpenWebUiPromptForTesting(
+          isLoadingConversation: ref.read(isLoadingConversationProvider),
+          ownerConversationId: ownerConversationId,
+          activeConversationId: conversation.id,
+        ) ||
         !conversationUsesOpenWebUiStorage(conversation) ||
         isTemporaryChat(conversation.id)) {
       throw StateError('Open WebUI chat is unavailable.');
     }
-    final chatId = conversation.id;
+    final chatId = ownerConversationId;
     final authEpoch = ref.read(openWebUiAuthSessionEpochProvider);
     final taskIds = await api.resolveChatMessageToolCall(
       chatId: chatId,
@@ -5250,6 +5263,17 @@ bool debugCanSubmitChatMessageForTesting({
   return !isLoadingConversation &&
       !isSavingTemporary &&
       !isPreparingMessageSend;
+}
+
+@visibleForTesting
+bool debugCanUsePersistedOpenWebUiPromptForTesting({
+  required bool isLoadingConversation,
+  required String? ownerConversationId,
+  required String? activeConversationId,
+}) {
+  return !isLoadingConversation &&
+      ownerConversationId != null &&
+      ownerConversationId == activeConversationId;
 }
 
 @visibleForTesting

--- a/lib/features/chat/widgets/assistant_message_widget.dart
+++ b/lib/features/chat/widgets/assistant_message_widget.dart
@@ -14,7 +14,6 @@ import '../../../shared/widgets/markdown/markdown_preprocessor.dart';
 import '../providers/text_to_speech_provider.dart';
 import '../providers/queued_completion_provider.dart';
 import '../providers/streaming_haptic_memory.dart';
-import '../../hermes/widgets/hermes_message_interactions.dart';
 import 'enhanced_image_attachment.dart';
 
 import 'package:conduit/l10n/app_localizations.dart';
@@ -1151,9 +1150,6 @@ class _AssistantMessageWidgetState extends ConsumerState<AssistantMessageWidget>
                     responseBuilder: responseBuilder,
                     activeSources: contentSources,
                   ),
-
-                if (_chatMessage case final message?)
-                  HermesMessageInteractions(message: message),
 
                 if (showQueuedRecoveryBanner) ...[
                   const SizedBox(height: Spacing.sm),

--- a/lib/features/chat/widgets/modern_chat_input.dart
+++ b/lib/features/chat/widgets/modern_chat_input.dart
@@ -287,6 +287,7 @@ class ModernChatInput extends ConsumerStatefulWidget {
   /// Receives the button size so the replacement can match layout.
   /// When provided, the default [ComposerAttachmentKeyboard] is not used.
   final Widget Function(double size)? overflowButtonBuilder;
+  final Widget? attachedOverlay;
 
   final Function()? onVoiceInput;
   final Function()? onVoiceCall;
@@ -314,6 +315,7 @@ class ModernChatInput extends ConsumerStatefulWidget {
     this.managesSystemKeyboardInset = false,
     this.placeholder,
     this.overflowButtonBuilder,
+    this.attachedOverlay,
     this.onVoiceInput,
     this.onVoiceCall,
     this.onFileAttachment,
@@ -3559,7 +3561,15 @@ class _ModernChatInputState extends ConsumerState<ModernChatInput>
       ),
       child: Column(
         mainAxisSize: MainAxisSize.min,
-        children: [?compactPromptOverlay, shell],
+        children: [
+          if (widget.attachedOverlay != null)
+            Padding(
+              padding: const EdgeInsets.only(bottom: Spacing.xs),
+              child: widget.attachedOverlay!,
+            ),
+          ?compactPromptOverlay,
+          shell,
+        ],
       ),
     );
     return _wrapWithComposerLineMeasurement(

--- a/lib/features/chat/widgets/openwebui_prompt_overlay.dart
+++ b/lib/features/chat/widgets/openwebui_prompt_overlay.dart
@@ -1,0 +1,434 @@
+import 'dart:async';
+import 'dart:math' as math;
+
+import 'package:material_ui/material_ui.dart';
+
+import '../../../core/models/openwebui_chat_prompt.dart';
+import '../../../l10n/app_localizations.dart';
+import '../../../shared/theme/theme_extensions.dart';
+import '../../../shared/widgets/conduit_components.dart';
+
+class OpenWebUiPromptOverlay extends StatefulWidget {
+  const OpenWebUiPromptOverlay({
+    super.key,
+    required this.prompt,
+    this.onAnswer,
+    this.onDecision,
+  });
+
+  final OpenWebUiComposerPrompt prompt;
+  final FutureOr<void> Function(Map<String, dynamic> answers)? onAnswer;
+  final FutureOr<void> Function(bool approved)? onDecision;
+
+  @override
+  State<OpenWebUiPromptOverlay> createState() => _OpenWebUiPromptOverlayState();
+}
+
+class _OpenWebUiPromptOverlayState extends State<OpenWebUiPromptOverlay> {
+  final Map<String, Map<String, dynamic>> _answers = {};
+  final Map<String, TextEditingController> _otherControllers = {};
+  var _questionIndex = 0;
+  var _busy = false;
+  var _failed = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _syncOtherControllers();
+  }
+
+  @override
+  void didUpdateWidget(covariant OpenWebUiPromptOverlay oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.prompt.identity == widget.prompt.identity) return;
+    for (final controller in _otherControllers.values) {
+      controller.dispose();
+    }
+    _otherControllers.clear();
+    _answers.clear();
+    _questionIndex = 0;
+    _busy = false;
+    _failed = false;
+    _syncOtherControllers();
+  }
+
+  @override
+  void dispose() {
+    for (final controller in _otherControllers.values) {
+      controller.dispose();
+    }
+    super.dispose();
+  }
+
+  void _syncOtherControllers() {
+    for (final question in widget.prompt.questions) {
+      _otherControllers[question.id] = TextEditingController();
+    }
+  }
+
+  bool get _complete =>
+      widget.prompt.questions.isNotEmpty &&
+      widget.prompt.questions.every((question) {
+        final answer = _answers[question.id];
+        return answer?['type'] == 'option' ||
+            (answer?['type'] == 'other' &&
+                (answer?['text']?.toString().trim().isNotEmpty ?? false));
+      });
+
+  Future<void> _run(FutureOr<void> Function() action) async {
+    if (_busy) return;
+    setState(() {
+      _busy = true;
+      _failed = false;
+    });
+    try {
+      await action();
+    } catch (_) {
+      if (mounted) {
+        setState(() {
+          _busy = false;
+          _failed = true;
+        });
+      }
+    }
+  }
+
+  void _selectOption(
+    OpenWebUiPromptQuestion question,
+    OpenWebUiPromptOption option,
+    int index,
+  ) {
+    setState(() {
+      _answers[question.id] = <String, dynamic>{
+        'type': 'option',
+        'option_index': index,
+        'label': option.label,
+        'description': option.description,
+      };
+    });
+  }
+
+  void _selectOther(OpenWebUiPromptQuestion question) {
+    setState(() {
+      _answers[question.id] = <String, dynamic>{
+        'type': 'other',
+        'text': _otherControllers[question.id]?.text.trim() ?? '',
+      };
+    });
+  }
+
+  void _updateOther(OpenWebUiPromptQuestion question, String value) {
+    setState(() {
+      _answers[question.id] = <String, dynamic>{'type': 'other', 'text': value};
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context)!;
+    final theme = context.conduitTheme;
+    return Semantics(
+      container: true,
+      liveRegion: true,
+      label: l10n.hermesApprovalRequired,
+      child: Container(
+        key: const ValueKey('openwebui-prompt-overlay'),
+        padding: const EdgeInsets.all(Spacing.md),
+        decoration: BoxDecoration(
+          color: theme.surfaceBackground,
+          borderRadius: BorderRadius.circular(AppBorderRadius.card),
+          border: Border.all(color: theme.cardBorder),
+          boxShadow: ConduitShadows.card(context),
+        ),
+        child: switch (widget.prompt.kind) {
+          OpenWebUiComposerPromptKind.askUser => _buildQuestions(context),
+          OpenWebUiComposerPromptKind.toolApproval => _buildDecision(
+            context,
+            approval: true,
+          ),
+          OpenWebUiComposerPromptKind.confirmation => _buildDecision(
+            context,
+            approval: false,
+          ),
+        },
+      ),
+    );
+  }
+
+  Widget _buildQuestions(BuildContext context) {
+    final l10n = AppLocalizations.of(context)!;
+    final theme = context.conduitTheme;
+    final question = widget.prompt.questions[_questionIndex];
+    final answer = _answers[question.id];
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Row(
+          children: [
+            Expanded(
+              child: Text(
+                question.header,
+                style: AppTypography.standard.copyWith(
+                  color: theme.textPrimary,
+                  fontWeight: FontWeight.w600,
+                ),
+              ),
+            ),
+            if (widget.prompt.questions.length > 1)
+              Text(
+                '${_questionIndex + 1}/${widget.prompt.questions.length}',
+                semanticsLabel:
+                    '${_questionIndex + 1} of ${widget.prompt.questions.length}',
+                style: AppTypography.bodySmallStyle.copyWith(
+                  color: theme.textSecondary,
+                ),
+              ),
+          ],
+        ),
+        const SizedBox(height: Spacing.xs),
+        Text(
+          question.question,
+          style: AppTypography.bodySmallStyle.copyWith(
+            color: theme.textSecondary,
+          ),
+        ),
+        const SizedBox(height: Spacing.sm),
+        ConstrainedBox(
+          constraints: BoxConstraints(
+            maxHeight: math.min(320, MediaQuery.sizeOf(context).height * 0.36),
+          ),
+          child: SingleChildScrollView(
+            child: Column(
+              children: [
+                for (var index = 0; index < question.options.length; index++)
+                  _buildOption(
+                    context,
+                    question,
+                    question.options[index],
+                    index,
+                    answer?['type'] == 'option' &&
+                        answer?['option_index'] == index,
+                  ),
+                if (question.allowOther) ...[
+                  const SizedBox(height: Spacing.xs),
+                  TextField(
+                    key: ValueKey('openwebui-other-${question.id}'),
+                    controller: _otherControllers[question.id],
+                    enabled: !_busy,
+                    maxLength: 500,
+                    minLines: 1,
+                    maxLines: 3,
+                    decoration: InputDecoration(
+                      labelText: l10n.openWebUiPromptOther,
+                      hintText: l10n.openWebUiPromptAnswerHint,
+                      counterText: '',
+                      isDense: true,
+                      border: const OutlineInputBorder(),
+                    ),
+                    onTap: () => _selectOther(question),
+                    onChanged: (value) => _updateOther(question, value),
+                  ),
+                ],
+              ],
+            ),
+          ),
+        ),
+        if (_failed) ...[
+          const SizedBox(height: Spacing.sm),
+          Text(
+            l10n.errorMessage,
+            key: const ValueKey('openwebui-prompt-error'),
+            style: AppTypography.bodySmallStyle.copyWith(color: theme.error),
+          ),
+        ],
+        const SizedBox(height: Spacing.sm),
+        Wrap(
+          spacing: Spacing.sm,
+          runSpacing: Spacing.xs,
+          alignment: WrapAlignment.end,
+          children: [
+            ConduitButton(
+              text: l10n.cancel,
+              isCompact: true,
+              isSecondary: true,
+              onPressed: _busy || widget.onDecision == null
+                  ? null
+                  : () => _run(() => widget.onDecision!(false)),
+            ),
+            if (_questionIndex > 0)
+              ConduitButton(
+                text: l10n.previousLabel,
+                isCompact: true,
+                isSecondary: true,
+                onPressed: _busy
+                    ? null
+                    : () => setState(() => _questionIndex--),
+              ),
+            if (_questionIndex < widget.prompt.questions.length - 1)
+              ConduitButton(
+                text: l10n.nextLabel,
+                isCompact: true,
+                isSecondary: true,
+                onPressed: _busy || answer == null
+                    ? null
+                    : () => setState(() => _questionIndex++),
+              ),
+            ConduitButton(
+              text: l10n.openWebUiPromptSubmit,
+              isCompact: true,
+              isLoading: _busy,
+              onPressed: _busy || !_complete || widget.onAnswer == null
+                  ? null
+                  : () => _run(
+                      () => widget.onAnswer!(<String, dynamic>{
+                        for (final entry in _answers.entries)
+                          entry.key: Map<String, dynamic>.from(entry.value)
+                            ..update(
+                              'text',
+                              (value) => value.toString().trim(),
+                              ifAbsent: () => '',
+                            )
+                            ..removeWhere(
+                              (key, _) =>
+                                  key == 'text' &&
+                                  entry.value['type'] != 'other',
+                            ),
+                      }),
+                    ),
+            ),
+          ],
+        ),
+      ],
+    );
+  }
+
+  Widget _buildOption(
+    BuildContext context,
+    OpenWebUiPromptQuestion question,
+    OpenWebUiPromptOption option,
+    int index,
+    bool selected,
+  ) {
+    final theme = context.conduitTheme;
+    return Semantics(
+      button: true,
+      selected: selected,
+      label: '${option.label}. ${option.description}',
+      child: InkWell(
+        key: ValueKey('openwebui-option-${question.id}-$index'),
+        onTap: _busy ? null : () => _selectOption(question, option, index),
+        borderRadius: BorderRadius.circular(AppBorderRadius.input),
+        child: Padding(
+          padding: const EdgeInsets.symmetric(vertical: Spacing.xs),
+          child: Row(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Icon(
+                selected ? Icons.radio_button_checked : Icons.radio_button_off,
+                size: IconSize.medium,
+                color: selected ? theme.buttonPrimary : theme.textSecondary,
+              ),
+              const SizedBox(width: Spacing.sm),
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      option.label,
+                      style: AppTypography.bodySmallStyle.copyWith(
+                        color: theme.textPrimary,
+                        fontWeight: FontWeight.w600,
+                      ),
+                    ),
+                    Text(
+                      option.description,
+                      style: AppTypography.bodySmallStyle.copyWith(
+                        color: theme.textSecondary,
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildDecision(BuildContext context, {required bool approval}) {
+    final l10n = AppLocalizations.of(context)!;
+    final theme = context.conduitTheme;
+    final title = widget.prompt.title.isEmpty
+        ? approval
+              ? l10n.hermesApprovalRequired
+              : l10n.confirm
+        : widget.prompt.title;
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          title,
+          style: AppTypography.standard.copyWith(
+            color: theme.textPrimary,
+            fontWeight: FontWeight.w600,
+          ),
+        ),
+        if (widget.prompt.message.isNotEmpty) ...[
+          const SizedBox(height: Spacing.xs),
+          ConstrainedBox(
+            constraints: BoxConstraints(
+              maxHeight: math.min(240, MediaQuery.sizeOf(context).height * 0.3),
+            ),
+            child: SingleChildScrollView(
+              child: Text(
+                widget.prompt.message,
+                key: const ValueKey('openwebui-prompt-message'),
+                style: approval
+                    ? AppTypography.codeStyle.copyWith(
+                        color: theme.textSecondary,
+                      )
+                    : AppTypography.bodySmallStyle.copyWith(
+                        color: theme.textSecondary,
+                      ),
+              ),
+            ),
+          ),
+        ],
+        if (_failed) ...[
+          const SizedBox(height: Spacing.sm),
+          Text(
+            l10n.errorMessage,
+            key: const ValueKey('openwebui-prompt-error'),
+            style: AppTypography.bodySmallStyle.copyWith(color: theme.error),
+          ),
+        ],
+        const SizedBox(height: Spacing.md),
+        Wrap(
+          spacing: Spacing.sm,
+          runSpacing: Spacing.xs,
+          children: [
+            ConduitButton(
+              text: approval ? l10n.hermesApprovalDenyAction : l10n.cancel,
+              isCompact: true,
+              isSecondary: true,
+              onPressed: _busy || widget.onDecision == null
+                  ? null
+                  : () => _run(() => widget.onDecision!(false)),
+            ),
+            ConduitButton(
+              text: approval ? l10n.hermesApprovalApproveAction : l10n.confirm,
+              isCompact: true,
+              isLoading: _busy,
+              onPressed: _busy || widget.onDecision == null
+                  ? null
+                  : () => _run(() => widget.onDecision!(true)),
+            ),
+          ],
+        ),
+      ],
+    );
+  }
+}

--- a/lib/features/chat/widgets/openwebui_prompt_overlay.dart
+++ b/lib/features/chat/widgets/openwebui_prompt_overlay.dart
@@ -6,6 +6,7 @@ import 'package:material_ui/material_ui.dart';
 import '../../../core/models/openwebui_chat_prompt.dart';
 import '../../../l10n/app_localizations.dart';
 import '../../../shared/theme/theme_extensions.dart';
+import '../../../shared/widgets/composer_prompt_surface.dart';
 import '../../../shared/widgets/conduit_components.dart';
 
 class OpenWebUiPromptOverlay extends StatefulWidget {
@@ -126,39 +127,24 @@ class _OpenWebUiPromptOverlayState extends State<OpenWebUiPromptOverlay> {
   @override
   Widget build(BuildContext context) {
     final l10n = AppLocalizations.of(context)!;
-    final theme = context.conduitTheme;
     final semanticsLabel =
         widget.prompt.kind == OpenWebUiComposerPromptKind.askUser
         ? widget.prompt.questions[_questionIndex].header
         : l10n.hermesApprovalRequired;
-    return Semantics(
-      container: true,
-      liveRegion: true,
-      label: semanticsLabel,
-      child: Material(
-        color: Colors.transparent,
-        child: Container(
-          key: const ValueKey('openwebui-prompt-overlay'),
-          padding: const EdgeInsets.all(Spacing.md),
-          decoration: BoxDecoration(
-            color: theme.surfaceBackground,
-            borderRadius: BorderRadius.circular(AppBorderRadius.card),
-            border: Border.all(color: theme.cardBorder),
-            boxShadow: ConduitShadows.card(context),
-          ),
-          child: switch (widget.prompt.kind) {
-            OpenWebUiComposerPromptKind.askUser => _buildQuestions(context),
-            OpenWebUiComposerPromptKind.toolApproval => _buildDecision(
-              context,
-              approval: true,
-            ),
-            OpenWebUiComposerPromptKind.confirmation => _buildDecision(
-              context,
-              approval: false,
-            ),
-          },
+    return ComposerPromptSurface(
+      semanticsLabel: semanticsLabel,
+      surfaceKey: const ValueKey('openwebui-prompt-overlay'),
+      child: switch (widget.prompt.kind) {
+        OpenWebUiComposerPromptKind.askUser => _buildQuestions(context),
+        OpenWebUiComposerPromptKind.toolApproval => _buildDecision(
+          context,
+          approval: true,
         ),
-      ),
+        OpenWebUiComposerPromptKind.confirmation => _buildDecision(
+          context,
+          approval: false,
+        ),
+      },
     );
   }
 

--- a/lib/features/chat/widgets/openwebui_prompt_overlay.dart
+++ b/lib/features/chat/widgets/openwebui_prompt_overlay.dart
@@ -127,10 +127,14 @@ class _OpenWebUiPromptOverlayState extends State<OpenWebUiPromptOverlay> {
   Widget build(BuildContext context) {
     final l10n = AppLocalizations.of(context)!;
     final theme = context.conduitTheme;
+    final semanticsLabel =
+        widget.prompt.kind == OpenWebUiComposerPromptKind.askUser
+        ? widget.prompt.questions[_questionIndex].header
+        : l10n.hermesApprovalRequired;
     return Semantics(
       container: true,
       liveRegion: true,
-      label: l10n.hermesApprovalRequired,
+      label: semanticsLabel,
       child: Container(
         key: const ValueKey('openwebui-prompt-overlay'),
         padding: const EdgeInsets.all(Spacing.md),
@@ -178,8 +182,6 @@ class _OpenWebUiPromptOverlayState extends State<OpenWebUiPromptOverlay> {
             if (widget.prompt.questions.length > 1)
               Text(
                 '${_questionIndex + 1}/${widget.prompt.questions.length}',
-                semanticsLabel:
-                    '${_questionIndex + 1} of ${widget.prompt.questions.length}',
                 style: AppTypography.bodySmallStyle.copyWith(
                   color: theme.textSecondary,
                 ),

--- a/lib/features/chat/widgets/openwebui_prompt_overlay.dart
+++ b/lib/features/chat/widgets/openwebui_prompt_overlay.dart
@@ -135,26 +135,29 @@ class _OpenWebUiPromptOverlayState extends State<OpenWebUiPromptOverlay> {
       container: true,
       liveRegion: true,
       label: semanticsLabel,
-      child: Container(
-        key: const ValueKey('openwebui-prompt-overlay'),
-        padding: const EdgeInsets.all(Spacing.md),
-        decoration: BoxDecoration(
-          color: theme.surfaceBackground,
-          borderRadius: BorderRadius.circular(AppBorderRadius.card),
-          border: Border.all(color: theme.cardBorder),
-          boxShadow: ConduitShadows.card(context),
+      child: Material(
+        color: Colors.transparent,
+        child: Container(
+          key: const ValueKey('openwebui-prompt-overlay'),
+          padding: const EdgeInsets.all(Spacing.md),
+          decoration: BoxDecoration(
+            color: theme.surfaceBackground,
+            borderRadius: BorderRadius.circular(AppBorderRadius.card),
+            border: Border.all(color: theme.cardBorder),
+            boxShadow: ConduitShadows.card(context),
+          ),
+          child: switch (widget.prompt.kind) {
+            OpenWebUiComposerPromptKind.askUser => _buildQuestions(context),
+            OpenWebUiComposerPromptKind.toolApproval => _buildDecision(
+              context,
+              approval: true,
+            ),
+            OpenWebUiComposerPromptKind.confirmation => _buildDecision(
+              context,
+              approval: false,
+            ),
+          },
         ),
-        child: switch (widget.prompt.kind) {
-          OpenWebUiComposerPromptKind.askUser => _buildQuestions(context),
-          OpenWebUiComposerPromptKind.toolApproval => _buildDecision(
-            context,
-            approval: true,
-          ),
-          OpenWebUiComposerPromptKind.confirmation => _buildDecision(
-            context,
-            approval: false,
-          ),
-        },
       ),
     );
   }

--- a/lib/features/hermes/widgets/hermes_approval_card.dart
+++ b/lib/features/hermes/widgets/hermes_approval_card.dart
@@ -2,13 +2,14 @@ import 'package:material_ui/material_ui.dart';
 
 import '../../../l10n/app_localizations.dart';
 import '../../../shared/theme/theme_extensions.dart';
+import '../../../shared/widgets/composer_prompt_surface.dart';
 import '../../../shared/widgets/conduit_components.dart';
 
 /// Resolution state of a Hermes approval gate, mirrored from the assistant
 /// message's `metadata['hermesApproval']['state']`.
 enum HermesApprovalState { pending, resolving, approved, denied }
 
-/// In-chat card shown when a Hermes run pauses for human approval.
+/// Composer prompt shown when a Hermes run pauses for human approval.
 ///
 /// Presentational only: [onDecision] is invoked with the user's choice; the
 /// caller performs the POST and updates the message metadata.
@@ -36,14 +37,8 @@ class HermesApprovalCard extends StatelessWidget {
         state == HermesApprovalState.approved ||
         state == HermesApprovalState.denied;
 
-    return Container(
-      margin: const EdgeInsets.only(top: Spacing.sm),
-      padding: const EdgeInsets.all(Spacing.md),
-      decoration: BoxDecoration(
-        color: theme.surfaceBackground,
-        borderRadius: BorderRadius.circular(AppBorderRadius.card),
-        border: Border.all(color: theme.cardBorder),
-      ),
+    return ComposerPromptSurface(
+      semanticsLabel: l10n.hermesApprovalRequired,
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [

--- a/lib/features/hermes/widgets/hermes_decision_card.dart
+++ b/lib/features/hermes/widgets/hermes_decision_card.dart
@@ -4,6 +4,7 @@ import 'package:material_ui/material_ui.dart';
 
 import '../../../l10n/app_localizations.dart';
 import '../../../shared/theme/theme_extensions.dart';
+import '../../../shared/widgets/composer_prompt_surface.dart';
 import '../../../shared/widgets/conduit_components.dart';
 import '../models/hermes_run_event.dart';
 
@@ -70,125 +71,116 @@ final class _HermesDecisionCardState extends State<HermesDecisionCard> {
       HermesDecisionKind.secret => l10n.hermesSecretTitle,
       HermesDecisionKind.mcpSetup => l10n.hermesMcpSetupTitle,
     };
-    return Material(
-      color: Colors.transparent,
-      child: Container(
-        margin: const EdgeInsets.only(top: Spacing.sm),
-        padding: const EdgeInsets.all(Spacing.md),
-        decoration: BoxDecoration(
-          color: theme.surfaceBackground,
-          borderRadius: BorderRadius.circular(AppBorderRadius.card),
-          border: Border.all(color: theme.cardBorder),
-        ),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
+    return ComposerPromptSurface(
+      semanticsLabel: title,
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            title,
+            style: AppTypography.standard.copyWith(
+              fontWeight: FontWeight.w600,
+              color: theme.textPrimary,
+            ),
+          ),
+          if (widget.prompt?.trim().isNotEmpty == true) ...[
+            const SizedBox(height: Spacing.xs),
             Text(
-              title,
-              style: AppTypography.standard.copyWith(
-                fontWeight: FontWeight.w600,
-                color: theme.textPrimary,
+              widget.prompt!,
+              style: AppTypography.bodySmallStyle.copyWith(
+                color: theme.textSecondary,
               ),
             ),
-            if (widget.prompt?.trim().isNotEmpty == true) ...[
-              const SizedBox(height: Spacing.xs),
+          ],
+          const SizedBox(height: Spacing.sm),
+          if (_resolved)
+            Text(
+              l10n.hermesResponseSent,
+              style: TextStyle(color: theme.success),
+            )
+          else ...[
+            if (widget.kind == HermesDecisionKind.mcpSetup) ...[
               Text(
-                widget.prompt!,
+                '${widget.mcpAction ?? 'Set up'} ${widget.mcpServer ?? 'MCP server'}',
                 style: AppTypography.bodySmallStyle.copyWith(
                   color: theme.textSecondary,
                 ),
               ),
-            ],
-            const SizedBox(height: Spacing.sm),
-            if (_resolved)
-              Text(
-                l10n.hermesResponseSent,
-                style: TextStyle(color: theme.success),
-              )
-            else ...[
-              if (widget.kind == HermesDecisionKind.mcpSetup) ...[
-                Text(
-                  '${widget.mcpAction ?? 'Set up'} ${widget.mcpServer ?? 'MCP server'}',
-                  style: AppTypography.bodySmallStyle.copyWith(
-                    color: theme.textSecondary,
+              const SizedBox(height: Spacing.sm),
+              Row(
+                children: [
+                  ConduitButton(
+                    text: l10n.hermesNotNow,
+                    isCompact: true,
+                    onPressed: _submitting ? null : () => _submit('decline'),
                   ),
-                ),
-                const SizedBox(height: Spacing.sm),
-                Row(
+                  const SizedBox(width: Spacing.sm),
+                  ConduitButton(
+                    text: l10n.hermesSetUp,
+                    isCompact: true,
+                    isLoading: _submitting,
+                    onPressed: _submitting ? null : () => _submit('approve'),
+                  ),
+                ],
+              ),
+            ] else ...[
+              if (widget.choices.isNotEmpty) ...[
+                Wrap(
+                  spacing: Spacing.xs,
+                  runSpacing: Spacing.xs,
                   children: [
-                    ConduitButton(
-                      text: l10n.hermesNotNow,
-                      isCompact: true,
-                      onPressed: _submitting ? null : () => _submit('decline'),
-                    ),
-                    const SizedBox(width: Spacing.sm),
-                    ConduitButton(
-                      text: l10n.hermesSetUp,
-                      isCompact: true,
-                      isLoading: _submitting,
-                      onPressed: _submitting ? null : () => _submit('approve'),
-                    ),
+                    for (final choice in widget.choices)
+                      FilterChip(
+                        label: Text(choice),
+                        selected: _selectedChoices.contains(choice),
+                        onSelected: _submitting
+                            ? null
+                            : (selected) {
+                                if (!widget.multiSelect && selected) {
+                                  _selectedChoices.clear();
+                                }
+                                setState(() {
+                                  selected
+                                      ? _selectedChoices.add(choice)
+                                      : _selectedChoices.remove(choice);
+                                });
+                              },
+                      ),
                   ],
                 ),
-              ] else ...[
-                if (widget.choices.isNotEmpty) ...[
-                  Wrap(
-                    spacing: Spacing.xs,
-                    runSpacing: Spacing.xs,
-                    children: [
-                      for (final choice in widget.choices)
-                        FilterChip(
-                          label: Text(choice),
-                          selected: _selectedChoices.contains(choice),
-                          onSelected: _submitting
-                              ? null
-                              : (selected) {
-                                  if (!widget.multiSelect && selected) {
-                                    _selectedChoices.clear();
-                                  }
-                                  setState(() {
-                                    selected
-                                        ? _selectedChoices.add(choice)
-                                        : _selectedChoices.remove(choice);
-                                  });
-                                },
-                        ),
-                    ],
-                  ),
-                  const SizedBox(height: Spacing.sm),
-                ],
-                TextField(
-                  controller: _controller,
-                  obscureText: _sensitive,
-                  enableSuggestions: !_sensitive,
-                  autocorrect: !_sensitive,
-                  enableIMEPersonalizedLearning: !_sensitive,
-                  decoration: InputDecoration(
-                    labelText: _sensitive
-                        ? l10n.hermesSensitiveResponse
-                        : l10n.hermesResponse,
-                  ),
-                  onSubmitted: (_) => _submit(),
-                ),
                 const SizedBox(height: Spacing.sm),
-                ConduitButton(
-                  text: l10n.hermesSendResponse,
-                  isCompact: true,
-                  isLoading: _submitting,
-                  onPressed: _submitting
-                      ? null
-                      : () => _submit(
-                          _selectedChoices.isEmpty
-                              ? null
-                              : widget.multiSelect
-                              ? jsonEncode(_selectedChoices.toList())
-                              : _selectedChoices.single,
-                        ),
-                ),
               ],
+              TextField(
+                controller: _controller,
+                obscureText: _sensitive,
+                enableSuggestions: !_sensitive,
+                autocorrect: !_sensitive,
+                enableIMEPersonalizedLearning: !_sensitive,
+                decoration: InputDecoration(
+                  labelText: _sensitive
+                      ? l10n.hermesSensitiveResponse
+                      : l10n.hermesResponse,
+                ),
+                onSubmitted: (_) => _submit(),
+              ),
+              const SizedBox(height: Spacing.sm),
+              ConduitButton(
+                text: l10n.hermesSendResponse,
+                isCompact: true,
+                isLoading: _submitting,
+                onPressed: _submitting
+                    ? null
+                    : () => _submit(
+                        _selectedChoices.isEmpty
+                            ? null
+                            : widget.multiSelect
+                            ? jsonEncode(_selectedChoices.toList())
+                            : _selectedChoices.single,
+                      ),
+              ),
             ],
           ],
-        ),
+        ],
       ),
     );
   }

--- a/lib/features/hermes/widgets/hermes_message_interactions.dart
+++ b/lib/features/hermes/widgets/hermes_message_interactions.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:dio/dio.dart' show CancelToken;
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:material_ui/material_ui.dart';
@@ -28,6 +30,11 @@ typedef _HermesApprovalBinding = ({
   String? storedSessionId,
 });
 
+String? _nonEmptyString(Object? value) {
+  final text = value?.toString();
+  return text == null || text.isEmpty ? null : text;
+}
+
 ChatMessage? findPendingHermesComposerPrompt(List<ChatMessage> messages) {
   for (final message in messages.reversed) {
     if (message.metadata?['archivedVariant'] == true) continue;
@@ -51,11 +58,11 @@ ChatMessage? findPendingHermesComposerPrompt(List<ChatMessage> messages) {
       decision['expiresAt']?.toString() ?? '',
     );
     final storedSessionId =
-        decision['storedSessionId']?.toString() ??
-        message.metadata?['hermesSessionId']?.toString();
-    if (decision['requestId']?.toString().isNotEmpty == true &&
-        decision['runtimeId']?.toString().isNotEmpty == true &&
-        storedSessionId?.isNotEmpty == true &&
+        _nonEmptyString(decision['storedSessionId']) ??
+        _nonEmptyString(message.metadata?['hermesSessionId']);
+    if (_nonEmptyString(decision['requestId']) != null &&
+        _nonEmptyString(decision['runtimeId']) != null &&
+        storedSessionId != null &&
         expiresAt != null &&
         expiresAt.isAfter(DateTime.now().toUtc())) {
       return message;
@@ -78,8 +85,12 @@ class HermesComposerPromptOverlay extends ConsumerStatefulWidget {
 
 class _HermesComposerPromptOverlayState
     extends ConsumerState<HermesComposerPromptOverlay> {
+  Timer? _expiryTimer;
+
   @override
   Widget build(BuildContext context) {
+    _expiryTimer?.cancel();
+    _expiryTimer = null;
     final messages = ref.watch(chatMessagesProvider);
     for (final message in messages.reversed) {
       final card = _buildPromptCard(message);
@@ -230,8 +241,8 @@ class _HermesComposerPromptOverlayState
     if (expiresAt == null || !expiresAt.isAfter(DateTime.now().toUtc())) {
       return null;
     }
-    final requestId = decision['requestId']?.toString();
-    final runtimeId = decision['runtimeId']?.toString();
+    final requestId = _nonEmptyString(decision['requestId']);
+    final runtimeId = _nonEmptyString(decision['runtimeId']);
     final kind = HermesDecisionKind.values.firstWhere(
       (value) => value.name == decision['kind'],
       orElse: () => HermesDecisionKind.clarification,
@@ -242,11 +253,14 @@ class _HermesComposerPromptOverlayState
     final activeConversation = ref.read(activeConversationProvider);
     final ownerConversationId = activeConversation?.id;
     final storedSessionId =
-        decision['storedSessionId']?.toString() ??
-        message.metadata?['hermesSessionId']?.toString();
+        _nonEmptyString(decision['storedSessionId']) ??
+        _nonEmptyString(message.metadata?['hermesSessionId']);
     if (ownerConversationId == null || storedSessionId == null) {
       return null;
     }
+    _expiryTimer = Timer(expiresAt.difference(DateTime.now().toUtc()), () {
+      if (mounted) setState(() {});
+    });
     return HermesDecisionCard(
       key: ValueKey('$runtimeId\u0000$requestId\u0000${kind.name}'),
       kind: kind,
@@ -312,6 +326,12 @@ class _HermesComposerPromptOverlayState
         }
       },
     );
+  }
+
+  @override
+  void dispose() {
+    _expiryTimer?.cancel();
+    super.dispose();
   }
 
   bool _ownsDesktopDecision({

--- a/lib/features/hermes/widgets/hermes_message_interactions.dart
+++ b/lib/features/hermes/widgets/hermes_message_interactions.dart
@@ -35,7 +35,13 @@ ChatMessage? findPendingHermesComposerPrompt(List<ChatMessage> messages) {
     if (approval is Map &&
         (approval['state'] == null ||
             approval['state'] == 'pending' ||
-            approval['state'] == 'resolving')) {
+            approval['state'] == 'resolving') &&
+        approval['runId'] is String &&
+        (approval['runId'] as String).isNotEmpty &&
+        approval['approvalId'] is String &&
+        (approval['approvalId'] as String).isNotEmpty &&
+        (message.metadata?['restoredDesktopDecision'] != true ||
+            approval['storedSessionId']?.toString().isNotEmpty == true)) {
       return message;
     }
     final decision = message.metadata?[kHermesDecisionMeta];
@@ -43,7 +49,14 @@ ChatMessage? findPendingHermesComposerPrompt(List<ChatMessage> messages) {
     final expiresAt = DateTime.tryParse(
       decision['expiresAt']?.toString() ?? '',
     );
-    if (expiresAt != null && expiresAt.isAfter(DateTime.now().toUtc())) {
+    final storedSessionId =
+        decision['storedSessionId']?.toString() ??
+        message.metadata?['hermesSessionId']?.toString();
+    if (decision['requestId']?.toString().isNotEmpty == true &&
+        decision['runtimeId']?.toString().isNotEmpty == true &&
+        storedSessionId?.isNotEmpty == true &&
+        expiresAt != null &&
+        expiresAt.isAfter(DateTime.now().toUtc())) {
       return message;
     }
   }
@@ -65,11 +78,22 @@ class HermesComposerPromptOverlay extends ConsumerStatefulWidget {
 class _HermesComposerPromptOverlayState
     extends ConsumerState<HermesComposerPromptOverlay> {
   @override
-  Widget build(BuildContext context) =>
-      _buildApprovalCard() ?? _buildDecisionCard() ?? const SizedBox.shrink();
+  Widget build(BuildContext context) {
+    final messages = ref.watch(chatMessagesProvider);
+    for (final message in messages.reversed) {
+      final card = _buildApprovalCard(message) ?? _buildDecisionCard(message);
+      if (card != null) return card;
+    }
+    if (messages.any((message) => message.id == widget.message.id)) {
+      return const SizedBox.shrink();
+    }
+    return _buildApprovalCard(widget.message) ??
+        _buildDecisionCard(widget.message) ??
+        const SizedBox.shrink();
+  }
 
-  Widget? _buildApprovalCard() {
-    final approval = widget.message.metadata?['hermesApproval'];
+  Widget? _buildApprovalCard(ChatMessage message) {
+    final approval = message.metadata?['hermesApproval'];
     if (approval is! Map) return null;
     if (approval['state'] != null &&
         approval['state'] != 'pending' &&
@@ -83,7 +107,7 @@ class _HermesComposerPromptOverlayState
     final approvalId = approval['approvalId'] is String
         ? approval['approvalId'] as String
         : null;
-    final messageId = widget.message.id;
+    final messageId = message.id;
     final activeConversation = ref.read(activeConversationProvider);
     final state = switch (approval['state']) {
       'resolving' => HermesApprovalState.resolving,
@@ -93,9 +117,9 @@ class _HermesComposerPromptOverlayState
     };
     final storedSessionId = approval['storedSessionId']?.toString();
     final choices = _approvalChoices(approval['choices']);
-    if (widget.message.metadata?['restoredDesktopDecision'] == true) {
+    if (message.metadata?['restoredDesktopDecision'] == true) {
       final service = ref.read(hermesApiServiceProvider);
-      if (widget.message.metadata?['transport'] != kHermesTransport ||
+      if (message.metadata?['transport'] != kHermesTransport ||
           service is! HermesDesktopApiService ||
           runId == null ||
           approvalId == null ||
@@ -152,7 +176,7 @@ class _HermesComposerPromptOverlayState
             generationToken: generationToken,
             runId: runId,
           );
-    if (widget.message.metadata?['transport'] != kHermesTransport ||
+    if (message.metadata?['transport'] != kHermesTransport ||
         runId == null ||
         approvalId == null ||
         runKey == null ||
@@ -188,11 +212,11 @@ class _HermesComposerPromptOverlayState
     );
   }
 
-  Widget? _buildDecisionCard() {
-    if (widget.message.metadata?['transport'] != kHermesTransport) {
+  Widget? _buildDecisionCard(ChatMessage message) {
+    if (message.metadata?['transport'] != kHermesTransport) {
       return null;
     }
-    final decision = widget.message.metadata?[kHermesDecisionMeta];
+    final decision = message.metadata?[kHermesDecisionMeta];
     if (decision is! Map || decision['state'] != 'pending') {
       return null;
     }
@@ -215,7 +239,7 @@ class _HermesComposerPromptOverlayState
     final ownerConversationId = activeConversation?.id;
     final storedSessionId =
         decision['storedSessionId']?.toString() ??
-        widget.message.metadata?['hermesSessionId']?.toString();
+        message.metadata?['hermesSessionId']?.toString();
     if (ownerConversationId == null || storedSessionId == null) {
       return null;
     }
@@ -231,6 +255,7 @@ class _HermesComposerPromptOverlayState
       },
       multiSelect: decision['multiSelect'] == true,
       onSubmit: (value) async {
+        if (!expiresAt.isAfter(DateTime.now().toUtc())) return false;
         final service = ref.read(hermesApiServiceProvider);
         if (service is! HermesDesktopApiService) return false;
         final configController = ref.read(hermesConfigProvider.notifier);
@@ -262,7 +287,7 @@ class _HermesComposerPromptOverlayState
             return false;
           }
           ref.read(chatMessagesProvider.notifier).updateMessageById(
-            widget.message.id,
+            message.id,
             (message) {
               final metadata = Map<String, dynamic>.from(
                 message.metadata ?? const {},

--- a/lib/features/hermes/widgets/hermes_message_interactions.dart
+++ b/lib/features/hermes/widgets/hermes_message_interactions.dart
@@ -30,6 +30,7 @@ typedef _HermesApprovalBinding = ({
 
 ChatMessage? findPendingHermesComposerPrompt(List<ChatMessage> messages) {
   for (final message in messages.reversed) {
+    if (message.metadata?['archivedVariant'] == true) continue;
     if (message.metadata?['transport'] != kHermesTransport) continue;
     final approval = message.metadata?[kHermesApprovalMeta];
     if (approval is Map &&
@@ -81,16 +82,19 @@ class _HermesComposerPromptOverlayState
   Widget build(BuildContext context) {
     final messages = ref.watch(chatMessagesProvider);
     for (final message in messages.reversed) {
-      final card = _buildApprovalCard(message) ?? _buildDecisionCard(message);
+      final card = _buildPromptCard(message);
       if (card != null) return card;
     }
     if (messages.any((message) => message.id == widget.message.id)) {
       return const SizedBox.shrink();
     }
-    return _buildApprovalCard(widget.message) ??
-        _buildDecisionCard(widget.message) ??
-        const SizedBox.shrink();
+    return _buildPromptCard(widget.message) ?? const SizedBox.shrink();
   }
+
+  Widget? _buildPromptCard(ChatMessage message) =>
+      message.metadata?['archivedVariant'] == true
+      ? null
+      : _buildApprovalCard(message) ?? _buildDecisionCard(message);
 
   Widget? _buildApprovalCard(ChatMessage message) {
     final approval = message.metadata?['hermesApproval'];

--- a/lib/features/hermes/widgets/hermes_message_interactions.dart
+++ b/lib/features/hermes/widgets/hermes_message_interactions.dart
@@ -28,29 +28,49 @@ typedef _HermesApprovalBinding = ({
   String? storedSessionId,
 });
 
-/// Hermes-owned approval and interactive-decision presentation for one
-/// assistant message.
-class HermesMessageInteractions extends ConsumerStatefulWidget {
-  const HermesMessageInteractions({super.key, required this.message});
+ChatMessage? findPendingHermesComposerPrompt(List<ChatMessage> messages) {
+  for (final message in messages.reversed) {
+    if (message.metadata?['transport'] != kHermesTransport) continue;
+    final approval = message.metadata?[kHermesApprovalMeta];
+    if (approval is Map &&
+        (approval['state'] == null ||
+            approval['state'] == 'pending' ||
+            approval['state'] == 'resolving')) {
+      return message;
+    }
+    final decision = message.metadata?[kHermesDecisionMeta];
+    if (decision is! Map || decision['state'] != 'pending') continue;
+    final expiresAt = DateTime.tryParse(
+      decision['expiresAt']?.toString() ?? '',
+    );
+    if (expiresAt != null && expiresAt.isAfter(DateTime.now().toUtc())) {
+      return message;
+    }
+  }
+  return null;
+}
+
+/// Hermes-owned approval and interactive-decision presentation attached to
+/// the active chat composer.
+class HermesComposerPromptOverlay extends ConsumerStatefulWidget {
+  const HermesComposerPromptOverlay({super.key, required this.message});
 
   final ChatMessage message;
 
   @override
-  ConsumerState<HermesMessageInteractions> createState() =>
-      _HermesMessageInteractionsState();
+  ConsumerState<HermesComposerPromptOverlay> createState() =>
+      _HermesComposerPromptOverlayState();
 }
 
-class _HermesMessageInteractionsState
-    extends ConsumerState<HermesMessageInteractions> {
+class _HermesComposerPromptOverlayState
+    extends ConsumerState<HermesComposerPromptOverlay> {
   @override
-  Widget build(BuildContext context) => Column(
-    crossAxisAlignment: CrossAxisAlignment.stretch,
-    children: [_buildApprovalCard(), _buildDecisionCard()],
-  );
+  Widget build(BuildContext context) =>
+      _buildApprovalCard() ?? _buildDecisionCard() ?? const SizedBox.shrink();
 
-  Widget _buildApprovalCard() {
+  Widget? _buildApprovalCard() {
     final approval = widget.message.metadata?['hermesApproval'];
-    if (approval is! Map) return const SizedBox.shrink();
+    if (approval is! Map) return null;
 
     final runId = approval['runId'] is String
         ? approval['runId'] as String
@@ -80,7 +100,7 @@ class _HermesMessageInteractionsState
             activeConversation.metadata['hermesSessionId']?.toString() ?? '',
             storedSessionId,
           )) {
-        return const SizedBox.shrink();
+        return null;
       }
       return HermesApprovalCard(
         state: state,
@@ -133,7 +153,7 @@ class _HermesMessageInteractionsState
         runKey == null ||
         generationToken == null ||
         cancelToken == null) {
-      return const SizedBox.shrink();
+      return null;
     }
     final binding = (
       runKey: runKey,
@@ -147,7 +167,7 @@ class _HermesMessageInteractionsState
 
     final capabilities = ref.watch(hermesCapabilitiesProvider).asData?.value;
     if (capabilities != null && !capabilities.runApproval) {
-      return const SizedBox.shrink();
+      return null;
     }
     return HermesApprovalCard(
       state: state,
@@ -163,19 +183,19 @@ class _HermesMessageInteractionsState
     );
   }
 
-  Widget _buildDecisionCard() {
+  Widget? _buildDecisionCard() {
     if (widget.message.metadata?['transport'] != kHermesTransport) {
-      return const SizedBox.shrink();
+      return null;
     }
     final decision = widget.message.metadata?[kHermesDecisionMeta];
     if (decision is! Map || decision['state'] != 'pending') {
-      return const SizedBox.shrink();
+      return null;
     }
     final expiresAt = DateTime.tryParse(
       decision['expiresAt']?.toString() ?? '',
     );
     if (expiresAt == null || !expiresAt.isAfter(DateTime.now().toUtc())) {
-      return const SizedBox.shrink();
+      return null;
     }
     final requestId = decision['requestId']?.toString();
     final runtimeId = decision['runtimeId']?.toString();
@@ -184,7 +204,7 @@ class _HermesMessageInteractionsState
       orElse: () => HermesDecisionKind.clarification,
     );
     if (requestId == null || runtimeId == null) {
-      return const SizedBox.shrink();
+      return null;
     }
     final activeConversation = ref.read(activeConversationProvider);
     final ownerConversationId = activeConversation?.id;
@@ -192,7 +212,7 @@ class _HermesMessageInteractionsState
         decision['storedSessionId']?.toString() ??
         widget.message.metadata?['hermesSessionId']?.toString();
     if (ownerConversationId == null || storedSessionId == null) {
-      return const SizedBox.shrink();
+      return null;
     }
     return HermesDecisionCard(
       key: ValueKey('$runtimeId\u0000$requestId\u0000${kind.name}'),

--- a/lib/features/hermes/widgets/hermes_message_interactions.dart
+++ b/lib/features/hermes/widgets/hermes_message_interactions.dart
@@ -71,6 +71,11 @@ class _HermesComposerPromptOverlayState
   Widget? _buildApprovalCard() {
     final approval = widget.message.metadata?['hermesApproval'];
     if (approval is! Map) return null;
+    if (approval['state'] != null &&
+        approval['state'] != 'pending' &&
+        approval['state'] != 'resolving') {
+      return null;
+    }
 
     final runId = approval['runId'] is String
         ? approval['runId'] as String

--- a/lib/features/terminal/controllers/terminal_session_controller.dart
+++ b/lib/features/terminal/controllers/terminal_session_controller.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 import 'dart:convert';
 import 'dart:typed_data';
 
+import 'package:flutter/foundation.dart';
 import 'package:web_socket_channel/web_socket_channel.dart';
 import 'package:xterm/xterm.dart';
 
@@ -14,6 +15,18 @@ typedef TerminalContextValidator = bool Function(
   TerminalServerInfo server,
   String sessionScopeId,
 );
+
+@visibleForTesting
+Map<String, dynamic> buildTerminalWebSocketAuthPayload(
+  TerminalServerInfo server, {
+  required String token,
+  required String sessionScopeId,
+}) => <String, dynamic>{
+  'type': 'auth',
+  'token': token,
+  if (server.isSystem && isSavedTerminalChatScopeId(sessionScopeId))
+    'chat_id': sessionScopeId,
+};
 
 /// Owns the interactive terminal session and its WebSocket lifecycle.
 ///
@@ -104,7 +117,13 @@ class TerminalSessionController {
       _gateway.setConnectionState(const TerminalConnectionState.connected());
 
       channel.sink.add(
-        jsonEncode(<String, dynamic>{'type': 'auth', 'token': token}),
+        jsonEncode(
+          buildTerminalWebSocketAuthPayload(
+            server,
+            token: token,
+            sessionScopeId: sessionScopeId,
+          ),
+        ),
       );
       _sendResizeEvent();
       _pingTimer = Timer.periodic(

--- a/lib/features/terminal/models/terminal_models.dart
+++ b/lib/features/terminal/models/terminal_models.dart
@@ -20,6 +20,8 @@ class TerminalServerInfo {
     this.name = '',
     this.raw = const <String, dynamic>{},
     this.selectedEnabled = false,
+    this.chatContextAvailable = true,
+    this.requiresSavedChatContext = false,
   });
 
   final TerminalServerKind kind;
@@ -30,10 +32,18 @@ class TerminalServerInfo {
   final String name;
   final Map<String, dynamic> raw;
   final bool selectedEnabled;
+  final bool chatContextAvailable;
+  final bool requiresSavedChatContext;
 
   bool get isDirect => kind == TerminalServerKind.direct;
 
   bool get isSystem => kind == TerminalServerKind.system;
+
+  bool isAvailableForChatScope(String sessionScopeId) {
+    if (!chatContextAvailable) return false;
+    return !requiresSavedChatContext ||
+        isSavedTerminalChatScopeId(sessionScopeId);
+  }
 
   String get displayName {
     final trimmedName = name.trim();
@@ -65,6 +75,15 @@ class TerminalServerInfo {
     final path = baseUrl.path == '/' ? '' : baseUrl.path;
     return sanitizeUtf16('$host$port$path');
   }
+}
+
+bool isSavedTerminalChatScopeId(String value) {
+  final id = value.trim();
+  return id.isNotEmpty &&
+      id != 'sidebar-terminal' &&
+      !id.startsWith('local:') &&
+      !id.startsWith('temporary:') &&
+      !id.startsWith('channel:');
 }
 
 class TerminalFileEntry {

--- a/lib/features/terminal/providers/terminal_providers.dart
+++ b/lib/features/terminal/providers/terminal_providers.dart
@@ -57,14 +57,50 @@ Future<List<TerminalServerInfo>> _probeTerminalServers(
   // last-known state. Deferred — can't mutate a provider during build.
   Future.microtask(() {
     if (!ref.mounted ||
+        !identical(ref.read(terminalServiceProvider), service) ||
         ref.read(terminalSessionScopeIdProvider) != sessionScopeId) {
       return;
     }
+    final enabled = servers.isNotEmpty;
+    ref.read(terminalFeatureEnabledProvider.notifier).setEnabled(enabled);
     ref
-        .read(terminalFeatureEnabledProvider.notifier)
-        .setEnabled(servers.isNotEmpty);
+        .read(_terminalScopedAvailabilityProvider.notifier)
+        .setEnabled(service, sessionScopeId, enabled);
   });
   return servers;
+}
+
+typedef _TerminalAvailabilityScope = ({
+  TerminalService? service,
+  String sessionScopeId,
+});
+
+final _terminalScopedAvailabilityProvider =
+    NotifierProvider<
+      _TerminalScopedAvailabilityNotifier,
+      Map<_TerminalAvailabilityScope, bool>
+    >(_TerminalScopedAvailabilityNotifier.new);
+
+class _TerminalScopedAvailabilityNotifier
+    extends Notifier<Map<_TerminalAvailabilityScope, bool>> {
+  @override
+  Map<_TerminalAvailabilityScope, bool> build() {
+    final service = ref.watch(terminalServiceProvider);
+    final cached = ref.watch(terminalFeatureEnabledProvider);
+    final sessionScopeId = ref.read(terminalSessionScopeIdProvider);
+    return {(service: service, sessionScopeId: sessionScopeId): cached};
+  }
+
+  void setEnabled(
+    TerminalService service,
+    String sessionScopeId,
+    bool enabled,
+  ) {
+    state = {
+      ...state,
+      (service: service, sessionScopeId: sessionScopeId): enabled,
+    };
+  }
 }
 
 /// Whether the Terminal tab should be visible. When the server list resolves,
@@ -74,11 +110,15 @@ Future<List<TerminalServerInfo>> _probeTerminalServers(
 /// optimistically showing the tab — so a server with terminal disabled doesn't
 /// surface the tab offline (matching notes/channels).
 final terminalTabVisibleProvider = Provider<bool>((ref) {
-  final cached = ref.watch(terminalFeatureEnabledProvider);
+  final service = ref.watch(terminalServiceProvider);
+  final sessionScopeId = ref.watch(terminalSessionScopeIdProvider);
+  final cached = ref.watch(
+    _terminalScopedAvailabilityProvider,
+  )[(service: service, sessionScopeId: sessionScopeId)];
   final serversAsync = ref.watch(terminalAvailableServersProvider);
   return serversAsync.maybeWhen(
     data: (servers) => servers.isNotEmpty,
-    orElse: () => cached,
+    orElse: () => cached ?? false,
   );
 });
 

--- a/lib/features/terminal/providers/terminal_providers.dart
+++ b/lib/features/terminal/providers/terminal_providers.dart
@@ -55,11 +55,15 @@ Future<List<TerminalServerInfo>> _probeTerminalServers(
   // A real probe succeeded for the current API/session: persist whether
   // terminal is enabled so the offline/error fallback reflects the true
   // last-known state. Deferred — can't mutate a provider during build.
-  Future.microtask(
-    () => ref
+  Future.microtask(() {
+    if (!ref.mounted ||
+        ref.read(terminalSessionScopeIdProvider) != sessionScopeId) {
+      return;
+    }
+    ref
         .read(terminalFeatureEnabledProvider.notifier)
-        .setEnabled(servers.isNotEmpty),
-  );
+        .setEnabled(servers.isNotEmpty);
+  });
   return servers;
 }
 

--- a/lib/features/terminal/providers/terminal_providers.dart
+++ b/lib/features/terminal/providers/terminal_providers.dart
@@ -28,6 +28,7 @@ final terminalServiceProvider = Provider<TerminalService?>((ref) {
 final terminalAvailableServersProvider =
     FutureProvider<List<TerminalServerInfo>>((ref) {
       final service = ref.watch(terminalServiceProvider);
+      final sessionScopeId = ref.watch(terminalSessionScopeIdProvider);
       if (service == null) {
         // No API/service yet (startup, auth/active-server rebuild). There is no
         // real probe to report: stay UNRESOLVED (loading) rather than resolving
@@ -40,14 +41,17 @@ final terminalAvailableServersProvider =
         return Completer<List<TerminalServerInfo>>().future;
       }
 
-      return _probeTerminalServers(ref, service);
+      return _probeTerminalServers(ref, service, sessionScopeId);
     });
 
 Future<List<TerminalServerInfo>> _probeTerminalServers(
   Ref ref,
   TerminalService service,
+  String sessionScopeId,
 ) async {
-  final servers = await service.getAvailableServers();
+  final servers = (await service.getAvailableServers())
+      .where((server) => server.isAvailableForChatScope(sessionScopeId))
+      .toList(growable: false);
   // A real probe succeeded for the current API/session: persist whether
   // terminal is enabled so the offline/error fallback reflects the true
   // last-known state. Deferred — can't mutate a provider during build.

--- a/lib/features/terminal/providers/terminal_providers.dart
+++ b/lib/features/terminal/providers/terminal_providers.dart
@@ -86,7 +86,7 @@ class _TerminalScopedAvailabilityNotifier
   @override
   Map<_TerminalAvailabilityScope, bool> build() {
     final service = ref.watch(terminalServiceProvider);
-    final cached = ref.watch(terminalFeatureEnabledProvider);
+    final cached = ref.read(terminalFeatureEnabledProvider);
     final sessionScopeId = ref.read(terminalSessionScopeIdProvider);
     return {(service: service, sessionScopeId: sessionScopeId): cached};
   }

--- a/lib/features/terminal/services/terminal_service.dart
+++ b/lib/features/terminal/services/terminal_service.dart
@@ -138,6 +138,18 @@ bool _isConfigEnabled(Map<String, dynamic> server) {
   return true;
 }
 
+({bool available, bool requiresSavedChat}) parseTerminalChatContextForTest(
+  Object? value,
+) {
+  final contexts = _coerceStringKeyedMap(value);
+  final chatContext = contexts['chat'];
+  final chatConfig = _coerceStringKeyedMap(chatContext);
+  return (
+    available: chatContext != false,
+    requiresSavedChat: chatConfig['context_id']?.toString() == 'chat_id',
+  );
+}
+
 String normalizeTerminalPath(String value) {
   var normalized = value.trim().replaceAll('\\', '/');
   normalized = normalized.replaceAll(RegExp(r'/+'), '/');
@@ -356,6 +368,7 @@ class TerminalService {
       if (systemId.isEmpty) {
         continue;
       }
+      final chatContext = parseTerminalChatContextForTest(server['contexts']);
 
       parsed.add(
         TerminalServerInfo(
@@ -367,6 +380,8 @@ class TerminalService {
           ),
           name: _stringValue(server['name']),
           raw: server,
+          chatContextAvailable: chatContext.available,
+          requiresSavedChatContext: chatContext.requiresSavedChat,
         ),
       );
     }

--- a/lib/features/workspace/models/workspace_resources.dart
+++ b/lib/features/workspace/models/workspace_resources.dart
@@ -73,6 +73,16 @@ class WorkspaceModelForm {
   final List<WorkspaceAccessGrantInput> accessGrants;
   final bool isActive;
 
+  WorkspaceModelForm withBaseModelId(String value) => WorkspaceModelForm(
+    id: id,
+    name: name,
+    baseModelId: value,
+    meta: meta,
+    params: params,
+    accessGrants: accessGrants,
+    isActive: isActive,
+  );
+
   Map<String, dynamic> toJson() => <String, dynamic>{
     'id': id,
     'base_model_id': baseModelId,
@@ -82,6 +92,13 @@ class WorkspaceModelForm {
     'access_grants': workspaceGrantInputs(accessGrants),
     'is_active': isActive,
   };
+}
+
+final class WorkspaceModelBaseRequiredException implements Exception {
+  const WorkspaceModelBaseRequiredException();
+
+  @override
+  String toString() => 'A base model is required for this operation.';
 }
 
 @immutable

--- a/lib/features/workspace/providers/workspace_providers.dart
+++ b/lib/features/workspace/providers/workspace_providers.dart
@@ -303,10 +303,10 @@ class WorkspaceModels extends _$WorkspaceModels {
           copy['id']?.toString() ?? '',
         );
         final existingBase = _baseModelId(existing?.baseModelId);
-        if (existing == null) {
+        if (existingBase == null) {
           throw const WorkspaceModelBaseRequiredException();
         }
-        if (existingBase != null) copy['base_model_id'] = existingBase;
+        copy['base_model_id'] = existingBase;
       }
       secured.add(copy);
     }

--- a/lib/features/workspace/providers/workspace_providers.dart
+++ b/lib/features/workspace/providers/workspace_providers.dart
@@ -1,11 +1,13 @@
 import 'dart:async';
 
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:dio/dio.dart' show DioException;
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 import 'package:conduit/core/providers/app_providers.dart';
 import 'package:conduit/core/services/api_service.dart';
 import 'package:conduit/core/utils/debug_logger.dart';
+import 'package:conduit/features/auth/providers/unified_auth_providers.dart';
 import 'package:conduit/features/chat/providers/knowledge_cache_provider.dart';
 import 'package:conduit/features/prompts/providers/prompts_providers.dart';
 import 'package:conduit/features/tools/providers/tools_providers.dart';
@@ -224,11 +226,24 @@ class WorkspaceModels extends _$WorkspaceModels {
     }
   }
 
-  Future<WorkspaceModelDetail> create(WorkspaceModelForm form) =>
-      _mutate((api) => api.createWorkspaceModel(form), detailId: form.id);
+  Future<WorkspaceModelDetail> create(WorkspaceModelForm form) async {
+    if (!_isAdmin && _baseModelId(form.baseModelId) == null) {
+      throw const WorkspaceModelBaseRequiredException();
+    }
+    return _mutate((api) => api.createWorkspaceModel(form), detailId: form.id);
+  }
 
   Future<WorkspaceModelDetail> updateItem(WorkspaceModelForm form) =>
-      _mutate((api) => api.updateWorkspaceModel(form), detailId: form.id);
+      _mutate((api) async {
+        if (_isAdmin || _baseModelId(form.baseModelId) != null) {
+          return api.updateWorkspaceModel(form);
+        }
+        final existing = await _existingModel(api, form.id);
+        final existingBase = _baseModelId(existing?.baseModelId);
+        return api.updateWorkspaceModel(
+          existingBase == null ? form : form.withBaseModelId(existingBase),
+        );
+      }, detailId: form.id);
 
   Future<WorkspaceModelDetail> updateAccess(
     String id,
@@ -248,8 +263,60 @@ class WorkspaceModels extends _$WorkspaceModels {
   }
 
   Future<bool> importItems(List<Map<String, dynamic>> items) async {
-    await _mutateBool((api) => api.importWorkspaceModels(items));
+    await _mutateBool(
+      (api) async => api.importWorkspaceModels(
+        _isAdmin ? items : await _secureNonAdminImports(api, items),
+      ),
+    );
     return true;
+  }
+
+  bool get _isAdmin => ref.read(currentUserProvider2)?.role == 'admin';
+
+  String? _baseModelId(Object? value) {
+    final normalized = value?.toString().trim();
+    return normalized == null || normalized.isEmpty ? null : normalized;
+  }
+
+  Future<WorkspaceModelSummary?> _existingModel(
+    ApiService api,
+    String id,
+  ) async {
+    final current = state.asData?.value;
+    if (current != null) {
+      for (final item in current.items) {
+        if (item.id == id) return item;
+      }
+    }
+    try {
+      return await api.getWorkspaceModel(id);
+    } on DioException catch (error) {
+      if (error.response?.statusCode == 404) return null;
+      rethrow;
+    }
+  }
+
+  Future<List<Map<String, dynamic>>> _secureNonAdminImports(
+    ApiService api,
+    List<Map<String, dynamic>> items,
+  ) async {
+    final secured = <Map<String, dynamic>>[];
+    for (final item in items) {
+      final copy = Map<String, dynamic>.from(item);
+      if (_baseModelId(copy['base_model_id']) == null) {
+        final existing = await _existingModel(
+          api,
+          copy['id']?.toString() ?? '',
+        );
+        final existingBase = _baseModelId(existing?.baseModelId);
+        if (existing == null) {
+          throw const WorkspaceModelBaseRequiredException();
+        }
+        if (existingBase != null) copy['base_model_id'] = existingBase;
+      }
+      secured.add(copy);
+    }
+    return secured;
   }
 
   /// Returns every readable model for export. Read-only: does not mutate state

--- a/lib/features/workspace/providers/workspace_providers.dart
+++ b/lib/features/workspace/providers/workspace_providers.dart
@@ -282,12 +282,6 @@ class WorkspaceModels extends _$WorkspaceModels {
     ApiService api,
     String id,
   ) async {
-    final current = state.asData?.value;
-    if (current != null) {
-      for (final item in current.items) {
-        if (item.id == id) return item;
-      }
-    }
     try {
       return await api.getWorkspaceModel(id);
     } on DioException catch (error) {

--- a/lib/features/workspace/views/models/workspace_model_basics_section.dart
+++ b/lib/features/workspace/views/models/workspace_model_basics_section.dart
@@ -14,11 +14,13 @@ final class WorkspaceModelBasicsSection extends StatelessWidget {
     super.key,
     required this.controller,
     required this.baseModels,
+    required this.baseModelRequired,
     required this.onAddTag,
   });
 
   final WorkspaceModelEditorController controller;
   final List<WorkspaceRelationshipOption> baseModels;
+  final bool baseModelRequired;
   final VoidCallback onAddTag;
 
   @override
@@ -81,19 +83,20 @@ final class WorkspaceModelBasicsSection extends StatelessWidget {
         selectedId == null ||
         baseModels.any((option) => option.id == selectedId);
     final options = <AdaptiveDropdownOption<String?>>[
-      AdaptiveDropdownOption<String?>(
-        value: null,
-        label: l10n.workspaceModelBaseModelNone,
-      ),
+      if (!baseModelRequired)
+        AdaptiveDropdownOption<String?>(
+          value: null,
+          label: l10n.workspaceModelBaseModelNone,
+        ),
       if (!hasSelectedOption)
         AdaptiveDropdownOption<String?>(value: selectedId, label: selectedId),
       for (final option in baseModels)
         AdaptiveDropdownOption<String?>(value: option.id, label: option.label),
     ];
     if (context.usesCupertinoChrome) {
-      final selectedLabel = options
-          .firstWhere((option) => option.value == selectedId)
-          .label;
+      final selectedLabel = selectedId == null
+          ? l10n.workspaceModelBaseModelNone
+          : options.firstWhere((option) => option.value == selectedId).label;
       final row = UtilityValueRow(
         key: const Key('workspace-model-base'),
         label: l10n.workspaceModelBaseModel,

--- a/lib/features/workspace/views/models/workspace_model_editor.dart
+++ b/lib/features/workspace/views/models/workspace_model_editor.dart
@@ -6,6 +6,7 @@ import 'package:material_ui/material_ui.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import 'package:conduit/core/utils/debug_logger.dart';
+import 'package:conduit/features/auth/providers/unified_auth_providers.dart';
 import 'package:conduit/features/workspace/models/workspace_capabilities.dart';
 import 'package:conduit/features/workspace/models/workspace_model_draft.dart';
 import 'package:conduit/features/workspace/models/workspace_resources.dart';
@@ -105,6 +106,11 @@ class _WorkspaceModelFormState extends ConsumerState<_WorkspaceModelForm> {
   WorkspaceModelDraft get _draft => _controller.draft;
   WorkspaceEditorSession get _session => _controller.session;
   bool get _readOnly => _controller.readOnly;
+  bool get _isAdmin => ref.read(currentUserProvider2)?.role == 'admin';
+  bool get _requiresBaseModel =>
+      !_isAdmin &&
+      (_session.isCreate ||
+          (widget.summary?.baseModelId?.trim().isNotEmpty ?? false));
 
   @override
   void initState() {
@@ -252,6 +258,10 @@ class _WorkspaceModelFormState extends ConsumerState<_WorkspaceModelForm> {
       );
       return;
     }
+    if (_requiresBaseModel && (_draft.baseModelId?.trim().isEmpty ?? true)) {
+      _session.setError(l10n.workspaceModelBaseModelRequired);
+      return;
+    }
 
     final notifier = ref.read(workspaceModelsProvider.notifier);
     final form = _draft.toForm();
@@ -278,6 +288,10 @@ class _WorkspaceModelFormState extends ConsumerState<_WorkspaceModelForm> {
     // form's actual contents, not stale draft values — matching _save and
     // _toggleHidden.
     if (!_syncDraftOrShowError()) return;
+    if (!_isAdmin && (_draft.baseModelId?.trim().isEmpty ?? true)) {
+      _session.setError(l10n.workspaceModelBaseModelRequired);
+      return;
+    }
     final clone = _controller.buildClone(l10n.workspaceModelCloneSuffix);
     await WorkspaceEditorMutationCoordinator.replaceWithClone<
       WorkspaceModelDetail
@@ -539,6 +553,7 @@ class _WorkspaceModelFormState extends ConsumerState<_WorkspaceModelForm> {
         child: WorkspaceModelEditorBody(
           controller: _controller,
           baseModels: baseModels,
+          baseModelRequired: _requiresBaseModel,
           onPickImage: _pickImage,
           onAddTag: () => _addTag(l10n),
           onAddSuggestion: () => _addSuggestion(l10n),

--- a/lib/features/workspace/views/models/workspace_model_editor_body.dart
+++ b/lib/features/workspace/views/models/workspace_model_editor_body.dart
@@ -18,6 +18,7 @@ final class WorkspaceModelEditorBody extends StatelessWidget {
     super.key,
     required this.controller,
     required this.baseModels,
+    required this.baseModelRequired,
     required this.onPickImage,
     required this.onAddTag,
     required this.onAddSuggestion,
@@ -27,6 +28,7 @@ final class WorkspaceModelEditorBody extends StatelessWidget {
 
   final WorkspaceModelEditorController controller;
   final List<WorkspaceRelationshipOption> baseModels;
+  final bool baseModelRequired;
   final VoidCallback onPickImage;
   final VoidCallback onAddTag;
   final VoidCallback onAddSuggestion;
@@ -45,6 +47,7 @@ final class WorkspaceModelEditorBody extends StatelessWidget {
         WorkspaceModelBasicsSection(
           controller: controller,
           baseModels: baseModels,
+          baseModelRequired: baseModelRequired,
           onAddTag: onAddTag,
         ),
         SizedBox(height: sectionGap),
@@ -80,10 +83,7 @@ final class WorkspaceModelEditorBody extends StatelessWidget {
           child: Column(
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
-              Text(
-                l10n.workspaceModelProfileImage,
-                style: theme.label,
-              ),
+              Text(l10n.workspaceModelProfileImage, style: theme.label),
               const SizedBox(height: Spacing.xs),
               if (!controller.readOnly)
                 Wrap(

--- a/lib/l10n/app_cs.arb
+++ b/lib/l10n/app_cs.arb
@@ -3576,6 +3576,8 @@
     "description": "Label for the base-model selector."
   },
   "workspaceModelBaseModelNone": "None (custom)",
+  "workspaceModelBaseModelRequired": "Vyberte základní model.",
+  "@workspaceModelBaseModelRequired": {"description": "Validation shown when a non-admin model create or protected edit has no base model."},
   "@workspaceModelBaseModelNone": {
     "description": "Base-model option meaning no base model is used."
   },
@@ -4562,6 +4564,12 @@
   "backendChooserHermesSubtitle": "Connect directly to a self-hosted Hermes agent — no Open WebUI server needed.",
   "hermesApprovalRequired": "Approval required",
   "hermesApprovalFallback": "The agent is requesting permission to continue.",
+  "openWebUiPromptOther": "Jiné",
+  "@openWebUiPromptOther": {"description": "Label for a free-form answer to an Open WebUI ask-user question."},
+  "openWebUiPromptAnswerHint": "Napište svou odpověď",
+  "@openWebUiPromptAnswerHint": {"description": "Placeholder for a free-form Open WebUI ask-user answer."},
+  "openWebUiPromptSubmit": "Odeslat",
+  "@openWebUiPromptSubmit": {"description": "Action that submits all answers to an Open WebUI ask-user prompt."},
   "hermesApprovalApproved": "Approved ✓",
   "hermesApprovalDenied": "Denied",
   "hermesApprovalApproveAction": "Approve",

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -1923,6 +1923,8 @@
     "description": "Label for the base-model selector."
   },
   "workspaceModelBaseModelNone": "None (custom)",
+  "workspaceModelBaseModelRequired": "Wähle ein Basismodell.",
+  "@workspaceModelBaseModelRequired": {"description": "Validation shown when a non-admin model create or protected edit has no base model."},
   "@workspaceModelBaseModelNone": {
     "description": "Base-model option meaning no base model is used."
   },
@@ -2907,6 +2909,12 @@
   "backendChooserHermesSubtitle": "Connect directly to a self-hosted Hermes agent — no Open WebUI server needed.",
   "hermesApprovalRequired": "Approval required",
   "hermesApprovalFallback": "The agent is requesting permission to continue.",
+  "openWebUiPromptOther": "Sonstiges",
+  "@openWebUiPromptOther": {"description": "Label for a free-form answer to an Open WebUI ask-user question."},
+  "openWebUiPromptAnswerHint": "Antwort eingeben",
+  "@openWebUiPromptAnswerHint": {"description": "Placeholder for a free-form Open WebUI ask-user answer."},
+  "openWebUiPromptSubmit": "Absenden",
+  "@openWebUiPromptSubmit": {"description": "Action that submits all answers to an Open WebUI ask-user prompt."},
   "hermesApprovalApproved": "Approved ✓",
   "hermesApprovalDenied": "Denied",
   "hermesApprovalApproveAction": "Approve",

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -4060,6 +4060,8 @@
   "workspaceModelBaseModel": "Base model",
   "@workspaceModelBaseModel": {"description":"Label for the base-model selector."},
   "workspaceModelBaseModelNone": "None (custom)",
+  "workspaceModelBaseModelRequired": "Choose a base model.",
+  "@workspaceModelBaseModelRequired": {"description": "Validation shown when a non-admin model create or protected edit has no base model."},
   "@workspaceModelBaseModelNone": {"description":"Base-model option meaning no base model is used."},
   "workspaceModelName": "Name",
   "@workspaceModelName": {"description":"Label for the model display-name field."},
@@ -5220,6 +5222,12 @@
   "@hermesApprovalFallback": {
     "description": "Fallback description for a Hermes approval request."
   },
+  "openWebUiPromptOther": "Other",
+  "@openWebUiPromptOther": {"description": "Label for a free-form answer to an Open WebUI ask-user question."},
+  "openWebUiPromptAnswerHint": "Type your answer",
+  "@openWebUiPromptAnswerHint": {"description": "Placeholder for a free-form Open WebUI ask-user answer."},
+  "openWebUiPromptSubmit": "Submit",
+  "@openWebUiPromptSubmit": {"description": "Action that submits all answers to an Open WebUI ask-user prompt."},
   "hermesApprovalApproved": "Approved ✓",
   "@hermesApprovalApproved": {
     "description": "Resolved status for an approved Hermes request."

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -1921,6 +1921,8 @@
     "description": "Label for the base-model selector."
   },
   "workspaceModelBaseModelNone": "None (custom)",
+  "workspaceModelBaseModelRequired": "Elige un modelo base.",
+  "@workspaceModelBaseModelRequired": {"description": "Validation shown when a non-admin model create or protected edit has no base model."},
   "@workspaceModelBaseModelNone": {
     "description": "Base-model option meaning no base model is used."
   },
@@ -2907,6 +2909,12 @@
   "backendChooserHermesSubtitle": "Conéctate directamente a un agente Hermes autohospedado; no necesitas un servidor Open WebUI.",
   "hermesApprovalRequired": "Se requiere aprobación",
   "hermesApprovalFallback": "El agente solicita permiso para continuar.",
+  "openWebUiPromptOther": "Otro",
+  "@openWebUiPromptOther": {"description": "Label for a free-form answer to an Open WebUI ask-user question."},
+  "openWebUiPromptAnswerHint": "Escribe tu respuesta",
+  "@openWebUiPromptAnswerHint": {"description": "Placeholder for a free-form Open WebUI ask-user answer."},
+  "openWebUiPromptSubmit": "Enviar",
+  "@openWebUiPromptSubmit": {"description": "Action that submits all answers to an Open WebUI ask-user prompt."},
   "hermesApprovalApproved": "Aprobado ✓",
   "hermesApprovalDenied": "Denegado",
   "hermesApprovalApproveAction": "Aprobar",

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -1921,6 +1921,8 @@
     "description": "Label for the base-model selector."
   },
   "workspaceModelBaseModelNone": "None (custom)",
+  "workspaceModelBaseModelRequired": "Choisissez un modèle de base.",
+  "@workspaceModelBaseModelRequired": {"description": "Validation shown when a non-admin model create or protected edit has no base model."},
   "@workspaceModelBaseModelNone": {
     "description": "Base-model option meaning no base model is used."
   },
@@ -2907,6 +2909,12 @@
   "backendChooserHermesSubtitle": "Connectez-vous directement à un agent Hermes auto-hébergé, sans serveur Open WebUI.",
   "hermesApprovalRequired": "Approbation requise",
   "hermesApprovalFallback": "L’agent demande l’autorisation de continuer.",
+  "openWebUiPromptOther": "Autre",
+  "@openWebUiPromptOther": {"description": "Label for a free-form answer to an Open WebUI ask-user question."},
+  "openWebUiPromptAnswerHint": "Saisissez votre réponse",
+  "@openWebUiPromptAnswerHint": {"description": "Placeholder for a free-form Open WebUI ask-user answer."},
+  "openWebUiPromptSubmit": "Envoyer",
+  "@openWebUiPromptSubmit": {"description": "Action that submits all answers to an Open WebUI ask-user prompt."},
   "hermesApprovalApproved": "Approuvé ✓",
   "hermesApprovalDenied": "Refusé",
   "hermesApprovalApproveAction": "Approuver",

--- a/lib/l10n/app_it.arb
+++ b/lib/l10n/app_it.arb
@@ -1921,6 +1921,8 @@
     "description": "Label for the base-model selector."
   },
   "workspaceModelBaseModelNone": "None (custom)",
+  "workspaceModelBaseModelRequired": "Scegli un modello di base.",
+  "@workspaceModelBaseModelRequired": {"description": "Validation shown when a non-admin model create or protected edit has no base model."},
   "@workspaceModelBaseModelNone": {
     "description": "Base-model option meaning no base model is used."
   },
@@ -2907,6 +2909,12 @@
   "backendChooserHermesSubtitle": "Connect directly to a self-hosted Hermes agent — no Open WebUI server needed.",
   "hermesApprovalRequired": "Approval required",
   "hermesApprovalFallback": "The agent is requesting permission to continue.",
+  "openWebUiPromptOther": "Altro",
+  "@openWebUiPromptOther": {"description": "Label for a free-form answer to an Open WebUI ask-user question."},
+  "openWebUiPromptAnswerHint": "Digita la risposta",
+  "@openWebUiPromptAnswerHint": {"description": "Placeholder for a free-form Open WebUI ask-user answer."},
+  "openWebUiPromptSubmit": "Invia",
+  "@openWebUiPromptSubmit": {"description": "Action that submits all answers to an Open WebUI ask-user prompt."},
   "hermesApprovalApproved": "Approved ✓",
   "hermesApprovalDenied": "Denied",
   "hermesApprovalApproveAction": "Approve",

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -3261,6 +3261,8 @@
     "description": "Label for the base-model selector."
   },
   "workspaceModelBaseModelNone": "None (custom)",
+  "workspaceModelBaseModelRequired": "ベースモデルを選択してください。",
+  "@workspaceModelBaseModelRequired": {"description": "Validation shown when a non-admin model create or protected edit has no base model."},
   "@workspaceModelBaseModelNone": {
     "description": "Base-model option meaning no base model is used."
   },
@@ -4247,6 +4249,12 @@
   "backendChooserHermesSubtitle": "Connect directly to a self-hosted Hermes agent — no Open WebUI server needed.",
   "hermesApprovalRequired": "Approval required",
   "hermesApprovalFallback": "The agent is requesting permission to continue.",
+  "openWebUiPromptOther": "その他",
+  "@openWebUiPromptOther": {"description": "Label for a free-form answer to an Open WebUI ask-user question."},
+  "openWebUiPromptAnswerHint": "回答を入力",
+  "@openWebUiPromptAnswerHint": {"description": "Placeholder for a free-form Open WebUI ask-user answer."},
+  "openWebUiPromptSubmit": "送信",
+  "@openWebUiPromptSubmit": {"description": "Action that submits all answers to an Open WebUI ask-user prompt."},
   "hermesApprovalApproved": "Approved ✓",
   "hermesApprovalDenied": "Denied",
   "hermesApprovalApproveAction": "Approve",

--- a/lib/l10n/app_ko.arb
+++ b/lib/l10n/app_ko.arb
@@ -1699,6 +1699,8 @@
     "description": "Label for the base-model selector."
   },
   "workspaceModelBaseModelNone": "None (custom)",
+  "workspaceModelBaseModelRequired": "기본 모델을 선택하세요.",
+  "@workspaceModelBaseModelRequired": {"description": "Validation shown when a non-admin model create or protected edit has no base model."},
   "@workspaceModelBaseModelNone": {
     "description": "Base-model option meaning no base model is used."
   },
@@ -2685,6 +2687,12 @@
   "backendChooserHermesSubtitle": "자체 호스팅 Hermes Agent에 직접 연결합니다. Open WebUI 서버가 필요하지 않습니다.",
   "hermesApprovalRequired": "승인 필요",
   "hermesApprovalFallback": "에이전트가 계속 진행할 권한을 요청하고 있습니다.",
+  "openWebUiPromptOther": "기타",
+  "@openWebUiPromptOther": {"description": "Label for a free-form answer to an Open WebUI ask-user question."},
+  "openWebUiPromptAnswerHint": "답변 입력",
+  "@openWebUiPromptAnswerHint": {"description": "Placeholder for a free-form Open WebUI ask-user answer."},
+  "openWebUiPromptSubmit": "제출",
+  "@openWebUiPromptSubmit": {"description": "Action that submits all answers to an Open WebUI ask-user prompt."},
   "hermesApprovalApproved": "승인됨 ✓",
   "hermesApprovalDenied": "거부됨",
   "hermesApprovalApproveAction": "승인",

--- a/lib/l10n/app_nl.arb
+++ b/lib/l10n/app_nl.arb
@@ -1921,6 +1921,8 @@
     "description": "Label for the base-model selector."
   },
   "workspaceModelBaseModelNone": "None (custom)",
+  "workspaceModelBaseModelRequired": "Kies een basismodel.",
+  "@workspaceModelBaseModelRequired": {"description": "Validation shown when a non-admin model create or protected edit has no base model."},
   "@workspaceModelBaseModelNone": {
     "description": "Base-model option meaning no base model is used."
   },
@@ -2907,6 +2909,12 @@
   "backendChooserHermesSubtitle": "Connect directly to a self-hosted Hermes agent — no Open WebUI server needed.",
   "hermesApprovalRequired": "Approval required",
   "hermesApprovalFallback": "The agent is requesting permission to continue.",
+  "openWebUiPromptOther": "Anders",
+  "@openWebUiPromptOther": {"description": "Label for a free-form answer to an Open WebUI ask-user question."},
+  "openWebUiPromptAnswerHint": "Typ je antwoord",
+  "@openWebUiPromptAnswerHint": {"description": "Placeholder for a free-form Open WebUI ask-user answer."},
+  "openWebUiPromptSubmit": "Indienen",
+  "@openWebUiPromptSubmit": {"description": "Action that submits all answers to an Open WebUI ask-user prompt."},
   "hermesApprovalApproved": "Approved ✓",
   "hermesApprovalDenied": "Denied",
   "hermesApprovalApproveAction": "Approve",

--- a/lib/l10n/app_pl.arb
+++ b/lib/l10n/app_pl.arb
@@ -4201,6 +4201,8 @@
     "description": "Label for the base-model selector."
   },
   "workspaceModelBaseModelNone": "Brak (własny)",
+  "workspaceModelBaseModelRequired": "Wybierz model bazowy.",
+  "@workspaceModelBaseModelRequired": {"description": "Validation shown when a non-admin model create or protected edit has no base model."},
   "@workspaceModelBaseModelNone": {
     "description": "Base-model option meaning no base model is used."
   },
@@ -5983,6 +5985,12 @@
   "@hermesApprovalFallback": {
     "description": "Fallback description for a Hermes approval request."
   },
+  "openWebUiPromptOther": "Inne",
+  "@openWebUiPromptOther": {"description": "Label for a free-form answer to an Open WebUI ask-user question."},
+  "openWebUiPromptAnswerHint": "Wpisz odpowiedź",
+  "@openWebUiPromptAnswerHint": {"description": "Placeholder for a free-form Open WebUI ask-user answer."},
+  "openWebUiPromptSubmit": "Prześlij",
+  "@openWebUiPromptSubmit": {"description": "Action that submits all answers to an Open WebUI ask-user prompt."},
   "hermesApprovalApproved": "Zatwierdzono ✓",
   "@hermesApprovalApproved": {
     "description": "Resolved status for an approved Hermes request."

--- a/lib/l10n/app_ru.arb
+++ b/lib/l10n/app_ru.arb
@@ -1935,6 +1935,8 @@
     "description": "Label for the base-model selector."
   },
   "workspaceModelBaseModelNone": "None (custom)",
+  "workspaceModelBaseModelRequired": "Выберите базовую модель.",
+  "@workspaceModelBaseModelRequired": {"description": "Validation shown when a non-admin model create or protected edit has no base model."},
   "@workspaceModelBaseModelNone": {
     "description": "Base-model option meaning no base model is used."
   },
@@ -2927,6 +2929,12 @@
   "backendChooserHermesSubtitle": "Прямое подключение к собственному агенту Hermes — сервер Open WebUI не требуется.",
   "hermesApprovalRequired": "Требуется подтверждение",
   "hermesApprovalFallback": "Агент запрашивает разрешение на продолжение.",
+  "openWebUiPromptOther": "Другое",
+  "@openWebUiPromptOther": {"description": "Label for a free-form answer to an Open WebUI ask-user question."},
+  "openWebUiPromptAnswerHint": "Введите ответ",
+  "@openWebUiPromptAnswerHint": {"description": "Placeholder for a free-form Open WebUI ask-user answer."},
+  "openWebUiPromptSubmit": "Отправить",
+  "@openWebUiPromptSubmit": {"description": "Action that submits all answers to an Open WebUI ask-user prompt."},
   "hermesApprovalApproved": "Одобрено ✓",
   "hermesApprovalDenied": "Отклонено",
   "hermesApprovalApproveAction": "Одобрить",

--- a/lib/l10n/app_sk.arb
+++ b/lib/l10n/app_sk.arb
@@ -3576,6 +3576,8 @@
     "description": "Label for the base-model selector."
   },
   "workspaceModelBaseModelNone": "None (custom)",
+  "workspaceModelBaseModelRequired": "Vyberte základný model.",
+  "@workspaceModelBaseModelRequired": {"description": "Validation shown when a non-admin model create or protected edit has no base model."},
   "@workspaceModelBaseModelNone": {
     "description": "Base-model option meaning no base model is used."
   },
@@ -4562,6 +4564,12 @@
   "backendChooserHermesSubtitle": "Connect directly to a self-hosted Hermes agent — no Open WebUI server needed.",
   "hermesApprovalRequired": "Approval required",
   "hermesApprovalFallback": "The agent is requesting permission to continue.",
+  "openWebUiPromptOther": "Iné",
+  "@openWebUiPromptOther": {"description": "Label for a free-form answer to an Open WebUI ask-user question."},
+  "openWebUiPromptAnswerHint": "Napíšte svoju odpoveď",
+  "@openWebUiPromptAnswerHint": {"description": "Placeholder for a free-form Open WebUI ask-user answer."},
+  "openWebUiPromptSubmit": "Odoslať",
+  "@openWebUiPromptSubmit": {"description": "Action that submits all answers to an Open WebUI ask-user prompt."},
   "hermesApprovalApproved": "Approved ✓",
   "hermesApprovalDenied": "Denied",
   "hermesApprovalApproveAction": "Approve",

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -1921,6 +1921,8 @@
     "description": "Label for the base-model selector."
   },
   "workspaceModelBaseModelNone": "None (custom)",
+  "workspaceModelBaseModelRequired": "请选择基础模型。",
+  "@workspaceModelBaseModelRequired": {"description": "Validation shown when a non-admin model create or protected edit has no base model."},
   "@workspaceModelBaseModelNone": {
     "description": "Base-model option meaning no base model is used."
   },
@@ -2907,6 +2909,12 @@
   "backendChooserHermesSubtitle": "Connect directly to a self-hosted Hermes agent — no Open WebUI server needed.",
   "hermesApprovalRequired": "Approval required",
   "hermesApprovalFallback": "The agent is requesting permission to continue.",
+  "openWebUiPromptOther": "其他",
+  "@openWebUiPromptOther": {"description": "Label for a free-form answer to an Open WebUI ask-user question."},
+  "openWebUiPromptAnswerHint": "输入你的回答",
+  "@openWebUiPromptAnswerHint": {"description": "Placeholder for a free-form Open WebUI ask-user answer."},
+  "openWebUiPromptSubmit": "提交",
+  "@openWebUiPromptSubmit": {"description": "Action that submits all answers to an Open WebUI ask-user prompt."},
   "hermesApprovalApproved": "Approved ✓",
   "hermesApprovalDenied": "Denied",
   "hermesApprovalApproveAction": "Approve",

--- a/lib/l10n/app_zh_Hant.arb
+++ b/lib/l10n/app_zh_Hant.arb
@@ -1921,6 +1921,8 @@
     "description": "Label for the base-model selector."
   },
   "workspaceModelBaseModelNone": "None (custom)",
+  "workspaceModelBaseModelRequired": "請選擇基礎模型。",
+  "@workspaceModelBaseModelRequired": {"description": "Validation shown when a non-admin model create or protected edit has no base model."},
   "@workspaceModelBaseModelNone": {
     "description": "Base-model option meaning no base model is used."
   },
@@ -2907,6 +2909,12 @@
   "backendChooserHermesSubtitle": "Connect directly to a self-hosted Hermes agent — no Open WebUI server needed.",
   "hermesApprovalRequired": "Approval required",
   "hermesApprovalFallback": "The agent is requesting permission to continue.",
+  "openWebUiPromptOther": "其他",
+  "@openWebUiPromptOther": {"description": "Label for a free-form answer to an Open WebUI ask-user question."},
+  "openWebUiPromptAnswerHint": "輸入你的回答",
+  "@openWebUiPromptAnswerHint": {"description": "Placeholder for a free-form Open WebUI ask-user answer."},
+  "openWebUiPromptSubmit": "提交",
+  "@openWebUiPromptSubmit": {"description": "Action that submits all answers to an Open WebUI ask-user prompt."},
   "hermesApprovalApproved": "Approved ✓",
   "hermesApprovalDenied": "Denied",
   "hermesApprovalApproveAction": "Approve",

--- a/lib/shared/widgets/composer_prompt_surface.dart
+++ b/lib/shared/widgets/composer_prompt_surface.dart
@@ -1,0 +1,40 @@
+import 'package:material_ui/material_ui.dart';
+
+import '../theme/theme_extensions.dart';
+
+class ComposerPromptSurface extends StatelessWidget {
+  const ComposerPromptSurface({
+    super.key,
+    required this.semanticsLabel,
+    required this.child,
+    this.surfaceKey,
+  });
+
+  final String semanticsLabel;
+  final Widget child;
+  final Key? surfaceKey;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = context.conduitTheme;
+    return Semantics(
+      container: true,
+      liveRegion: true,
+      label: semanticsLabel,
+      child: Material(
+        color: Colors.transparent,
+        child: Container(
+          key: surfaceKey,
+          padding: const EdgeInsets.all(Spacing.md),
+          decoration: BoxDecoration(
+            color: theme.surfaceBackground,
+            borderRadius: BorderRadius.circular(AppBorderRadius.card),
+            border: Border.all(color: theme.cardBorder),
+            boxShadow: ConduitShadows.card(context),
+          ),
+          child: child,
+        ),
+      ),
+    );
+  }
+}

--- a/test/core/models/openwebui_chat_prompt_test.dart
+++ b/test/core/models/openwebui_chat_prompt_test.dart
@@ -24,6 +24,8 @@ void main() {
 
     check(prompt).isNotNull();
     check(prompt!.questions.single.header.length).equals(48);
+    check(boundedOpenWebUiString('${List.filled(47, 'H').join()}😀', 48))
+        .equals(List.filled(47, 'H').join());
     check(prompt.questions.single.allowOther).isTrue();
     check(prompt.timeout).equals(const Duration(minutes: 2));
     check(
@@ -129,7 +131,7 @@ void main() {
       final output = <Map<String, dynamic>>[
         {
           'type': 'function_call',
-          'call_id': 'call-1',
+          'call_id': ' call-1 ',
           'name': 'ask_user',
           'status': 'pending',
         },

--- a/test/core/models/openwebui_chat_prompt_test.dart
+++ b/test/core/models/openwebui_chat_prompt_test.dart
@@ -75,7 +75,7 @@ void main() {
           },
           {
             'type': 'function_call_output',
-            'call_id': 'resolved-call',
+            'call_id': ' resolved-call ',
             'output': const [],
           },
           {

--- a/test/core/models/openwebui_chat_prompt_test.dart
+++ b/test/core/models/openwebui_chat_prompt_test.dart
@@ -1,0 +1,181 @@
+import 'dart:convert';
+
+import 'package:checks/checks.dart';
+import 'package:conduit/core/models/chat_message.dart';
+import 'package:conduit/core/models/openwebui_chat_prompt.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('ask-user parser enforces the upstream shape and bounds text', () {
+    final prompt = parseOpenWebUiAskUserPrompt(<String, dynamic>{
+      'questions': [
+        {
+          'id': 'choice',
+          'header': List.filled(80, 'H').join(),
+          'question': 'Pick one',
+          'options': [
+            {'label': 'First', 'description': 'The first option'},
+            {'label': 'Second', 'description': 'The second option'},
+          ],
+        },
+      ],
+      'timeout_ms': 300000,
+    }, identity: 'live:1');
+
+    check(prompt).isNotNull();
+    check(prompt!.questions.single.header.length).equals(48);
+    check(prompt.questions.single.allowOther).isTrue();
+    check(prompt.timeout).equals(const Duration(minutes: 2));
+    check(
+      parseOpenWebUiAskUserPrompt({
+        'questions': [
+          {
+            'id': 'duplicate',
+            'question': 'One',
+            'options': [
+              {'label': 'A', 'description': 'A'},
+              {'label': 'B', 'description': 'B'},
+            ],
+          },
+          {
+            'id': 'duplicate',
+            'question': 'Two',
+            'options': [
+              {'label': 'A', 'description': 'A'},
+              {'label': 'B', 'description': 'B'},
+            ],
+          },
+        ],
+      }, identity: 'invalid'),
+    ).isNull();
+  });
+
+  test(
+    'pending detector skips resolved calls and selects the newest prompt',
+    () {
+      final messages = [
+        _assistant('older', [
+          {
+            'type': 'function_call',
+            'call_id': 'old-call',
+            'name': 'old_tool',
+            'arguments': '{}',
+            'status': 'pending',
+          },
+        ]),
+        _assistant('newer', [
+          {
+            'type': 'function_call',
+            'call_id': 'resolved-call',
+            'name': 'resolved_tool',
+            'arguments': '{}',
+            'status': 'pending',
+          },
+          {
+            'type': 'function_call_output',
+            'call_id': 'resolved-call',
+            'output': const [],
+          },
+          {
+            'type': 'function_call',
+            'call_id': 'ask-call',
+            'name': 'ask_user',
+            'arguments': jsonEncode({
+              'questions': [
+                {
+                  'id': 'scope',
+                  'header': 'Scope',
+                  'question': 'Which scope?',
+                  'options': [
+                    {'label': 'One', 'description': 'One scope'},
+                    {'label': 'All', 'description': 'Every scope'},
+                  ],
+                },
+              ],
+            }),
+            'status': 'pending',
+          },
+        ]),
+      ];
+
+      final pending = findPendingOpenWebUiToolPrompt(messages);
+      check(pending).isNotNull();
+      check(pending!.messageId).equals('newer');
+      check(pending.callId).equals('ask-call');
+      check(pending.prompt.kind).equals(OpenWebUiComposerPromptKind.askUser);
+    },
+  );
+
+  test('pending detector surfaces unapproved queued calls', () {
+    final pending = findPendingOpenWebUiToolPrompt([
+      _assistant('assistant', [
+        {
+          'type': 'function_call',
+          'call_id': 'queued-call',
+          'name': 'filesystem',
+          'arguments': const {'path': '/tmp'},
+          'status': 'queued',
+        },
+      ]),
+    ]);
+
+    check(pending).isNotNull();
+    check(pending!.callId).equals('queued-call');
+  });
+
+  test(
+    'resolution projection matches approve, reject, and answer contracts',
+    () {
+      final output = <Map<String, dynamic>>[
+        {
+          'type': 'function_call',
+          'call_id': 'call-1',
+          'name': 'ask_user',
+          'status': 'pending',
+        },
+      ];
+      final answered = applyOpenWebUiToolCallResolution(
+        output: output,
+        callId: 'call-1',
+        action: 'answer',
+        answers: const {
+          'scope': {'type': 'other', 'text': 'this chat'},
+        },
+      );
+      check(answered.first['status']).equals('completed');
+      final answerText =
+          ((answered.last['output'] as List).single as Map)['text'] as String;
+      expect(jsonDecode(answerText), {
+        'status': 'answered',
+        'answers': {
+          'scope': {'type': 'other', 'text': 'this chat'},
+        },
+      });
+
+      final approved = applyOpenWebUiToolCallResolution(
+        output: output,
+        callId: 'call-1',
+        action: 'approve',
+      );
+      check(approved.single['status']).equals('queued');
+      check(approved.single['approved']).equals(true);
+
+      final rejected = applyOpenWebUiToolCallResolution(
+        output: output,
+        callId: 'call-1',
+        action: 'reject',
+      );
+      check(rejected.first['status']).equals('rejected');
+      check(rejected.last['status']).equals('rejected');
+    },
+  );
+}
+
+ChatMessage _assistant(String id, List<Map<String, dynamic>> output) =>
+    ChatMessage(
+      id: id,
+      role: 'assistant',
+      content: '',
+      timestamp: DateTime(2026),
+      output: output,
+    );

--- a/test/core/providers/account_profile_password_test.dart
+++ b/test/core/providers/account_profile_password_test.dart
@@ -1,0 +1,102 @@
+import 'package:checks/checks.dart';
+import 'package:conduit/core/auth/auth_state_manager.dart';
+import 'package:conduit/core/models/account_metadata.dart';
+import 'package:conduit/core/models/server_config.dart';
+import 'package:conduit/core/providers/app_providers.dart';
+import 'package:conduit/core/services/api_service.dart';
+import 'package:conduit/core/services/worker_manager.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('successful password update logs out the revoked session', () async {
+    final api = _PasswordApi();
+    final container = _container(api);
+    addTearDown(container.dispose);
+
+    await container
+        .read(accountProfileProvider.notifier)
+        .updatePassword(password: 'old-password', newPassword: 'new-password');
+
+    final auth = container.read(
+      authStateManagerProvider.notifier,
+    ) as _LogoutSpyAuthStateManager;
+    check(api.updates)
+        .deepEquals([(password: 'old-password', newPassword: 'new-password')]);
+    check(auth.logoutCalls).equals(1);
+  });
+
+  test('failed password update keeps the current session', () async {
+    final api = _PasswordApi()..failure = StateError('rejected');
+    final container = _container(api);
+    addTearDown(container.dispose);
+
+    await check(
+      container
+          .read(accountProfileProvider.notifier)
+          .updatePassword(
+            password: 'wrong-password',
+            newPassword: 'new-password',
+          ),
+    ).throws<StateError>();
+
+    final auth = container.read(
+      authStateManagerProvider.notifier,
+    ) as _LogoutSpyAuthStateManager;
+    check(auth.logoutCalls).equals(0);
+  });
+}
+
+ProviderContainer _container(_PasswordApi api) => ProviderContainer(
+  overrides: [
+    apiServiceProvider.overrideWithValue(api),
+    authStateManagerProvider.overrideWith(_LogoutSpyAuthStateManager.new),
+  ],
+);
+
+final class _LogoutSpyAuthStateManager extends AuthStateManager {
+  var logoutCalls = 0;
+
+  @override
+  Future<AuthState> build() async =>
+      const AuthState(status: AuthStatus.authenticated, token: 'session-token');
+
+  @override
+  Future<void> logout() async {
+    logoutCalls++;
+  }
+}
+
+final class _PasswordApi extends ApiService {
+  _PasswordApi()
+    : super(
+        serverConfig: const ServerConfig(
+          id: 'server',
+          name: 'Server',
+          url: 'https://example.test',
+        ),
+        workerManager: WorkerManager(),
+      );
+
+  final updates = <({String password, String newPassword})>[];
+  Object? failure;
+
+  @override
+  Future<AccountMetadata> getAccountMetadata() async => const AccountMetadata(
+    id: 'user',
+    email: 'user@example.test',
+    name: 'User',
+    role: 'user',
+    isActive: true,
+  );
+
+  @override
+  Future<void> updateAccountPassword({
+    required String password,
+    required String newPassword,
+  }) async {
+    final error = failure;
+    if (error != null) throw error;
+    updates.add((password: password, newPassword: newPassword));
+  }
+}

--- a/test/core/providers/account_profile_password_test.dart
+++ b/test/core/providers/account_profile_password_test.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:checks/checks.dart';
 import 'package:conduit/core/auth/auth_state_manager.dart';
 import 'package:conduit/core/models/account_metadata.dart';
@@ -45,6 +47,34 @@ void main() {
     ) as _LogoutSpyAuthStateManager;
     check(auth.logoutCalls).equals(0);
   });
+
+  test('password update does not log out a replacement session', () async {
+    final originalApi = _PasswordApi()..updateGate = Completer<void>();
+    var currentApi = originalApi;
+    final container = ProviderContainer(
+      overrides: [
+        apiServiceProvider.overrideWith((ref) => currentApi),
+        authStateManagerProvider.overrideWith(_LogoutSpyAuthStateManager.new),
+      ],
+    );
+    addTearDown(container.dispose);
+
+    final update = container
+        .read(accountProfileProvider.notifier)
+        .updatePassword(password: 'old-password', newPassword: 'new-password');
+    await Future<void>.delayed(Duration.zero);
+
+    currentApi = _PasswordApi();
+    container.invalidate(apiServiceProvider);
+    check(container.read(apiServiceProvider)).identicalTo(currentApi);
+    originalApi.updateGate!.complete();
+    await update;
+
+    final auth = container.read(
+      authStateManagerProvider.notifier,
+    ) as _LogoutSpyAuthStateManager;
+    check(auth.logoutCalls).equals(0);
+  });
 }
 
 ProviderContainer _container(_PasswordApi api) => ProviderContainer(
@@ -80,6 +110,7 @@ final class _PasswordApi extends ApiService {
 
   final updates = <({String password, String newPassword})>[];
   Object? failure;
+  Completer<void>? updateGate;
 
   @override
   Future<AccountMetadata> getAccountMetadata() async => const AccountMetadata(
@@ -97,6 +128,7 @@ final class _PasswordApi extends ApiService {
   }) async {
     final error = failure;
     if (error != null) throw error;
+    await updateGate?.future;
     updates.add((password: password, newPassword: newPassword));
   }
 }

--- a/test/core/providers/server_incompatible_provider_test.dart
+++ b/test/core/providers/server_incompatible_provider_test.dart
@@ -41,7 +41,7 @@ void main() {
     test('warns when the active server\'s config is unsupported', () async {
       final container = await _container(
         activeServer: _server('A'),
-        config: const BackendConfig(version: '0.11.1', serverId: 'A'),
+        config: const BackendConfig(version: '0.11.2', serverId: 'A'),
       );
       addTearDown(container.dispose);
 
@@ -51,7 +51,7 @@ void main() {
     test('does not warn when the active server is supported', () async {
       final container = await _container(
         activeServer: _server('A'),
-        config: const BackendConfig(version: '0.11.0', serverId: 'A'),
+        config: const BackendConfig(version: '0.11.1', serverId: 'A'),
       );
       addTearDown(container.dispose);
 
@@ -65,7 +65,7 @@ void main() {
         // the still-cached A config must not warn for B.
         final container = await _container(
           activeServer: _server('B'),
-          config: const BackendConfig(version: '0.11.1', serverId: 'A'),
+          config: const BackendConfig(version: '0.11.2', serverId: 'A'),
         );
         addTearDown(container.dispose);
 
@@ -80,7 +80,7 @@ void main() {
       // warning about a supported server because of a stale cache.
       final container = await _container(
         activeServer: _server('A'),
-        config: const BackendConfig(version: '0.11.1'),
+        config: const BackendConfig(version: '0.11.2'),
       );
       addTearDown(container.dispose);
 
@@ -90,7 +90,7 @@ void main() {
     test('fails open when there is no active server', () async {
       final container = await _container(
         activeServer: null,
-        config: const BackendConfig(version: '0.11.1', serverId: 'A'),
+        config: const BackendConfig(version: '0.11.2', serverId: 'A'),
       );
       addTearDown(container.dispose);
 

--- a/test/core/services/api_service_chat_completion_test.dart
+++ b/test/core/services/api_service_chat_completion_test.dart
@@ -187,6 +187,43 @@ void main() {
     },
   );
 
+  test(
+    'tool approval actions omit answers and accept singular task ids',
+    () async {
+      final adapter = _QueuedFakeAdapter([
+        _FakeAdapter.json({'status': true, 'task_id': 'task-3'}),
+        _FakeAdapter.json({'status': true}),
+      ]);
+      final api = _buildApiServiceForTest(adapter);
+
+      final approved = await api.resolveChatMessageToolCall(
+        chatId: 'chat-1',
+        messageId: 'message-1',
+        callId: 'call-1',
+        action: OpenWebUiToolCallAction.approve,
+        answers: const {'ignored': true},
+      );
+      final rejected = await api.resolveChatMessageToolCall(
+        chatId: 'chat-1',
+        messageId: 'message-1',
+        callId: 'call-2',
+        action: OpenWebUiToolCallAction.reject,
+        answers: const {'ignored': true},
+      );
+
+      expect(adapter.requests[0].data, {
+        'call_id': 'call-1',
+        'action': 'approve',
+      });
+      expect(adapter.requests[1].data, {
+        'call_id': 'call-2',
+        'action': 'reject',
+      });
+      expect(approved, ['task-3']);
+      expect(rejected, isEmpty);
+    },
+  );
+
   // -----------------------------------------------------------------------
   // 1. taskSocket classification from JSON with task_id
   // -----------------------------------------------------------------------

--- a/test/core/services/api_service_chat_completion_test.dart
+++ b/test/core/services/api_service_chat_completion_test.dart
@@ -5,6 +5,7 @@ import 'dart:typed_data';
 
 import 'package:checks/checks.dart';
 import 'package:conduit/core/models/chat_message.dart';
+import 'package:conduit/core/models/openwebui_chat_prompt.dart';
 import 'package:conduit/core/services/api_service.dart';
 import 'package:conduit/core/services/chat_completion_transport.dart';
 import 'package:conduit/core/models/server_config.dart';
@@ -154,6 +155,38 @@ Map<String, dynamic> _legacyChatPayload({
 }
 
 void main() {
+  test(
+    'tool-call resolution sends the 0.11.1 form and normalizes task ids',
+    () async {
+      final adapter = _FakeAdapter.json({
+        'status': true,
+        'task_ids': ['task-1', '', 'task-1', 'task-2'],
+      });
+      final api = _buildApiServiceForTest(adapter);
+
+      final taskIds = await api.resolveChatMessageToolCall(
+        chatId: 'chat/1',
+        messageId: 'message/1',
+        callId: 'call-1',
+        action: OpenWebUiToolCallAction.answer,
+        answers: const {
+          'scope': {'type': 'other', 'text': 'this chat'},
+        },
+      );
+
+      check(adapter.lastRequest?.path)
+          .equals('/api/v1/chats/chat%2F1/messages/message%2F1/resolve');
+      expect(adapter.lastRequest?.data, {
+        'call_id': 'call-1',
+        'action': 'answer',
+        'answers': {
+          'scope': {'type': 'other', 'text': 'this chat'},
+        },
+      });
+      expect(taskIds, ['task-1', 'task-2']);
+    },
+  );
+
   // -----------------------------------------------------------------------
   // 1. taskSocket classification from JSON with task_id
   // -----------------------------------------------------------------------

--- a/test/core/utils/server_version_compat_test.dart
+++ b/test/core/utils/server_version_compat_test.dart
@@ -5,7 +5,7 @@ import 'package:flutter_test/flutter_test.dart';
 void main() {
   group('ServerVersionCompat.isSupported', () {
     test('the max supported version itself is supported', () {
-      check(ServerVersionCompat.isSupported('0.11.0')).isTrue();
+      check(ServerVersionCompat.isSupported('0.11.1')).isTrue();
     });
 
     test('older versions are supported', () {
@@ -23,22 +23,22 @@ void main() {
     });
 
     test('newer patch / minor / major versions are unsupported', () {
-      for (final v in ['0.11.1', '0.12.0', '0.20.0', '1.0.0', '2.5.3']) {
+      for (final v in ['0.11.2', '0.12.0', '0.20.0', '1.0.0', '2.5.3']) {
         check(because: v, ServerVersionCompat.isSupported(v)).isFalse();
       }
     });
 
     test('tolerates a leading v prefix', () {
-      check(ServerVersionCompat.isSupported('v0.11.0')).isTrue();
-      check(ServerVersionCompat.isSupported('v0.11.1')).isFalse();
+      check(ServerVersionCompat.isSupported('v0.11.1')).isTrue();
+      check(ServerVersionCompat.isSupported('v0.11.2')).isFalse();
     });
 
     test('strips pre-release / build metadata before comparing', () {
       // A pre-release of the max version is treated as the max version.
-      check(ServerVersionCompat.isSupported('0.11.0-dev')).isTrue();
-      check(ServerVersionCompat.isSupported('0.11.0+build.7')).isTrue();
+      check(ServerVersionCompat.isSupported('0.11.1-dev')).isTrue();
+      check(ServerVersionCompat.isSupported('0.11.1+build.7')).isTrue();
       // Metadata on a newer core still gates.
-      check(ServerVersionCompat.isSupported('0.11.1-rc1')).isFalse();
+      check(ServerVersionCompat.isSupported('0.11.2-rc1')).isFalse();
     });
 
     test('partial versions are padded with zeros', () {
@@ -58,8 +58,8 @@ void main() {
     });
 
     test('isUnsupported is the inverse of isSupported', () {
-      check(ServerVersionCompat.isUnsupported('0.11.1')).isTrue();
-      check(ServerVersionCompat.isUnsupported('0.11.0')).isFalse();
+      check(ServerVersionCompat.isUnsupported('0.11.2')).isTrue();
+      check(ServerVersionCompat.isUnsupported('0.11.1')).isFalse();
       check(ServerVersionCompat.isUnsupported(null)).isFalse();
     });
 

--- a/test/features/chat/assistant_group_header_test.dart
+++ b/test/features/chat/assistant_group_header_test.dart
@@ -105,6 +105,26 @@ void main() {
         ),
       ).isFalse();
     });
+
+    test('a composer-hosted Hermes prompt does not leave a message gap', () {
+      final message = ChatMessage(
+        id: 'prompt-only',
+        role: 'assistant',
+        content: '',
+        timestamp: DateTime.fromMillisecondsSinceEpoch(0),
+        metadata: const {
+          'hermesDecision': {'state': 'pending'},
+        },
+      );
+
+      check(
+        debugCanCollapseGroupedAssistantRowForTesting(
+          message,
+          showModelHeader: false,
+          showActionBar: false,
+        ),
+      ).isTrue();
+    });
   });
 
   group('action bar placement', () {
@@ -158,7 +178,7 @@ void main() {
 
     test('skipped rows neither break a response nor host its bar', () {
       // Archived variants render as zero-size placeholders and restored
-      // decision cards carry no text of their own; a toolbar under either
+      // decision prompts carry no text of their own; a toolbar under either
       // would act on content it does not show.
       final placements = debugResolveAssistantGroupingForTesting([
         hermes,
@@ -243,7 +263,7 @@ const ChatGroupingRow versioned = (
 );
 
 /// A row that renders no response of its own: an archived variant (a zero-size
-/// placeholder) or a restored Hermes decision card. Both reach this seam as the
+/// placeholder) or a restored Hermes decision prompt. Both reach this seam as the
 /// same shape.
 const ChatGroupingRow skipped = (
   isUser: false,

--- a/test/features/chat/providers/chat_messages_notifier_remote_sync_test.dart
+++ b/test/features/chat/providers/chat_messages_notifier_remote_sync_test.dart
@@ -186,6 +186,8 @@ class _FakeApiService extends ApiService {
   set conversation(Conversation value) => _conversation = value;
 
   List<String> taskIds = const <String>[];
+  bool deferTaskIdRequests = false;
+  final List<Completer<List<String>>> taskIdRequests = [];
   int taskIdFailuresRemaining = 0;
 
   int getConversationCalls = 0;
@@ -200,6 +202,11 @@ class _FakeApiService extends ApiService {
   @override
   Future<List<String>> getTaskIdsByChat(String chatId) async {
     getTaskIdsCalls++;
+    if (deferTaskIdRequests) {
+      final request = Completer<List<String>>();
+      taskIdRequests.add(request);
+      return request.future;
+    }
     if (taskIdFailuresRemaining > 0) {
       taskIdFailuresRemaining--;
       throw StateError('transient task registry failure');
@@ -415,6 +422,80 @@ void main() {
         check(api.getConversationCalls).isGreaterOrEqual(1);
       },
     );
+
+    test('non-tail tool task monitors remain independently owned', () async {
+      final timestamp = DateTime.now();
+      ChatMessage assistant(String id, String callId, {bool approved = false}) {
+        return ChatMessage(
+          id: id,
+          role: 'assistant',
+          content: 'Waiting for approval',
+          timestamp: timestamp,
+          output: [
+            {
+              'type': 'function_call',
+              'call_id': callId,
+              'name': 'filesystem',
+              'status': approved ? 'queued' : 'pending',
+              if (approved) 'approved': true,
+            },
+          ],
+        );
+      }
+
+      final messages = [
+        assistant('assistant-1', 'call-1'),
+        _userMessage('user-1', 'Newer turn one', timestamp),
+        assistant('assistant-2', 'call-2'),
+        _userMessage('user-2', 'Newer turn two', timestamp),
+      ];
+      final api = _FakeApiService(
+        _conversation('chat-1', [
+          assistant('assistant-1', 'call-1', approved: true),
+          messages[1],
+          assistant('assistant-2', 'call-2', approved: true),
+          messages[3],
+        ], timestamp),
+      )..deferTaskIdRequests = true;
+      final container = ProviderContainer(
+        overrides: [
+          ...openWebUiStorageOpenOverrides(),
+          activeConversationProvider.overrideWith(
+            _TestActiveConversationNotifier.new,
+          ),
+          socketServiceProvider.overrideWithValue(null),
+          apiServiceProvider.overrideWithValue(api),
+        ],
+      );
+      addTearDown(container.dispose);
+      container
+          .read(activeConversationProvider.notifier)
+          .set(_conversation('chat-1', messages, timestamp));
+      final notifier = container.read(chatMessagesProvider.notifier);
+
+      await notifier.resumeAfterOpenWebUiToolCall(
+        messageId: 'assistant-1',
+        callId: 'call-1',
+        action: OpenWebUiToolCallAction.approve,
+        taskIds: const ['task-1'],
+      );
+      await notifier.resumeAfterOpenWebUiToolCall(
+        messageId: 'assistant-2',
+        callId: 'call-2',
+        action: OpenWebUiToolCallAction.approve,
+        taskIds: const ['task-2'],
+      );
+      await pumpMicrotasks();
+      check(api.taskIdRequests.length).equals(2);
+
+      for (final request in api.taskIdRequests) {
+        request.complete(const ['task-1', 'task-2']);
+      }
+      await pumpMicrotasks();
+      await pumpMicrotasks();
+
+      check(api.getConversationCalls).equals(2);
+    });
 
     test(
       'a slower model lookup cannot overwrite a newer conversation',

--- a/test/features/chat/providers/chat_messages_notifier_remote_sync_test.dart
+++ b/test/features/chat/providers/chat_messages_notifier_remote_sync_test.dart
@@ -442,7 +442,7 @@ void main() {
       },
     );
 
-    test('non-tail task monitor survives delayed task registration', () async {
+    test('staggered task registrations remain monitored', () async {
       final timestamp = DateTime.now();
       final assistant = ChatMessage(
         id: 'assistant-1',
@@ -465,9 +465,9 @@ void main() {
             )
             ..taskIdResponses.addAll(const [
               <String>[],
-              <String>[],
-              <String>[],
               <String>['task-1'],
+              <String>[],
+              <String>['task-2'],
             ]);
       final container = ProviderContainer(
         overrides: [
@@ -490,7 +490,7 @@ void main() {
             messageId: 'assistant-1',
             callId: 'call-1',
             action: OpenWebUiToolCallAction.approve,
-            taskIds: const ['task-1'],
+            taskIds: const ['task-1', 'task-2'],
           );
       await _waitForCondition(() => api.getConversationCalls == 1);
       check(api.getTaskIdsCalls).equals(1);

--- a/test/features/chat/providers/chat_messages_notifier_remote_sync_test.dart
+++ b/test/features/chat/providers/chat_messages_notifier_remote_sync_test.dart
@@ -5,6 +5,7 @@ import 'package:conduit/core/database/chat_database_repository.dart';
 import 'package:conduit/core/models/chat_message.dart';
 import 'package:conduit/core/models/conversation.dart';
 import 'package:conduit/core/models/model.dart';
+import 'package:conduit/core/models/openwebui_chat_prompt.dart';
 import 'package:conduit/core/models/server_config.dart';
 import 'package:conduit/core/providers/app_providers.dart';
 import 'package:conduit/core/services/api_service.dart';
@@ -342,6 +343,54 @@ void main() {
   });
 
   group('ChatMessagesNotifier remote sync', () {
+    test('tool-call resume ignores a non-tail assistant task', () async {
+      final timestamp = DateTime.now();
+      final assistant = ChatMessage(
+        id: 'assistant-1',
+        role: 'assistant',
+        content: 'Waiting for approval',
+        timestamp: timestamp,
+        output: const [
+          {
+            'type': 'function_call',
+            'call_id': 'call-1',
+            'name': 'filesystem',
+            'status': 'pending',
+          },
+        ],
+      );
+      final messages = [
+        assistant,
+        _userMessage('user-2', 'A newer turn', timestamp),
+      ];
+      final container = ProviderContainer(
+        overrides: [
+          ...openWebUiStorageOpenOverrides(),
+          activeConversationProvider.overrideWith(
+            _TestActiveConversationNotifier.new,
+          ),
+          socketServiceProvider.overrideWithValue(null),
+        ],
+      );
+      addTearDown(container.dispose);
+      container
+          .read(activeConversationProvider.notifier)
+          .set(_conversation('chat-1', messages, timestamp));
+
+      await container
+          .read(chatMessagesProvider.notifier)
+          .resumeAfterOpenWebUiToolCall(
+            messageId: 'assistant-1',
+            callId: 'call-1',
+            action: OpenWebUiToolCallAction.approve,
+            taskIds: const ['task-1'],
+          );
+
+      final unchanged = container.read(chatMessagesProvider).first;
+      check(unchanged.isStreaming).isFalse();
+      check(unchanged.output!.single['status']).equals('pending');
+    });
+
     test(
       'a slower model lookup cannot overwrite a newer conversation',
       () async {

--- a/test/features/chat/providers/chat_messages_notifier_remote_sync_test.dart
+++ b/test/features/chat/providers/chat_messages_notifier_remote_sync_test.dart
@@ -186,6 +186,7 @@ class _FakeApiService extends ApiService {
   set conversation(Conversation value) => _conversation = value;
 
   List<String> taskIds = const <String>[];
+  final List<List<String>> taskIdResponses = <List<String>>[];
   bool deferTaskIdRequests = false;
   final List<Completer<List<String>>> taskIdRequests = [];
   int taskIdFailuresRemaining = 0;
@@ -207,6 +208,7 @@ class _FakeApiService extends ApiService {
       taskIdRequests.add(request);
       return request.future;
     }
+    if (taskIdResponses.isNotEmpty) return taskIdResponses.removeAt(0);
     if (taskIdFailuresRemaining > 0) {
       taskIdFailuresRemaining--;
       throw StateError('transient task registry failure');
@@ -439,6 +441,76 @@ void main() {
         check(api.getConversationCalls).isGreaterOrEqual(1);
       },
     );
+
+    test('non-tail task monitor survives delayed task registration', () async {
+      final timestamp = DateTime.now();
+      final assistant = ChatMessage(
+        id: 'assistant-1',
+        role: 'assistant',
+        content: 'Waiting for approval',
+        timestamp: timestamp,
+        output: const [
+          {
+            'type': 'function_call',
+            'call_id': 'call-1',
+            'name': 'filesystem',
+            'status': 'pending',
+          },
+        ],
+      );
+      final newerUser = _userMessage('user-2', 'A newer turn', timestamp);
+      final api =
+          _FakeApiService(
+              _conversation('chat-1', [assistant, newerUser], timestamp),
+            )
+            ..taskIdResponses.addAll(const [
+              <String>[],
+              <String>['task-1'],
+            ]);
+      final container = ProviderContainer(
+        overrides: [
+          ...openWebUiStorageOpenOverrides(),
+          activeConversationProvider.overrideWith(
+            _TestActiveConversationNotifier.new,
+          ),
+          socketServiceProvider.overrideWithValue(null),
+          apiServiceProvider.overrideWithValue(api),
+        ],
+      );
+      addTearDown(container.dispose);
+      container
+          .read(activeConversationProvider.notifier)
+          .set(_conversation('chat-1', [assistant, newerUser], timestamp));
+
+      await container
+          .read(chatMessagesProvider.notifier)
+          .resumeAfterOpenWebUiToolCall(
+            messageId: 'assistant-1',
+            callId: 'call-1',
+            action: OpenWebUiToolCallAction.approve,
+            taskIds: const ['task-1'],
+          );
+      await _waitForCondition(() => api.getConversationCalls == 1);
+      check(api.getTaskIdsCalls).equals(1);
+      final registrationGapMessage = container.read(chatMessagesProvider).first;
+      check(registrationGapMessage.output!.single['status']).equals('queued');
+      check(registrationGapMessage.output!.single['approved']).equals(true);
+
+      api.conversation = _conversation('chat-1', [
+        assistant.copyWith(content: 'Continued after approval'),
+        newerUser,
+      ], timestamp);
+      await _waitForCondition(() => api.getTaskIdsCalls >= 2);
+      await _waitForCondition(
+        () =>
+            container.read(chatMessagesProvider).first.content ==
+            'Continued after approval',
+      );
+
+      check(api.getTaskIdsCalls).isGreaterOrEqual(2);
+      check(container.read(chatMessagesProvider).first.metadata?['taskId'])
+          .equals('task-1');
+    });
 
     test('non-tail tool task monitors remain independently owned', () async {
       final timestamp = DateTime.now();

--- a/test/features/chat/providers/chat_messages_notifier_remote_sync_test.dart
+++ b/test/features/chat/providers/chat_messages_notifier_remote_sync_test.dart
@@ -343,53 +343,58 @@ void main() {
   });
 
   group('ChatMessagesNotifier remote sync', () {
-    test('tool-call resume ignores a non-tail assistant task', () async {
-      final timestamp = DateTime.now();
-      final assistant = ChatMessage(
-        id: 'assistant-1',
-        role: 'assistant',
-        content: 'Waiting for approval',
-        timestamp: timestamp,
-        output: const [
-          {
-            'type': 'function_call',
-            'call_id': 'call-1',
-            'name': 'filesystem',
-            'status': 'pending',
-          },
-        ],
-      );
-      final messages = [
-        assistant,
-        _userMessage('user-2', 'A newer turn', timestamp),
-      ];
-      final container = ProviderContainer(
-        overrides: [
-          ...openWebUiStorageOpenOverrides(),
-          activeConversationProvider.overrideWith(
-            _TestActiveConversationNotifier.new,
-          ),
-          socketServiceProvider.overrideWithValue(null),
-        ],
-      );
-      addTearDown(container.dispose);
-      container
-          .read(activeConversationProvider.notifier)
-          .set(_conversation('chat-1', messages, timestamp));
+    test(
+      'tool-call resume resolves but does not stream a non-tail task',
+      () async {
+        final timestamp = DateTime.now();
+        final assistant = ChatMessage(
+          id: 'assistant-1',
+          role: 'assistant',
+          content: 'Waiting for approval',
+          timestamp: timestamp,
+          output: const [
+            {
+              'type': 'function_call',
+              'call_id': 'call-1',
+              'name': 'filesystem',
+              'status': 'pending',
+            },
+          ],
+        );
+        final messages = [
+          assistant,
+          _userMessage('user-2', 'A newer turn', timestamp),
+        ];
+        final container = ProviderContainer(
+          overrides: [
+            ...openWebUiStorageOpenOverrides(),
+            activeConversationProvider.overrideWith(
+              _TestActiveConversationNotifier.new,
+            ),
+            socketServiceProvider.overrideWithValue(null),
+          ],
+        );
+        addTearDown(container.dispose);
+        container
+            .read(activeConversationProvider.notifier)
+            .set(_conversation('chat-1', messages, timestamp));
 
-      await container
-          .read(chatMessagesProvider.notifier)
-          .resumeAfterOpenWebUiToolCall(
-            messageId: 'assistant-1',
-            callId: 'call-1',
-            action: OpenWebUiToolCallAction.approve,
-            taskIds: const ['task-1'],
-          );
+        await container
+            .read(chatMessagesProvider.notifier)
+            .resumeAfterOpenWebUiToolCall(
+              messageId: 'assistant-1',
+              callId: 'call-1',
+              action: OpenWebUiToolCallAction.approve,
+              taskIds: const ['task-1'],
+            );
 
-      final unchanged = container.read(chatMessagesProvider).first;
-      check(unchanged.isStreaming).isFalse();
-      check(unchanged.output!.single['status']).equals('pending');
-    });
+        final resolved = container.read(chatMessagesProvider).first;
+        check(resolved.isStreaming).isFalse();
+        check(resolved.output!.single['status']).equals('queued');
+        check(resolved.output!.single['approved']).equals(true);
+        check(resolved.metadata?['taskId']).isNull();
+      },
+    );
 
     test(
       'a slower model lookup cannot overwrite a newer conversation',

--- a/test/features/chat/providers/chat_messages_notifier_remote_sync_test.dart
+++ b/test/features/chat/providers/chat_messages_notifier_remote_sync_test.dart
@@ -361,10 +361,25 @@ void main() {
             },
           ],
         );
-        final messages = [
-          assistant,
-          _userMessage('user-2', 'A newer turn', timestamp),
-        ];
+        final newerUser = _userMessage('user-2', 'A newer turn', timestamp);
+        final messages = [assistant, newerUser];
+        final api = _FakeApiService(
+          _conversation('chat-1', [
+            assistant.copyWith(
+              content: 'Continued after approval',
+              output: const [
+                {
+                  'type': 'function_call',
+                  'call_id': 'call-1',
+                  'name': 'filesystem',
+                  'status': 'queued',
+                  'approved': true,
+                },
+              ],
+            ),
+            newerUser,
+          ], timestamp),
+        )..taskIds = const ['task-1'];
         final container = ProviderContainer(
           overrides: [
             ...openWebUiStorageOpenOverrides(),
@@ -372,6 +387,7 @@ void main() {
               _TestActiveConversationNotifier.new,
             ),
             socketServiceProvider.overrideWithValue(null),
+            apiServiceProvider.overrideWithValue(api),
           ],
         );
         addTearDown(container.dispose);
@@ -387,12 +403,16 @@ void main() {
               action: OpenWebUiToolCallAction.approve,
               taskIds: const ['task-1'],
             );
+        await Future<void>.delayed(const Duration(milliseconds: 50));
 
         final resolved = container.read(chatMessagesProvider).first;
         check(resolved.isStreaming).isFalse();
+        check(resolved.content).equals('Continued after approval');
         check(resolved.output!.single['status']).equals('queued');
         check(resolved.output!.single['approved']).equals(true);
-        check(resolved.metadata?['taskId']).isNull();
+        check(resolved.metadata?['taskId']).equals('task-1');
+        check(api.getTaskIdsCalls).isGreaterOrEqual(1);
+        check(api.getConversationCalls).isGreaterOrEqual(1);
       },
     );
 

--- a/test/features/chat/providers/chat_messages_notifier_remote_sync_test.dart
+++ b/test/features/chat/providers/chat_messages_notifier_remote_sync_test.dart
@@ -242,6 +242,19 @@ Conversation _conversation(
 
 Future<void> pumpMicrotasks() => Future<void>.delayed(Duration.zero);
 
+Future<void> _waitForCondition(
+  bool Function() condition, {
+  Duration timeout = const Duration(seconds: 5),
+}) async {
+  final deadline = DateTime.now().add(timeout);
+  while (!condition()) {
+    if (DateTime.now().isAfter(deadline)) {
+      fail('Timed out waiting for asynchronous state');
+    }
+    await Future<void>.delayed(const Duration(milliseconds: 10));
+  }
+}
+
 Future<void> _drainRemoteTaskStatusCheck(ChatMessagesNotifier notifier) async {
   notifier.debugCancelRemoteTaskMonitorTimer();
   while (notifier.debugTaskStatusCheckInFlight) {
@@ -410,7 +423,11 @@ void main() {
               action: OpenWebUiToolCallAction.approve,
               taskIds: const ['task-1'],
             );
-        await Future<void>.delayed(const Duration(milliseconds: 50));
+        await _waitForCondition(
+          () =>
+              container.read(chatMessagesProvider).first.content ==
+              'Continued after approval',
+        );
 
         final resolved = container.read(chatMessagesProvider).first;
         check(resolved.isStreaming).isFalse();
@@ -485,14 +502,13 @@ void main() {
         action: OpenWebUiToolCallAction.approve,
         taskIds: const ['task-2'],
       );
-      await pumpMicrotasks();
+      await _waitForCondition(() => api.taskIdRequests.length == 2);
       check(api.taskIdRequests.length).equals(2);
 
       for (final request in api.taskIdRequests) {
         request.complete(const ['task-1', 'task-2']);
       }
-      await pumpMicrotasks();
-      await pumpMicrotasks();
+      await _waitForCondition(() => api.getConversationCalls == 2);
 
       check(api.getConversationCalls).equals(2);
     });

--- a/test/features/chat/providers/chat_messages_notifier_remote_sync_test.dart
+++ b/test/features/chat/providers/chat_messages_notifier_remote_sync_test.dart
@@ -465,6 +465,8 @@ void main() {
             )
             ..taskIdResponses.addAll(const [
               <String>[],
+              <String>[],
+              <String>[],
               <String>['task-1'],
             ]);
       final container = ProviderContainer(
@@ -500,14 +502,14 @@ void main() {
         assistant.copyWith(content: 'Continued after approval'),
         newerUser,
       ], timestamp);
-      await _waitForCondition(() => api.getTaskIdsCalls >= 2);
+      await _waitForCondition(() => api.getTaskIdsCalls >= 4);
       await _waitForCondition(
         () =>
             container.read(chatMessagesProvider).first.content ==
             'Continued after approval',
       );
 
-      check(api.getTaskIdsCalls).isGreaterOrEqual(2);
+      check(api.getTaskIdsCalls).isGreaterOrEqual(4);
       check(container.read(chatMessagesProvider).first.metadata?['taskId'])
           .equals('task-1');
     });

--- a/test/features/chat/providers/openwebui_chat_prompt_provider_test.dart
+++ b/test/features/chat/providers/openwebui_chat_prompt_provider_test.dart
@@ -1,0 +1,138 @@
+import 'package:checks/checks.dart';
+import 'package:conduit/features/chat/providers/openwebui_chat_prompt_provider.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  tearDown(() => debugOpenWebUiPromptTimeoutOverride = null);
+
+  test('live ask-user acknowledges one exact answer', () {
+    final container = ProviderContainer();
+    addTearDown(container.dispose);
+    final responses = <dynamic>[];
+    final notifier = container.read(openWebUiLivePromptProvider.notifier);
+    notifier.handleSocketRequest(
+      conversationId: 'chat-1',
+      type: 'request:user_input',
+      data: _questionData(),
+      acknowledge: responses.add,
+    );
+    final prompt = container.read(openWebUiLivePromptProvider)!.prompt;
+
+    notifier.answer(prompt.identity, const {
+      'scope': {
+        'type': 'option',
+        'option_index': 0,
+        'label': 'This chat',
+        'description': 'Use this chat only',
+      },
+    });
+    notifier.answer(prompt.identity, const {});
+
+    check(responses).deepEquals([
+      {
+        'status': 'answered',
+        'answers': {
+          'scope': {
+            'type': 'option',
+            'option_index': 0,
+            'label': 'This chat',
+            'description': 'Use this chat only',
+          },
+        },
+      },
+    ]);
+  });
+
+  test('replacement and ownership changes cancel each request once', () {
+    final container = ProviderContainer();
+    addTearDown(container.dispose);
+    final first = <dynamic>[];
+    final second = <dynamic>[];
+    final notifier = container.read(openWebUiLivePromptProvider.notifier);
+    notifier.handleSocketRequest(
+      conversationId: 'chat-1',
+      type: 'request:user_input',
+      data: _questionData(),
+      acknowledge: first.add,
+    );
+    notifier.handleSocketRequest(
+      conversationId: 'chat-2',
+      type: 'request:user_input',
+      data: _questionData(),
+      acknowledge: second.add,
+    );
+    notifier.cancelForConversation('chat-1');
+    notifier.cancelForConversation('chat-2');
+
+    check(first).deepEquals([
+      {'status': 'cancelled', 'answers': {}},
+    ]);
+    check(second).deepEquals([
+      {'status': 'cancelled', 'answers': {}},
+    ]);
+  });
+
+  test(
+    'invalid requests fail immediately and timeout cancels valid input',
+    () async {
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+      final invalid = <dynamic>[];
+      final timedOut = <dynamic>[];
+      final notifier = container.read(openWebUiLivePromptProvider.notifier);
+      notifier.handleSocketRequest(
+        conversationId: 'chat-1',
+        type: 'request:user_input',
+        data: const {'questions': []},
+        acknowledge: invalid.add,
+      );
+      check(invalid).deepEquals([
+        {'error': 'Invalid user input request.'},
+      ]);
+
+      debugOpenWebUiPromptTimeoutOverride = const Duration(milliseconds: 5);
+      notifier.handleSocketRequest(
+        conversationId: 'chat-1',
+        type: 'request:user_input',
+        data: _questionData(),
+        acknowledge: timedOut.add,
+      );
+      await Future<void>.delayed(const Duration(milliseconds: 20));
+      check(timedOut).deepEquals([
+        {'status': 'cancelled', 'answers': {}},
+      ]);
+    },
+  );
+
+  test('legacy confirmation acknowledges a boolean', () {
+    final container = ProviderContainer();
+    addTearDown(container.dispose);
+    final responses = <dynamic>[];
+    final notifier = container.read(openWebUiLivePromptProvider.notifier);
+    notifier.handleSocketRequest(
+      conversationId: 'chat-1',
+      type: 'confirmation',
+      data: const {'title': 'Continue?', 'message': 'Run the tool?'},
+      acknowledge: responses.add,
+    );
+    final prompt = container.read(openWebUiLivePromptProvider)!.prompt;
+    notifier.decide(prompt.identity, true);
+    check(responses).deepEquals([true]);
+  });
+}
+
+Map<String, dynamic> _questionData() => {
+  'questions': [
+    {
+      'id': 'scope',
+      'header': 'Scope',
+      'question': 'Which scope?',
+      'options': [
+        {'label': 'This chat', 'description': 'Use this chat only'},
+        {'label': 'All chats', 'description': 'Use every chat'},
+      ],
+    },
+  ],
+  'timeout_ms': 60000,
+};

--- a/test/features/chat/providers/openwebui_chat_prompt_provider_test.dart
+++ b/test/features/chat/providers/openwebui_chat_prompt_provider_test.dart
@@ -120,6 +120,28 @@ void main() {
     notifier.decide(prompt.identity, true);
     check(responses).deepEquals([true]);
   });
+
+  test('legacy confirmation bounds text and times out to false', () async {
+    final container = ProviderContainer();
+    addTearDown(container.dispose);
+    final responses = <dynamic>[];
+    final notifier = container.read(openWebUiLivePromptProvider.notifier);
+    debugOpenWebUiPromptTimeoutOverride = const Duration(milliseconds: 5);
+    notifier.handleSocketRequest(
+      conversationId: 'chat-1',
+      type: 'confirmation',
+      data: {
+        'title': '${List.filled(119, 'T').join()}😀',
+        'message': 'Run the tool?',
+      },
+      acknowledge: responses.add,
+    );
+
+    final prompt = container.read(openWebUiLivePromptProvider)!.prompt;
+    check(prompt.title).equals(List.filled(119, 'T').join());
+    await Future<void>.delayed(const Duration(milliseconds: 20));
+    check(responses).deepEquals([false]);
+  });
 }
 
 Map<String, dynamic> _questionData() => {

--- a/test/features/chat/views/chat_page_layout_metadata_test.dart
+++ b/test/features/chat/views/chat_page_layout_metadata_test.dart
@@ -243,6 +243,33 @@ void main() {
     );
   });
 
+  test('persisted prompts stay bound to their loaded conversation', () {
+    expect(
+      debugCanUsePersistedOpenWebUiPromptForTesting(
+        isLoadingConversation: false,
+        ownerConversationId: 'chat-a',
+        activeConversationId: 'chat-a',
+      ),
+      isTrue,
+    );
+    expect(
+      debugCanUsePersistedOpenWebUiPromptForTesting(
+        isLoadingConversation: true,
+        ownerConversationId: 'chat-a',
+        activeConversationId: 'chat-a',
+      ),
+      isFalse,
+    );
+    expect(
+      debugCanUsePersistedOpenWebUiPromptForTesting(
+        isLoadingConversation: false,
+        ownerConversationId: 'chat-a',
+        activeConversationId: 'chat-b',
+      ),
+      isFalse,
+    );
+  });
+
   test('older send cleanup cannot release a newer send admission', () {
     final guard = ChatMessageSendAdmissionGuard();
     final firstSend = guard.tryAcquire();

--- a/test/features/chat/widgets/hermes_approval_ownership_test.dart
+++ b/test/features/chat/widgets/hermes_approval_ownership_test.dart
@@ -14,7 +14,7 @@ import 'package:conduit/core/sync/id_remapper.dart';
 import 'package:conduit/core/sync/sync_engine.dart';
 import 'package:conduit/features/chat/providers/chat_providers.dart';
 import 'package:conduit/features/chat/providers/text_to_speech_provider.dart';
-import 'package:conduit/features/chat/widgets/assistant_message_widget.dart';
+import 'package:conduit/features/hermes/widgets/hermes_message_interactions.dart';
 import 'package:conduit/features/hermes/models/hermes_capabilities.dart';
 import 'package:conduit/features/hermes/models/hermes_config.dart';
 import 'package:conduit/features/hermes/models/hermes_run_event.dart';
@@ -259,14 +259,7 @@ void main() {
           theme: AppTheme.light(TweakcnThemes.t3Chat),
           localizationsDelegates: conduitLocalizationsDelegates,
           supportedLocales: AppLocalizations.supportedLocales,
-          home: Scaffold(
-            body: AssistantMessageWidget(
-              message: first,
-              isStreaming: false,
-              animateOnMount: false,
-              onDelete: () {},
-            ),
-          ),
+          home: Scaffold(body: HermesComposerPromptOverlay(message: first)),
         ),
       ),
     );
@@ -367,14 +360,7 @@ void main() {
           theme: AppTheme.light(TweakcnThemes.t3Chat),
           localizationsDelegates: conduitLocalizationsDelegates,
           supportedLocales: AppLocalizations.supportedLocales,
-          home: Scaffold(
-            body: AssistantMessageWidget(
-              message: first,
-              isStreaming: false,
-              animateOnMount: false,
-              onDelete: () {},
-            ),
-          ),
+          home: Scaffold(body: HermesComposerPromptOverlay(message: first)),
         ),
       ),
     );
@@ -516,12 +502,7 @@ void main() {
               localizationsDelegates: conduitLocalizationsDelegates,
               supportedLocales: AppLocalizations.supportedLocales,
               home: Scaffold(
-                body: AssistantMessageWidget(
-                  message: pending,
-                  isStreaming: true,
-                  animateOnMount: false,
-                  onDelete: () {},
-                ),
+                body: HermesComposerPromptOverlay(message: pending),
               ),
             ),
           ),
@@ -680,12 +661,7 @@ void main() {
             supportedLocales: AppLocalizations.supportedLocales,
             home: Scaffold(
               body: SingleChildScrollView(
-                child: AssistantMessageWidget(
-                  message: pending,
-                  isStreaming: true,
-                  animateOnMount: false,
-                  onDelete: () {},
-                ),
+                child: HermesComposerPromptOverlay(message: pending),
               ),
             ),
           ),
@@ -866,14 +842,7 @@ void main() {
           theme: AppTheme.light(TweakcnThemes.t3Chat),
           localizationsDelegates: conduitLocalizationsDelegates,
           supportedLocales: AppLocalizations.supportedLocales,
-          home: Scaffold(
-            body: AssistantMessageWidget(
-              message: pending,
-              isStreaming: true,
-              animateOnMount: false,
-              onDelete: () {},
-            ),
-          ),
+          home: Scaffold(body: HermesComposerPromptOverlay(message: pending)),
         ),
       ),
     );

--- a/test/features/chat/widgets/openwebui_prompt_overlay_test.dart
+++ b/test/features/chat/widgets/openwebui_prompt_overlay_test.dart
@@ -1,0 +1,193 @@
+import 'package:conduit/core/models/openwebui_chat_prompt.dart';
+import 'package:conduit/core/providers/app_providers.dart';
+import 'package:conduit/features/chat/providers/chat_providers.dart';
+import 'package:conduit/features/chat/widgets/modern_chat_input.dart';
+import 'package:conduit/features/chat/widgets/openwebui_prompt_overlay.dart';
+import 'package:conduit/features/hermes/models/hermes_capabilities.dart';
+import 'package:conduit/features/hermes/models/hermes_model.dart';
+import 'package:conduit/features/hermes/providers/hermes_providers.dart';
+import 'package:conduit/l10n/app_localizations.dart';
+import 'package:conduit/l10n/conduit_localizations.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:material_ui/material_ui.dart';
+
+void main() {
+  testWidgets('collects multiple questions and a free-form answer', (
+    tester,
+  ) async {
+    Map<String, dynamic>? submitted;
+    await _pump(
+      tester,
+      OpenWebUiPromptOverlay(
+        prompt: _askPrompt,
+        onAnswer: (answers) => submitted = answers,
+        onDecision: (_) {},
+      ),
+    );
+
+    await tester.tap(find.byKey(const ValueKey('openwebui-option-scope-0')));
+    await tester.pump();
+    await tester.tap(find.text('Next'));
+    await tester.pump();
+    await tester.enterText(
+      find.byKey(const ValueKey('openwebui-other-detail')),
+      'Only files',
+    );
+    await tester.pump();
+    await tester.tap(find.text('Submit'));
+    await tester.pump();
+
+    expect(submitted, {
+      'scope': {
+        'type': 'option',
+        'option_index': 0,
+        'label': 'This chat',
+        'description': 'Use this chat only',
+      },
+      'detail': {'type': 'other', 'text': 'Only files'},
+    });
+  });
+
+  testWidgets('keeps a failed approval visible with an inline error', (
+    tester,
+  ) async {
+    await _pump(
+      tester,
+      OpenWebUiPromptOverlay(
+        prompt: const OpenWebUiComposerPrompt(
+          identity: 'tool:1',
+          kind: OpenWebUiComposerPromptKind.toolApproval,
+          title: 'filesystem',
+          message: '<script>alert(1)</script>',
+        ),
+        onDecision: (_) => throw StateError('server rejected request'),
+      ),
+    );
+
+    expect(find.text('<script>alert(1)</script>'), findsOneWidget);
+    await tester.tap(find.text('Approve'));
+    await tester.pump();
+    expect(
+      find.byKey(const ValueKey('openwebui-prompt-overlay')),
+      findsOneWidget,
+    );
+    expect(
+      find.byKey(const ValueKey('openwebui-prompt-error')),
+      findsOneWidget,
+    );
+  });
+
+  testWidgets('attached overlay renders above the composer shell', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          selectedModelProvider.overrideWithValue(hermesSyntheticModel()),
+          isChatStreamingProvider.overrideWithValue(false),
+          hermesCapabilitiesProvider.overrideWith(
+            (_) => Future.value(const HermesCapabilities()),
+          ),
+          apiServiceProvider.overrideWithValue(null),
+          webSearchAvailableProvider.overrideWithValue(false),
+          imageGenerationAvailableProvider.overrideWithValue(false),
+        ],
+        child: MaterialApp(
+          localizationsDelegates: conduitLocalizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: Scaffold(
+            body: ModernChatInput(
+              onSendMessage: (_) {},
+              attachedOverlay: const Text(
+                'Attached approval',
+                key: ValueKey('attached-approval'),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    final overlayTop = tester
+        .getTopLeft(find.byKey(const ValueKey('attached-approval')))
+        .dy;
+    final composerTop = tester
+        .getTopLeft(find.byKey(const ValueKey('composer-native-shell')))
+        .dy;
+    expect(overlayTop, lessThan(composerTop));
+  });
+
+  testWidgets('remains usable with large accessibility text', (tester) async {
+    await _pump(
+      tester,
+      OpenWebUiPromptOverlay(
+        prompt: _askPrompt,
+        onAnswer: (_) {},
+        onDecision: (_) {},
+      ),
+      textScaler: const TextScaler.linear(2.5),
+    );
+
+    expect(tester.takeException(), isNull);
+    expect(
+      find.byKey(const ValueKey('openwebui-prompt-overlay')),
+      findsOneWidget,
+    );
+  });
+}
+
+Future<void> _pump(
+  WidgetTester tester,
+  Widget child, {
+  TextScaler textScaler = TextScaler.noScaling,
+}) async {
+  await tester.pumpWidget(
+    MaterialApp(
+      localizationsDelegates: conduitLocalizationsDelegates,
+      supportedLocales: AppLocalizations.supportedLocales,
+      builder: (context, child) => MediaQuery(
+        data: MediaQuery.of(context).copyWith(textScaler: textScaler),
+        child: child!,
+      ),
+      home: Scaffold(
+        body: Center(child: SizedBox(width: 420, child: child)),
+      ),
+    ),
+  );
+  await tester.pumpAndSettle();
+}
+
+const _askPrompt = OpenWebUiComposerPrompt(
+  identity: 'ask:1',
+  kind: OpenWebUiComposerPromptKind.askUser,
+  questions: [
+    OpenWebUiPromptQuestion(
+      id: 'scope',
+      header: 'Scope',
+      question: 'Which scope?',
+      options: [
+        OpenWebUiPromptOption(
+          label: 'This chat',
+          description: 'Use this chat only',
+        ),
+        OpenWebUiPromptOption(
+          label: 'All chats',
+          description: 'Use every chat',
+        ),
+      ],
+      allowOther: false,
+    ),
+    OpenWebUiPromptQuestion(
+      id: 'detail',
+      header: 'Details',
+      question: 'What should be included?',
+      options: [
+        OpenWebUiPromptOption(label: 'Files', description: 'Include files'),
+        OpenWebUiPromptOption(label: 'Notes', description: 'Include notes'),
+      ],
+      allowOther: true,
+    ),
+  ],
+);

--- a/test/features/chat/widgets/openwebui_prompt_overlay_test.dart
+++ b/test/features/chat/widgets/openwebui_prompt_overlay_test.dart
@@ -8,6 +8,9 @@ import 'package:conduit/features/hermes/models/hermes_model.dart';
 import 'package:conduit/features/hermes/providers/hermes_providers.dart';
 import 'package:conduit/l10n/app_localizations.dart';
 import 'package:conduit/l10n/conduit_localizations.dart';
+import 'package:conduit/shared/theme/app_theme.dart';
+import 'package:conduit/shared/theme/tweakcn_themes.dart';
+import 'package:cupertino_ui/cupertino_ui.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:material_ui/material_ui.dart';
@@ -155,6 +158,30 @@ void main() {
       find.byKey(const ValueKey('openwebui-prompt-overlay')),
       findsOneWidget,
     );
+  });
+
+  testWidgets('renders interactive controls in a Cupertino tree', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      CupertinoApp(
+        localizationsDelegates: conduitLocalizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+        home: Theme(
+          data: AppTheme.light(TweakcnThemes.t3Chat),
+          child: OpenWebUiPromptOverlay(
+            prompt: _askPrompt,
+            onAnswer: (_) {},
+            onDecision: (_) {},
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byKey(const ValueKey('openwebui-option-scope-0')));
+    await tester.pump();
+    expect(tester.takeException(), isNull);
   });
 }
 

--- a/test/features/chat/widgets/openwebui_prompt_overlay_test.dart
+++ b/test/features/chat/widgets/openwebui_prompt_overlay_test.dart
@@ -78,6 +78,26 @@ void main() {
     );
   });
 
+  testWidgets('announces the current question and fraction', (tester) async {
+    await _pump(
+      tester,
+      OpenWebUiPromptOverlay(
+        prompt: _askPrompt,
+        onAnswer: (_) {},
+        onDecision: (_) {},
+      ),
+    );
+
+    final overlay = tester.getSemantics(
+      find.byKey(const ValueKey('openwebui-prompt-overlay')),
+    );
+    expect(overlay.label, contains('Scope'));
+    expect(overlay.label, isNot(contains('Approval required')));
+    final progressLabel = tester.getSemantics(find.text('1/2')).label;
+    expect(progressLabel, contains('1/2'));
+    expect(progressLabel, isNot(contains('1 of 2')));
+  });
+
   testWidgets('attached overlay renders above the composer shell', (
     tester,
   ) async {

--- a/test/features/hermes/hermes_approval_card_test.dart
+++ b/test/features/hermes/hermes_approval_card_test.dart
@@ -5,6 +5,7 @@ import 'package:conduit/l10n/conduit_localizations.dart';
 import 'package:conduit/shared/theme/app_theme.dart';
 import 'package:conduit/shared/theme/tweakcn_themes.dart';
 import 'package:conduit/shared/widgets/conduit_components.dart';
+import 'package:cupertino_ui/cupertino_ui.dart';
 import 'package:material_ui/material_ui.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -59,5 +60,27 @@ void main() {
 
     await tester.tap(find.text('Allow for session'));
     expect(choice, 'session');
+  });
+
+  testWidgets('renders in the shared Cupertino composer surface', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      CupertinoApp(
+        localizationsDelegates: conduitLocalizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+        home: Theme(
+          data: AppTheme.light(TweakcnThemes.t3Chat),
+          child: HermesApprovalCard(
+            state: HermesApprovalState.pending,
+            onDecision: (_) {},
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('Approval required'), findsOneWidget);
+    expect(tester.takeException(), isNull);
   });
 }

--- a/test/features/hermes/hermes_decision_card_test.dart
+++ b/test/features/hermes/hermes_decision_card_test.dart
@@ -1,6 +1,7 @@
 import 'package:conduit/core/models/chat_message.dart';
 import 'package:conduit/core/models/conversation.dart';
 import 'package:conduit/core/providers/app_providers.dart';
+import 'package:conduit/features/chat/providers/chat_providers.dart';
 import 'package:conduit/features/hermes/models/hermes_run_event.dart';
 import 'package:conduit/features/hermes/services/hermes_run_transport.dart';
 import 'package:conduit/features/hermes/widgets/hermes_decision_card.dart';
@@ -23,6 +24,15 @@ class _DecisionConversation extends ActiveConversationNotifier {
     updatedAt: DateTime(2026),
     metadata: const {'hermesSessionId': 'session'},
   );
+}
+
+class _DecisionMessages extends ChatMessagesNotifier {
+  _DecisionMessages(this.messages);
+
+  final List<ChatMessage> messages;
+
+  @override
+  List<ChatMessage> build() => messages;
 }
 
 void main() {
@@ -190,6 +200,123 @@ void main() {
 
     expect(find.text('Hermes needs clarification'), findsOneWidget);
     expect(find.text('Approve'), findsNothing);
+  });
+
+  testWidgets('an empty-id decision cannot hide an older valid prompt', (
+    tester,
+  ) async {
+    ChatMessage decisionMessage({
+      required String id,
+      required String prompt,
+      required String requestId,
+      required String runtimeId,
+      required String storedSessionId,
+    }) => ChatMessage(
+      id: id,
+      role: 'assistant',
+      content: '',
+      timestamp: DateTime(2026),
+      metadata: {
+        'transport': kHermesTransport,
+        kHermesDecisionMeta: {
+          'state': 'pending',
+          'kind': HermesDecisionKind.clarification.name,
+          'prompt': prompt,
+          'requestId': requestId,
+          'runtimeId': runtimeId,
+          'storedSessionId': storedSessionId,
+          'expiresAt': DateTime.now()
+              .add(const Duration(hours: 1))
+              .toUtc()
+              .toIso8601String(),
+        },
+      },
+    );
+    final older = decisionMessage(
+      id: 'older',
+      prompt: 'Older valid prompt',
+      requestId: 'request',
+      runtimeId: 'runtime',
+      storedSessionId: 'session',
+    );
+    final invalid = decisionMessage(
+      id: 'invalid',
+      prompt: 'Invalid newer prompt',
+      requestId: '',
+      runtimeId: '',
+      storedSessionId: '',
+    );
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          activeConversationProvider.overrideWith(_DecisionConversation.new),
+          chatMessagesProvider.overrideWith(
+            () => _DecisionMessages([older, invalid]),
+          ),
+        ],
+        child: CupertinoApp(
+          localizationsDelegates: conduitLocalizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: Theme(
+            data: AppTheme.light(TweakcnThemes.t3Chat),
+            child: HermesComposerPromptOverlay(message: older),
+          ),
+        ),
+      ),
+    );
+
+    expect(find.text('Older valid prompt'), findsOneWidget);
+    expect(find.text('Invalid newer prompt'), findsNothing);
+  });
+
+  testWidgets('a decision disappears when its wall-clock expiry passes', (
+    tester,
+  ) async {
+    final message = ChatMessage(
+      id: 'expiring',
+      role: 'assistant',
+      content: '',
+      timestamp: DateTime(2026),
+      metadata: {
+        'transport': kHermesTransport,
+        kHermesDecisionMeta: {
+          'state': 'pending',
+          'kind': HermesDecisionKind.clarification.name,
+          'prompt': 'Short-lived prompt',
+          'requestId': 'request',
+          'runtimeId': 'runtime',
+          'storedSessionId': 'session',
+          'expiresAt': DateTime.now()
+              .add(const Duration(milliseconds: 50))
+              .toUtc()
+              .toIso8601String(),
+        },
+      },
+    );
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          activeConversationProvider.overrideWith(_DecisionConversation.new),
+        ],
+        child: CupertinoApp(
+          localizationsDelegates: conduitLocalizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: Theme(
+            data: AppTheme.light(TweakcnThemes.t3Chat),
+            child: HermesComposerPromptOverlay(message: message),
+          ),
+        ),
+      ),
+    );
+    expect(find.text('Short-lived prompt'), findsOneWidget);
+
+    await tester.runAsync(
+      () => Future<void>.delayed(const Duration(milliseconds: 75)),
+    );
+    await tester.pump(const Duration(milliseconds: 75));
+
+    expect(find.text('Short-lived prompt'), findsNothing);
   });
 
   testWidgets('renders its response field in a Cupertino tree', (tester) async {

--- a/test/features/hermes/hermes_decision_card_test.dart
+++ b/test/features/hermes/hermes_decision_card_test.dart
@@ -67,7 +67,7 @@ void main() {
     );
   });
 
-  test('skips an incomplete newer Hermes prompt', () {
+  test('skips incomplete and archived newer Hermes prompts', () {
     final older = ChatMessage(
       id: 'older',
       role: 'assistant',
@@ -92,8 +92,26 @@ void main() {
         kHermesApprovalMeta: {'state': 'pending'},
       },
     );
+    final archived = ChatMessage(
+      id: 'archived',
+      role: 'assistant',
+      content: '',
+      timestamp: DateTime(2026),
+      metadata: const {
+        'transport': kHermesTransport,
+        'archivedVariant': true,
+        kHermesApprovalMeta: {
+          'state': 'pending',
+          'runId': 'archived-run',
+          'approvalId': 'archived-approval',
+        },
+      },
+    );
 
-    expect(findPendingHermesComposerPrompt([older, incomplete]), same(older));
+    expect(
+      findPendingHermesComposerPrompt([older, incomplete, archived]),
+      same(older),
+    );
   });
 
   test('ignores resolved and expired Hermes prompts', () {

--- a/test/features/hermes/hermes_decision_card_test.dart
+++ b/test/features/hermes/hermes_decision_card_test.dart
@@ -1,5 +1,8 @@
+import 'package:conduit/core/models/chat_message.dart';
 import 'package:conduit/features/hermes/models/hermes_run_event.dart';
+import 'package:conduit/features/hermes/services/hermes_run_transport.dart';
 import 'package:conduit/features/hermes/widgets/hermes_decision_card.dart';
+import 'package:conduit/features/hermes/widgets/hermes_message_interactions.dart';
 import 'package:conduit/l10n/app_localizations.dart';
 import 'package:conduit/l10n/conduit_localizations.dart';
 import 'package:conduit/shared/theme/app_theme.dart';
@@ -9,6 +12,69 @@ import 'package:material_ui/material_ui.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
+  test('selects the newest unresolved Hermes composer prompt', () {
+    final approval = ChatMessage(
+      id: 'approval',
+      role: 'assistant',
+      content: '',
+      timestamp: DateTime(2026),
+      metadata: const {
+        'transport': kHermesTransport,
+        kHermesApprovalMeta: {'state': 'resolving'},
+      },
+    );
+    final decision = ChatMessage(
+      id: 'decision',
+      role: 'assistant',
+      content: '',
+      timestamp: DateTime(2026),
+      metadata: {
+        'transport': kHermesTransport,
+        kHermesDecisionMeta: {
+          'state': 'pending',
+          'expiresAt': DateTime.now()
+              .add(const Duration(hours: 1))
+              .toUtc()
+              .toIso8601String(),
+        },
+      },
+    );
+
+    expect(
+      findPendingHermesComposerPrompt([approval, decision]),
+      same(decision),
+    );
+  });
+
+  test('ignores resolved and expired Hermes prompts', () {
+    ChatMessage message(String id, Map<String, dynamic> metadata) =>
+        ChatMessage(
+          id: id,
+          role: 'assistant',
+          content: '',
+          timestamp: DateTime(2026),
+          metadata: {'transport': kHermesTransport, ...metadata},
+        );
+
+    expect(
+      findPendingHermesComposerPrompt([
+        message('approval', const {
+          kHermesApprovalMeta: {'state': 'approved'},
+        }),
+        message('decision', {
+          kHermesDecisionMeta: {
+            'state': 'pending',
+            'expiresAt': DateTime.now()
+                .subtract(const Duration(minutes: 1))
+                .toUtc()
+                .toIso8601String(),
+          },
+        }),
+      ]),
+      isNull,
+    );
+  });
+
   testWidgets('renders its response field in a Cupertino tree', (tester) async {
     await tester.pumpWidget(
       CupertinoApp(

--- a/test/features/hermes/hermes_decision_card_test.dart
+++ b/test/features/hermes/hermes_decision_card_test.dart
@@ -34,7 +34,11 @@ void main() {
       timestamp: DateTime(2026),
       metadata: const {
         'transport': kHermesTransport,
-        kHermesApprovalMeta: {'state': 'resolving'},
+        kHermesApprovalMeta: {
+          'state': 'resolving',
+          'runId': 'run',
+          'approvalId': 'approval',
+        },
       },
     );
     final decision = ChatMessage(
@@ -46,6 +50,9 @@ void main() {
         'transport': kHermesTransport,
         kHermesDecisionMeta: {
           'state': 'pending',
+          'requestId': 'request',
+          'runtimeId': 'runtime',
+          'storedSessionId': 'session',
           'expiresAt': DateTime.now()
               .add(const Duration(hours: 1))
               .toUtc()
@@ -58,6 +65,35 @@ void main() {
       findPendingHermesComposerPrompt([approval, decision]),
       same(decision),
     );
+  });
+
+  test('skips an incomplete newer Hermes prompt', () {
+    final older = ChatMessage(
+      id: 'older',
+      role: 'assistant',
+      content: '',
+      timestamp: DateTime(2026),
+      metadata: const {
+        'transport': kHermesTransport,
+        kHermesApprovalMeta: {
+          'state': 'pending',
+          'runId': 'run',
+          'approvalId': 'approval',
+        },
+      },
+    );
+    final incomplete = ChatMessage(
+      id: 'incomplete',
+      role: 'assistant',
+      content: '',
+      timestamp: DateTime(2026),
+      metadata: const {
+        'transport': kHermesTransport,
+        kHermesApprovalMeta: {'state': 'pending'},
+      },
+    );
+
+    expect(findPendingHermesComposerPrompt([older, incomplete]), same(older));
   });
 
   test('ignores resolved and expired Hermes prompts', () {
@@ -89,7 +125,7 @@ void main() {
     );
   });
 
-  testWidgets('a resolved approval cannot hide a pending decision', (
+  testWidgets('an unrenderable approval cannot hide a pending decision', (
     tester,
   ) async {
     final message = ChatMessage(
@@ -99,7 +135,11 @@ void main() {
       timestamp: DateTime(2026),
       metadata: {
         'transport': kHermesTransport,
-        kHermesApprovalMeta: const {'state': 'approved'},
+        kHermesApprovalMeta: const {
+          'state': 'pending',
+          'runId': 'missing-run',
+          'approvalId': 'approval',
+        },
         kHermesDecisionMeta: {
           'state': 'pending',
           'kind': HermesDecisionKind.clarification.name,
@@ -131,7 +171,7 @@ void main() {
     );
 
     expect(find.text('Hermes needs clarification'), findsOneWidget);
-    expect(find.text('Approved ✓'), findsNothing);
+    expect(find.text('Approve'), findsNothing);
   });
 
   testWidgets('renders its response field in a Cupertino tree', (tester) async {

--- a/test/features/hermes/hermes_decision_card_test.dart
+++ b/test/features/hermes/hermes_decision_card_test.dart
@@ -1,4 +1,6 @@
 import 'package:conduit/core/models/chat_message.dart';
+import 'package:conduit/core/models/conversation.dart';
+import 'package:conduit/core/providers/app_providers.dart';
 import 'package:conduit/features/hermes/models/hermes_run_event.dart';
 import 'package:conduit/features/hermes/services/hermes_run_transport.dart';
 import 'package:conduit/features/hermes/widgets/hermes_decision_card.dart';
@@ -9,7 +11,19 @@ import 'package:conduit/shared/theme/app_theme.dart';
 import 'package:conduit/shared/theme/tweakcn_themes.dart';
 import 'package:cupertino_ui/cupertino_ui.dart';
 import 'package:material_ui/material_ui.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
+
+class _DecisionConversation extends ActiveConversationNotifier {
+  @override
+  Conversation? build() => Conversation(
+    id: 'conversation',
+    title: 'Conversation',
+    createdAt: DateTime(2026),
+    updatedAt: DateTime(2026),
+    metadata: const {'hermesSessionId': 'session'},
+  );
+}
 
 void main() {
   test('selects the newest unresolved Hermes composer prompt', () {
@@ -73,6 +87,51 @@ void main() {
       ]),
       isNull,
     );
+  });
+
+  testWidgets('a resolved approval cannot hide a pending decision', (
+    tester,
+  ) async {
+    final message = ChatMessage(
+      id: 'decision',
+      role: 'assistant',
+      content: '',
+      timestamp: DateTime(2026),
+      metadata: {
+        'transport': kHermesTransport,
+        kHermesApprovalMeta: const {'state': 'approved'},
+        kHermesDecisionMeta: {
+          'state': 'pending',
+          'kind': HermesDecisionKind.clarification.name,
+          'requestId': 'request',
+          'runtimeId': 'runtime',
+          'storedSessionId': 'session',
+          'expiresAt': DateTime.now()
+              .add(const Duration(hours: 1))
+              .toUtc()
+              .toIso8601String(),
+        },
+      },
+    );
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          activeConversationProvider.overrideWith(_DecisionConversation.new),
+        ],
+        child: CupertinoApp(
+          localizationsDelegates: conduitLocalizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: Theme(
+            data: AppTheme.light(TweakcnThemes.t3Chat),
+            child: HermesComposerPromptOverlay(message: message),
+          ),
+        ),
+      ),
+    );
+
+    expect(find.text('Hermes needs clarification'), findsOneWidget);
+    expect(find.text('Approved ✓'), findsNothing);
   });
 
   testWidgets('renders its response field in a Cupertino tree', (tester) async {

--- a/test/features/terminal/providers/terminal_tab_visible_test.dart
+++ b/test/features/terminal/providers/terminal_tab_visible_test.dart
@@ -22,6 +22,7 @@ void main() {
   test('live: a non-empty server list shows the tab', () async {
     final container = ProviderContainer(
       overrides: [
+        terminalServiceProvider.overrideWithValue(null),
         terminalAvailableServersProvider.overrideWith(
           (ref) async => [_server()],
         ),
@@ -38,6 +39,7 @@ void main() {
     () async {
       final container = ProviderContainer(
         overrides: [
+          terminalServiceProvider.overrideWithValue(null),
           terminalAvailableServersProvider.overrideWith(
             (ref) async => const <TerminalServerInfo>[],
           ),
@@ -58,6 +60,7 @@ void main() {
     () {
       final container = ProviderContainer(
         overrides: [
+          terminalServiceProvider.overrideWithValue(null),
           // Last-known state: terminal disabled.
           terminalFeatureEnabledProvider.overrideWith(
             () => _FixedTerminalFlag(false),
@@ -77,6 +80,7 @@ void main() {
   test('offline with a known-enabled cache shows the tab', () {
     final container = ProviderContainer(
       overrides: [
+        terminalServiceProvider.overrideWithValue(null),
         terminalFeatureEnabledProvider.overrideWith(
           () => _FixedTerminalFlag(true),
         ),
@@ -127,6 +131,44 @@ void main() {
       await oldScopeProbe;
       await Future<void>.delayed(Duration.zero);
       check(container.read(terminalFeatureEnabledProvider)).isFalse();
+    },
+  );
+
+  test(
+    'an unresolved new scope does not reuse the previous scope flag',
+    () async {
+      var scopeId = 'saved-chat';
+      final service = _DelayedTerminalService();
+      final container = ProviderContainer(
+        overrides: [
+          terminalServiceProvider.overrideWithValue(service),
+          terminalSessionScopeIdProvider.overrideWith((ref) => scopeId),
+          terminalFeatureEnabledProvider.overrideWith(
+            () => _FixedTerminalFlag(false),
+          ),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      final savedChatProbe = container.read(
+        terminalAvailableServersProvider.future,
+      );
+      await Future<void>.delayed(Duration.zero);
+      service.requests[0].complete([_savedChatServer()]);
+      await savedChatProbe;
+      await Future<void>.delayed(Duration.zero);
+      check(container.read(terminalTabVisibleProvider)).isTrue();
+
+      scopeId = 'sidebar-terminal';
+      container.invalidate(terminalSessionScopeIdProvider);
+      final sidebarProbe = container.read(
+        terminalAvailableServersProvider.future,
+      );
+      await Future<void>.delayed(Duration.zero);
+
+      check(container.read(terminalTabVisibleProvider)).isFalse();
+      service.requests[1].complete([_savedChatServer()]);
+      await sidebarProbe;
     },
   );
 }

--- a/test/features/terminal/providers/terminal_tab_visible_test.dart
+++ b/test/features/terminal/providers/terminal_tab_visible_test.dart
@@ -3,10 +3,13 @@ import 'dart:async';
 import 'package:checks/checks.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
 
 import 'package:conduit/core/providers/app_providers.dart';
+import 'package:conduit/core/services/api_service.dart';
 import 'package:conduit/features/terminal/models/terminal_models.dart';
 import 'package:conduit/features/terminal/providers/terminal_providers.dart';
+import 'package:conduit/features/terminal/services/terminal_service.dart';
 
 TerminalServerInfo _server() => TerminalServerInfo(
   kind: TerminalServerKind.direct,
@@ -86,7 +89,54 @@ void main() {
 
     check(container.read(terminalTabVisibleProvider)).isTrue();
   });
+
+  test(
+    'a stale scope probe cannot overwrite the current terminal flag',
+    () async {
+      var scopeId = 'saved-chat';
+      final service = _DelayedTerminalService();
+      final container = ProviderContainer(
+        overrides: [
+          terminalServiceProvider.overrideWithValue(service),
+          terminalSessionScopeIdProvider.overrideWith((ref) => scopeId),
+          terminalFeatureEnabledProvider.overrideWith(
+            () => _FixedTerminalFlag(true),
+          ),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      final oldScopeProbe = container.read(
+        terminalAvailableServersProvider.future,
+      );
+      await Future<void>.delayed(Duration.zero);
+
+      scopeId = 'sidebar-terminal';
+      container.invalidate(terminalSessionScopeIdProvider);
+      final currentScopeProbe = container.read(
+        terminalAvailableServersProvider.future,
+      );
+      await Future<void>.delayed(Duration.zero);
+
+      service.requests[1].complete([_savedChatServer()]);
+      await currentScopeProbe;
+      await Future<void>.delayed(Duration.zero);
+      check(container.read(terminalFeatureEnabledProvider)).isFalse();
+
+      service.requests[0].complete([_savedChatServer()]);
+      await oldScopeProbe;
+      await Future<void>.delayed(Duration.zero);
+      check(container.read(terminalFeatureEnabledProvider)).isFalse();
+    },
+  );
 }
+
+TerminalServerInfo _savedChatServer() => TerminalServerInfo(
+  kind: TerminalServerKind.system,
+  selectionId: 'saved-chat-terminal',
+  baseUrl: Uri.parse('https://example.com/saved-chat-terminal'),
+  requiresSavedChatContext: true,
+);
 
 class _FixedTerminalFlag extends TerminalFeatureEnabledNotifier {
   _FixedTerminalFlag(this._value);
@@ -95,4 +145,19 @@ class _FixedTerminalFlag extends TerminalFeatureEnabledNotifier {
 
   @override
   bool build() => _value;
+}
+
+class _MockApiService extends Mock implements ApiService {}
+
+class _DelayedTerminalService extends TerminalService {
+  _DelayedTerminalService() : super(_MockApiService());
+
+  final requests = <Completer<List<TerminalServerInfo>>>[];
+
+  @override
+  Future<List<TerminalServerInfo>> getAvailableServers() {
+    final request = Completer<List<TerminalServerInfo>>();
+    requests.add(request);
+    return request.future;
+  }
 }

--- a/test/features/terminal/providers/terminal_tab_visible_test.dart
+++ b/test/features/terminal/providers/terminal_tab_visible_test.dart
@@ -134,43 +134,48 @@ void main() {
     },
   );
 
-  test(
-    'an unresolved new scope does not reuse the previous scope flag',
-    () async {
-      var scopeId = 'saved-chat';
-      final service = _DelayedTerminalService();
-      final container = ProviderContainer(
-        overrides: [
-          terminalServiceProvider.overrideWithValue(service),
-          terminalSessionScopeIdProvider.overrideWith((ref) => scopeId),
-          terminalFeatureEnabledProvider.overrideWith(
-            () => _FixedTerminalFlag(false),
-          ),
-        ],
-      );
-      addTearDown(container.dispose);
+  test('unresolved scopes use only their own cached flag', () async {
+    var scopeId = 'saved-chat';
+    final service = _DelayedTerminalService();
+    final container = ProviderContainer(
+      overrides: [
+        terminalServiceProvider.overrideWithValue(service),
+        terminalSessionScopeIdProvider.overrideWith((ref) => scopeId),
+        terminalFeatureEnabledProvider.overrideWith(
+          () => _FixedTerminalFlag(false),
+        ),
+      ],
+    );
+    addTearDown(container.dispose);
 
-      final savedChatProbe = container.read(
-        terminalAvailableServersProvider.future,
-      );
-      await Future<void>.delayed(Duration.zero);
-      service.requests[0].complete([_savedChatServer()]);
-      await savedChatProbe;
-      await Future<void>.delayed(Duration.zero);
-      check(container.read(terminalTabVisibleProvider)).isTrue();
+    final savedChatProbe = container.read(
+      terminalAvailableServersProvider.future,
+    );
+    await Future<void>.delayed(Duration.zero);
+    service.requests[0].complete([_savedChatServer()]);
+    await savedChatProbe;
+    await Future<void>.delayed(Duration.zero);
+    check(container.read(terminalTabVisibleProvider)).isTrue();
 
-      scopeId = 'sidebar-terminal';
-      container.invalidate(terminalSessionScopeIdProvider);
-      final sidebarProbe = container.read(
-        terminalAvailableServersProvider.future,
-      );
-      await Future<void>.delayed(Duration.zero);
+    scopeId = 'sidebar-terminal';
+    container.invalidate(terminalSessionScopeIdProvider);
+    final sidebarProbe = container.read(
+      terminalAvailableServersProvider.future,
+    );
+    await Future<void>.delayed(Duration.zero);
 
-      check(container.read(terminalTabVisibleProvider)).isFalse();
-      service.requests[1].complete([_savedChatServer()]);
-      await sidebarProbe;
-    },
-  );
+    check(container.read(terminalTabVisibleProvider)).isFalse();
+    service.requests[1].complete([_savedChatServer()]);
+    await sidebarProbe;
+    await Future<void>.delayed(Duration.zero);
+
+    scopeId = 'saved-chat';
+    container.invalidate(terminalSessionScopeIdProvider);
+    container.read(terminalAvailableServersProvider.future);
+    await Future<void>.delayed(Duration.zero);
+
+    check(container.read(terminalTabVisibleProvider)).isTrue();
+  });
 }
 
 TerminalServerInfo _savedChatServer() => TerminalServerInfo(

--- a/test/features/terminal/services/terminal_service_test.dart
+++ b/test/features/terminal/services/terminal_service_test.dart
@@ -1,4 +1,5 @@
 import 'package:conduit/features/terminal/models/terminal_models.dart';
+import 'package:conduit/features/terminal/controllers/terminal_session_controller.dart';
 import 'package:conduit/features/terminal/services/terminal_service.dart';
 import 'package:flutter_test/flutter_test.dart';
 
@@ -86,6 +87,80 @@ void main() {
       expect(ensureTerminalDirectoryPath('/tmp/data'), '/tmp/data/');
       expect(joinTerminalPath('/tmp/data', 'notes.md'), '/tmp/data/notes.md');
       expect(parentTerminalPath('/tmp/data/project/'), '/tmp/data/');
+    });
+
+    test('parses chat context availability and saved-chat scoping', () {
+      expect(parseTerminalChatContextForTest(null), (
+        available: true,
+        requiresSavedChat: false,
+      ));
+      expect(parseTerminalChatContextForTest(const {'chat': false}), (
+        available: false,
+        requiresSavedChat: false,
+      ));
+      expect(
+        parseTerminalChatContextForTest(const {
+          'chat': {'context_id': 'chat_id'},
+        }),
+        (available: true, requiresSavedChat: true),
+      );
+
+      final scoped = TerminalServerInfo(
+        kind: TerminalServerKind.system,
+        selectionId: 'scoped',
+        baseUrl: Uri.parse('https://example.test'),
+        requiresSavedChatContext: true,
+      );
+      expect(scoped.isAvailableForChatScope('sidebar-terminal'), isFalse);
+      expect(scoped.isAvailableForChatScope('local:draft'), isFalse);
+      expect(scoped.isAvailableForChatScope('temporary:socket'), isFalse);
+      expect(scoped.isAvailableForChatScope('channel:team'), isFalse);
+      expect(scoped.isAvailableForChatScope('saved-chat'), isTrue);
+    });
+
+    test('system websocket auth carries only a saved chat id', () {
+      final system = TerminalServerInfo(
+        kind: TerminalServerKind.system,
+        selectionId: 'system',
+        baseUrl: Uri.parse('https://example.test'),
+      );
+      final direct = TerminalServerInfo(
+        kind: TerminalServerKind.direct,
+        selectionId: 'direct',
+        baseUrl: Uri.parse('https://terminal.example.test'),
+      );
+
+      expect(
+        buildTerminalWebSocketAuthPayload(
+          system,
+          token: 'token',
+          sessionScopeId: 'saved-chat',
+        ),
+        {'type': 'auth', 'token': 'token', 'chat_id': 'saved-chat'},
+      );
+      expect(
+        buildTerminalWebSocketAuthPayload(
+          direct,
+          token: 'key',
+          sessionScopeId: 'saved-chat',
+        ),
+        {'type': 'auth', 'token': 'key'},
+      );
+      for (final unsavedId in [
+        'sidebar-terminal',
+        'local:draft',
+        'temporary:socket',
+        'channel:team',
+      ]) {
+        expect(
+          buildTerminalWebSocketAuthPayload(
+            system,
+            token: 'token',
+            sessionScopeId: unsavedId,
+          ),
+          {'type': 'auth', 'token': 'token'},
+        );
+      }
     });
   });
 }

--- a/test/features/workspace/providers/workspace_providers_test.dart
+++ b/test/features/workspace/providers/workspace_providers_test.dart
@@ -138,29 +138,33 @@ void main() {
     },
   );
 
-  test('non-admin update and import preserve an existing base model', () async {
-    final api = _WorkspaceModelsApi();
-    final container = _container(api);
-    addTearDown(container.dispose);
-    await container.read(workspaceModelsProvider.future);
-    final notifier = container.read(workspaceModelsProvider.notifier);
+  test(
+    'non-admin update and import preserve the current server base',
+    () async {
+      final api = _WorkspaceModelsApi();
+      final container = _container(api);
+      addTearDown(container.dispose);
+      await container.read(workspaceModelsProvider.future);
+      final notifier = container.read(workspaceModelsProvider.notifier);
 
-    await notifier.updateItem(
-      const WorkspaceModelForm(id: 'model-1', name: 'Updated'),
-    );
-    check(api.updated.single.baseModelId).equals('base-1');
+      await notifier.updateItem(
+        const WorkspaceModelForm(id: 'model-1', name: 'Updated'),
+      );
+      check(api.updated.single.baseModelId).equals('base-1');
 
-    await notifier.importItems(const [
-      {'id': 'model-1', 'name': 'Imported'},
-    ]);
-    check(api.imported.single.single['base_model_id']).equals('base-1');
+      api.detailBaseModelId = 'base-2';
+      await notifier.importItems(const [
+        {'id': 'model-1', 'name': 'Imported'},
+      ]);
+      check(api.imported.single.single['base_model_id']).equals('base-2');
 
-    await check(
-      notifier.importItems(const [
-        {'id': 'new-model', 'name': 'No base'},
-      ]),
-    ).throws<WorkspaceModelBaseRequiredException>();
-  });
+      await check(
+        notifier.importItems(const [
+          {'id': 'new-model', 'name': 'No base'},
+        ]),
+      ).throws<WorkspaceModelBaseRequiredException>();
+    },
+  );
 
   test('bool mutation (delete) succeeds when the post-write refresh fails', () async {
     final api = _WorkspaceModelsApi();
@@ -491,6 +495,7 @@ class _WorkspaceModelsApi extends ApiService {
       );
 
   Object? refreshError;
+  String detailBaseModelId = 'base-1';
   final deleted = <String>[];
   final created = <WorkspaceModelForm>[];
   final updated = <WorkspaceModelForm>[];
@@ -531,11 +536,11 @@ class _WorkspaceModelsApi extends ApiService {
   @override
   Future<WorkspaceModelDetail?> getWorkspaceModel(String id) async =>
       id == 'model-1'
-      ? const WorkspaceModelSummary(
+      ? WorkspaceModelSummary(
           id: 'model-1',
           name: 'Model 1',
           userId: 'user-1',
-          baseModelId: 'base-1',
+          baseModelId: detailBaseModelId,
         )
       : null;
 

--- a/test/features/workspace/providers/workspace_providers_test.dart
+++ b/test/features/workspace/providers/workspace_providers_test.dart
@@ -158,6 +158,13 @@ void main() {
       ]);
       check(api.imported.single.single['base_model_id']).equals('base-2');
 
+      api.detailBaseModelId = null;
+      await check(
+        notifier.importItems(const [
+          {'id': 'model-1', 'name': 'No current base'},
+        ]),
+      ).throws<WorkspaceModelBaseRequiredException>();
+
       await check(
         notifier.importItems(const [
           {'id': 'new-model', 'name': 'No base'},
@@ -495,7 +502,7 @@ class _WorkspaceModelsApi extends ApiService {
       );
 
   Object? refreshError;
-  String detailBaseModelId = 'base-1';
+  String? detailBaseModelId = 'base-1';
   final deleted = <String>[];
   final created = <WorkspaceModelForm>[];
   final updated = <WorkspaceModelForm>[];

--- a/test/features/workspace/providers/workspace_providers_test.dart
+++ b/test/features/workspace/providers/workspace_providers_test.dart
@@ -108,6 +108,60 @@ void main() {
     check(state.items.map((item) => item.id)).deepEquals(['model-1']);
   });
 
+  test(
+    'non-admin create requires a base model while admin create does not',
+    () async {
+      final userApi = _WorkspaceModelsApi();
+      final userContainer = _container(userApi);
+      addTearDown(userContainer.dispose);
+      await userContainer.read(workspaceModelsProvider.future);
+
+      await check(
+        userContainer
+            .read(workspaceModelsProvider.notifier)
+            .create(
+              const WorkspaceModelForm(id: 'new-model', name: 'New model'),
+            ),
+      ).throws<WorkspaceModelBaseRequiredException>();
+      check(userApi.created).isEmpty();
+
+      final adminApi = _WorkspaceModelsApi();
+      final adminContainer = _container(adminApi, role: 'admin');
+      addTearDown(adminContainer.dispose);
+      await adminContainer.read(workspaceModelsProvider.future);
+      await adminContainer
+          .read(workspaceModelsProvider.notifier)
+          .create(
+            const WorkspaceModelForm(id: 'admin-model', name: 'Admin model'),
+          );
+      check(adminApi.created.single.baseModelId).isNull();
+    },
+  );
+
+  test('non-admin update and import preserve an existing base model', () async {
+    final api = _WorkspaceModelsApi();
+    final container = _container(api);
+    addTearDown(container.dispose);
+    await container.read(workspaceModelsProvider.future);
+    final notifier = container.read(workspaceModelsProvider.notifier);
+
+    await notifier.updateItem(
+      const WorkspaceModelForm(id: 'model-1', name: 'Updated'),
+    );
+    check(api.updated.single.baseModelId).equals('base-1');
+
+    await notifier.importItems(const [
+      {'id': 'model-1', 'name': 'Imported'},
+    ]);
+    check(api.imported.single.single['base_model_id']).equals('base-1');
+
+    await check(
+      notifier.importItems(const [
+        {'id': 'new-model', 'name': 'No base'},
+      ]),
+    ).throws<WorkspaceModelBaseRequiredException>();
+  });
+
   test('bool mutation (delete) succeeds when the post-write refresh fails', () async {
     final api = _WorkspaceModelsApi();
     final container = _container(api);
@@ -317,7 +371,7 @@ ProviderContainer _toolsContainer(
   );
 }
 
-ProviderContainer _container(ApiService api) {
+ProviderContainer _container(ApiService api, {String role = 'user'}) {
   return ProviderContainer(
     overrides: [
       reviewerModeProvider.overrideWithValue(false),
@@ -330,11 +384,11 @@ ProviderContainer _container(ApiService api) {
         ),
       ),
       currentUserProvider2.overrideWithValue(
-        const User(
+        User(
           id: 'user-1',
           username: 'user',
           email: 'user@example.com',
-          role: 'user',
+          role: role,
         ),
       ),
       authTokenProvider3.overrideWithValue('token-1'),
@@ -438,6 +492,52 @@ class _WorkspaceModelsApi extends ApiService {
 
   Object? refreshError;
   final deleted = <String>[];
+  final created = <WorkspaceModelForm>[];
+  final updated = <WorkspaceModelForm>[];
+  final imported = <List<Map<String, dynamic>>>[];
+
+  @override
+  Future<WorkspaceModelDetail?> createWorkspaceModel(
+    WorkspaceModelForm form,
+  ) async {
+    created.add(form);
+    return WorkspaceModelSummary(
+      id: form.id,
+      name: form.name,
+      userId: 'user-1',
+      baseModelId: form.baseModelId,
+    );
+  }
+
+  @override
+  Future<WorkspaceModelDetail?> updateWorkspaceModel(
+    WorkspaceModelForm form,
+  ) async {
+    updated.add(form);
+    return WorkspaceModelSummary(
+      id: form.id,
+      name: form.name,
+      userId: 'user-1',
+      baseModelId: form.baseModelId,
+    );
+  }
+
+  @override
+  Future<bool> importWorkspaceModels(List<Map<String, dynamic>> models) async {
+    imported.add(models);
+    return true;
+  }
+
+  @override
+  Future<WorkspaceModelDetail?> getWorkspaceModel(String id) async =>
+      id == 'model-1'
+      ? const WorkspaceModelSummary(
+          id: 'model-1',
+          name: 'Model 1',
+          userId: 'user-1',
+          baseModelId: 'base-1',
+        )
+      : null;
 
   @override
   Future<WorkspaceModelDetail?> toggleWorkspaceModel(String id) async {
@@ -475,7 +575,12 @@ class _WorkspaceModelsApi extends ApiService {
     }
     return const WorkspacePagedResponse(
       items: [
-        WorkspaceModelSummary(id: 'model-1', name: 'Model 1', userId: 'user-1'),
+        WorkspaceModelSummary(
+          id: 'model-1',
+          name: 'Model 1',
+          userId: 'user-1',
+          baseModelId: 'base-1',
+        ),
       ],
       total: 2,
     );

--- a/test/features/workspace/views/workspace_model_editor_test.dart
+++ b/test/features/workspace/views/workspace_model_editor_test.dart
@@ -7,6 +7,7 @@ import 'package:flutter_riverpod/misc.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:go_router/go_router.dart';
 
+import 'package:conduit/core/models/user.dart';
 import 'package:conduit/core/models/server_config.dart';
 import 'package:conduit/core/models/model.dart';
 import 'package:conduit/core/network/conduit_user_agent.dart';
@@ -69,6 +70,7 @@ void main() {
       find.byKey(const Key('workspace-model-name')),
       'My Model',
     );
+    await _selectBaseModel(tester);
     await tester.tap(find.byKey(const Key('workspace-editor-save')));
     await tester.pump();
     await tester.pump();
@@ -92,6 +94,36 @@ void main() {
 
     expect(fake.createdForms, isEmpty);
     expect(find.byKey(const Key('workspace-editor-error')), findsOneWidget);
+  });
+
+  testWidgets('non-admin create requires a base model', (tester) async {
+    final fake = _FakeWorkspaceModels();
+    await tester.pumpWidget(
+      _harness(models: fake, mode: WorkspaceRouteMode.create),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.enterText(
+      find.byKey(const Key('workspace-model-id')),
+      'my-model',
+    );
+    await tester.enterText(
+      find.byKey(const Key('workspace-model-name')),
+      'My Model',
+    );
+    await tester.tap(find.byKey(const Key('workspace-editor-save')));
+    await tester.pump();
+
+    expect(fake.createdForms, isEmpty);
+    expect(find.text('Choose a base model.'), findsOneWidget);
+    await tester.tap(
+      find.descendant(
+        of: find.byKey(const Key('workspace-model-base')),
+        matching: find.byType(DropdownButton<String?>),
+      ),
+    );
+    await tester.pumpAndSettle();
+    expect(find.text('None (custom)'), findsNothing);
   });
 
   testWidgets('compact toolbar back confirms before discarding edits', (
@@ -305,6 +337,7 @@ void main() {
       find.byKey(const Key('workspace-model-name')),
       'Shared Model',
     );
+    await _selectBaseModel(tester);
     await tester.tap(find.byKey(const Key('workspace-editor-save')));
     await tester.pump();
     await tester.pump();
@@ -678,6 +711,18 @@ Future<void> _scrollTo(
   );
 }
 
+Future<void> _selectBaseModel(WidgetTester tester) async {
+  await tester.tap(
+    find.descendant(
+      of: find.byKey(const Key('workspace-model-base')),
+      matching: find.byType(DropdownButton<String?>),
+    ),
+  );
+  await tester.pumpAndSettle();
+  await tester.tap(find.text('Base One').last);
+  await tester.pumpAndSettle();
+}
+
 Widget _harness({
   required _FakeWorkspaceModels models,
   required WorkspaceRouteMode mode,
@@ -704,6 +749,14 @@ List<Override> _baseOverrides(
 }) {
   return [
     reviewerModeProvider.overrideWithValue(false),
+    currentUserProvider2.overrideWithValue(
+      const User(
+        id: 'user',
+        username: 'user',
+        email: 'user@example.com',
+        role: 'user',
+      ),
+    ),
     apiServiceProvider.overrideWithValue(api),
     authTokenProvider3.overrideWithValue(api == null ? null : 'token'),
     workspaceCapabilitiesProvider.overrideWith(

--- a/test/shared/widgets/server_version_warning_card_test.dart
+++ b/test/shared/widgets/server_version_warning_card_test.dart
@@ -55,7 +55,7 @@ void main() {
       await tester.pumpWidget(
         _buildCard(
           authState: AuthNavigationState.authenticated,
-          config: const BackendConfig(version: '0.11.1', serverId: 'A'),
+          config: const BackendConfig(version: '0.11.2', serverId: 'A'),
         ),
       );
       await tester.pump();
@@ -64,21 +64,21 @@ void main() {
         find.byKey(const ValueKey('server-version-warning-card')).evaluate(),
       ).length.equals(1);
       check(find.text('Server not supported').evaluate()).length.equals(1);
+      check(find.textContaining('0.11.2').evaluate()).length.equals(1);
       check(find.textContaining('0.11.1').evaluate()).length.equals(1);
-      check(find.textContaining('0.11.0').evaluate()).length.equals(1);
     });
 
     testWidgets('disables text decoration on Android', (tester) async {
       await tester.pumpWidget(
         _buildCard(
           authState: AuthNavigationState.authenticated,
-          config: const BackendConfig(version: '0.11.1', serverId: 'A'),
+          config: const BackendConfig(version: '0.11.2', serverId: 'A'),
         ),
       );
       await tester.pump();
 
       final title = tester.widget<Text>(find.text('Server not supported'));
-      final message = tester.widget<Text>(find.textContaining('0.11.1'));
+      final message = tester.widget<Text>(find.textContaining('0.11.2'));
       check(title.style?.decoration).equals(TextDecoration.none);
       check(message.style?.decoration).equals(TextDecoration.none);
     });
@@ -92,7 +92,7 @@ void main() {
       await tester.pumpWidget(
         _buildCard(
           authState: AuthNavigationState.authenticated,
-          config: const BackendConfig(version: '0.11.1', serverId: 'A'),
+          config: const BackendConfig(version: '0.11.2', serverId: 'A'),
           body: MediaQuery(
             data: const MediaQueryData(
               size: Size(390, 420),
@@ -137,7 +137,7 @@ void main() {
       await tester.pumpWidget(
         _buildCard(
           authState: AuthNavigationState.authenticated,
-          config: const BackendConfig(version: '0.11.1', serverId: 'A'),
+          config: const BackendConfig(version: '0.11.2', serverId: 'A'),
           body: debugBuildChatEmptyStateViewportForTesting(
             padding: const EdgeInsets.symmetric(vertical: 100, horizontal: 24),
             children: const [
@@ -164,7 +164,7 @@ void main() {
       await tester.pumpWidget(
         _buildCard(
           authState: AuthNavigationState.authenticated,
-          config: const BackendConfig(version: '0.11.0', serverId: 'A'),
+          config: const BackendConfig(version: '0.11.1', serverId: 'A'),
         ),
       );
       await tester.pump();
@@ -176,7 +176,7 @@ void main() {
       await tester.pumpWidget(
         _buildCard(
           authState: AuthNavigationState.authenticated,
-          config: const BackendConfig(version: '0.11.1', serverId: 'B'),
+          config: const BackendConfig(version: '0.11.2', serverId: 'B'),
         ),
       );
       await tester.pump();
@@ -190,7 +190,7 @@ void main() {
       await tester.pumpWidget(
         _buildCard(
           authState: AuthNavigationState.needsLogin,
-          config: const BackendConfig(version: '0.11.1', serverId: 'A'),
+          config: const BackendConfig(version: '0.11.2', serverId: 'A'),
         ),
       );
       await tester.pump();


### PR DESCRIPTION
## Summary

- update `openwebui-src` to the upstream `v0.11.1` tag
- add live and persisted `ask_user` and tool-approval handling in an attached composer overlay
- handle password session revocation, terminal chat contexts, and workspace base-model rules
- reuse the attached composer prompt surface for Hermes approvals and interactive decisions, removing inline decision UI
- raise the supported Open WebUI version ceiling to `0.11.1`

## API drift audit

- resolved: `request:user_input`, persisted approvals and `ask_user`, and legacy confirmations
- resolved: successful password updates now clear the revoked local session
- resolved: terminal context filtering and saved-chat WebSocket authentication
- resolved: non-admin workspace model base preservation
- compatible: additive config and model fields, chat overlays, note sanitization, and tag normalization
- unused: provider-model management, URL processing, memory reindexing, and admin OAuth endpoints
- live Open WebUI 0.11.1 verification covered persisted `ask_user` restoration, submission, and resumed completion; generic approval was unavailable without changing shared server policy

## Testing

- `flutter pub get`
- `dart pub get --directory tool/pigeon_codegen`
- `flutter gen-l10n`
- `dart run tool/validate_arb_locales.dart`
- `dart run tool/verify_arb_descriptions.dart`
- `dart run build_runner build`
- `flutter analyze`
- `flutter test` across all non-performance test files — 5,680 passed, 4 skipped; final Hermes review follow-ups covered by the focused suite
- `flutter test test/core/database/fts_perf_test.dart` — 7 passed
- focused 113-test composer, prompt ownership, and layout suite
- fresh isolated iOS verification against Open WebUI 0.11.1: restored an unresolved `ask_user`, submitted an answer, and observed resumed completion
- live Hermes verification skipped at user request

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Support OpenWebUI v0.11.1 with composer-hosted interactive prompts and tool-call polling
> - Bumps `maxSupportedVersion` in [server_version_compat.dart](https://github.com/cogwheel0/conduit/pull/667/files#diff-26aba364aaae3f3a77898e609dfe7b2e3279a54ecdb3244d27ad38bec742a2fb) from `0.11.0` to `0.11.1`
> - Introduces `OpenWebUiLivePromptNotifier` in [openwebui_chat_prompt_provider.dart](https://github.com/cogwheel0/conduit/pull/667/files#diff-7172b105637672b496144813e17b2d43f605cd333e669af4dca720240225bccc) to handle live `request:user_input` and `confirmation` prompts with timeout and cancellation; renders them via the new `OpenWebUiPromptOverlay` widget attached to the composer in [chat_page.dart](https://github.com/cogwheel0/conduit/pull/667/files#diff-84403526b0e1de6a48ac9f2c5ba0a7c0d9ebe6626d63e1494d6f4f1fc629d109)
> - Adds `ChatMessagesNotifier.resumeAfterOpenWebUiToolCall` and `_monitorNonTailToolTask` in [chat_providers.dart](https://github.com/cogwheel0/conduit/pull/667/files#diff-d40cac4b005693ed296f14004f1b80f218a826122c0e89df2756d9a98a43e28b) to resolve tool calls via `ApiService.resolveChatMessageToolCall` and poll the server for task completion on non-tail messages
> - Moves Hermes approval/decision cards from beneath assistant messages into the composer overlay via `HermesComposerPromptOverlay` (renamed from `HermesMessageInteractions`)
> - Enforces base model requirement for non-admin workspace model create/update/import in [workspace_providers.dart](https://github.com/cogwheel0/conduit/pull/667/files#diff-661cdefdc3859eee2617605dec81812b31b7b907c8c8bcf1ed637859809c993e), throwing `WorkspaceModelBaseRequiredException` when missing
> - Adds per-session-scope terminal availability caching and sends `chat_id` in WebSocket auth for saved-chat scopes in [terminal_session_controller.dart](https://github.com/cogwheel0/conduit/pull/667/files#diff-e693ba10c3e097eb5564ef3c13a1c5db1af0f429c18514aefc6bbc621b8f0ac8)
> - Logs out the current session after a successful password change in [app_providers.dart](https://github.com/cogwheel0/conduit/pull/667/files#diff-09d0818b68d5a1a0ec161c7f5b5a4dd163466be28adae31c3c7bc8ff3a945e40)
> - Risk: `WorkspaceModelEditorBody` and `WorkspaceModelBasicsSection` now require a `baseModelRequired` parameter; existing callers must supply it. Non-admin users can no longer create or import workspace models without a base model. Terminal tab visibility now defaults to false when no scoped cache exists.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1d48161.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added interactive Open WebUI questions, free-form answers, confirmations, and tool approvals in chat.
  * Chat resumes after tool responses while tracking background task completion.
  * Added chat-context-aware terminal availability.
  * Workspace model forms enforce required base-model selection.
  * Standardized approval and decision prompts with improved accessibility.
* **Bug Fixes**
  * Prevented outdated sessions from being logged out after password changes.
  * Improved prompt handling when conversations or sessions change.
* **Compatibility**
  * Added support for Open WebUI 0.11.1.
* **Localization**
  * Added translations for prompts and workspace validation messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->













<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This update adds Open WebUI prompt compatibility, places interactive Open WebUI and Hermes prompts in the composer surface, and strengthens reconciliation for tool calls resolved from earlier conversation messages.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

No blocking failure remains.

No accepted blocking findings remain after reviewing the current task-monitor and prompt ownership implementations.
</details>


<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Compared the earlier monitor implementation with the current non-tail tool-call reconciliation to establish baseline behavior.
- Tried running Flutter-based tests for API service chat completion and chat messages notifier, but the commands exited with code 127 due to the Flutter SDK not being installed.
- Inspected the composer-attached Open WebUI and Hermes prompt paths, and attempted the narrow Open WebUI overlay and Hermes-related tests against both revisions; each command exited 127 because Flutter was not installed.
- Noted a concrete blocker: neither Flutter nor Dart nor a Chromium executable is installed or on PATH, so rendered widget behavior cannot be validated in this runtime.
- Captured that the monitor ties to the vendored Open WebUI resolve endpoint and records function\_call\_output and terminal statuses before resuming chat completion.

<a href="https://app.greptile.com/trex/runs/20794438/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (8): Last reviewed commit: ["fix: expire Hermes decision prompts"](https://github.com/cogwheel0/conduit/commit/1d4816102388feba4df6877a2b52be01c009cea6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56976055)</sub>

<!-- /greptile_comment -->