### PR TITLE
Support Open WebUI v0.11.3

### DIFF
--- a/lib/core/utils/server_version_compat.dart
+++ b/lib/core/utils/server_version_compat.dart
@@ -17,10 +17,10 @@ class ServerVersionCompat {
   /// Servers reporting a `/api/config` `version` strictly greater than this are
   /// shown a compatibility warning. Bump this (and re-verify against
   /// `openwebui-src/`) whenever a newer server release is validated.
-  static const String maxSupportedVersion = '0.11.1';
+  static const String maxSupportedVersion = '0.11.3';
 
   /// Parsed [maxSupportedVersion] components: `[major, minor, patch]`.
-  static const List<int> _maxSupported = [0, 11, 1];
+  static const List<int> _maxSupported = [0, 11, 3];
 
   /// Whether [rawVersion] is within the supported range (<= [maxSupportedVersion]).
   ///

--- a/lib/features/chat/views/chat_page.dart
+++ b/lib/features/chat/views/chat_page.dart
@@ -2968,7 +2968,6 @@ class _ChatPageState extends ConsumerState<ChatPage> {
                 );
               },
             ),
-      trailingContent: const ServerVersionWarningCard(),
       topContentInset: topPadding,
       bottomPadding: bottomPadding,
       horizontalPadding: Spacing.inputPadding,

