### PR TITLE
Fix Hermes approvals, tool-call markup, and restored running state

### DIFF
--- a/lib/features/chat/providers/chat_providers.dart
+++ b/lib/features/chat/providers/chat_providers.dart
@@ -3010,6 +3010,7 @@ class ChatMessagesNotifier extends Notifier<List<ChatMessage>>
     if (checkpoint.role != 'assistant' ||
         (expectedMessageId != null && checkpoint.id != expectedMessageId) ||
         !checkpoint.isStreaming ||
+        isRestoredHermesDesktopRunningMessage(checkpoint) ||
         checkpoint.metadata?['transport'] != kHermesTransport ||
         _hasLiveHermesProjection(conversation, checkpoint) ||
         _coldHermesRecoveryMessageId == checkpoint.id) {

--- a/lib/features/chat/views/chat_page.dart
+++ b/lib/features/chat/views/chat_page.dart
@@ -1058,7 +1058,9 @@ class _ChatPageState extends ConsumerState<ChatPage> {
         active.metadata['hermesSessionId'] != storedId) {
       return;
     }
-    if (ref.read(isChatStreamingProvider)) {
+    final visibleTail = ref.read(chatMessagesProvider).lastOrNull;
+    if (ref.read(isChatStreamingProvider) &&
+        !isRestoredHermesDesktopRunningMessage(visibleTail)) {
       _pendingHermesTranscriptRefresh = storedId;
       return;
     }
@@ -1106,7 +1108,7 @@ class _ChatPageState extends ConsumerState<ChatPage> {
               connectionIdentity: connectionIdentity,
               sessionId: storedId,
             );
-      final messages =
+      var messages =
           hermesMessagesToChatMessages(
             raw,
             modelId: model.id,
@@ -1114,15 +1116,26 @@ class _ChatPageState extends ConsumerState<ChatPage> {
           )..addAll(
             hermesPendingDesktopDecisionMessages(pending, modelId: model.id),
           );
+      messages = restoreHermesDesktopRunningMessage(
+        messages,
+        sessionId: storedId,
+        modelId: model.id,
+        isRunning:
+            service.turnStateFor(storedId) == HermesDesktopTurnState.running,
+      );
       final currentMessages = ref.read(chatMessagesProvider);
       final currentAuthoritativeCount = currentMessages
           .where(
-            (message) => message.metadata?['restoredDesktopDecision'] != true,
+            (message) =>
+                message.metadata?['restoredDesktopDecision'] != true &&
+                !isRestoredHermesDesktopRunningPlaceholder(message),
           )
           .length;
       final candidateAuthoritativeCount = messages
           .where(
-            (message) => message.metadata?['restoredDesktopDecision'] != true,
+            (message) =>
+                message.metadata?['restoredDesktopDecision'] != true &&
+                !isRestoredHermesDesktopRunningPlaceholder(message),
           )
           .length;
       if (currentAuthoritativeCount > 0 &&

--- a/lib/features/hermes/providers/hermes_providers.dart
+++ b/lib/features/hermes/providers/hermes_providers.dart
@@ -2063,6 +2063,22 @@ class HermesRunRegistry {
     return true;
   }
 
+  /// Associates an inline stream with a run announced by one of its events.
+  bool bindRunId(
+    HermesRunKey key, {
+    required CancelToken cancelToken,
+    required String runId,
+  }) {
+    final run = _runs[key];
+    if (run == null ||
+        run.cancelled ||
+        !identical(run.cancelToken, cancelToken)) {
+      return false;
+    }
+    run.runId = runId;
+    return true;
+  }
+
   /// Compatibility helper for callers that already have a live run.
   void register(
     HermesRunKey key, {

--- a/lib/features/hermes/providers/hermes_providers.dart
+++ b/lib/features/hermes/providers/hermes_providers.dart
@@ -2072,7 +2072,8 @@ class HermesRunRegistry {
     final run = _runs[key];
     if (run == null ||
         run.cancelled ||
-        !identical(run.cancelToken, cancelToken)) {
+        !identical(run.cancelToken, cancelToken) ||
+        (run.runId != null && run.runId != runId)) {
       return false;
     }
     run.runId = runId;

--- a/lib/features/hermes/services/hermes_message_mapper.dart
+++ b/lib/features/hermes/services/hermes_message_mapper.dart
@@ -74,7 +74,9 @@ List<ChatMessage> restoreHermesDesktopRunningMessage(
 
   final restored = List<ChatMessage>.of(messages);
   final tail = restored.lastOrNull;
-  if (tail?.role == 'assistant' && tail?.error == null) {
+  if (tail?.role == 'assistant' &&
+      tail?.error == null &&
+      tail?.metadata?['restoredDesktopDecision'] != true) {
     restored[restored.length - 1] = tail!.copyWith(
       isStreaming: true,
       metadata: <String, dynamic>{

--- a/lib/features/hermes/services/hermes_message_mapper.dart
+++ b/lib/features/hermes/services/hermes_message_mapper.dart
@@ -21,6 +21,9 @@ const int kHermesMaxHistoryInlineImageDataUrlCharacters =
 const int kHermesMaxHistoryImageUrlCharacters =
     kHermesMaxHistoryInlineImageDataUrlCharacters +
     (kHermesMaxHistoryImages * kHermesMaxHistoryRemoteImageUrlCharacters);
+const String kHermesRestoredDesktopRunningMetadataKey =
+    'restoredDesktopRunning';
+const String _hermesRestoredDesktopPlaceholder = 'placeholder';
 
 final Expando<bool> _trustedLocalDocumentDescriptors = Expando<bool>();
 
@@ -50,6 +53,56 @@ bool isTrustedHermesLocalDocumentDescriptor(Map<String, dynamic> descriptor) =>
 /// Object-identity provenance is intentionally lost on serialization.
 void markTrustedHermesLocalDocumentDescriptor(Map<String, dynamic> descriptor) {
   _trustedLocalDocumentDescriptors[descriptor] = true;
+}
+
+bool isRestoredHermesDesktopRunningMessage(ChatMessage? message) =>
+    message?.metadata?[kHermesRestoredDesktopRunningMetadataKey] != null;
+
+bool isRestoredHermesDesktopRunningPlaceholder(ChatMessage message) =>
+    message.metadata?[kHermesRestoredDesktopRunningMetadataKey] ==
+    _hermesRestoredDesktopPlaceholder;
+
+/// Reinstates the live assistant row for a Desktop session whose authoritative
+/// gateway state says it is still running after its transcript was restored.
+List<ChatMessage> restoreHermesDesktopRunningMessage(
+  List<ChatMessage> messages, {
+  required String sessionId,
+  required String modelId,
+  required bool isRunning,
+}) {
+  if (!isRunning) return messages;
+
+  final restored = List<ChatMessage>.of(messages);
+  final tail = restored.lastOrNull;
+  if (tail?.role == 'assistant' && tail?.error == null) {
+    restored[restored.length - 1] = tail!.copyWith(
+      isStreaming: true,
+      metadata: <String, dynamic>{
+        ...?tail.metadata,
+        kHermesRestoredDesktopRunningMetadataKey: true,
+      },
+    );
+    return restored;
+  }
+
+  restored.add(
+    ChatMessage(
+      id: const Uuid().v5(
+        Namespace.url.value,
+        'conduit:hermes-desktop:$sessionId:running',
+      ),
+      role: 'assistant',
+      content: '',
+      timestamp: DateTime.now(),
+      model: modelId,
+      isStreaming: true,
+      metadata: const <String, dynamic>{
+        kHermesRestoredDesktopRunningMetadataKey:
+            _hermesRestoredDesktopPlaceholder,
+      },
+    ),
+  );
+  return restored;
 }
 
 /// Maps a Hermes session's raw message history (`GET /api/sessions/{id}/messages`)

--- a/lib/features/hermes/services/hermes_run_transport.dart
+++ b/lib/features/hermes/services/hermes_run_transport.dart
@@ -261,9 +261,25 @@ Future<bool> dispatchHermesTurn({
           sensitiveValues: sensitiveProviderValues,
         );
       }
+      var eventRunId = responseId;
+      if (event case HermesApprovalRequested(:final raw)) {
+        final rawRunId = raw.containsKey('run_id') ? raw['run_id'] : responseId;
+        eventRunId = _validatedHermesOpaqueIdentifier(
+          rawRunId is String ? rawRunId : null,
+          sensitiveValues: sensitiveProviderValues,
+        );
+        if (eventRunId != null &&
+            !registry.bindRunId(
+              registryKey(),
+              cancelToken: responseCancelToken,
+              runId: eventRunId,
+            )) {
+          eventRunId = null;
+        }
+      }
       _handleEvent(
         event,
-        runId: responseId,
+        runId: eventRunId,
         storedSessionId: responseStream.sessionId,
         sensitiveValues: sensitiveProviderValues,
         appendContent: appendContent,
@@ -1312,8 +1328,8 @@ void _handleEvent(
       :final approvalId,
       :final summary,
       :final choices,
+      :final raw,
     ):
-      if (runId == null) break;
       final safeApprovalId = _validatedHermesOpaqueIdentifier(
         approvalId,
         sensitiveValues: sensitiveValues,
@@ -1342,7 +1358,9 @@ void _handleEvent(
               summary,
               sensitiveValues: sensitiveValues,
             );
-      final safeChoices = _boundedHermesDecisionChoices(choices);
+      final safeChoices = _boundedHermesDecisionChoices(
+        choices.isEmpty ? raw['choices'] : choices,
+      );
       updateMessage((m) {
         final meta = Map<String, dynamic>.from(m.metadata ?? const {});
         meta[kHermesApprovalMeta] = {

--- a/lib/features/hermes/widgets/hermes_session_tile.dart
+++ b/lib/features/hermes/widgets/hermes_session_tile.dart
@@ -14,6 +14,7 @@ import '../../../shared/widgets/sidebar_layout_contract.dart';
 import '../../../shared/widgets/themed_dialogs.dart';
 import '../../chat/providers/chat_providers.dart' show isChatStreamingProvider;
 import '../../navigation/widgets/conversation_tile.dart';
+import '../models/hermes_config.dart';
 import '../models/hermes_model.dart';
 import '../models/hermes_session.dart';
 import '../models/hermes_bot.dart';
@@ -326,7 +327,7 @@ Future<void> openHermesSession(
           connectionIdentity: connectionIdentity,
           sessionId: session.id,
         );
-  final messages =
+  var messages =
       hermesMessagesToChatMessages(
         raw,
         modelId: hermesModel.id,
@@ -337,6 +338,15 @@ Future<void> openHermesSession(
           modelId: hermesModel.id,
         ),
       );
+  if (service is HermesDesktopApiService) {
+    messages = restoreHermesDesktopRunningMessage(
+      messages,
+      sessionId: session.id,
+      modelId: hermesModel.id,
+      isRunning:
+          service.turnStateFor(session.id) == HermesDesktopTurnState.running,
+    );
+  }
 
   ref.read(hermesActiveSessionProvider.notifier).set(session.id);
   // Mark as a manual selection (same as startNewHermesChat) so the default-

--- a/lib/shared/widgets/markdown/markdown_preprocessor.dart
+++ b/lib/shared/widgets/markdown/markdown_preprocessor.dart
@@ -64,6 +64,10 @@ class ConduitMarkdownPreprocessor {
     multiLine: true,
     dotAll: true,
   );
+  static final _attachedToolCallDetailsOpen = RegExp(
+    r'''([^\n])(<details\b(?=[^>]*\btype\s*=\s*["']tool_calls["']))''',
+    caseSensitive: false,
+  );
   static final _codeSpanOrFence = RegExp(r'(`+)([\s\S]*?)\1');
   static final _allDetailsBlocks = RegExp(
     r'<details[^>]*>[\s\S]*?</details>',
@@ -155,6 +159,17 @@ class ConduitMarkdownPreprocessor {
     // Separate consecutive links
     output = _separateConsecutiveLinks(output);
 
+    // Raw model output can attach Open WebUI's tool-call block directly to
+    // answer text. Put it on a Markdown block boundary without rewriting
+    // literal examples inside code spans or fences.
+    if (_attachedToolCallDetailsOpen.hasMatch(output)) {
+      output = _replaceMatchesOutsideCode(
+        output,
+        _attachedToolCallDetailsOpen,
+        (match) => '${match[1]}\n\n${match[2]}',
+      );
+    }
+
     return output;
   }
 
@@ -181,7 +196,8 @@ class ConduitMarkdownPreprocessor {
         .replaceAll('\r\n', '\n')
         .transform(_stripLinkReferenceDefinitions)
         .transform(
-          (content) => _removeMatchesOutsideCode(content, _reasoningBlocks),
+          (content) =>
+              _replaceMatchesOutsideCode(content, _reasoningBlocks, (_) => ''),
         )
         .replaceAll(_multipleNewlines, '\n\n')
         .trim();
@@ -196,7 +212,7 @@ class ConduitMarkdownPreprocessor {
     if (input.isEmpty) return input;
 
     final sanitized = sanitize(input);
-    return _removeMatchesOutsideCode(sanitized, _toolCallBlocks)
+    return _replaceMatchesOutsideCode(sanitized, _toolCallBlocks, (_) => '')
         // Stored assistant content is HTML-escaped for the renderer; the
         // clipboard needs the literal text back (`"` not `&quot;`). API
         // replay deliberately does NOT decode — it cannot distinguish
@@ -252,7 +268,7 @@ class ConduitMarkdownPreprocessor {
   static String removeAllDetails(String input) {
     if (input.isEmpty) return input;
 
-    return _removeMatchesOutsideCode(input, _allDetailsBlocks);
+    return _replaceMatchesOutsideCode(input, _allDetailsBlocks, (_) => '');
   }
 
   /// Breaks long inline code spans for better wrapping.
@@ -338,7 +354,11 @@ class ConduitMarkdownPreprocessor {
   static String _stripLinkReferenceDefinitions(String input) {
     if (!hasLinkReferenceDefinitionLine(input)) return input;
 
-    final stripped = _removeMatchesOutsideCode(input, _linkReferenceDefinition);
+    final stripped = _replaceMatchesOutsideCode(
+      input,
+      _linkReferenceDefinition,
+      (_) => '',
+    );
     return stripped.replaceAll(_multipleNewlines, '\n\n').trim();
   }
 
@@ -346,7 +366,11 @@ class ConduitMarkdownPreprocessor {
     return _openWebUiRemoveFormattings(_removeEmojis(input.trim()));
   }
 
-  static String _removeMatchesOutsideCode(String input, RegExp pattern) {
+  static String _replaceMatchesOutsideCode(
+    String input,
+    RegExp pattern,
+    String Function(Match) replace,
+  ) {
     final codeSpans = <String>[];
     var marker = '\u0000conduit-code-span-';
     while (input.contains(marker)) {
@@ -358,7 +382,7 @@ class ConduitMarkdownPreprocessor {
       codeSpans.add(match[0] ?? '');
       return '$marker$index\u0000';
     });
-    var output = masked.replaceAll(pattern, '');
+    var output = masked.replaceAllMapped(pattern, replace);
 
     // Placeholders inside removed matches no longer exist, so only code from
     // the retained content is restored.

--- a/test/features/chat/providers/chat_messages_notifier_streaming_seams_test.dart
+++ b/test/features/chat/providers/chat_messages_notifier_streaming_seams_test.dart
@@ -5794,6 +5794,46 @@ void main() {
     );
 
     test(
+      'restored Desktop running row stays owned by transcript reconciliation',
+      () async {
+        final service = _RecoveredHermesApi();
+        final container = _testContainer(
+          overrides: [
+            activeConversationProvider.overrideWith(
+              () => _TestActiveConversationNotifier(),
+            ),
+            apiServiceProvider.overrideWithValue(null),
+            socketServiceProvider.overrideWithValue(null),
+            hermesApiServiceProvider.overrideWithValue(service),
+          ],
+        );
+        addTearDown(container.dispose);
+        final assistant = _assistantMessage(
+          id: 'desktop-running-row',
+          content: 'Still working',
+          isStreaming: true,
+          metadata: const <String, dynamic>{
+            'transport': kHermesTransport,
+            'hermesRunId': 'run-desktop',
+            kHermesRestoredDesktopRunningMetadataKey: true,
+          },
+        );
+        final conversation = markNativeHermesConversation(
+          withChatStorageProvenance(
+            _conversation('local:hermes_desktop', <ChatMessage>[assistant]),
+            ChatStorageKind.directLocal,
+          ),
+        );
+
+        container.read(activeConversationProvider.notifier).set(conversation);
+        await pumpEventQueue();
+
+        check(container.read(chatMessagesProvider).single.isStreaming).isTrue();
+        check(service.getRunCalls).equals(0);
+      },
+    );
+
+    test(
       'cold Hermes checkpoint settles when its recovery service is unavailable',
       () async {
         final container = _buildContainer();

--- a/test/features/hermes/hermes_run_transport_test.dart
+++ b/test/features/hermes/hermes_run_transport_test.dart
@@ -378,6 +378,22 @@ void main() {
     expect(identityA, isNot(identityB));
   });
 
+  test('inline run id binding rejects stale response generations', () {
+    final registry = HermesRunRegistry();
+    final key = legacyHermesRunKey('response-message');
+    final staleToken = registry.registerPending(key, onCancelled: () {});
+    final currentToken = registry.registerPending(key, onCancelled: () {});
+
+    check(
+      registry.bindRunId(key, cancelToken: staleToken, runId: 'stale-run'),
+    ).isFalse();
+    check(registry.runIdFor(key)).isNull();
+    check(
+      registry.bindRunId(key, cancelToken: currentToken, runId: 'current-run'),
+    ).isTrue();
+    check(registry.runIdFor(key)).equals('current-run');
+  });
+
   group('dispatchHermesResponse', () {
     test('forwards typed input and response chain context', () async {
       final input = HermesChatInput.multimodal([
@@ -479,6 +495,62 @@ void main() {
           .equals(kHermesResponsesMode);
       check(message.metadata?['hermesResponseId']).equals('resp-1');
       check(message.metadata?['hermesRunId']).isNull();
+    });
+
+    test('binds inline approvals to their run id', () async {
+      final registry = HermesRunRegistry();
+      final runKey = hermesRunKey(
+        ownerConversationId: 'conversation-1',
+        assistantMessageId: 'm',
+      );
+      var message = ChatMessage(
+        id: 'm',
+        role: 'assistant',
+        content: '',
+        timestamp: DateTime.fromMillisecondsSinceEpoch(0),
+      );
+      Object? approvalGeneration;
+      final fake = _FakeHermesApiService(
+        const [],
+        responseEvents: const [
+          HermesApprovalRequested(
+            approvalId: 'approval-1',
+            summary: 'Write the file?',
+            raw: {
+              'run_id': 'run-attachment',
+              'choices': ['once', 'deny'],
+            },
+          ),
+          HermesRunDone(),
+        ],
+      );
+
+      await _dispatchFakeHermesResponse(
+        service: fake,
+        registry: registry,
+        assistantMessageId: message.id,
+        runKey: runKey,
+        input: HermesChatInput.text('hello'),
+        appendContent: (_) {},
+        appendStatus: (_) {},
+        updateMessage: (updater) {
+          message = updater(message);
+          if (message.metadata?[kHermesApprovalMeta] != null) {
+            approvalGeneration = registry.generationTokenFor(
+              runKey,
+              runId: 'run-attachment',
+            );
+          }
+        },
+        finishStreaming: () {},
+        completeStreamingUi: () {},
+      );
+
+      final approval = message.metadata?[kHermesApprovalMeta] as Map;
+      check(approval['runId']).equals('run-attachment');
+      check(approval['approvalId']).equals('approval-1');
+      check(approval['choices'] as List<Object?>).deepEquals(['once', 'deny']);
+      check(approvalGeneration).isNotNull();
     });
 
     test('routes Desktop slash prefill back to the composer', () async {

--- a/test/features/hermes/hermes_run_transport_test.dart
+++ b/test/features/hermes/hermes_run_transport_test.dart
@@ -392,6 +392,10 @@ void main() {
       registry.bindRunId(key, cancelToken: currentToken, runId: 'current-run'),
     ).isTrue();
     check(registry.runIdFor(key)).equals('current-run');
+    check(
+      registry.bindRunId(key, cancelToken: currentToken, runId: 'other-run'),
+    ).isFalse();
+    check(registry.runIdFor(key)).equals('current-run');
   });
 
   group('dispatchHermesResponse', () {

--- a/test/features/hermes/hermes_sessions_test.dart
+++ b/test/features/hermes/hermes_sessions_test.dart
@@ -293,6 +293,37 @@ void main() {
   });
 
   group('hermesMessagesToChatMessages', () {
+    test('restores a running Desktop assistant after a cold open', () {
+      final restoredAssistant = restoreHermesDesktopRunningMessage(
+        hermesMessagesToChatMessages([
+          {'id': 'assistant-1', 'role': 'assistant', 'content': 'Working'},
+        ]),
+        sessionId: 'session-1',
+        modelId: 'hermes:agent:default',
+        isRunning: true,
+      );
+      final restoredPlaceholder = restoreHermesDesktopRunningMessage(
+        hermesMessagesToChatMessages([
+          {'id': 'user-1', 'role': 'user', 'content': 'Start work'},
+        ]),
+        sessionId: 'session-2',
+        modelId: 'hermes:agent:default',
+        isRunning: true,
+      );
+
+      check(restoredAssistant.single.isStreaming).isTrue();
+      check(isRestoredHermesDesktopRunningMessage(restoredAssistant.single))
+          .isTrue();
+      check(restoredPlaceholder)
+          .has((messages) => messages.length, 'length')
+          .equals(2);
+      check(restoredPlaceholder.last.role).equals('assistant');
+      check(restoredPlaceholder.last.content).isEmpty();
+      check(restoredPlaceholder.last.isStreaming).isTrue();
+      check(isRestoredHermesDesktopRunningPlaceholder(restoredPlaceholder.last))
+          .isTrue();
+    });
+
     test('replaces null and empty message ids with non-empty UUIDs', () {
       final messages = hermesMessagesToChatMessages([
         {'id': null, 'role': 'user', 'content': 'Null id'},

--- a/test/features/hermes/hermes_sessions_test.dart
+++ b/test/features/hermes/hermes_sessions_test.dart
@@ -310,6 +310,18 @@ void main() {
         modelId: 'hermes:agent:default',
         isRunning: true,
       );
+      final restoredDecision = restoreHermesDesktopRunningMessage(
+        [
+          hermesMessagesToChatMessages([
+            {'id': 'decision-1', 'role': 'assistant', 'content': 'Approve?'},
+          ]).single.copyWith(
+            metadata: const <String, dynamic>{'restoredDesktopDecision': true},
+          ),
+        ],
+        sessionId: 'session-3',
+        modelId: 'hermes:agent:default',
+        isRunning: true,
+      );
 
       check(restoredAssistant.single.isStreaming).isTrue();
       check(isRestoredHermesDesktopRunningMessage(restoredAssistant.single))
@@ -321,6 +333,12 @@ void main() {
       check(restoredPlaceholder.last.content).isEmpty();
       check(restoredPlaceholder.last.isStreaming).isTrue();
       check(isRestoredHermesDesktopRunningPlaceholder(restoredPlaceholder.last))
+          .isTrue();
+      check(restoredDecision)
+          .has((messages) => messages.length, 'length')
+          .equals(2);
+      check(restoredDecision.first.isStreaming).isFalse();
+      check(isRestoredHermesDesktopRunningPlaceholder(restoredDecision.last))
           .isTrue();
     });
 

--- a/test/shared/widgets/markdown/markdown_preprocessor_test.dart
+++ b/test/shared/widgets/markdown/markdown_preprocessor_test.dart
@@ -65,6 +65,16 @@ void main() {
       // Should add a blank line between the bold text and the dashes.
       check(result).contains('**Bold**\n\n');
     });
+
+    test('separates attached tool-call details outside code', () {
+      const details = '<details type="tool_calls" done="true"></details>';
+      final result = ConduitMarkdownPreprocessor.normalize(
+        'Answer$details\n\n`Example$details`',
+      );
+
+      check(result).contains('Answer\n\n$details');
+      check(result).contains('`Example$details`');
+    });
   });
 
   group('ConduitMarkdownPreprocessor.sanitize', () {

--- a/test/shared/widgets/markdown/renderer/streaming_markdown_widget_test.dart
+++ b/test/shared/widgets/markdown/renderer/streaming_markdown_widget_test.dart
@@ -2175,7 +2175,7 @@ After
         'arguments="{&quot;url&quot;:&quot;https://example.com&quot;}" '
         'result="&quot;done&quot;">\n</details>';
 
-    await tester.pumpWidget(buildHarness(content));
+    await tester.pumpWidget(buildHarness(content, isStreaming: true));
 
     expect(find.text('View Result from fetch_url'), findsOneWidget);
     expect(find.textContaining('<details'), findsNothing);

--- a/test/shared/widgets/markdown/renderer/streaming_markdown_widget_test.dart
+++ b/test/shared/widgets/markdown/renderer/streaming_markdown_widget_test.dart
@@ -2167,6 +2167,20 @@ After
     },
   );
 
+  testWidgets('renders a tool-call block attached to raw streamed text', (
+    tester,
+  ) async {
+    const content =
+        'Before<details type="tool_calls" done="true" name="fetch_url" '
+        'arguments="{&quot;url&quot;:&quot;https://example.com&quot;}" '
+        'result="&quot;done&quot;">\n</details>';
+
+    await tester.pumpWidget(buildHarness(content));
+
+    expect(find.text('View Result from fetch_url'), findsOneWidget);
+    expect(find.textContaining('<details'), findsNothing);
+  });
+
   testWidgets(
     'uses tool call body content as structured output without leaking raw text',
     (tester) async {


### PR DESCRIPTION
## Summary

- render raw Open WebUI `<details type="tool_calls">` blocks received through streamed content deltas
- route `/v1/responses` approval requests through the same Hermes approval projection used by runs
- restore the session-tile spinner, assistant shimmer, and typing orbit when a running Hermes Desktop session is opened after a cold launch
- keep restored Desktop turns owned by authoritative transcript reconciliation instead of `/v1/runs` checkpoint recovery

## Testing

- `flutter test test/features/hermes/hermes_run_transport_test.dart`
- `flutter test test/shared/widgets/markdown/markdown_preprocessor_test.dart test/shared/widgets/markdown/renderer/streaming_markdown_widget_test.dart`
- `flutter test test/features/hermes/hermes_sessions_test.dart`
- `flutter test test/features/hermes/hermes_session_tile_test.dart test/features/chat/providers/chat_messages_notifier_streaming_seams_test.dart`
- `flutter test test/features/chat/views/chat_timeline_render_model_test.dart test/features/chat/widgets/streaming_turn_footer_test.dart`
- targeted `flutter analyze` for affected files
- production iOS simulator build and verifier doctor

Closes #675
Closes #677

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved restoration of active Desktop assistant sessions after reopening, preserving the visible running state.
  * Approval requests now retain their associated run information and choices more reliably.
  * Improved rendering of tool-call details attached directly to streamed text.

* **Bug Fixes**
  * Prevented restored running messages from entering unnecessary recovery flows.
  * Improved handling of stale or invalid approval events.
  * Preserved tool-call formatting inside code spans and code fences.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->



<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This update associates Hermes approvals with the active run, restores visible running state when reopening active Desktop sessions, and formats attached streamed tool-call details as structured Markdown content.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

No blocking failure remains.

No blocking failure remains.
</details>


<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex attempted to run the test suite as part of contract validation to exercise the Flutter/Dart tests.
- The attempt ended in command startup failure before Flutter/Dart could execute any tests, and no severity-bearing proof was available.

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (2): Last reviewed commit: ["Address PR review feedback"](https://github.com/cogwheel0/conduit/commit/cb85a4e23d6ae3ea9be1fa42a136a18dc2b85d3a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57831886)</sub>

<!-- /greptile_comment -->