### PR TITLE
feat: add OrcaRouter as a first-class direct provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,16 +111,17 @@ later, and skip any sign-in you don't need.
 | | | |
 | --- | --- | --- |
 | **Open WebUI** | Your self-hosted server | Full feature set: chats, folders, notes, channels, workspace, tools, web search, image generation |
-| **Direct** | OpenAI-compatible, Ollama, OpenRouter | Talk straight to a provider or a model on your own machine. No Open WebUI account required |
+| **Direct** | OpenAI-compatible, Ollama, OpenRouter, OrcaRouter | Talk straight to a provider or a model on your own machine. No Open WebUI account required |
 | **Apple On-Device** | Apple Intelligence | Run Apple's local model offline on eligible iOS 26 devices without an API key |
 | **Apple PCC** | Apple Private Cloud Compute | Use Apple's private cloud model on eligible iOS 27 devices without an API key |
 | **Hermes** | Your self-hosted agent | An agent that runs tools, asks before sensitive steps, and works on a schedule |
 
 **Direct connections** cover OpenAI-compatible endpoints (Chat Completions or
 Responses), LM Studio, Azure-style API versions, native Ollama, and first-party
-OpenRouter. Bring an API key, or skip it for a local endpoint that doesn't want
-one. Direct connections you already configured in Open WebUI come along
-automatically. Keys and custom headers stay in platform secure storage.
+OpenRouter and OrcaRouter. Bring an API key, or skip it for a local endpoint
+that doesn't want one. Direct connections you already configured in Open WebUI
+come along automatically. Keys and custom headers stay in platform secure
+storage.
 
 **Apple On-Device** is an iOS-only Direct provider backed by Apple's local
 SystemLanguageModel. It requires iOS 26 and Apple Intelligence, works offline,

--- a/lib/features/direct_connections/controllers/direct_connection_editor_draft.dart
+++ b/lib/features/direct_connections/controllers/direct_connection_editor_draft.dart
@@ -10,7 +10,7 @@ enum DirectAuthenticationMode { bearer, apiKeyHeader, none, unsupported }
 /// Canonical authentication mode encoded by a locally persisted profile.
 DirectAuthenticationMode directAuthenticationForProfile(
   DirectConnectionProfile profile,
-) => profile.isOpenRouter
+) => profile.isOpenRouter || profile.isOrcaRouter
     ? DirectAuthenticationMode.bearer
     : (profile.apiKey ?? '').isEmpty
     ? DirectAuthenticationMode.none
@@ -152,12 +152,14 @@ enum DirectDraftValidationIssue {
   nameRequired,
   invalidUrl,
   invalidOpenRouterUrl,
+  invalidOrcaRouterUrl,
   credentialsReentryRequired,
   apiKeyRequired,
   unsupportedAuthentication,
 }
 
 const String kOpenRouterProviderPreset = 'openrouter';
