### PR TITLE
Show Apple models for existing backends

### DIFF
--- a/lib/features/direct_connections/providers/direct_connection_providers.dart
+++ b/lib/features/direct_connections/providers/direct_connection_providers.dart
@@ -183,9 +183,10 @@ abstract class _QueuedBoolPreferenceController extends Notifier<bool> {
   Future<void> _mutationQueue = Future<void>.value();
 
   String get preferenceKey;
+  bool get defaultValue => false;
 
   @override
-  bool build() => PreferencesStore.getBool(preferenceKey) ?? false;
+  bool build() => PreferencesStore.getBool(preferenceKey) ?? defaultValue;
 
   Future<void> setEnabled(bool enabled) {
     final result = _mutationQueue.then<void>(
@@ -208,6 +209,9 @@ abstract class _QueuedBoolPreferenceController extends Notifier<bool> {
 class ApplePccEnabledController extends _QueuedBoolPreferenceController {
   @override
   String get preferenceKey => PreferenceKeys.applePccEnabled;
+
+  @override
+  bool get defaultValue => true;
 }
 
 final applePccEnabledProvider =
@@ -218,6 +222,9 @@ final applePccEnabledProvider =
 class AppleOnDeviceEnabledController extends _QueuedBoolPreferenceController {
   @override
   String get preferenceKey => PreferenceKeys.appleOnDeviceEnabled;
+
+  @override
+  bool get defaultValue => true;
 }
 
 final appleOnDeviceEnabledProvider =

--- a/test/features/auth/views/backend_onboarding_adaptive_test.dart
+++ b/test/features/auth/views/backend_onboarding_adaptive_test.dart
@@ -285,6 +285,8 @@ void main() {
         findsOneWidget,
       );
       expect(find.text('No direct connections yet'), findsOneWidget);
+      expect(find.text('Apple On-Device'), findsOneWidget);
+      expect(find.text('Apple Private Cloud Compute'), findsOneWidget);
       expect(find.text('Direct Connections'), findsNothing);
       expect(
         find.byKey(const ValueKey<String>('finish-direct-onboarding-button')),
@@ -293,10 +295,10 @@ void main() {
       final navigationBarBottom = tester
           .getBottomLeft(find.byType(ConduitAdaptiveCupertinoNavigationBar))
           .dy;
-      final emptyTitleTop = tester
-          .getTopLeft(find.text('No direct connections yet'))
+      final firstSectionTop = tester
+          .getTopLeft(find.text('Apple Intelligence'))
           .dy;
-      check(emptyTitleTop - navigationBarBottom).isLessOrEqual(Spacing.xxxl);
+      check(firstSectionTop - navigationBarBottom).isLessOrEqual(Spacing.xxxl);
 
       await tester.tap(
         find.byKey(const ValueKey<String>('direct-onboarding-back-button')),

--- a/test/features/direct_connections/direct_providers_test.dart
+++ b/test/features/direct_connections/direct_providers_test.dart
@@ -141,7 +141,25 @@ void main() {
     );
   });
 
+  test('Apple profiles are enabled by default on supported iOS', () async {
+    final container = ProviderContainer(
+      overrides: [applePccPlatformSupportedProvider.overrideWithValue(true)],
+    );
+    addTearDown(container.dispose);
+
+    await container.read(directConnectionProfilesProvider.future);
+    final profiles = container
+        .read(effectiveDirectConnectionProfilesProvider)
+        .requireValue;
+
+    expect(profiles.map((profile) => profile.id), {
+      kAppleOnDeviceProfileId,
+      kApplePccProfileId,
+    });
+  });
+
   test('enabled PCC is exposed as a built-in Direct profile on iOS', () async {
+    await PreferencesStore.put(PreferenceKeys.appleOnDeviceEnabled, false);
     await PreferencesStore.put(PreferenceKeys.applePccEnabled, true);
     final container = ProviderContainer(
       overrides: [applePccPlatformSupportedProvider.overrideWithValue(true)],
@@ -177,6 +195,7 @@ void main() {
     'enabled Apple On-Device is exposed as a built-in Direct profile',
     () async {
       await PreferencesStore.put(PreferenceKeys.appleOnDeviceEnabled, true);
+      await PreferencesStore.put(PreferenceKeys.applePccEnabled, false);
       final container = ProviderContainer(
         overrides: [applePccPlatformSupportedProvider.overrideWithValue(true)],
       );


### PR DESCRIPTION
## Summary

- enable Apple On-Device and Private Cloud Compute when no preference has been saved
- preserve explicit saved choices and the existing iOS platform gate
- cover the default profiles and updated Direct onboarding layout

## Testing

- `flutter test test/features/direct_connections/direct_providers_test.dart test/features/auth/views/backend_onboarding_adaptive_test.dart`
- `flutter test test/core/database/fts_perf_test.dart`
- `flutter analyze lib test`

Root `flutter analyze` remains blocked by the existing standalone `tool/pigeon_codegen` import of `package:pigeon`, which is unavailable from the root package.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Default `applePccEnabledProvider` and `appleOnDeviceEnabledProvider` to `true`
> - Adds an overridable `defaultValue` getter to `_QueuedBoolPreferenceController` so subclasses control the fallback when the preference is unset, instead of hardcoding `false`
> - `ApplePccEnabledController` and `AppleOnDeviceEnabledController` override `defaultValue` to return `true`, making Apple On-Device and Apple Private Cloud Compute profiles visible on supported iOS without stored preferences
> - Updates onboarding and provider tests to expect Apple profiles by default and isolate scenarios by explicitly disabling the counterpart preference
> - Behavioral Change: existing users with no stored `PreferenceKeys.applePccEnabled` or `PreferenceKeys.appleOnDeviceEnabled` value now see Apple profiles enabled instead of hidden
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 64e4462.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Apple On-Device and Apple Private Cloud Compute options are now enabled by default on supported iOS devices.
  * Both options appear during direct connection onboarding.

* **Bug Fixes**
  * Improved profile selection behavior so disabling one Apple option produces the expected available profiles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This change enables Apple On-Device and Private Cloud Compute profiles when their saved preferences are absent, while preserving saved choices and the iOS platform gate.

The Direct onboarding readiness check can accept synthesized Apple profiles before device support, locale eligibility, and quota availability are known. An iOS user can therefore complete Direct onboarding with no Apple model that can actually serve a chat.

## T-Rex validation blocked

The focused Flutter test could not run because the required Flutter tool is not installed. Dart, FVM, and iOS tooling are also unavailable, preventing execution of the unavailable-device, unsupported-locale, and quota-reached paths.

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Changes to the Apple default-profile behavior should not merge until Direct readiness also accounts for native Apple availability.

The source path consistently shows that absent preferences create structurally usable Apple profiles and that onboarding accepts structural usability before the adapter performs native availability checks. Runtime confirmation remains unavailable because the Flutter and iOS test tools are missing.

**Files Needing Attention:** lib/features/direct_connections/providers/direct_connection_providers.dart needs availability-aware profile or readiness gating; the related onboarding readiness path and Apple adapter integration should be covered by a focused unavailable-status test.
</details>


<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex compared the prior Apple preference behavior with the updated defaults and traced the resulting profile and onboarding paths, confirming that missing Apple preferences are synthesized by the new defaults and that onboarding accepts their structure before the native adapter checks availability.
- T-Rex attempted the Flutter provider test focused on default Apple profiles but could not run it because the Flutter tool is not installed, blocking execution of the unavailable-native-status path.
- T-Rex produced a proof for a posted P2 finding, documenting the outcome for reviewer trace.
- T-Rex captured before-and-after results and summarized the changes: before, missing preferences were resolved to disabled; after, defaults synthesize Apple profiles, profile injection occurs, onboarding readiness is demonstrated, and native adapter enforcement is noted later, while the test does not model unavailable device/locale/quota states or assert onboarding remains blocked.

<a href="https://app.greptile.com/trex/runs/20848365/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. General comment 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Unable to execute the claimed Apple-unavailable onboarding failure path**

   - **Bug**
     - The source-level path indicates that blank Apple preferences now synthesize valid Apple profiles on iOS and can satisfy Direct onboarding before native status is consulted. However, the required Flutter test runtime and iOS tooling are absent, so this behavior could not be executed end-to-end or confirmed as an observed failure.
   - **Cause**
     - The environment has no `flutter`, `dart`, or `fvm` executable; the exact test command terminates with `/bin/sh: 1: flutter: not found` (exit 127). iOS tooling is also unavailable.
   - **Fix**
     - Provide a Flutter SDK (and an iOS-capable runtime for native-status integration) and run a narrow test that overrides Apple status to unavailable, locale-unsupported, and quota-reached while preferences are absent, then asserts the Direct onboarding finish action is disabled and no Apple Direct model is routable.

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>

</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (1): Last reviewed commit: ["fix: enable Apple models for existing ba..."](https://github.com/cogwheel0/conduit/commit/64e446298234476c8be84524964ddf07785d53f0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57161461)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->