### PR TITLE
Add Mac desktop UX and chat scrollbars

### DIFF
--- a/ios/Runner/AppDelegate.swift
+++ b/ios/Runner/AppDelegate.swift
@@ -17,6 +17,7 @@ private let conduitShareAppGroupIdKey = "AppGroupId"
 private let conduitVoiceAudioRouteChannelName = "app.cogwheel.conduit/voice_audio_route"
 private let nativeIosTtsMethodChannelName = "app.cogwheel.conduit/native_ios_tts"
 private let nativeIosTtsEventChannelName = "app.cogwheel.conduit/native_ios_tts/events"
+private let platformEnvironmentChannelName = "app.cogwheel.conduit/platform_environment"
 
 func nativeSharedPayloadTypeIsText(_ type: Any?) -> Bool {
   if let type = type as? String {
@@ -2608,6 +2609,18 @@ private func cookieIsPreferred(
   private func configureApplicationFlutterChannels(
     messenger: FlutterBinaryMessenger
   ) {
+    let platformEnvironmentChannel = FlutterMethodChannel(
+      name: platformEnvironmentChannelName,
+      binaryMessenger: messenger
+    )
+    platformEnvironmentChannel.setMethodCallHandler { call, result in
+      guard call.method == "isIOSAppOnMac" else {
+        result(FlutterMethodNotImplemented)
+        return
+      }
+      result(ProcessInfo.processInfo.isiOSAppOnMac)
+    }
+
     AppIntentBridge.shared = AppIntentBridge(messenger: messenger)
     ConduitCarPlayBridge.shared.configure(messenger: messenger)
     NativePasteBridge.shared.configure(messenger: messenger)

--- a/lib/features/chat/views/chat_page.dart
+++ b/lib/features/chat/views/chat_page.dart
@@ -7,7 +7,7 @@ import '../../../shared/theme/theme_extensions.dart';
 import '../../../shared/utils/platform_scroll_physics.dart';
 
 import 'package:flutter/services.dart';
-import 'package:flutter/foundation.dart' show listEquals;
+import 'package:flutter/foundation.dart' show listEquals, visibleForTesting;
 import 'package:conduit/core/services/haptic_service.dart';
 import 'package:cupertino_ui/cupertino_ui.dart';
 import 'package:flutter/rendering.dart' show ScrollCacheExtent;
@@ -95,6 +95,12 @@ import 'chat_turn_render_state.dart';
 import '../widgets/streaming_turn_footer.dart';
 import '../widgets/openwebui_prompt_overlay.dart';
 import '../widgets/chat_timeline_viewport.dart';
+
+@visibleForTesting
+bool? chatResizeToAvoidBottomInset({
+  required bool isAndroid,
+  required bool isIOSAppOnMac,
+}) => isAndroid || isIOSAppOnMac ? false : null;
 
 /// Keeps the assistant row's element ancestry identical while it moves from
 /// the live-tail slot into stable history. This matters for generated images:
@@ -4026,7 +4032,10 @@ class _ChatPageState extends ConsumerState<ChatPage> {
         );
       },
       child: AdaptiveScaffold(
-        resizeToAvoidBottomInset: Platform.isAndroid ? false : null,
+        resizeToAvoidBottomInset: chatResizeToAvoidBottomInset(
+          isAndroid: Platform.isAndroid,
+          isIOSAppOnMac: PlatformInfo.isIOSAppOnMac,
+        ),
         // Replace Scaffold drawer with a tunable slide drawer for gentler snap behavior.
         drawerEnableOpenDragGesture: false,
         extendBodyBehindAppBar: true,

--- a/lib/features/chat/widgets/chat_timeline_viewport.dart
+++ b/lib/features/chat/widgets/chat_timeline_viewport.dart
@@ -1,6 +1,8 @@
 import 'dart:async';
 import 'dart:math' as math;
 
+import 'package:conduit/shared/widgets/platform_ui/platform_ui.dart';
+import 'package:cupertino_ui/cupertino_ui.dart';
 import 'package:flutter/foundation.dart' show listEquals, visibleForTesting;
 import 'package:material_ui/material_ui.dart';
 import 'package:flutter/rendering.dart'
@@ -2021,6 +2023,10 @@ class _ChatTimelineViewportState extends State<ChatTimelineViewport>
       ),
     );
 
+    final scrollableTranscript = PlatformInfo.isIOS
+        ? CupertinoScrollbar(controller: _scrollController, child: transcript)
+        : Scrollbar(controller: _scrollController, child: transcript);
+
     return Stack(
       key: _viewportKey,
       children: [
@@ -2033,7 +2039,7 @@ class _ChatTimelineViewportState extends State<ChatTimelineViewport>
               child: IgnorePointer(
                 key: const ValueKey<String>('sliver-transcript-interaction'),
                 ignoring: shouldHide,
-                child: transcript,
+                child: scrollableTranscript,
               ),
             ),
           ),

--- a/lib/features/navigation/providers/sidebar_search_providers.dart
+++ b/lib/features/navigation/providers/sidebar_search_providers.dart
@@ -1,4 +1,5 @@
 import 'package:material_ui/material_ui.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 part 'sidebar_search_providers.g.dart';
@@ -25,4 +26,18 @@ FocusNode sidebarSearchFieldFocusNode(Ref ref) {
   final node = FocusNode(debugLabel: 'sidebar_header_search');
   ref.onDispose(node.dispose);
   return node;
+}
+
+void openSidebarSearch(WidgetRef ref) {
+  ref.read(sidebarHeaderSearchExpandedProvider.notifier).setExpanded(true);
+  final focusNode = ref.read(sidebarSearchFieldFocusNodeProvider);
+  WidgetsBinding.instance.addPostFrameCallback((_) {
+    if (focusNode.context != null) focusNode.requestFocus();
+  });
+}
+
+void closeSidebarSearch(WidgetRef ref) {
+  ref.read(sidebarSearchFieldControllerProvider).clear();
+  ref.read(sidebarSearchFieldFocusNodeProvider).unfocus();
+  ref.read(sidebarHeaderSearchExpandedProvider.notifier).setExpanded(false);
 }

--- a/lib/features/navigation/widgets/conversation_tile.dart
+++ b/lib/features/navigation/widgets/conversation_tile.dart
@@ -2,6 +2,7 @@ import 'dart:io' show Platform;
 
 import 'package:cupertino_ui/cupertino_ui.dart';
 import 'package:material_ui/material_ui.dart';
+import 'package:flutter/services.dart';
 
 import '../../../shared/theme/theme_extensions.dart';
 
@@ -131,6 +132,8 @@ class ChatStyleSidebarTile extends StatefulWidget {
 
 class _ChatStyleSidebarTileState extends State<ChatStyleSidebarTile> {
   bool _pressed = false;
+  bool _hovered = false;
+  bool _focused = false;
 
   void _setPressed(bool pressed) {
     if (_pressed == pressed) return;
@@ -140,14 +143,17 @@ class _ChatStyleSidebarTileState extends State<ChatStyleSidebarTile> {
   @override
   void didUpdateWidget(covariant ChatStyleSidebarTile oldWidget) {
     super.didUpdateWidget(oldWidget);
-    if ((!widget.enabled || widget.onTap == null) && _pressed) {
+    if (!widget.enabled || widget.onTap == null) {
       _pressed = false;
+      _hovered = false;
+      _focused = false;
     }
   }
 
   @override
   Widget build(BuildContext context) {
     final effectiveEnabled = widget.enabled && widget.onTap != null;
+    final highlighted = _pressed || _hovered || _focused;
     return Semantics(
       button: true,
       selected: widget.selected,
@@ -159,20 +165,46 @@ class _ChatStyleSidebarTileState extends State<ChatStyleSidebarTile> {
         child: ConversationTileSurface(
           theme: context.conduitTheme,
           selected: widget.selected,
-          pressed: _pressed,
+          pressed: highlighted,
           tintKey: widget.tintKey,
           pressedKey: widget.pressedKey,
-          child: Listener(
-            behavior: HitTestBehavior.opaque,
-            onPointerDown: effectiveEnabled ? (_) => _setPressed(true) : null,
-            onPointerUp: effectiveEnabled ? (_) => _setPressed(false) : null,
-            onPointerCancel: effectiveEnabled
-                ? (_) => _setPressed(false)
-                : null,
-            child: GestureDetector(
+          child: FocusableActionDetector(
+            enabled: effectiveEnabled,
+            mouseCursor: effectiveEnabled
+                ? SystemMouseCursors.click
+                : MouseCursor.defer,
+            shortcuts: const <ShortcutActivator, Intent>{
+              SingleActivator(LogicalKeyboardKey.enter): ActivateIntent(),
+              SingleActivator(LogicalKeyboardKey.space): ActivateIntent(),
+            },
+            actions: <Type, Action<Intent>>{
+              ActivateIntent: CallbackAction<ActivateIntent>(
+                onInvoke: (_) {
+                  widget.onTap?.call();
+                  return null;
+                },
+              ),
+            },
+            onShowHoverHighlight: (value) {
+              if (_hovered == value) return;
+              setState(() => _hovered = value);
+            },
+            onShowFocusHighlight: (value) {
+              if (_focused == value) return;
+              setState(() => _focused = value);
+            },
+            child: Listener(
               behavior: HitTestBehavior.opaque,
-              onTap: effectiveEnabled ? widget.onTap : null,
-              child: widget.child,
+              onPointerDown: effectiveEnabled ? (_) => _setPressed(true) : null,
+              onPointerUp: effectiveEnabled ? (_) => _setPressed(false) : null,
+              onPointerCancel: effectiveEnabled
+                  ? (_) => _setPressed(false)
+                  : null,
+              child: GestureDetector(
+                behavior: HitTestBehavior.opaque,
+                onTap: effectiveEnabled ? widget.onTap : null,
+                child: widget.child,
+              ),
             ),
           ),
         ),

--- a/lib/features/navigation/widgets/drawer_shell_page.dart
+++ b/lib/features/navigation/widgets/drawer_shell_page.dart
@@ -122,8 +122,11 @@ class MacDesktopShortcuts extends ConsumerWidget {
 
     return CallbackShortcuts(
       bindings: <ShortcutActivator, VoidCallback>{
-        const SingleActivator(LogicalKeyboardKey.keyN, meta: true):
-            createForActiveTab,
+        const SingleActivator(
+          LogicalKeyboardKey.keyN,
+          meta: true,
+          includeRepeats: false,
+        ): createForActiveTab,
         const SingleActivator(LogicalKeyboardKey.keyK, meta: true):
             focusSidebarSearch,
         const SingleActivator(LogicalKeyboardKey.digit1, meta: true): () =>

--- a/lib/features/navigation/widgets/drawer_shell_page.dart
+++ b/lib/features/navigation/widgets/drawer_shell_page.dart
@@ -1,17 +1,22 @@
+import 'dart:async';
 import 'dart:io' show Platform;
 
 import 'package:material_ui/material_ui.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter/services.dart';
 
+import '../../../core/services/navigation_service.dart';
 import '../../../core/services/haptic_service.dart';
 import '../../../l10n/app_localizations.dart';
 import '../../../shared/theme/theme_extensions.dart';
 import '../../../shared/widgets/sidebar_layout_constants.dart';
+import '../../../shared/widgets/platform_ui/platform_ui.dart';
 import '../../chat/providers/chat_providers.dart';
 import '../providers/sidebar_providers.dart';
 import 'responsive_drawer_layout.dart';
 import '../../../shared/widgets/sidebar_layout_contract.dart';
 import 'sidebar_page.dart';
+import 'sidebar_tab_registry.dart';
 
 /// Shell widget that wraps child routes with a persistent
 /// [ResponsiveDrawerLayout] + [SidebarPage] drawer.
@@ -66,6 +71,75 @@ class DrawerShellPage extends ConsumerWidget {
         } catch (_) {}
       },
       drawer: const SidebarPage(),
+      layoutBuilder: (layout) => MacDesktopShortcuts(child: layout),
+      child: child,
+    );
+  }
+}
+
+class MacDesktopShortcuts extends ConsumerWidget {
+  const MacDesktopShortcuts({super.key, required this.child});
+
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    if (!PlatformInfo.isIOSAppOnMac) return child;
+
+    void createForActiveTab() {
+      final navigation = ref.read(sidebarNavigationSnapshotProvider);
+      final action = sidebarTabDescriptor(navigation.selectedTab).createAction;
+      if (action != null) unawaited(action.run(context, ref));
+    }
+
+    void focusSidebarSearch() {
+      final drawer = SidebarDrawerControllerScope.maybeOf(context);
+      if (drawer?.isOpen == false) drawer?.open();
+      openSidebarSearch(ref);
+    }
+
+    void dismissDesktopLayer() {
+      if (ref.read(sidebarHeaderSearchExpandedProvider)) {
+        closeSidebarSearch(ref);
+        return;
+      }
+      final drawer = SidebarDrawerControllerScope.maybeOf(context);
+      if (!usesPersistentTabletSidebar(context) && drawer?.isOpen == true) {
+        drawer?.close();
+        return;
+      }
+      FocusManager.instance.primaryFocus?.unfocus();
+    }
+
+    void openSettings() {
+      final path = Uri.tryParse(NavigationService.currentRoute ?? '')?.path;
+      if (path == Routes.profile ||
+          path?.startsWith('${Routes.profile}/') == true) {
+        return;
+      }
+      unawaited(NavigationService.pushTo(Routes.profile));
+    }
+
+    return CallbackShortcuts(
+      bindings: <ShortcutActivator, VoidCallback>{
+        const SingleActivator(LogicalKeyboardKey.keyN, meta: true):
+            createForActiveTab,
+        const SingleActivator(LogicalKeyboardKey.keyK, meta: true):
+            focusSidebarSearch,
+        const SingleActivator(LogicalKeyboardKey.digit1, meta: true): () =>
+            selectSidebarTab(context, ref, 0),
+        const SingleActivator(LogicalKeyboardKey.digit2, meta: true): () =>
+            selectSidebarTab(context, ref, 1),
+        const SingleActivator(LogicalKeyboardKey.digit3, meta: true): () =>
+            selectSidebarTab(context, ref, 2),
+        const SingleActivator(LogicalKeyboardKey.digit4, meta: true): () =>
+            selectSidebarTab(context, ref, 3),
+        const SingleActivator(LogicalKeyboardKey.digit5, meta: true): () =>
+            selectSidebarTab(context, ref, 4),
+        const SingleActivator(LogicalKeyboardKey.comma, meta: true):
+            openSettings,
+        const SingleActivator(LogicalKeyboardKey.escape): dismissDesktopLayer,
+      },
       child: child,
     );
   }

--- a/lib/features/navigation/widgets/responsive_drawer_layout.dart
+++ b/lib/features/navigation/widgets/responsive_drawer_layout.dart
@@ -30,6 +30,7 @@ enum _DrawerSettleEndpoint { open, closed }
 class ResponsiveDrawerLayout extends StatefulWidget {
   final Widget child;
   final Widget drawer;
+  final Widget Function(Widget child)? layoutBuilder;
 
   // Mobile-specific configuration
   final double maxFraction; // 0..1 of screen width for mobile drawer
@@ -58,6 +59,7 @@ class ResponsiveDrawerLayout extends StatefulWidget {
     super.key,
     required this.child,
     required this.drawer,
+    this.layoutBuilder,
     this.maxFraction = 0.84,
     this.edgeFraction = 0.5,
     this.settleFraction = 0.12,
@@ -724,12 +726,13 @@ class ResponsiveDrawerLayoutState extends State<ResponsiveDrawerLayout>
     final layout = isTablet
         ? _buildTabletLayout(theme)
         : _buildMobileLayout(theme, scrim);
+    final scopedLayout = HorizontalGesturePriorityScope(
+      buildPrioritizedGestureArena: _buildPrioritizedDrawerGestureArena,
+      child: layout,
+    );
     return SidebarDrawerControllerScope(
       controller: this,
-      child: HorizontalGesturePriorityScope(
-        buildPrioritizedGestureArena: _buildPrioritizedDrawerGestureArena,
-        child: layout,
-      ),
+      child: widget.layoutBuilder?.call(scopedLayout) ?? scopedLayout,
     );
   }
 

--- a/lib/features/navigation/widgets/sidebar_page.dart
+++ b/lib/features/navigation/widgets/sidebar_page.dart
@@ -27,6 +27,40 @@ const double _kSidebarSearchFieldReserve = 96;
 // Mirrors Conduit platform UI's iPadOS window-control reservation.
 const double _kSidebarWindowedLeadingInset = 62;
 
+@visibleForTesting
+double resolveSidebarWindowedLeadingInset({
+  required bool usesNativeIOS26Chrome,
+  required bool isWindowed,
+  required bool isIOSAppOnMac,
+}) => usesNativeIOS26Chrome && isWindowed && !isIOSAppOnMac
+    ? _kSidebarWindowedLeadingInset
+    : 0;
+
+void selectSidebarTab(BuildContext context, WidgetRef ref, int index) {
+  final navigation = ref.read(sidebarNavigationSnapshotProvider);
+  if (index < 0 || index >= navigation.tabs.length) return;
+
+  final selectedTab = sidebarTabDescriptor(navigation.tabs[index]);
+  if (selectedTab.id == navigation.selectedTab) {
+    if (navigation.isLegacySelection) {
+      ref.read(sidebarActiveTabProvider.notifier).set(selectedTab.id);
+    }
+    unawaited(
+      ref
+          .read(sidebarTabScrollRegistryProvider)
+          .scrollToTop(
+            selectedTab.id,
+            duration: context.motionDuration(AnimationDuration.fast),
+          ),
+    );
+    return;
+  }
+
+  sidebarTabDescriptor(navigation.selectedTab).behavior.onDeselected(ref);
+  ref.read(sidebarActiveTabProvider.notifier).set(selectedTab.id);
+  selectedTab.behavior.onSelected(ref);
+}
+
 class _SidebarNavigationItem {
   const _SidebarNavigationItem({
     required this.label,
@@ -301,20 +335,6 @@ class _SidebarPageState extends ConsumerState<SidebarPage> {
     ];
   }
 
-  void _openSidebarSearch() {
-    ref.read(sidebarHeaderSearchExpandedProvider.notifier).setExpanded(true);
-    WidgetsBinding.instance.addPostFrameCallback((_) {
-      if (!mounted) return;
-      ref.read(sidebarSearchFieldFocusNodeProvider).requestFocus();
-    });
-  }
-
-  void _closeSidebarSearch() {
-    ref.read(sidebarSearchFieldControllerProvider).clear();
-    ref.read(sidebarSearchFieldFocusNodeProvider).unfocus();
-    ref.read(sidebarHeaderSearchExpandedProvider.notifier).setExpanded(false);
-  }
-
   Widget _sidebarAppBarLeading({
     required AppLocalizations localizations,
     required bool isSearchExpanded,
@@ -358,7 +378,7 @@ class _SidebarPageState extends ConsumerState<SidebarPage> {
           iosSymbol: 'xmark',
           icon: UiUtils.closeIcon,
           tintColor: defaultTint,
-          onPressed: _closeSidebarSearch,
+          onPressed: () => closeSidebarSearch(ref),
         ),
       ];
     }
@@ -374,7 +394,7 @@ class _SidebarPageState extends ConsumerState<SidebarPage> {
         iosSymbol: 'magnifyingglass',
         icon: Icons.search,
         tintColor: defaultTint,
-        onPressed: _openSidebarSearch,
+        onPressed: () => openSidebarSearch(ref),
       ),
       ...contextualActions,
       if (createAction != null)
@@ -467,7 +487,6 @@ class _SidebarPageState extends ConsumerState<SidebarPage> {
       context,
     );
     final hasBottomNavigationBar = hasMultipleTabs;
-    final activeTabNotifier = ref.read(sidebarActiveTabProvider.notifier);
     final activeIndex = navigation.selectedIndex;
     final navigationItems = _sidebarNavigationItems(
       tabs,
@@ -491,25 +510,7 @@ class _SidebarPageState extends ConsumerState<SidebarPage> {
 
     void onTap(int index) {
       ConduitHaptics.selectionClick();
-      final selectedTab = tabs[index];
-      if (index == activeIndex) {
-        if (navigation.isLegacySelection) {
-          activeTabNotifier.set(selectedTab.id);
-        }
-        unawaited(
-          ref
-              .read(sidebarTabScrollRegistryProvider)
-              .scrollToTop(
-                selectedTab.id,
-                duration: context.motionDuration(AnimationDuration.fast),
-              ),
-        );
-        return;
-      }
-      final previousTab = tabs[activeIndex];
-      previousTab.behavior.onDeselected(ref);
-      ref.read(sidebarActiveTabProvider.notifier).set(selectedTab.id);
-      selectedTab.behavior.onSelected(ref);
+      selectSidebarTab(context, ref, index);
     }
 
     final sidebarTabStack = _SidebarTabStack(
@@ -541,10 +542,11 @@ class _SidebarPageState extends ConsumerState<SidebarPage> {
           final toolbarWidth = constraints.hasBoundedWidth
               ? constraints.maxWidth
               : MediaQuery.sizeOf(context).width;
-          final windowedLeadingInset =
-              useNativeIos26Chrome && _isWindowed(context)
-              ? _kSidebarWindowedLeadingInset
-              : 0.0;
+          final windowedLeadingInset = resolveSidebarWindowedLeadingInset(
+            usesNativeIOS26Chrome: useNativeIos26Chrome,
+            isWindowed: _isWindowed(context),
+            isIOSAppOnMac: PlatformInfo.isIOSAppOnMac,
+          );
           final appBarLeading = _sidebarAppBarLeading(
             localizations: localizations,
             isSearchExpanded: isSearchExpanded,

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -200,6 +200,7 @@ void main() {
       );
       final hiveBoxesFuture = HiveBootstrap.instance.ensureInitialized();
       final preferencesFuture = PreferencesStore.ensureInitialized();
+      final platformUiFuture = PlatformUiCapabilities.initialize();
 
       try {
         await QuickActionsBootstrap.initialize();
@@ -219,6 +220,8 @@ void main() {
       _startupTimeline?.instant('hive_ready');
       await preferencesFuture;
       _startupTimeline?.instant('prefs_ready');
+      await platformUiFuture;
+      _startupTimeline?.instant('platform_ui_ready');
 
       // Run migration checks (fast-pathed after first run).
       final migrator = PersistenceMigrator(hiveBoxes: hiveBoxes);

--- a/lib/shared/utils/conversation_context_menu.dart
+++ b/lib/shared/utils/conversation_context_menu.dart
@@ -75,26 +75,38 @@ class _ConduitContextMenuState extends State<ConduitContextMenu> {
       return widget.child;
     }
 
+    final adaptiveActions = [
+      for (final action in widget.actions)
+        AdaptiveContextMenuAction(
+          title: action.label,
+          icon: action.materialIcon,
+          isDestructive: action.destructive,
+          onPressed: () {
+            ConduitHaptics.selectionClick();
+            action.onBeforeClose?.call();
+            action.onSelected();
+          },
+        ),
+    ];
+
     if (PlatformInfo.isIOS) {
-      return _buildCupertinoContextMenu(context);
+      return GestureDetector(
+        behavior: HitTestBehavior.translucent,
+        onSecondaryTapDown: (details) => showAdaptiveContextMenu(
+          context: context,
+          actions: adaptiveActions,
+          globalAnchor: Rect.fromLTWH(
+            details.globalPosition.dx,
+            details.globalPosition.dy,
+            0,
+            0,
+          ),
+        ),
+        child: _buildCupertinoContextMenu(context),
+      );
     }
 
-    return AdaptiveContextMenu(
-      actions: [
-        for (final action in widget.actions)
-          AdaptiveContextMenuAction(
-            title: action.label,
-            icon: action.materialIcon,
-            isDestructive: action.destructive,
-            onPressed: () {
-              ConduitHaptics.selectionClick();
-              action.onBeforeClose?.call();
-              action.onSelected();
-            },
-          ),
-      ],
-      child: widget.child,
-    );
+    return AdaptiveContextMenu(actions: adaptiveActions, child: widget.child);
   }
 
   Widget _buildCupertinoContextMenu(BuildContext context) {

--- a/lib/shared/widgets/platform_ui/src/adaptive_layout.dart
+++ b/lib/shared/widgets/platform_ui/src/adaptive_layout.dart
@@ -746,6 +746,38 @@ class AdaptiveContextMenuAction {
   final bool isDisabled;
 }
 
+Future<void> showAdaptiveContextMenu({
+  required BuildContext context,
+  required List<AdaptiveContextMenuAction> actions,
+  required Rect globalAnchor,
+}) async {
+  final overlayObject = Overlay.of(context).context.findRenderObject();
+  if (overlayObject is! RenderBox || !overlayObject.attached) return;
+
+  final anchor = Rect.fromPoints(
+    overlayObject.globalToLocal(globalAnchor.topLeft),
+    overlayObject.globalToLocal(globalAnchor.bottomRight),
+  );
+  final selected = await showMenu<int>(
+    context: context,
+    position: RelativeRect.fromRect(anchor, Offset.zero & overlayObject.size),
+    items: [
+      for (var index = 0; index < actions.length; index++)
+        PopupMenuItem<int>(
+          value: index,
+          enabled: !actions[index].isDisabled,
+          child: Text(
+            actions[index].title,
+            style: actions[index].isDestructive
+                ? const TextStyle(color: Colors.red)
+                : null,
+          ),
+        ),
+    ],
+  );
+  if (selected != null) actions[selected].onPressed();
+}
+
 class AdaptiveContextMenu extends StatelessWidget {
   const AdaptiveContextMenu({
     super.key,
@@ -782,44 +814,30 @@ class AdaptiveContextMenu extends StatelessWidget {
       );
     }
     return GestureDetector(
-      onLongPress: () async {
+      onSecondaryTapDown: (details) => showAdaptiveContextMenu(
+        context: context,
+        actions: actions,
+        globalAnchor: Rect.fromLTWH(
+          details.globalPosition.dx,
+          details.globalPosition.dy,
+          0,
+          0,
+        ),
+      ),
+      onLongPress: () {
         final renderObject = context.findRenderObject();
-        final overlayObject = Overlay.of(context).context.findRenderObject();
-        if (renderObject is! RenderBox ||
-            overlayObject is! RenderBox ||
-            !renderObject.attached ||
-            !overlayObject.attached) {
+        if (renderObject is! RenderBox || !renderObject.attached) {
           return;
         }
-        final topLeft = renderObject.localToGlobal(
-          Offset.zero,
-          ancestor: overlayObject,
-        );
+        final topLeft = renderObject.localToGlobal(Offset.zero);
         final bottomRight = renderObject.localToGlobal(
           renderObject.size.bottomRight(Offset.zero),
-          ancestor: overlayObject,
         );
-        final selected = await showMenu<int>(
+        showAdaptiveContextMenu(
           context: context,
-          position: RelativeRect.fromRect(
-            Rect.fromPoints(topLeft, bottomRight),
-            Offset.zero & overlayObject.size,
-          ),
-          items: [
-            for (var index = 0; index < actions.length; index++)
-              PopupMenuItem<int>(
-                value: index,
-                enabled: !actions[index].isDisabled,
-                child: Text(
-                  actions[index].title,
-                  style: actions[index].isDestructive
-                      ? const TextStyle(color: Colors.red)
-                      : null,
-                ),
-              ),
-          ],
+          actions: actions,
+          globalAnchor: Rect.fromPoints(topLeft, bottomRight),
         );
-        if (selected != null) actions[selected].onPressed();
       },
       child: child,
     );

--- a/lib/shared/widgets/platform_ui/src/platform_ui_capabilities.dart
+++ b/lib/shared/widgets/platform_ui/src/platform_ui_capabilities.dart
@@ -1,11 +1,19 @@
 import 'package:cupertino_native_better/cupertino_native_better.dart';
 import 'package:flutter/foundation.dart';
+import 'package:flutter/services.dart';
 
 import 'operating_system_version_stub.dart'
     if (dart.library.io) 'operating_system_version_io.dart';
 
 /// Central capability gate for Conduit's platform UI compatibility layer.
 abstract final class PlatformUiCapabilities {
+  static const _platformEnvironmentChannel = MethodChannel(
+    'app.cogwheel.conduit/platform_environment',
+  );
+
+  static Future<void>? _initialization;
+  static bool _isIOSAppOnMac = false;
+
   @visibleForTesting
   static TargetPlatform? debugPlatformOverride;
 
@@ -15,11 +23,33 @@ abstract final class PlatformUiCapabilities {
   @visibleForTesting
   static bool? debugNativeIOS26Override;
 
+  @visibleForTesting
+  static bool? debugIOSAppOnMacOverride;
+
   static TargetPlatform get platform =>
       debugPlatformOverride ?? defaultTargetPlatform;
 
   static bool get isIOS => !kIsWeb && platform == TargetPlatform.iOS;
   static bool get isAndroid => !kIsWeb && platform == TargetPlatform.android;
+
+  static bool get isIOSAppOnMac =>
+      isIOS && (debugIOSAppOnMacOverride ?? _isIOSAppOnMac);
+
+  static Future<void> initialize() =>
+      _initialization ??= _initializePlatformEnvironment();
+
+  static Future<void> _initializePlatformEnvironment() async {
+    if (!isIOS) return;
+    try {
+      _isIOSAppOnMac =
+          await _platformEnvironmentChannel.invokeMethod<bool>(
+            'isIOSAppOnMac',
+          ) ??
+          false;
+    } catch (_) {
+      _isIOSAppOnMac = false;
+    }
+  }
 
   static int get iOSMajorVersion {
     if (!isIOS) return 0;
@@ -61,6 +91,9 @@ abstract final class PlatformUiCapabilities {
     debugPlatformOverride = null;
     debugIOSMajorVersionOverride = null;
     debugNativeIOS26Override = null;
+    debugIOSAppOnMacOverride = null;
+    _isIOSAppOnMac = false;
+    _initialization = null;
   }
 }
 
@@ -68,6 +101,7 @@ abstract final class PlatformUiCapabilities {
 abstract final class PlatformInfo {
   static bool get isIOS => PlatformUiCapabilities.isIOS;
   static bool get isAndroid => PlatformUiCapabilities.isAndroid;
+  static bool get isIOSAppOnMac => PlatformUiCapabilities.isIOSAppOnMac;
   static bool get isMacOS =>
       !kIsWeb && PlatformUiCapabilities.platform == TargetPlatform.macOS;
   static bool get isWindows =>

--- a/test/features/chat/views/chat_page_back_navigation_test.dart
+++ b/test/features/chat/views/chat_page_back_navigation_test.dart
@@ -2,6 +2,21 @@ import 'package:conduit/features/chat/views/chat_page.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
+  test('Mac hardware keyboards do not resize the chat scaffold', () {
+    expect(
+      chatResizeToAvoidBottomInset(isAndroid: false, isIOSAppOnMac: true),
+      false,
+    );
+    expect(
+      chatResizeToAvoidBottomInset(isAndroid: false, isIOSAppOnMac: false),
+      isNull,
+    );
+    expect(
+      chatResizeToAvoidBottomInset(isAndroid: true, isIOSAppOnMac: false),
+      false,
+    );
+  });
+
   test('cancelling root exit leaves an active stream untouched', () async {
     final events = <String>[];
 

--- a/test/features/chat/widgets/chat_timeline_viewport_test.dart
+++ b/test/features/chat/widgets/chat_timeline_viewport_test.dart
@@ -12,6 +12,8 @@ import 'package:conduit/l10n/app_localizations.dart';
 import 'package:conduit/l10n/conduit_localizations.dart';
 import 'package:conduit/shared/theme/app_theme.dart';
 import 'package:conduit/shared/theme/tweakcn_themes.dart';
+import 'package:conduit/shared/widgets/platform_ui/platform_ui.dart';
+import 'package:cupertino_ui/cupertino_ui.dart';
 import 'package:flutter/gestures.dart';
 import 'package:material_ui/material_ui.dart';
 import 'package:flutter/rendering.dart';
@@ -172,6 +174,46 @@ Future<void> _pumpSettleFrames(
 }
 
 void main() {
+  _viewportTest('uses one scroll controller for each platform scrollbar', (
+    tester,
+  ) async {
+    final controller = _controller(tester);
+    final ids = List<String>.generate(30, (index) => 'message-$index');
+    addTearDown(PlatformUiCapabilities.resetDebugOverrides);
+
+    PlatformUiCapabilities.debugPlatformOverride = TargetPlatform.android;
+    await tester.pumpWidget(
+      _viewportHost(_viewport(controller: controller, ids: ids)),
+    );
+    await tester.pump();
+
+    final scrollView = tester.widget<CustomScrollView>(
+      find.byType(CustomScrollView),
+    );
+    final materialScrollbar = tester.widget<Scrollbar>(find.byType(Scrollbar));
+    expect(
+      identical(materialScrollbar.controller, scrollView.controller),
+      true,
+    );
+
+    PlatformUiCapabilities.debugPlatformOverride = TargetPlatform.iOS;
+    await tester.pumpWidget(
+      _viewportHost(_viewport(controller: controller, ids: ids)),
+    );
+    await tester.pump();
+
+    final cupertinoScrollbar = tester.widget<CupertinoScrollbar>(
+      find.byType(CupertinoScrollbar),
+    );
+    final iosScrollView = tester.widget<CustomScrollView>(
+      find.byType(CustomScrollView),
+    );
+    expect(
+      identical(cupertinoScrollbar.controller, iosScrollView.controller),
+      true,
+    );
+  });
+
   test(
     'viewport rejects simultaneous anchor maintenance and latest follow',
     () {

--- a/test/features/navigation/widgets/conversation_tile_test.dart
+++ b/test/features/navigation/widgets/conversation_tile_test.dart
@@ -2,7 +2,9 @@ import 'package:conduit/features/navigation/widgets/conversation_tile.dart';
 import 'package:conduit/shared/theme/app_theme.dart';
 import 'package:conduit/shared/theme/theme_extensions.dart';
 import 'package:conduit/shared/theme/tweakcn_themes.dart';
+import 'package:flutter/gestures.dart';
 import 'package:material_ui/material_ui.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
@@ -159,6 +161,66 @@ void main() {
     await gesture.cancel();
     await tester.pump();
     expect(find.byKey(pressedKey), findsNothing);
+  });
+
+  testWidgets('chat-style sidebar rows highlight under a mouse pointer', (
+    tester,
+  ) async {
+    final previousStrategy = FocusManager.instance.highlightStrategy;
+    FocusManager.instance.highlightStrategy =
+        FocusHighlightStrategy.alwaysTraditional;
+    addTearDown(
+      () => FocusManager.instance.highlightStrategy = previousStrategy,
+    );
+    const pressedKey = ValueKey<String>('shared-row-hover');
+    await tester.pumpWidget(
+      _harness(
+        ChatStyleSidebarTile(
+          selected: false,
+          onTap: () {},
+          pressedKey: pressedKey,
+          child: const Padding(
+            padding: EdgeInsets.all(16),
+            child: Text('Hover row'),
+          ),
+        ),
+      ),
+    );
+
+    final mouse = await tester.createGesture(kind: PointerDeviceKind.mouse);
+    await mouse.addPointer(location: tester.getCenter(find.text('Hover row')));
+    await tester.pump();
+    expect(find.byKey(pressedKey), findsOneWidget);
+
+    await mouse.moveTo(const Offset(799, 599));
+    await tester.pump();
+    expect(find.byKey(pressedKey), findsNothing);
+    await mouse.removePointer();
+  });
+
+  testWidgets('focused sidebar rows activate with Enter and Space', (
+    tester,
+  ) async {
+    var activations = 0;
+    await tester.pumpWidget(
+      _harness(
+        ChatStyleSidebarTile(
+          selected: false,
+          onTap: () => activations++,
+          child: const Padding(
+            padding: EdgeInsets.all(16),
+            child: Text('Keyboard row'),
+          ),
+        ),
+      ),
+    );
+
+    await tester.sendKeyEvent(LogicalKeyboardKey.tab);
+    await tester.pump();
+    await tester.sendKeyEvent(LogicalKeyboardKey.enter);
+    await tester.sendKeyEvent(LogicalKeyboardKey.space);
+
+    expect(activations, 2);
   });
 
   testWidgets('selected sidebar rows keep the 4.0.3 Hermes edge gutter', (

--- a/test/features/navigation/widgets/drawer_shell_shortcuts_test.dart
+++ b/test/features/navigation/widgets/drawer_shell_shortcuts_test.dart
@@ -32,7 +32,11 @@ void main() {
     expect(
       bindings.keys,
       containsAll(<ShortcutActivator>[
-        const SingleActivator(LogicalKeyboardKey.keyN, meta: true),
+        const SingleActivator(
+          LogicalKeyboardKey.keyN,
+          meta: true,
+          includeRepeats: false,
+        ),
         const SingleActivator(LogicalKeyboardKey.keyK, meta: true),
         const SingleActivator(LogicalKeyboardKey.digit1, meta: true),
         const SingleActivator(LogicalKeyboardKey.digit2, meta: true),
@@ -43,6 +47,53 @@ void main() {
         const SingleActivator(LogicalKeyboardKey.escape),
       ]),
     );
+  });
+
+  testWidgets('Command-N accepts an initial press but ignores repeats', (
+    tester,
+  ) async {
+    PlatformUiCapabilities.debugPlatformOverride = TargetPlatform.iOS;
+    PlatformUiCapabilities.debugIOSAppOnMacOverride = true;
+
+    await tester.pumpWidget(
+      const ProviderScope(
+        child: MaterialApp(
+          home: MacDesktopShortcuts(child: Focus(child: Text('Content'))),
+        ),
+      ),
+    );
+
+    final bindings = tester
+        .widget<CallbackShortcuts>(find.byType(CallbackShortcuts))
+        .bindings;
+    final commandN = bindings.keys.whereType<SingleActivator>().singleWhere(
+      (activator) => activator.trigger == LogicalKeyboardKey.keyN,
+    );
+
+    await tester.sendKeyDownEvent(LogicalKeyboardKey.metaLeft);
+    expect(
+      commandN.accepts(
+        const KeyDownEvent(
+          physicalKey: PhysicalKeyboardKey.keyN,
+          logicalKey: LogicalKeyboardKey.keyN,
+          timeStamp: Duration.zero,
+        ),
+        HardwareKeyboard.instance,
+      ),
+      true,
+    );
+    expect(
+      commandN.accepts(
+        const KeyRepeatEvent(
+          physicalKey: PhysicalKeyboardKey.keyN,
+          logicalKey: LogicalKeyboardKey.keyN,
+          timeStamp: Duration.zero,
+        ),
+        HardwareKeyboard.instance,
+      ),
+      false,
+    );
+    await tester.sendKeyUpEvent(LogicalKeyboardKey.metaLeft);
   });
 
   testWidgets('Command-K focuses search and Escape closes it', (tester) async {

--- a/test/features/navigation/widgets/drawer_shell_shortcuts_test.dart
+++ b/test/features/navigation/widgets/drawer_shell_shortcuts_test.dart
@@ -1,0 +1,140 @@
+import 'package:conduit/features/navigation/providers/sidebar_providers.dart';
+import 'package:conduit/features/navigation/models/sidebar_navigation_model.dart';
+import 'package:conduit/features/navigation/widgets/drawer_shell_page.dart';
+import 'package:conduit/shared/widgets/platform_ui/platform_ui.dart';
+import 'package:material_ui/material_ui.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'sidebar_page_test_support.dart';
+
+void main() {
+  tearDown(PlatformUiCapabilities.resetDebugOverrides);
+
+  testWidgets('Mac shell exposes the complete desktop shortcut set', (
+    tester,
+  ) async {
+    PlatformUiCapabilities.debugPlatformOverride = TargetPlatform.iOS;
+    PlatformUiCapabilities.debugIOSAppOnMacOverride = true;
+
+    await tester.pumpWidget(
+      const ProviderScope(
+        child: MaterialApp(
+          home: MacDesktopShortcuts(child: Focus(child: Text('Content'))),
+        ),
+      ),
+    );
+
+    final bindings = tester
+        .widget<CallbackShortcuts>(find.byType(CallbackShortcuts))
+        .bindings;
+    expect(
+      bindings.keys,
+      containsAll(<ShortcutActivator>[
+        const SingleActivator(LogicalKeyboardKey.keyN, meta: true),
+        const SingleActivator(LogicalKeyboardKey.keyK, meta: true),
+        const SingleActivator(LogicalKeyboardKey.digit1, meta: true),
+        const SingleActivator(LogicalKeyboardKey.digit2, meta: true),
+        const SingleActivator(LogicalKeyboardKey.digit3, meta: true),
+        const SingleActivator(LogicalKeyboardKey.digit4, meta: true),
+        const SingleActivator(LogicalKeyboardKey.digit5, meta: true),
+        const SingleActivator(LogicalKeyboardKey.comma, meta: true),
+        const SingleActivator(LogicalKeyboardKey.escape),
+      ]),
+    );
+  });
+
+  testWidgets('Command-K focuses search and Escape closes it', (tester) async {
+    PlatformUiCapabilities.debugPlatformOverride = TargetPlatform.iOS;
+    PlatformUiCapabilities.debugIOSAppOnMacOverride = true;
+
+    await tester.pumpWidget(
+      const ProviderScope(
+        child: MaterialApp(
+          home: MacDesktopShortcuts(
+            child: Consumer(builder: _searchShortcutTestChild),
+          ),
+        ),
+      ),
+    );
+    final context = tester.element(find.text('Content'));
+    final container = ProviderScope.containerOf(context);
+
+    await tester.sendKeyDownEvent(LogicalKeyboardKey.metaLeft);
+    await tester.sendKeyEvent(LogicalKeyboardKey.keyK);
+    await tester.sendKeyUpEvent(LogicalKeyboardKey.metaLeft);
+    await tester.pump();
+
+    expect(container.read(sidebarHeaderSearchExpandedProvider), true);
+    expect(container.read(sidebarSearchFieldFocusNodeProvider).hasFocus, true);
+
+    container.read(sidebarSearchFieldControllerProvider).text = 'query';
+    await tester.sendKeyEvent(LogicalKeyboardKey.escape);
+    await tester.pump();
+
+    expect(container.read(sidebarHeaderSearchExpandedProvider), false);
+    expect(container.read(sidebarSearchFieldControllerProvider).text, isEmpty);
+  });
+
+  testWidgets('number shortcuts select from the visible sidebar order', (
+    tester,
+  ) async {
+    PlatformUiCapabilities.debugPlatformOverride = TargetPlatform.iOS;
+    PlatformUiCapabilities.debugIOSAppOnMacOverride = true;
+    final activeTab = SidebarTestTestSidebarActiveTab(SidebarTabId.chats);
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          sidebarNavigationSnapshotProvider.overrideWithValue(
+            SidebarNavigationSnapshot(
+              tabs: const [SidebarTabId.chats, SidebarTabId.notes],
+              selectedTab: SidebarTabId.chats,
+            ),
+          ),
+          sidebarActiveTabProvider.overrideWith(() => activeTab),
+        ],
+        child: const MaterialApp(
+          home: MacDesktopShortcuts(
+            child: Focus(autofocus: true, child: Text('Content')),
+          ),
+        ),
+      ),
+    );
+
+    await tester.sendKeyDownEvent(LogicalKeyboardKey.metaLeft);
+    await tester.sendKeyEvent(LogicalKeyboardKey.digit2);
+    await tester.sendKeyUpEvent(LogicalKeyboardKey.metaLeft);
+    await tester.pump();
+
+    expect(activeTab.currentValue, SidebarTabId.notes);
+  });
+
+  testWidgets('non-Mac iOS does not install desktop shortcuts', (tester) async {
+    PlatformUiCapabilities.debugPlatformOverride = TargetPlatform.iOS;
+    PlatformUiCapabilities.debugIOSAppOnMacOverride = false;
+
+    await tester.pumpWidget(
+      const ProviderScope(
+        child: MaterialApp(home: MacDesktopShortcuts(child: Text('Content'))),
+      ),
+    );
+
+    expect(find.byType(CallbackShortcuts), findsNothing);
+  });
+}
+
+Widget _searchShortcutTestChild(
+  BuildContext context,
+  WidgetRef ref,
+  Widget? child,
+) => Column(
+  children: [
+    const Focus(autofocus: true, child: Text('Content')),
+    Focus(
+      focusNode: ref.watch(sidebarSearchFieldFocusNodeProvider),
+      child: const SizedBox.shrink(),
+    ),
+  ],
+);

--- a/test/features/navigation/widgets/sidebar_page_test.dart
+++ b/test/features/navigation/widgets/sidebar_page_test.dart
@@ -28,6 +28,25 @@ import 'package:flutter_test/flutter_test.dart';
 import 'sidebar_page_test_support.dart';
 
 void main() {
+  test('Mac windows do not reserve the iPad window-control inset', () {
+    expect(
+      resolveSidebarWindowedLeadingInset(
+        usesNativeIOS26Chrome: true,
+        isWindowed: true,
+        isIOSAppOnMac: true,
+      ),
+      0,
+    );
+    expect(
+      resolveSidebarWindowedLeadingInset(
+        usesNativeIOS26Chrome: true,
+        isWindowed: true,
+        isIOSAppOnMac: false,
+      ),
+      62,
+    );
+  });
+
   testWidgets('native glass profile avatar uses one compact native button', (
     tester,
   ) async {

--- a/test/shared/utils/conversation_context_menu_test.dart
+++ b/test/shared/utils/conversation_context_menu_test.dart
@@ -5,6 +5,7 @@ import 'package:conduit/features/navigation/widgets/conversation_tile.dart';
 import 'package:conduit/shared/widgets/platform_ui/platform_ui.dart';
 import 'package:cupertino_ui/cupertino_ui.dart';
 import 'package:material_ui/material_ui.dart';
+import 'package:flutter/gestures.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 Widget _buildHarness(Widget child) {
@@ -52,6 +53,38 @@ void main() {
 
     expect(find.text('Child'), findsOneWidget);
     expect(find.byType(GestureDetector), findsOneWidget);
+  });
+
+  testWidgets('secondary click opens and runs the existing action on iOS', (
+    tester,
+  ) async {
+    PlatformUiCapabilities.debugPlatformOverride = TargetPlatform.iOS;
+    final events = <String>[];
+
+    await tester.pumpWidget(
+      _buildHarness(
+        ConduitContextMenu(
+          actions: [
+            ConduitContextMenuAction(
+              cupertinoIcon: CupertinoIcons.doc_on_clipboard,
+              materialIcon: Icons.copy,
+              label: 'Copy',
+              onBeforeClose: () => events.add('before-close'),
+              onSelected: () async => events.add('selected'),
+            ),
+          ],
+          child: const Text('Child'),
+        ),
+      ),
+    );
+
+    await tester.tap(find.text('Child'), buttons: kSecondaryMouseButton);
+    await tester.pumpAndSettle();
+    expect(find.text('Copy'), findsOneWidget);
+
+    await tester.tap(find.text('Copy'));
+    await tester.pumpAndSettle();
+    expect(events, ['before-close', 'selected']);
   });
 
   testWidgets('does not build lazy top widget before the menu opens', (

--- a/test/shared/widgets/platform_ui/platform_ui_test.dart
+++ b/test/shared/widgets/platform_ui/platform_ui_test.dart
@@ -10,6 +10,7 @@ import 'package:cupertino_ui/cupertino_ui.dart';
 import 'package:flutter/foundation.dart'
     show debugDefaultTargetPlatformOverride;
 import 'package:material_ui/material_ui.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
@@ -23,6 +24,66 @@ void main() {
   });
 
   group('PlatformUiCapabilities', () {
+    test('detects and caches the iOS app running on Mac', () async {
+      PlatformUiCapabilities.debugPlatformOverride = TargetPlatform.iOS;
+      const channel = MethodChannel(
+        'app.cogwheel.conduit/platform_environment',
+      );
+      var calls = 0;
+      final messenger =
+          TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger;
+      messenger.setMockMethodCallHandler(channel, (call) async {
+        calls++;
+        expect(call.method, 'isIOSAppOnMac');
+        return true;
+      });
+      addTearDown(() => messenger.setMockMethodCallHandler(channel, null));
+
+      await PlatformUiCapabilities.initialize();
+      await PlatformUiCapabilities.initialize();
+
+      check(PlatformUiCapabilities.isIOSAppOnMac).isTrue();
+      check(PlatformInfo.isIOSAppOnMac).isTrue();
+      check(calls).equals(1);
+    });
+
+    test('falls back when the native Mac capability is unavailable', () async {
+      PlatformUiCapabilities.debugPlatformOverride = TargetPlatform.iOS;
+
+      await PlatformUiCapabilities.initialize();
+
+      check(PlatformUiCapabilities.isIOSAppOnMac).isFalse();
+    });
+
+    test('debug reset clears the cached Mac capability', () async {
+      PlatformUiCapabilities.debugPlatformOverride = TargetPlatform.iOS;
+      const channel = MethodChannel(
+        'app.cogwheel.conduit/platform_environment',
+      );
+      var calls = 0;
+      final messenger =
+          TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger;
+      messenger.setMockMethodCallHandler(channel, (_) async => calls++ == 0);
+      addTearDown(() => messenger.setMockMethodCallHandler(channel, null));
+
+      await PlatformUiCapabilities.initialize();
+      check(PlatformUiCapabilities.isIOSAppOnMac).isTrue();
+
+      PlatformUiCapabilities.resetDebugOverrides();
+      PlatformUiCapabilities.debugPlatformOverride = TargetPlatform.iOS;
+      await PlatformUiCapabilities.initialize();
+
+      check(PlatformUiCapabilities.isIOSAppOnMac).isFalse();
+      check(calls).equals(2);
+    });
+
+    test('never reports an iOS app on Mac for another platform', () {
+      PlatformUiCapabilities.debugPlatformOverride = TargetPlatform.android;
+      PlatformUiCapabilities.debugIOSAppOnMacOverride = true;
+
+      check(PlatformUiCapabilities.isIOSAppOnMac).isFalse();
+    });
+
     test('selects Flutter Material on Android regardless of iOS override', () {
       PlatformUiCapabilities.debugPlatformOverride = TargetPlatform.android;
       PlatformUiCapabilities.debugIOSMajorVersionOverride = 26;


### PR DESCRIPTION
## Summary

- detect Designed-for-iPad-on-Mac at startup and remove the Mac-only keyboard and sidebar inset artifacts
- add shared secondary-click menus, sidebar hover/focus behavior, keyboard activation, and Mac shell shortcuts
- add platform-adaptive fading scrollbars to the chat transcript without changing its scroll controller

## Testing

- `flutter analyze lib test`
- focused Flutter tests: 160 passed
- full `flutter test`: 5,734 passed, 4 live-endpoint tests skipped
- fresh iPhone 17 Pro simulator build, launch, and onboarding navigation
- Xcode build for My Mac (Designed for iPad/iPhone)

## Notes

- A live Designed-for-iPad-on-Mac launch could not be automated because Xcode did not expose a controllable workspace window in the verification session. The destination build completed successfully.
- Root-wide `flutter analyze` still encounters the existing nested `tool/pigeon_codegen` package-resolution issue; analysis of `lib` and `test` is clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved iOS-on-Mac support with native keyboard shortcuts for navigation, search, tab selection, settings, and dismissal.
  * Added hover and keyboard-focus feedback for sidebar items.
  * Added iOS-appropriate scrollbars and secondary-click context menus.
  * Improved sidebar search behavior and adaptive window layouts.

* **Bug Fixes**
  * Improved chat resizing when using iOS on Mac.
  * Corrected window insets and context-menu positioning across platforms.

* **Tests**
  * Added coverage for platform detection, shortcuts, scrolling, focus interactions, resizing, and context menus.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->



<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This update adds Designed-for-iPad-on-Mac detection and uses it to provide desktop keyboard shortcuts, sidebar interactions, context menus, and platform-adaptive chat presentation. No blocking failure remains.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

No blocking failure remains.

No accepted blocking findings remain.
</details>


<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- The code-execution run failed due to a missing Flutter tool, confirming the runtime blocker.
- I reviewed the PR diff to verify coordinate handling, confirming global-to-overlay-local conversion in adaptive\_layout.dart and that long-press and secondary-click paths pass global anchors.

<a href="https://app.greptile.com/trex/runs/21279417/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (2): Last reviewed commit: ["Prevent repeated Mac create shortcuts"](https://github.com/cogwheel0/conduit/commit/e2d21e076703faa56512dc27e7724509ac383b99) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57989317)</sub>

<!-- /greptile_comment -->