+const String kOrcaRouterProviderPreset = 'orcarouter';
 
 Map<String, String> parseDirectCustomHeaders(String source) {
   final trimmed = source.trim();
@@ -333,6 +335,7 @@ final class DirectConnectionDraft {
   final Map<String, String> customHeaders;
 
   bool get isOpenRouter => providerPreset == kOpenRouterProviderPreset;
+  bool get isOrcaRouter => providerPreset == kOrcaRouterProviderPreset;
 
   bool get originChanged => directConnectionOriginChanged(
     savedProfile: savedProfile,
@@ -363,6 +366,8 @@ final class DirectConnectionDraft {
       urlIssue = DirectDraftValidationIssue.invalidUrl;
     } else if (isOpenRouter && !isOpenRouterApiBaseUrl(normalizedBaseUrl)) {
       urlIssue = DirectDraftValidationIssue.invalidOpenRouterUrl;
+    } else if (isOrcaRouter && !isOrcaRouterApiBaseUrl(normalizedBaseUrl)) {
+      urlIssue = DirectDraftValidationIssue.invalidOrcaRouterUrl;
     } else if (!originBoundSecretsReviewed) {
       urlIssue = DirectDraftValidationIssue.credentialsReentryRequired;
     }

--- a/lib/features/direct_connections/controllers/direct_connection_editor_form.dart
+++ b/lib/features/direct_connections/controllers/direct_connection_editor_form.dart
@@ -64,10 +64,12 @@ final class DirectConnectionEditorForm extends ChangeNotifier {
   DirectHeaderValidationError? get headerError => headers.error;
   bool get isOllama => adapterKey == kOllamaAdapterKey;
   bool get isOpenRouter => providerPreset == kOpenRouterProviderPreset;
+  bool get isOrcaRouter => providerPreset == kOrcaRouterProviderPreset;
   DirectConnectionEditorPolicy get policy => mode.policy;
-  bool get canSelectApiKeyHeader => policy.allowsApiKeyHeader && !isOpenRouter;
+  bool get canSelectApiKeyHeader =>
+      policy.allowsApiKeyHeader && !isOpenRouter && !isOrcaRouter;
   bool get canSelectNoAuthentication =>
-      policy.allowsManagedAnonymousAuth || !isOpenRouter;
+      policy.allowsManagedAnonymousAuth || (!isOpenRouter && !isOrcaRouter);
   bool get canAddCustomHeader => headerName.text.trim().isNotEmpty;
   int get draftRevision => _draftRevision;
 
@@ -116,6 +118,8 @@ final class DirectConnectionEditorForm extends ChangeNotifier {
       _adapterKey = profile.adapterKey;
       _providerPreset = profile.isOpenRouter
           ? kOpenRouterProviderPreset
+          : profile.isOrcaRouter
+          ? kOrcaRouterProviderPreset
           : profile.adapterKey;
       _openAiApiMode = profile.openAiApiMode;
       _authentication =
@@ -148,6 +152,7 @@ final class DirectConnectionEditorForm extends ChangeNotifier {
     String value, {
     required String ollamaDefaultName,
     required String openRouterDefaultName,
+    required String orcaRouterDefaultName,
   }) {
     if (providerPreset == value) return;
     _providerPreset = value;
@@ -160,15 +165,18 @@ final class DirectConnectionEditorForm extends ChangeNotifier {
       baseUrl.text = switch (value) {
         kOllamaAdapterKey => 'https://ollama.com',
         kOpenRouterProviderPreset => kOpenRouterApiBaseUrl,
+        kOrcaRouterProviderPreset => kOrcaRouterApiBaseUrl,
         _ => 'https://api.openai.com/v1',
       };
       if (mode.isNew &&
           (name.text == 'My provider' ||
               name.text == ollamaDefaultName ||
-              name.text == openRouterDefaultName)) {
+              name.text == openRouterDefaultName ||
+              name.text == orcaRouterDefaultName)) {
         name.text = switch (value) {
           kOllamaAdapterKey => ollamaDefaultName,
           kOpenRouterProviderPreset => openRouterDefaultName,
+          kOrcaRouterProviderPreset => orcaRouterDefaultName,
           _ => 'My provider',
         };
       }

--- a/lib/features/direct_connections/models/direct_connection_profile.dart
+++ b/lib/features/direct_connections/models/direct_connection_profile.dart
@@ -22,6 +22,9 @@ const String kApplePccRemoteModelId = 'private-cloud-compute';
 /// Canonical first-party OpenRouter API root.
 const String kOpenRouterApiBaseUrl = 'https://openrouter.ai/api/v1';
 
+/// Canonical first-party OrcaRouter API root.
+const String kOrcaRouterApiBaseUrl = 'https://api.orcarouter.ai/v1';
+
 /// OpenAI-family completion protocol selected for one connection profile.
 ///
 /// This remains profile data rather than a separate adapter key so OpenAI,
@@ -183,6 +186,14 @@ final class DirectConnectionProfile {
   bool get supportsOpenRouterImageGeneration => isOpenRouter;
   bool get supportsOpenRouterPdfInputs =>
       isOpenRouter && openAiApiMode == DirectOpenAiApiMode.chatCompletions;
+
+  /// OrcaRouter intentionally shares the OpenAI-compatible adapter. Provider
+  /// identity is bound to the exact HTTPS API root so Conduit can treat
+  /// OrcaRouter as a first-class named provider rather than an anonymous
+  /// custom base URL. No OrcaRouter-owned request fields are sent today.
+  bool get isOrcaRouter =>
+      adapterKey == kOpenAiCompatibleAdapterKey &&
+      isOrcaRouterApiBaseUrl(baseUrl);
 
   /// Ollama Cloud executes models remotely and does not expose the local
   /// `/api/ps` RAM/VRAM lifecycle used by self-hosted Ollama servers.
@@ -560,6 +571,20 @@ bool isOpenRouterApiBaseUrl(String value) {
     return false;
   }
   return uri.path == '/api/v1' || uri.path == '/api/v1/';
+}
+
+bool isOrcaRouterApiBaseUrl(String value) {
+  final uri = Uri.tryParse(value.trim());
+  if (uri == null ||
+      uri.scheme.toLowerCase() != 'https' ||
+      uri.host.toLowerCase() != 'api.orcarouter.ai' ||
+      (uri.hasPort && uri.port != 443) ||
+      uri.userInfo.isNotEmpty ||
+      uri.hasQuery ||
+      uri.hasFragment) {
+    return false;
+  }
+  return uri.path == '/v1' || uri.path == '/v1/';
 }
 
 /// Versioned envelope used for the single secure-storage profile document.

--- a/lib/features/direct_connections/services/direct_model_registry.dart
+++ b/lib/features/direct_connections/services/direct_model_registry.dart
@@ -294,6 +294,7 @@ final class DirectModelRegistry {
         capabilities: <String, dynamic>{
           ...remote.capabilities,
           'openrouter': profile.isOpenRouter,
+          'orcarouter': profile.isOrcaRouter,
           if (profile.isOpenRouter) ...<String, dynamic>{
             'web_search': profile.supportsOpenRouterWebSearch,
             // This is OpenRouter's server tool, which can be called by any

--- a/lib/features/direct_connections/views/direct_connection_advanced_settings.dart
+++ b/lib/features/direct_connections/views/direct_connection_advanced_settings.dart
@@ -562,6 +562,8 @@ String? directDraftValidationMessage(
   DirectDraftValidationIssue.invalidUrl => l10n.directConnectionUrlInvalid,
   DirectDraftValidationIssue.invalidOpenRouterUrl =>
     l10n.directOpenRouterUrlInvalid,
+  DirectDraftValidationIssue.invalidOrcaRouterUrl =>
+    l10n.directOrcaRouterUrlInvalid,
   DirectDraftValidationIssue.credentialsReentryRequired =>
     l10n.directConnectionCredentialsReentryRequired,
   DirectDraftValidationIssue.apiKeyRequired =>

--- a/lib/features/direct_connections/views/direct_connection_editor_sections.dart
+++ b/lib/features/direct_connections/views/direct_connection_editor_sections.dart
@@ -109,6 +109,10 @@ List<AdaptiveDropdownOption<String>> _providerOptions(AppLocalizations l10n) =>
         value: kOpenRouterProviderPreset,
         label: l10n.openRouterProviderName,
       ),
+      AdaptiveDropdownOption(
+        value: kOrcaRouterProviderPreset,
+        label: l10n.orcaRouterProviderName,
+      ),
       AdaptiveDropdownOption(value: kOllamaAdapterKey, label: l10n.ollama),
     ];
 
@@ -138,6 +142,7 @@ void _selectProvider(
   value,
   ollamaDefaultName: l10n.ollamaCloudDefaultName,
   openRouterDefaultName: l10n.openRouterProviderName,
+  orcaRouterDefaultName: l10n.orcaRouterProviderName,
 );
 
 final class _NativeProviderRow extends StatelessWidget {
@@ -264,6 +269,14 @@ final class DirectConnectionProviderSection extends StatelessWidget {
             onTap: () => select(kOpenRouterProviderPreset),
           ),
           UtilitySelectionRow(
+            leading: const _ProviderIcon(icon: Icons.waves_outlined),
+            title: l10n.orcaRouterProviderName,
+            subtitle: null,
+            selected: form.providerPreset == kOrcaRouterProviderPreset,
+            showDivider: true,
+            onTap: () => select(kOrcaRouterProviderPreset),
+          ),
+          UtilitySelectionRow(
             leading: const _ProviderIcon(icon: Icons.computer_outlined),
             title: l10n.ollama,
             subtitle: null,
@@ -293,10 +306,13 @@ final class DirectConnectionDetailsSection extends StatelessWidget {
     final l10n = AppLocalizations.of(context)!;
     final isOllama = form.isOllama;
     final isOpenRouter = form.isOpenRouter;
+    final isOrcaRouter = form.isOrcaRouter;
     final baseUrlDescription = isOllama
         ? l10n.ollamaCloudBaseUrlDescription
         : isOpenRouter
         ? l10n.directOpenRouterBaseUrlDescription
+        : isOrcaRouter
+        ? l10n.directOrcaRouterBaseUrlDescription
         : l10n.directBaseUrlDescription;
     final authenticationOptions = _authenticationOptions(l10n, form);
 
@@ -307,6 +323,8 @@ final class DirectConnectionDetailsSection extends StatelessWidget {
           ? l10n.ollamaCloudDefaultName
           : isOpenRouter
           ? l10n.openRouterProviderName
+          : isOrcaRouter
+          ? l10n.orcaRouterProviderName
           : 'My provider',
       controller: form.name,
       errorText: directDraftValidationMessage(l10n, form.errors.name),
@@ -321,6 +339,8 @@ final class DirectConnectionDetailsSection extends StatelessWidget {
           ? l10n.ollamaCloudBaseUrlHint
           : isOpenRouter
           ? kOpenRouterApiBaseUrl
+          : isOrcaRouter
+          ? kOrcaRouterApiBaseUrl
           : 'https://api.openai.com/v1',
       controller: form.baseUrl,
       keyboardType: TextInputType.url,

--- a/lib/l10n/app_cs.arb
+++ b/lib/l10n/app_cs.arb
@@ -4659,6 +4659,10 @@
   "directApiBaseUrl": "Base URL",
   "directOpenRouterUrlInvalid": "Use OpenRouter’s HTTPS /api/v1 root (global or EU).",
   "directOpenRouterBaseUrlDescription": "Uses your OpenRouter API key, authenticated model catalog, and Conduit-managed tools.",
+
+  "orcaRouterProviderName": "OrcaRouter",
+  "directOrcaRouterUrlInvalid": "Use OrcaRouter’s HTTPS /v1 root (https://api.orcarouter.ai/v1).",
+  "directOrcaRouterBaseUrlDescription": "Connect with an OrcaRouter API key.",
   "directOpenRouterChatCompletionsDescription": "Chat Completions is used for native web search, image generation, PDF parsing, and reusable PDF annotations.",
   "directCompletionApi": "Completion API",
   "directChatCompletions": "Chat Completions",

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -3004,6 +3004,10 @@
   "directApiBaseUrl": "Base URL",
   "directOpenRouterUrlInvalid": "Verwende den HTTPS-/api/v1-Stammpfad von OpenRouter (global oder EU).",
   "directOpenRouterBaseUrlDescription": "Verwendet deinen OpenRouter-API-Schlüssel, den authentifizierten Modellkatalog und von Conduit verwaltete Tools.",
+
+  "orcaRouterProviderName": "OrcaRouter",
+  "directOrcaRouterUrlInvalid": "Use OrcaRouter’s HTTPS /v1 root (https://api.orcarouter.ai/v1).",
+  "directOrcaRouterBaseUrlDescription": "Connect with an OrcaRouter API key.",
   "directOpenRouterChatCompletionsDescription": "Chat Completions wird für native Websuche, Bildgenerierung, PDF-Analyse und wiederverwendbare PDF-Anmerkungen verwendet.",
   "directCompletionApi": "Completion API",
   "directChatCompletions": "Chat Completions",

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -4813,6 +4813,10 @@
   "@openRouterProviderName": {
     "description": "Provider name used by the OpenRouter connection preset."
   },
+  "orcaRouterProviderName": "OrcaRouter",
+  "@orcaRouterProviderName": {
+    "description": "Provider name used by the OrcaRouter connection preset."
+  },
   "ollamaCloudDefaultName": "Ollama Cloud",
   "@ollamaCloudDefaultName": {
     "description": "Default connection name and field hint for Ollama Cloud."
@@ -4943,9 +4947,17 @@
   "@directOpenRouterUrlInvalid": {
     "description": "Validation error shown when an OpenRouter direct connection does not use an approved API root."
   },
+  "directOrcaRouterUrlInvalid": "Use OrcaRouter’s HTTPS /v1 root (https://api.orcarouter.ai/v1).",
+  "@directOrcaRouterUrlInvalid": {
+    "description": "Validation error shown when an OrcaRouter direct connection does not use the approved API root."
+  },
   "directOpenRouterBaseUrlDescription": "Connect with an OpenRouter API key.",
   "@directOpenRouterBaseUrlDescription": {
     "description": "Help text shown below the OpenRouter direct connection base URL."
+  },
+  "directOrcaRouterBaseUrlDescription": "Connect with an OrcaRouter API key.",
+  "@directOrcaRouterBaseUrlDescription": {
+    "description": "Help text shown below the OrcaRouter direct connection base URL."
   },
   "directOpenRouterChatCompletionsDescription": "Chat Completions is used for native web search, image generation, PDF parsing, and reusable PDF annotations.",
   "@directOpenRouterChatCompletionsDescription": {

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -3004,6 +3004,10 @@
   "directApiBaseUrl": "URL base",
   "directOpenRouterUrlInvalid": "Use OpenRouter’s HTTPS /api/v1 root (global or EU).",
   "directOpenRouterBaseUrlDescription": "Uses your OpenRouter API key, authenticated model catalog, and Conduit-managed tools.",
+
+  "orcaRouterProviderName": "OrcaRouter",
+  "directOrcaRouterUrlInvalid": "Use OrcaRouter’s HTTPS /v1 root (https://api.orcarouter.ai/v1).",
+  "directOrcaRouterBaseUrlDescription": "Connect with an OrcaRouter API key.",
   "directOpenRouterChatCompletionsDescription": "Chat Completions is used for native web search, image generation, PDF parsing, and reusable PDF annotations.",
   "directCompletionApi": "API de finalización",
   "directChatCompletions": "Finalizaciones de chat",

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -3004,6 +3004,10 @@
   "directApiBaseUrl": "URL de base",
   "directOpenRouterUrlInvalid": "Utilisez la racine HTTPS /api/v1 d’OpenRouter (globale ou UE).",
   "directOpenRouterBaseUrlDescription": "Utilise votre clé API OpenRouter, le catalogue de modèles authentifié et les outils gérés par Conduit.",
+
+  "orcaRouterProviderName": "OrcaRouter",
+  "directOrcaRouterUrlInvalid": "Use OrcaRouter’s HTTPS /v1 root (https://api.orcarouter.ai/v1).",
+  "directOrcaRouterBaseUrlDescription": "Connect with an OrcaRouter API key.",
   "directOpenRouterChatCompletionsDescription": "Les complétions de chat sont utilisées pour la recherche web native, la génération d’images, l’analyse des PDF et les annotations PDF réutilisables.",
   "directCompletionApi": "API de complétion",
   "directChatCompletions": "Complétions de chat",

--- a/lib/l10n/app_it.arb
+++ b/lib/l10n/app_it.arb
@@ -3004,6 +3004,10 @@
   "directApiBaseUrl": "Base URL",
   "directOpenRouterUrlInvalid": "Use OpenRouter’s HTTPS /api/v1 root (global or EU).",
   "directOpenRouterBaseUrlDescription": "Uses your OpenRouter API key, authenticated model catalog, and Conduit-managed tools.",
+
+  "orcaRouterProviderName": "OrcaRouter",
+  "directOrcaRouterUrlInvalid": "Use OrcaRouter’s HTTPS /v1 root (https://api.orcarouter.ai/v1).",
+  "directOrcaRouterBaseUrlDescription": "Connect with an OrcaRouter API key.",
   "directOpenRouterChatCompletionsDescription": "Chat Completions is used for native web search, image generation, PDF parsing, and reusable PDF annotations.",
   "directCompletionApi": "Completion API",
   "directChatCompletions": "Chat Completions",

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -4344,6 +4344,10 @@
   "directApiBaseUrl": "Base URL",
   "directOpenRouterUrlInvalid": "Use OpenRouter’s HTTPS /api/v1 root (global or EU).",
   "directOpenRouterBaseUrlDescription": "Uses your OpenRouter API key, authenticated model catalog, and Conduit-managed tools.",
+
+  "orcaRouterProviderName": "OrcaRouter",
+  "directOrcaRouterUrlInvalid": "Use OrcaRouter’s HTTPS /v1 root (https://api.orcarouter.ai/v1).",
+  "directOrcaRouterBaseUrlDescription": "Connect with an OrcaRouter API key.",
   "directOpenRouterChatCompletionsDescription": "Chat Completions is used for native web search, image generation, PDF parsing, and reusable PDF annotations.",
   "directCompletionApi": "Completion API",
   "directChatCompletions": "Chat Completions",

--- a/lib/l10n/app_ko.arb
+++ b/lib/l10n/app_ko.arb
@@ -2782,6 +2782,10 @@
   "directApiBaseUrl": "기본 URL",
   "directOpenRouterUrlInvalid": "OpenRouter의 HTTPS /api/v1 루트(글로벌 또는 EU)를 사용하세요.",
   "directOpenRouterBaseUrlDescription": "OpenRouter API 키, 인증된 모델 카탈로그 및 Conduit에서 관리하는 도구를 사용합니다.",
+
+  "orcaRouterProviderName": "OrcaRouter",
+  "directOrcaRouterUrlInvalid": "Use OrcaRouter’s HTTPS /v1 root (https://api.orcarouter.ai/v1).",
+  "directOrcaRouterBaseUrlDescription": "Connect with an OrcaRouter API key.",
   "directOpenRouterChatCompletionsDescription": "Chat Completions는 기본 웹 검색, 이미지 생성, PDF 분석 및 재사용 가능한 PDF 주석에 사용됩니다.",
   "directCompletionApi": "Completion API",
   "directChatCompletions": "Chat Completions",

--- a/lib/l10n/app_nl.arb
+++ b/lib/l10n/app_nl.arb
@@ -3004,6 +3004,10 @@
   "directApiBaseUrl": "Base URL",
   "directOpenRouterUrlInvalid": "Gebruik de HTTPS-/api/v1-hoofd-URL van OpenRouter (wereldwijd of EU).",
   "directOpenRouterBaseUrlDescription": "Conduit gebruikt je OpenRouter-API-sleutel, geverifieerde modelcatalogus en door Conduit beheerde tools.",
+
+  "orcaRouterProviderName": "OrcaRouter",
+  "directOrcaRouterUrlInvalid": "Use OrcaRouter’s HTTPS /v1 root (https://api.orcarouter.ai/v1).",
+  "directOrcaRouterBaseUrlDescription": "Connect with an OrcaRouter API key.",
   "directOpenRouterChatCompletionsDescription": "Chat Completions wordt gebruikt voor ingebouwd zoeken op het web, afbeeldingsgeneratie, PDF-verwerking en herbruikbare PDF-annotaties.",
   "directCompletionApi": "Completion API",
   "directChatCompletions": "Chat Completions",

--- a/lib/l10n/app_pl.arb
+++ b/lib/l10n/app_pl.arb
@@ -5705,6 +5705,10 @@
     "description": "Validation error shown when an OpenRouter direct connection does not use an approved API root."
   },
   "directOpenRouterBaseUrlDescription": "Używa Twojego klucza API OpenRouter, uwierzytelnionego katalogu modeli i narzędzi zarządzanych przez Conduit.",
+
+  "orcaRouterProviderName": "OrcaRouter",
+  "directOrcaRouterUrlInvalid": "Use OrcaRouter’s HTTPS /v1 root (https://api.orcarouter.ai/v1).",
+  "directOrcaRouterBaseUrlDescription": "Connect with an OrcaRouter API key.",
   "@directOpenRouterBaseUrlDescription": {
     "description": "Help text shown below the OpenRouter direct connection base URL."
   },

--- a/lib/l10n/app_ru.arb
+++ b/lib/l10n/app_ru.arb
@@ -3031,6 +3031,10 @@
   "directApiBaseUrl": "Базовый URL",
   "directOpenRouterUrlInvalid": "Используйте корневой HTTPS-адрес /api/v1 OpenRouter (глобальный или для ЕС).",
   "directOpenRouterBaseUrlDescription": "Использует ваш API-ключ OpenRouter, авторизованный каталог моделей и инструменты, управляемые Conduit.",
+
+  "orcaRouterProviderName": "OrcaRouter",
+  "directOrcaRouterUrlInvalid": "Use OrcaRouter’s HTTPS /v1 root (https://api.orcarouter.ai/v1).",
+  "directOrcaRouterBaseUrlDescription": "Connect with an OrcaRouter API key.",
   "directOpenRouterChatCompletionsDescription": "Chat Completions используется для встроенного веб-поиска, генерации изображений, анализа PDF и повторно используемых аннотаций PDF.",
   "directCompletionApi": "API завершения",
   "directChatCompletions": "Chat Completions",

--- a/lib/l10n/app_sk.arb
+++ b/lib/l10n/app_sk.arb
@@ -4659,6 +4659,10 @@
   "directApiBaseUrl": "Base URL",
   "directOpenRouterUrlInvalid": "Použite koreňovú adresu HTTPS /api/v1 služby OpenRouter (globálnu alebo EÚ).",
   "directOpenRouterBaseUrlDescription": "Používa váš kľúč API OpenRouter, overený katalóg modelov a nástroje spravované aplikáciou Conduit.",
+
+  "orcaRouterProviderName": "OrcaRouter",
+  "directOrcaRouterUrlInvalid": "Use OrcaRouter’s HTTPS /v1 root (https://api.orcarouter.ai/v1).",
+  "directOrcaRouterBaseUrlDescription": "Connect with an OrcaRouter API key.",
   "directOpenRouterChatCompletionsDescription": "Chat Completions sa používa na natívne vyhľadávanie na webe, generovanie obrázkov, analýzu PDF a opakovane použiteľné anotácie PDF.",
   "directCompletionApi": "Completion API",
   "directChatCompletions": "Chat Completions",

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -3004,6 +3004,10 @@
   "directApiBaseUrl": "Base URL",
   "directOpenRouterUrlInvalid": "Use OpenRouter’s HTTPS /api/v1 root (global or EU).",
   "directOpenRouterBaseUrlDescription": "Uses your OpenRouter API key, authenticated model catalog, and Conduit-managed tools.",
+
+  "orcaRouterProviderName": "OrcaRouter",
+  "directOrcaRouterUrlInvalid": "Use OrcaRouter’s HTTPS /v1 root (https://api.orcarouter.ai/v1).",
+  "directOrcaRouterBaseUrlDescription": "Connect with an OrcaRouter API key.",
   "directOpenRouterChatCompletionsDescription": "Chat Completions is used for native web search, image generation, PDF parsing, and reusable PDF annotations.",
   "directCompletionApi": "Completion API",
   "directChatCompletions": "Chat Completions",

--- a/lib/l10n/app_zh_Hant.arb
+++ b/lib/l10n/app_zh_Hant.arb
@@ -3004,6 +3004,10 @@
   "directApiBaseUrl": "Base URL",
   "directOpenRouterUrlInvalid": "Use OpenRouter’s HTTPS /api/v1 root (global or EU).",
   "directOpenRouterBaseUrlDescription": "Uses your OpenRouter API key, authenticated model catalog, and Conduit-managed tools.",
+
+  "orcaRouterProviderName": "OrcaRouter",
+  "directOrcaRouterUrlInvalid": "Use OrcaRouter’s HTTPS /v1 root (https://api.orcarouter.ai/v1).",
+  "directOrcaRouterBaseUrlDescription": "Connect with an OrcaRouter API key.",
   "directOpenRouterChatCompletionsDescription": "Chat Completions is used for native web search, image generation, PDF parsing, and reusable PDF annotations.",
   "directCompletionApi": "Completion API",
   "directChatCompletions": "Chat Completions",

--- a/test/features/direct_connections/direct_connection_editor_controller_test.dart
+++ b/test/features/direct_connections/direct_connection_editor_controller_test.dart
@@ -20,6 +20,7 @@ void main() {
       kOllamaAdapterKey,
       ollamaDefaultName: 'Ollama Cloud',
       openRouterDefaultName: 'OpenRouter',
+      orcaRouterDefaultName: 'OrcaRouter',
     );
 
     check(editor.form.adapterKey).equals(kOllamaAdapterKey);

--- a/test/features/direct_connections/direct_profile_security_test.dart
+++ b/test/features/direct_connections/direct_profile_security_test.dart
@@ -30,6 +30,27 @@ void main() {
         .isFalse();
   });
 
+  test('OrcaRouter identity requires its exact HTTPS API root', () {
+    check(isOrcaRouterApiBaseUrl(kOrcaRouterApiBaseUrl)).isTrue();
+    check(isOrcaRouterApiBaseUrl('https://api.orcarouter.ai/v1/')).isTrue();
+    check(isOrcaRouterApiBaseUrl('https://api.orcarouter.ai/v1/extra'))
+        .isFalse();
+    check(isOrcaRouterApiBaseUrl('http://api.orcarouter.ai/v1')).isFalse();
+    check(isOrcaRouterApiBaseUrl('https://api.orcarouter.example/v1'))
+        .isFalse();
+    check(isOrcaRouterApiBaseUrl('https://api.orcarouter.ai.evil.test/v1'))
+        .isFalse();
+    check(isOrcaRouterApiBaseUrl('https://user:pass@api.orcarouter.ai/v1'))
+        .isFalse();
+    check(isOrcaRouterApiBaseUrl('https://api.orcarouter.ai/v1?key=leak'))
+        .isFalse();
+    check(isOrcaRouterApiBaseUrl('https://api.orcarouter.ai/v1#fragment'))
+        .isFalse();
+    check(isOrcaRouterApiBaseUrl('https://api.orcarouter.ai:8443/v1'))
+        .isFalse();
+    check(isOrcaRouterApiBaseUrl('https://api.orcarouter.ai/api/v1')).isFalse();
+  });
+
   group('DirectConnectionProfile security', () {
     test('versioned document round-trips secrets without redaction loss', () {
       final profile = _profile(


### PR DESCRIPTION
# feat: add OrcaRouter as a first-class direct provider

Conduit describes Direct connections as covering "OpenAI-compatible endpoints
(Chat Completions or Responses), LM Studio, Azure-style API versions, native
Ollama, and **first-party OpenRouter**". This change adds **OrcaRouter** as the
second first-party named Direct provider, mirroring the existing OpenRouter
wiring so Conduit users can reach OrcaRouter's OpenAI-compatible gateway
without treating it as an anonymous custom base URL.

[OrcaRouter](https://www.orcarouter.ai) is an OpenAI-compatible AI gateway
built for both models and agents. Like OpenRouter, it exposes a provider/model
namespace across many models — but it also combines adaptive routing,
automatic failover, zero-markup inference, observability, guardrails, and
agent-tool governance behind the same endpoint. Adding orcarouter as a
first-class provider means Conduit users can use that stack directly, without
treating OrcaRouter as an anonymous custom base URL. It also runs gateway-level,
zero-trust security for AI agents on the same endpoint — screening every
prompt/response and governing every tool call on a default-deny basis, with no
application code changes.

## How it mirrors the OpenRouter preset

OrcaRouter intentionally shares the OpenAI-compatible adapter, exactly like
OpenRouter does. Provider identity is bound to the exact HTTPS API root
(`https://api.orcarouter.ai/v1`), and everything else follows Conduit's
existing provider-preset flow:

| File | What mirrors OpenRouter |
| --- | --- |
| `lib/features/direct_connections/models/direct_connection_profile.dart` | `kOrcaRouterApiBaseUrl` + `isOrcaRouter` + `isOrcaRouterApiBaseUrl()`, the same exact-root identity binding OpenRouter uses |
| `lib/features/direct_connections/controllers/direct_connection_editor_draft.dart` | `kOrcaRouterProviderPreset` preset, forced bearer auth, and `invalidOrcaRouterUrl` draft validation |
| `lib/features/direct_connections/controllers/direct_connection_editor_form.dart` | preset selection fills `https://api.orcarouter.ai/v1` and the default name, and locks out API-key-header/no-auth modes just like OpenRouter |
| `lib/features/direct_connections/views/direct_connection_editor_sections.dart` | OrcaRouter row in the provider picker (iOS dropdown + Android selection list) and the details section base-URL description/hints |
| `lib/features/direct_connections/views/direct_connection_advanced_settings.dart` | maps `invalidOrcaRouterUrl` to its localized message |
| `lib/features/direct_connections/services/direct_model_registry.dart` | exposes an `orcarouter` capability flag on discovered models |
| `lib/l10n/app_*.arb` | `orcaRouterProviderName`, `directOrcaRouterUrlInvalid`, `directOrcaRouterBaseUrlDescription` across all 14 locales |
| `README.md` | Direct-connection table and paragraph now list OrcaRouter alongside OpenRouter |
| `test/features/direct_connections/direct_profile_security_test.dart` | identity requires the exact HTTPS API root (same suite as OpenRouter) |

Because OrcaRouter is a plain OpenAI-compatible `/v1` endpoint, model discovery
uses the generic `models` route and chat uses `chat/completions` — no
OrcaRouter-specific request fields are sent today, so the shared adapter
handles it with zero special-casing.

## Verification

- **L3 live test** against the real endpoint using the exact adapter code path:
  - `GET https://api.orcarouter.ai/v1/models` → HTTP 200, 204 models
    (`orcarouter/free`, `orcarouter/fusion`, …)
  - `POST https://api.orcarouter.ai/v1/chat/completions` (model `orcarouter/free`) → HTTP 200, valid completion
- `dart format --output=none --set-exit-if-changed` passes on every modified
  Dart file (0 changed).
- `verify_arb_descriptions.dart` passes (all keys have `@meta.description`).
- New keys present in all 14 ARB locales; `validate_arb_locales.dart` reports
  no new missing keys (the pre-existing missing-key list is unchanged and
  unrelated to this PR).

## Notes

- OrcaRouter's API key uses the `sk-orca-` prefix and is sent as a bearer token,
  matching Conduit's existing secure-storage credential handling.
- I could not run `flutter analyze`/`flutter test` end-to-end here (the full
  Flutter SDK is not available in this environment), so I validated the
  localization gates CI actually runs, ran `dart format`, and verified the
  provider-identity logic standalone.

Discord: discord.gg/YEubt8enRA · X: https://x.com/OrcaRouter

I'm an engineer on the OrcaRouter team.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added OrcaRouter as a first-party direct-connection provider.
  - Users can select OrcaRouter, configure its secure API endpoint, and connect using bearer authentication.
  - OrcaRouter models are identified and handled appropriately within direct connections.
- **Bug Fixes**
  - Added validation to reject unsupported or unsafe OrcaRouter base URLs.
- **Documentation**
  - Updated connection guidance to include OrcaRouter.
- **Localization**
  - Added OrcaRouter names, setup guidance, and validation messages across supported languages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds OrcaRouter as a named OpenAI-compatible direct provider, including its canonical endpoint, provider selection, model metadata, localization, documentation, and profile identity handling.

Existing local profiles at the OrcaRouter endpoint can have their stored API-key-header or anonymous authentication mode changed to bearer when edited and saved. Switching an existing profile with an entered credential to OrcaRouter can also retain that credential for the new endpoint after origin review.

### T-Rex validation blocked

The Flutter tool is missing from the environment (`flutter: not found`), so the focused profile-hydration and provider-switch save flows could not execute.

<details><summary><h3>Confidence Score: 2/5</h3></summary>

Do not merge until provider changes discard or require explicit re-entry of credentials and persisted generic authentication modes remain intact.

Two independent failures remain: authentication persistence is overwritten for exact OrcaRouter origins, and a credential can be carried from another provider to OrcaRouter. The latter exposes a provider secret to a different origin.

**Files Needing Attention:** `lib/features/direct_connections/controllers/direct_connection_editor_draft.dart` needs to preserve persisted generic authentication modes; `lib/features/direct_connections/controllers/direct_connection_editor_form.dart` needs to clear or re-confirm credentials when selecting a provider preset.
</details>


<details open><summary><h3>Security Review</h3></summary>

Switching to OrcaRouter retains an entered credential from the previous provider. If the user accepts the origin review, that credential can be saved for use with `api.orcarouter.ai`, disclosing a secret intended for a different provider to the new service.
</details>


<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- A focused Flutter test was authored to hydrate exact-URL local OrcaRouter profiles with a persisted API-key header and anonymous authentication, then build the saved draft.
- The test was attempted against both the parent and current revisions, but the commands exited 127 because Flutter is not installed.
- A focused Flutter harness was authored to edit a credential, select OrcaRouter, accept origin review, and save the profile.
- Running the Flutter harness test exited 127 because Flutter is unavailable, so the credential-transfer flow did not execute.
- T-Rex produced a proof for a posted P1 finding, and the corresponding review comment details the finding.

<a href="https://app.greptile.com/trex/runs/21455822/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. General comment 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Exact OrcaRouter local profiles are coerced to bearer during authentication hydration**

   - **Bug**
     - For a local profile with `adapterKey == kOpenAiCompatibleAdapterKey` and base URL exactly `https://api.orcarouter.ai/v1`, `profile.isOrcaRouter` is true. `directAuthenticationForProfile` then returns `DirectAuthenticationMode.bearer` unconditionally, so persisted `apiKeyHeader` is lost during hydration; a keyless persisted profile is likewise treated as bearer rather than none. The form uses this function at `direct_connection_editor_form.dart:125-127`, and `build()` serializes every non-`apiKeyHeader` selection as bearer at `direct_connection_editor_draft.dart:405-407`, meaning a subsequent save changes persisted auth or requires a key.
   - **Cause**
     - The newly added `profile.isOrcaRouter` condition was included in the same unconditional bearer branch as OpenRouter, ahead of persisted API-key mode and empty-key detection.
   - **Fix**
     - Do not force OrcaRouter profiles through the bearer branch when hydrating a local persisted profile. Preserve `apiKeyAuthMode` when a key exists and return `none` when no key exists; apply OrcaRouter bearer-only restrictions only to newly selected/provider-managed configuration if intended.

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>

</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (1): Last reviewed commit: ["feat: add OrcaRouter as a first-class di..."](https://github.com/cogwheel0/conduit/commit/7dbeededd13c62fcb0da01fbe6a944365e2b20c0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58335870)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->