### PR TITLE
ci: add Hermes Agent workflow on push/PR

### DIFF
--- a/.github/workflows/hermes.yml
+++ b/.github/workflows/hermes.yml
@@ -1,0 +1,96 @@
+# Hermes Agent CI — invoked on push and PRs.
+# Invokes `hermes` to run a task defined by the repo's own instructions.
+#
+# Prerequisites (one-time setup in this repo's Settings → Secrets):
+#   HERMES_HOME           path to a Hermes installation inside the runner
+#   HERMES_API_KEY        your LLM provider key (or HERMES_OATH_TOKEN etc.)
+#   HERMES_TASK           the prompt Hermes should run on each CI trigger
+#
+# Optional: pin a specific agent by adding HERMES_SESSION or HERMES_SESSION_TAG.
+# The task can read HERMES_TRIGGER (= push|pr), the branch/ref, and
+# GH_EVENT_PATH (the raw GitHub event JSON) from the environment.
+
+name: Hermes Agent
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+    inputs:
+      hermes_task:
+        description: "Hermes task prompt (overrides HERMES_TASK secret)"
+        required: false
+
+permissions:
+  contents: read
+  actions: read
+
+concurrency:
+  group: hermes-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  hermes:
+    name: Hermes Agent
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    env:
+      HERMES_TRIGGER: ${{ github.event_name }}
+      HERMES_REF: ${{ github.ref_name }}
+      HERMES_SHA: ${{ github.sha }}
+      GH_EVENT_PATH: ${{ github.event_path }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+          submodules: recursive
+
+      - name: Install Hermes Agent
+        run: |
+          curl -fsSL https://hermes-agent.nousresearch.com/install.sh | bash
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+
+      - name: Configure Hermes (non-secret settings only)
+        env:
+          HERMES_HOME: ${{ secrets.HERMES_HOME || '$HOME/.hermes' }}
+        run: |
+          mkdir -p "$HERMES_HOME"
+          # Secrets (API keys, OAuth tokens) MUST live in .env, never in config.yaml.
+          # If you have a pre-baked .env for the runner, drop it in here:
+          #   cp .hermes-runner-env "$HERMES_HOME/.env"
+          # Otherwise set provider keys as repository secrets and write them now:
+          if [ -n "${{ secrets.HERMES_API_KEY }}" ]; then
+            cat > "$HERMES_HOME/.env" <<'ENV'
+            HERMES_API_KEY=${{ secrets.HERMES_API_KEY }}
+            ENV
+          fi
+
+      - name: Run Hermes task
+        env:
+          HERMES_HOME: ${{ secrets.HERMES_HOME || '$HOME/.hermes' }}
+          HERMES_TASK: ${{ inputs.hermes_task || secrets.HERMES_TASK }}
+        run: |
+          if [ -z "$HERMES_TASK" ]; then
+            echo "::error::HERMES_TASK is empty — set the secret or pass via workflow_dispatch"
+            exit 1
+          fi
+          hermes chat -q "$HERMES_TASK"
+
+      # Optional: surface Hermes stdout as a PR comment or job summary.
+      # Uncomment and adapt when you want Hermes output attached to the run.
+      #
+      # - name: Post Hermes summary
+      #   if: always() && github.event_name == 'pull_request'
+      #   uses: actions/github-script@v7
+      #   with:
+      #     script: |
+      #       const fs = require('fs');
+      #       const log = fs.readFileSync(process.env.GITHUB_STEP_SUMMARY, 'utf8');
+      #       await github.rest.issues.createComment({
+      #         owner: context.repo.owner,
+      #         repo: context.repo.repo,
+      #         issue_number: context.issue.number,
+      #         body: '## Hermes Agent\n\n' + log,
+      #       });


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/hermes.yml` — invokes Hermes Agent on push to `main`, on PRs to `main`, and via `workflow_dispatch`.
- Hermes task comes from the `HERMES_TASK` secret (or the `workflow_dispatch` input). Provider keys live in `.env` (or `HERMES_API_KEY` secret) — never committed.
- Requires one-time secret setup in the repo: `HERMES_TASK` (the prompt to run), plus any provider auth (e.g. `HERMES_API_KEY`).

## Non-goals / notes
- This is CI for the Hermes agent itself, not the mobile build — the existing `release.yml` and `l10n.yml` are untouched.
- Hermes Agent is an install-and-run tool; the workflow installs it from the shell script and runs `hermes chat -q "$HERMES_TASK"`.

🤖 Generated with [Hermes Agent](https://github.com/NousResearch/hermes-agent).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated Hermes Agent workflow support for pushes, pull requests, and manual runs.
  * Manual runs can accept a custom task, with validation to prevent empty tasks.
  * Provides relevant run context to the agent for improved automation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This change adds a GitHub Actions workflow that installs Hermes Agent and runs a configured task for pushes, pull requests, and manual dispatches. The workflow fails for fork-originated pull requests because the secret-backed task is unavailable, and its default Hermes home path is written under the checkout instead of the runner home. It also executes mutable third-party code before handling Hermes credentials. The workflow should not be merged until these failures and credential-exposure paths are addressed.

<details><summary><h3>Confidence Score: 0/5</h3></summary>

The workflow is not safe to merge because it can fail legitimate pull requests and introduces mutable code execution before sensitive Hermes credentials are handled.

Focused executable checks reproduced the pull-request failure, the literal home-path expansion behavior, and both external-code trust paths with synthetic inputs and read-only workflow inspection.

**Files Needing Attention:** .github/workflows/hermes.yml requires attention at the checkout action reference, Hermes installer command, home-path fallback, and task execution guard.
</details>


<details open><summary><h3>Security Review</h3></summary>

The workflow executes two mutable external dependencies before it writes or uses Hermes provider credentials: a remote installer piped directly into Bash and an action referenced by a movable major-version tag. Safe local simulations confirmed that altered installer-provided code can read the later-created Hermes credential file. Pin and integrity-verify executable dependencies before materializing or using provider credentials.
</details>


<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex produced a proof for a posted P1 finding and attached the Hermes fork pull-request task-resolution harness source and related run logs.
- T-Rex produced a second proof for another P1 finding, including a narrow shell harness for literal and expanded Hermes home paths and two execution logs.
- T-Rex produced a third proof for a posted P1 finding, including a safe local verifier for checkout pinning and secret-step ordering, a SHA-pinned control run, and a note about a mutable checkout tag in the observed workflow.
- T-Rex produced a general-contract-validation-proof modeling the control, fork PR, and Dependabot scenarios with an executable validation harness, without changing repository code.
- T-Rex produced a final general-contract-validation-proof detailing the plain-language execution record, the checks run, and the evidence artifacts from the Hermes pin-order verification.

<a href="https://app.greptile.com/trex/runs/21163270/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (4)</h3></summary>

1. General comment 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Fork and standard Dependabot pull requests unconditionally fail the Hermes job**

   - **Bug**
     - The workflow runs on `pull_request` (line 17), but `HERMES_TASK` on line 73 is `${{ inputs.hermes_task || secrets.HERMES_TASK }}`. On a fork-originated PR, `inputs.hermes_task` is unavailable because the trigger is not `workflow_dispatch`, and repository secrets are withheld. The expression therefore resolves empty. Lines 75-77 detect the empty variable and explicitly `exit 1`, failing the job. The executed fork harness captured exactly this result. Standard Dependabot PRs likewise lack normal repository secrets, so they follow the same path unless an appropriate Dependabot secret is configured.
   - **Cause**
     - The workflow requires a secret-backed task while also running on untrusted `pull_request` events where the required secret is intentionally unavailable; it has no conditional skip or safe non-secret task fallback for those events.
   - **Fix**
     - Gate the Hermes task step/job so it only runs when a non-empty task is available and when the event is trusted, or skip it for fork/Dependabot PRs. If Dependabot execution is intended, configure the task in Dependabot secrets and explicitly test that event path. Do not switch this workflow to `pull_request_target` merely to access secrets, because it checks out pull-request code.

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>


2. General comment 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Hermes fallback home path is used literally and writes into the workspace**

   - **Bug**
     - When `secrets.HERMES_HOME` is unset, lines 57 and 72 provide `$HOME/.hermes` as an environment value. The configure step’s `mkdir -p "$HERMES_HOME"` and `.env` redirection then create a relative directory named `$HOME/.hermes` from the job workspace, instead of using the runner’s home directory.
   - **Cause**
     - Shell parameter expansion is non-recursive: expanding `"$HERMES_HOME"` yields the literal characters `$HOME/.hermes`; it does not perform a second expansion of the embedded `$HOME`.
   - **Fix**
     - Use an already-expanded absolute fallback, such as `${{ secrets.HERMES_HOME || format('{0}/.hermes', env.HOME) }}`, or set `HERMES_HOME` in the shell with `HERMES_HOME="${HERMES_HOME:-$HOME/.hermes}"` while leaving the workflow environment value unset when no secret is supplied.

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>


3. General comment 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Mutable remote Hermes installer can later read and exfiltrate provider credentials**

   - **Bug**
     - `.github/workflows/hermes.yml:52` streams a mutable remote script into `bash`. Its resulting executable is placed on the command path at line 53. The workflow subsequently writes `HERMES_API_KEY` to `$HERMES_HOME/.env` at lines 64–68 and invokes `hermes` with `HERMES_HOME` at lines 72–79. A safe altered-installer simulation confirmed that the installer-provided executable can read that file after it is created.
   - **Cause**
     - The installer endpoint and its script contents are not integrity-pinned, verified, or otherwise constrained before execution, while the binary it installs is trusted later in the same job after secrets are materialized.
   - **Fix**
     - Replace `curl ... | bash` with a version- and digest-pinned, independently verified release artifact; verify its checksum/signature before execution. Avoid placing provider credentials in a location readable by unverified installer-provided code, and only invoke a verified binary after secret materialization.

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>


4. General comment 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Mutable checkout action tag precedes Hermes secret-bearing steps**

   - **Bug**
     - At `.github/workflows/hermes.yml:45`, the job invokes `actions/checkout@v6`. The tag reference is not a full commit SHA and is therefore mutable. This action executes before `Configure Hermes` (lines 55–69), which references `secrets.HERMES_HOME` at line 57 and `secrets.HERMES_API_KEY` at lines 64 and 66, and before `Run Hermes task` (lines 70–96), which references `secrets.HERMES_HOME` at line 72 and `secrets.HERMES_TASK` at line 73.
   - **Cause**
     - The workflow trusts a symbolic release tag for third-party action code instead of an immutable full 40-character commit SHA at a point before sensitive Hermes credentials and task input are introduced.
   - **Fix**
     - Pin `actions/checkout` to the reviewed full 40-character commit SHA for the intended v6 release, and maintain that pin through a reviewed dependency-update process. Consider enforcing GitHub Actions SHA pinning through repository or organization policy.

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>

</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (1): Last reviewed commit: ["ci: add Hermes Agent workflow on push/PR"](https://github.com/cogwheel0/conduit/commit/01d4b7a63666385d6d9c03176c721f1ffadf7737) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57764727)</sub>

> Greptile also left **4 inline comments** on this PR.

<!-- /greptile_comment -->