### PR TITLE
fix(hermes): allow continued dashboard chats

### DIFF
--- a/lib/features/hermes/services/hermes_desktop_turn_runtime.dart
+++ b/lib/features/hermes/services/hermes_desktop_turn_runtime.dart
@@ -882,7 +882,7 @@ extension _HermesDesktopTurnRuntime on HermesDesktopApiService {
               query: {
                 'limit': 20,
                 'offset': 0,
-                'order': 'recent',
+                'order': 'latest',
                 'include_compacted': true,
                 ..._sessionScope(storedId),
               },

--- a/test/features/hermes/hermes_desktop_turn_state_test.dart
+++ b/test/features/hermes/hermes_desktop_turn_state_test.dart
@@ -230,6 +230,55 @@ void main() {
         .equals(HermesDesktopTurnState.running);
   });
 
+  test('continued chats request the latest transcript page', () async {
+    SharedPreferences.setMockInitialValues({});
+    PreferencesStore.debugOverride(await SharedPreferences.getInstance());
+    final harness = _GatewayHarness();
+    final adapter = _StubAdapter();
+    final rpc = HermesDesktopRpcClient(
+      channelFactory: (_, _, {httpClient}) => harness.channel,
+    );
+    final service = HermesDesktopApiService(
+      config: HermesConfig(
+        enabled: true,
+        baseUrl: 'https://hermes.example',
+        mode: HermesBackendMode.desktopGateway,
+        desktopCredentials: HermesDesktopCredentials(
+          legacyToken: 'session-token',
+        ),
+      ),
+      dio: _statusDio(adapter),
+      rpc: rpc,
+    );
+    addTearDown(() async {
+      service.close();
+      await harness.dispose();
+    });
+
+    harness.responder = (method) => switch (method) {
+      'session.resume' => {
+        'session_id': 'runtime-existing',
+        'stored_session_id': 'stored-existing',
+        'running': false,
+      },
+      'config.get' => {'value': 'medium'},
+      _ => const {},
+    };
+
+    final response = await service.streamDesktopResponse(
+      HermesChatInput.text('second message'),
+      sessionId: 'stored-existing',
+      options: const HermesDesktopSessionOptions(),
+    );
+    harness.sessionInfo('runtime-existing', running: false);
+    await response.events.toList();
+
+    final historyRequest = adapter.requested.singleWhere(
+      (uri) => uri.path.endsWith('/messages'),
+    );
+    check(historyRequest.queryParameters['order']).equals('latest');
+  });
+
   test('a new bot chat opens before its first prompt is persisted', () async {
     SharedPreferences.setMockInitialValues({});
     PreferencesStore.debugOverride(await SharedPreferences.getInstance());


### PR DESCRIPTION
## Summary

- request the latest Hermes transcript page before continued Desktop Gateway prompts
- cover the continued-chat preflight query with a regression test

Fixes #668.

## Testing

- flutter test test/features/hermes/hermes_desktop_turn_state_test.dart
- flutter analyze lib test
- full flutter test: 5,709 passed, 4 skipped; 3 unrelated tests failed under suite load and passed individually
- flutter pub get
- dart run build_runner build

Root flutter analyze still reports the existing standalone tool/pigeon_codegen package missing package:pigeon from the root package graph. The fresh simulator build was stopped before device creation at the user's request; the authenticated Dashboard continuation is covered at the request boundary by the regression test.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix continued dashboard chats by fetching `order=latest` transcript page in `HermesDesktopApiService`
> Changes the message history query parameter from `order=recent` to `order=latest` in `HermesDesktopApiService._runtimeStreamDesktopResponse` so resumed dashboard sessions load the correct transcript page. Adds a test in [hermes_desktop_turn_state_test.dart](https://github.com/cogwheel0/conduit/pull/670/files#diff-ff36400d808007250453cecbfcbc19440a9d3e2f4461b8b3729aff8b5c186eb3) verifying the `order=latest` parameter is sent.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a4b96f8.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This change makes continued Hermes Desktop Gateway chats request the newest transcript page before submitting the next prompt, with focused coverage that checks the outgoing request uses `order=latest`.

No product defects were identified in the changed code.

## T-Rex validation blocked

The required Flutter tool is missing from PATH. Both the focused PR test and the parent-version comparison exited with `flutter: not found`, so the continued-chat flow could not be executed in this environment.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The implementation and its focused request assertion are consistent, with no review findings requiring changes.

No scoring findings remain. Execution coverage is unavailable because the Flutter tool is not installed, but the environment limitation does not add a product defect.

**Files Needing Attention:** No source changes require follow-up; run the focused Hermes test once a compatible Flutter SDK is available.
</details>


<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex attempted to run the focused Hermes desktop turn\_state test and the preceding-state comparison, but Flutter is not installed in the environment.
- No review-authored test or script was created, and no repository files were modified.
- Artifacts documenting the test attempt, its after-state, and the updated transcript were prepared and uploaded for reviewer inspection.

<a href="https://app.greptile.com/trex/runs/20847644/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(hermes): allow continued dashboard c..."](https://github.com/cogwheel0/conduit/commit/a4b96f8b4f42447d640bfc55d52ab412870e8546) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57160275)</sub>

<!-- /greptile_comment -->