--- a/test/core/providers/server_incompatible_provider_test.dart
+++ b/test/core/providers/server_incompatible_provider_test.dart
@@ -41,7 +41,7 @@ void main() {
     test('warns when the active server\'s config is unsupported', () async {
       final container = await _container(
         activeServer: _server('A'),
-        config: const BackendConfig(version: '0.11.2', serverId: 'A'),
+        config: const BackendConfig(version: '0.11.4', serverId: 'A'),
       );
       addTearDown(container.dispose);
 
@@ -51,7 +51,7 @@ void main() {
     test('does not warn when the active server is supported', () async {
       final container = await _container(
         activeServer: _server('A'),
-        config: const BackendConfig(version: '0.11.1', serverId: 'A'),
+        config: const BackendConfig(version: '0.11.3', serverId: 'A'),
       );
       addTearDown(container.dispose);
 
@@ -65,7 +65,7 @@ void main() {
         // the still-cached A config must not warn for B.
         final container = await _container(
           activeServer: _server('B'),
-          config: const BackendConfig(version: '0.11.2', serverId: 'A'),
+          config: const BackendConfig(version: '0.11.4', serverId: 'A'),
         );
         addTearDown(container.dispose);
 
@@ -80,7 +80,7 @@ void main() {
       // warning about a supported server because of a stale cache.
       final container = await _container(
         activeServer: _server('A'),
-        config: const BackendConfig(version: '0.11.2'),
+        config: const BackendConfig(version: '0.11.4'),
       );
       addTearDown(container.dispose);
 
@@ -90,7 +90,7 @@ void main() {
     test('fails open when there is no active server', () async {
       final container = await _container(
         activeServer: null,
-        config: const BackendConfig(version: '0.11.2', serverId: 'A'),
+        config: const BackendConfig(version: '0.11.4', serverId: 'A'),
       );
       addTearDown(container.dispose);
 

--- a/test/core/utils/server_version_compat_test.dart
+++ b/test/core/utils/server_version_compat_test.dart
@@ -5,7 +5,7 @@ import 'package:flutter_test/flutter_test.dart';
 void main() {
   group('ServerVersionCompat.isSupported', () {
     test('the max supported version itself is supported', () {
-      check(ServerVersionCompat.isSupported('0.11.1')).isTrue();
+      check(ServerVersionCompat.isSupported('0.11.3')).isTrue();
     });
 
     test('older versions are supported', () {
@@ -23,22 +23,22 @@ void main() {
     });
 
     test('newer patch / minor / major versions are unsupported', () {
-      for (final v in ['0.11.2', '0.12.0', '0.20.0', '1.0.0', '2.5.3']) {
+      for (final v in ['0.11.4', '0.12.0', '0.20.0', '1.0.0', '2.5.3']) {
         check(because: v, ServerVersionCompat.isSupported(v)).isFalse();
       }
     });
 
     test('tolerates a leading v prefix', () {
-      check(ServerVersionCompat.isSupported('v0.11.1')).isTrue();
-      check(ServerVersionCompat.isSupported('v0.11.2')).isFalse();
+      check(ServerVersionCompat.isSupported('v0.11.3')).isTrue();
+      check(ServerVersionCompat.isSupported('v0.11.4')).isFalse();
     });
 
     test('strips pre-release / build metadata before comparing', () {
       // A pre-release of the max version is treated as the max version.
-      check(ServerVersionCompat.isSupported('0.11.1-dev')).isTrue();
-      check(ServerVersionCompat.isSupported('0.11.1+build.7')).isTrue();
+      check(ServerVersionCompat.isSupported('0.11.3-dev')).isTrue();
+      check(ServerVersionCompat.isSupported('0.11.3+build.7')).isTrue();
       // Metadata on a newer core still gates.
-      check(ServerVersionCompat.isSupported('0.11.2-rc1')).isFalse();
+      check(ServerVersionCompat.isSupported('0.11.4-rc1')).isFalse();
     });
 
     test('partial versions are padded with zeros', () {
@@ -47,8 +47,8 @@ void main() {
       check(ServerVersionCompat.isSupported('1')).isFalse();
     });
 
-    test('the previous max (0.10.2) remains supported after the bump', () {
-      check(ServerVersionCompat.isSupported('0.10.2')).isTrue();
+    test('the previous max (0.11.1) remains supported after the bump', () {
+      check(ServerVersionCompat.isSupported('0.11.1')).isTrue();
     });
 
     test('fails open on null / empty / unparseable versions', () {
@@ -58,8 +58,8 @@ void main() {
     });
 
     test('isUnsupported is the inverse of isSupported', () {
-      check(ServerVersionCompat.isUnsupported('0.11.2')).isTrue();
-      check(ServerVersionCompat.isUnsupported('0.11.1')).isFalse();
+      check(ServerVersionCompat.isUnsupported('0.11.4')).isTrue();
+      check(ServerVersionCompat.isUnsupported('0.11.3')).isFalse();
       check(ServerVersionCompat.isUnsupported(null)).isFalse();
     });
 

--- a/test/shared/widgets/server_version_warning_card_test.dart
+++ b/test/shared/widgets/server_version_warning_card_test.dart
@@ -55,7 +55,7 @@ void main() {
       await tester.pumpWidget(
         _buildCard(
           authState: AuthNavigationState.authenticated,
-          config: const BackendConfig(version: '0.11.2', serverId: 'A'),
+          config: const BackendConfig(version: '0.11.4', serverId: 'A'),
         ),
       );
       await tester.pump();
@@ -64,21 +64,21 @@ void main() {
         find.byKey(const ValueKey('server-version-warning-card')).evaluate(),
       ).length.equals(1);
       check(find.text('Server not supported').evaluate()).length.equals(1);
-      check(find.textContaining('0.11.2').evaluate()).length.equals(1);
-      check(find.textContaining('0.11.1').evaluate()).length.equals(1);
+      check(find.textContaining('0.11.4').evaluate()).length.equals(1);
+      check(find.textContaining('0.11.3').evaluate()).length.equals(1);
     });
 
     testWidgets('disables text decoration on Android', (tester) async {
       await tester.pumpWidget(
         _buildCard(
           authState: AuthNavigationState.authenticated,
-          config: const BackendConfig(version: '0.11.2', serverId: 'A'),
+          config: const BackendConfig(version: '0.11.4', serverId: 'A'),
         ),
       );
       await tester.pump();
 
       final title = tester.widget<Text>(find.text('Server not supported'));
-      final message = tester.widget<Text>(find.textContaining('0.11.2'));
+      final message = tester.widget<Text>(find.textContaining('0.11.4'));
       check(title.style?.decoration).equals(TextDecoration.none);
       check(message.style?.decoration).equals(TextDecoration.none);
     });
@@ -92,7 +92,7 @@ void main() {
       await tester.pumpWidget(
         _buildCard(
           authState: AuthNavigationState.authenticated,
-          config: const BackendConfig(version: '0.11.2', serverId: 'A'),
+          config: const BackendConfig(version: '0.11.4', serverId: 'A'),
           body: MediaQuery(
             data: const MediaQueryData(
               size: Size(390, 420),
@@ -137,7 +137,7 @@ void main() {
       await tester.pumpWidget(
         _buildCard(
           authState: AuthNavigationState.authenticated,
-          config: const BackendConfig(version: '0.11.2', serverId: 'A'),
+          config: const BackendConfig(version: '0.11.4', serverId: 'A'),
           body: debugBuildChatEmptyStateViewportForTesting(
             padding: const EdgeInsets.symmetric(vertical: 100, horizontal: 24),
             children: const [
@@ -164,7 +164,7 @@ void main() {
       await tester.pumpWidget(
         _buildCard(
           authState: AuthNavigationState.authenticated,
-          config: const BackendConfig(version: '0.11.1', serverId: 'A'),
+          config: const BackendConfig(version: '0.11.3', serverId: 'A'),
         ),
       );
       await tester.pump();
@@ -176,7 +176,7 @@ void main() {
       await tester.pumpWidget(
         _buildCard(
           authState: AuthNavigationState.authenticated,
-          config: const BackendConfig(version: '0.11.2', serverId: 'B'),
+          config: const BackendConfig(version: '0.11.4', serverId: 'B'),
         ),
       );
       await tester.pump();
@@ -190,7 +190,7 @@ void main() {
       await tester.pumpWidget(
         _buildCard(
           authState: AuthNavigationState.needsLogin,
-          config: const BackendConfig(version: '0.11.2', serverId: 'A'),
+          config: const BackendConfig(version: '0.11.4', serverId: 'A'),
         ),
       );
       await tester.pump();


### PR DESCRIPTION
## Summary
- update the Open WebUI reference submodule to v0.11.3
- raise the maximum supported server version after checking API drift
- show the unsupported-server warning only on the new-chat greeting

## Compatibility audit
No route, authentication, realtime event, chat, or model contract changes require Conduit updates. The v0.11.3 image response additions are backward-compatible with the existing dynamic URL handling.

## Verification
- `dart analyze lib/features/chat/views/chat_page.dart`
- 245 focused Flutter tests
- iOS Simulator: verified a new chat and a populated chat

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Updates Conduit’s Open WebUI compatibility support through version 0.11.3 and limits the unsupported-server warning to the new-chat greeting. The executed comparison confirmed that 0.11.3 is accepted, 0.11.4 is warned about, the warning remains in the empty greeting, and populated chat timelines no longer include it.

## T-Rex validation blocked
The Flutter and Dart tools are unavailable in this environment, so the focused native unit and widget test command could not execute. A source-based executable check against both the base and updated revisions completed successfully for the version boundary and warning placement.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

No defects were found in the reviewed behavior, and the requested compatibility and warning-placement behavior was confirmed.

The executed comparison passed all checks for the updated supported version and the warning’s placement, leaving no review findings.

**Files Needing Attention:** None. Native Flutter unit and widget tests should still be run in an environment with the Flutter and Dart tools installed.
</details>


<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- - I ran a focused executable comparison between the base revision and the PR revision to verify the Open WebUI version boundary and warning-card placement.
- - I attempted the Flutter unit and widget tests, but the Flutter and Dart executables are not installed in this environment, so those tests could not run.
- - I validated the version-compatibility logic by confirming that ServerVersionCompat.isSupported('0.11.3') is true and isSupported('0.11.4') is false, and I noted the warning appears in the empty greeting while the populated timeline insertion was removed.
- - I consulted the before/after artifact logs and the fallback script to corroborate the boundary and placement results, including the review-focused shell script and the test-blocked Flutter runtime observations.

<a href="https://app.greptile.com/trex/runs/21861807/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["feat(openwebui): support v0.11.3"](https://github.com/cogwheel0/conduit/commit/46b68ba21523421157cc55f56bf4a0ce2768dd59) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59133185)</sub>

<!-- /greptile_comment -->