### PR TITLE
Fix Markdown blockquote rendering

### DIFF
--- a/lib/core/services/semantic_message_builder.dart
+++ b/lib/core/services/semantic_message_builder.dart
@@ -158,8 +158,11 @@ String renderSemanticMessageBlocks(List<SemanticMessageBlock> blocks) {
 /// has no code delimiter; once one appears they must rebuild the authoritative
 /// value with [renderSemanticMessageBlocks] so [_escapeText] can parse the
 /// complete Markdown context.
-String renderSemanticPlainTextFragment(String value) =>
-    _semanticTextEscape.convert(value);
+String renderSemanticPlainTextFragment(String value) => _semanticTextEscape
+    .convert(value)
+    .split('\n')
+    .map(_restoreMarkdownBlockquotePrefix)
+    .join('\n');
 
 String _renderDetailsBlock(SemanticDetailsBlock block) {
   final attributes = <String, String>{
@@ -235,6 +238,12 @@ final _indentedCodeLine = RegExp(r'^(?:    | {0,3}\t)');
 final _semanticDetailsBlockStart = RegExp(
   r'^\s{0,3}<details(?:\s+[^>]*)?>',
   caseSensitive: false,
+);
+final _escapedMarkdownBlockquotePrefix = RegExp(r'^ {0,3}(?:&gt;[ \t]?)+');
+
+String _restoreMarkdownBlockquotePrefix(String line) => line.replaceFirstMapped(
+  _escapedMarkdownBlockquotePrefix,
+  (match) => match[0]!.replaceAll('&gt;', '>'),
 );
 
 // These alternatives mirror the Markdown package's line-local CodeSyntax,
@@ -575,7 +584,7 @@ String _escapeText(String value) {
       protectedSpans: multilineCodeSpans,
       spanIndex: multilineSpanIndex,
     );
-    result.add(escapedLine.text);
+    result.add(_restoreMarkdownBlockquotePrefix(escapedLine.text));
     multilineSpanIndex = escapedLine.nextSpanIndex;
     sourceStart += rawLine.length + 1;
   }

--- a/lib/core/services/semantic_message_builder.dart
+++ b/lib/core/services/semantic_message_builder.dart
@@ -239,7 +239,7 @@ final _semanticDetailsBlockStart = RegExp(
   r'^\s{0,3}<details(?:\s+[^>]*)?>',
   caseSensitive: false,
 );
-final _escapedMarkdownBlockquotePrefix = RegExp(r'^ {0,3}(?:&gt;[ \t]?)+');
+final _escapedMarkdownBlockquotePrefix = RegExp(r'^ {0,3}(?:&gt;[ \t]*)+');
 
 String _restoreMarkdownBlockquotePrefix(String line) => line.replaceFirstMapped(
   _escapedMarkdownBlockquotePrefix,
@@ -452,6 +452,13 @@ String _escapeInlineMarkdownSegment(String value) => value.splitMapJoin(
   }
 
   final result = StringBuffer();
+  void writeEscaped(String value) {
+    final escaped = _escapeInlineMarkdownSegment(value);
+    result.write(
+      result.isEmpty ? _restoreMarkdownBlockquotePrefix(escaped) : escaped,
+    );
+  }
+
   var lineOffset = 0;
   var candidateIndex = nextSpanIndex;
   while (candidateIndex < protectedSpans.length) {
@@ -464,11 +471,7 @@ String _escapeInlineMarkdownSegment(String value) => value.splitMapJoin(
         ? line.length
         : span.end - sourceStart;
     if (protectedStart > lineOffset) {
-      result.write(
-        _escapeInlineMarkdownSegment(
-          line.substring(lineOffset, protectedStart),
-        ),
-      );
+      writeEscaped(line.substring(lineOffset, protectedStart));
     }
     if (protectedEnd > lineOffset) {
       result.write(line.substring(protectedStart, protectedEnd));
@@ -482,7 +485,7 @@ String _escapeInlineMarkdownSegment(String value) => value.splitMapJoin(
     }
   }
   if (lineOffset < line.length) {
-    result.write(_escapeInlineMarkdownSegment(line.substring(lineOffset)));
+    writeEscaped(line.substring(lineOffset));
   }
   return (text: result.toString(), nextSpanIndex: nextSpanIndex);
 }
@@ -584,7 +587,7 @@ String _escapeText(String value) {
       protectedSpans: multilineCodeSpans,
       spanIndex: multilineSpanIndex,
     );
-    result.add(_restoreMarkdownBlockquotePrefix(escapedLine.text));
+    result.add(escapedLine.text);
     multilineSpanIndex = escapedLine.nextSpanIndex;
     sourceStart += rawLine.length + 1;
   }

--- a/test/core/services/semantic_message_builder_test.dart
+++ b/test/core/services/semantic_message_builder_test.dart
@@ -67,6 +67,28 @@ void main() {
       check(rendered).not((it) => it.contains('<details>'));
     });
 
+    test('preserves CommonMark blockquote prefixes', () {
+      const text =
+          '  > > **Author:** Quoted <source>.\n'
+          'Paragraph > comparison.';
+      final renderedValues = [
+        renderSemanticMessageBlocks([const SemanticTextBlock(text)]),
+        renderSemanticPlainTextFragment(text),
+      ];
+
+      for (final rendered in renderedValues) {
+        check(rendered).startsWith('  > > **Author:**');
+        check(rendered).contains('&lt;source&gt;');
+        check(rendered).contains('Paragraph &gt; comparison.');
+
+        final parsed = md.Document(
+          extensionSet: md.ExtensionSet.gitHubWeb,
+          encodeHtml: false,
+        ).parse(rendered);
+        check((parsed.first as md.Element).tag).equals('blockquote');
+      }
+    });
+
     // The markdown renderer never decodes entity references inside code spans
     // or fenced code blocks, so text-block escaping must leave those regions
     // untouched (same failure class as #549, extended to `<` `>` `&` `"`).

--- a/test/core/services/semantic_message_builder_test.dart
+++ b/test/core/services/semantic_message_builder_test.dart
@@ -69,7 +69,7 @@ void main() {
 
     test('preserves CommonMark blockquote prefixes', () {
       const text =
-          '  > > **Author:** Quoted <source>.\n'
+          '  >  > **Author:** Quoted <source>.\n'
           'Paragraph > comparison.';
       final renderedValues = [
         renderSemanticMessageBlocks([const SemanticTextBlock(text)]),
@@ -77,7 +77,7 @@ void main() {
       ];
 
       for (final rendered in renderedValues) {
-        check(rendered).startsWith('  > > **Author:**');
+        check(rendered).startsWith('  >  > **Author:**');
         check(rendered).contains('&lt;source&gt;');
         check(rendered).contains('Paragraph &gt; comparison.');
 
@@ -85,9 +85,25 @@ void main() {
           extensionSet: md.ExtensionSet.gitHubWeb,
           encodeHtml: false,
         ).parse(rendered);
-        check((parsed.first as md.Element).tag).equals('blockquote');
+        final outerQuote = parsed.first as md.Element;
+        check(outerQuote.tag).equals('blockquote');
+        check((outerQuote.children!.first as md.Element).tag)
+            .equals('blockquote');
       }
     });
+
+    test(
+      'leaves line-leading entities inside multiline code spans untouched',
+      () {
+        const text = '`first line\n&gt; literal entity`';
+
+        final rendered = renderSemanticMessageBlocks([
+          const SemanticTextBlock(text),
+        ]);
+
+        check(rendered).equals(text);
+      },
+    );
 
     // The markdown renderer never decodes entity references inside code spans
     // or fenced code blocks, so text-block escaping must leave those regions


### PR DESCRIPTION
## Summary

- preserve line-leading CommonMark blockquote markers after semantic text escaping
- keep arbitrary HTML escaped in complete and incremental Open WebUI output
- add regression coverage for blockquote parsing, nested prefixes, and HTML safety

## Testing

- `flutter analyze`
- `flutter test` (5,715 passed, 4 live-provider tests skipped)
- real iOS Simulator: streamed and reopened Open WebUI blockquotes render with blockquote styling and no literal marker

Fixes #666
