### PR TITLE
Fix chat streaming and native mobile regressions

### DIFF
--- a/lib/core/database/daos/messages_dao.dart
+++ b/lib/core/database/daos/messages_dao.dart
@@ -142,22 +142,24 @@ class MessagesDao extends DatabaseAccessor<AppDatabase>
     );
   }
 
-  /// Durability barrier written immediately before the completion POST.
+  /// Durability barrier written immediately after the completion POST is
+  /// accepted.
   ///
-  /// The marker means submission may have started; it deliberately does not
-  /// claim that the server accepted the request or that a response landed. A
-  /// recreated outbox runner recovers by pull only, preventing a duplicate POST
-  /// across crashes in the ambiguous marker-to-response window.
+  /// The marker means the server accepted the request, not that a response
+  /// landed. A recreated outbox runner recovers by pull only, preventing a
+  /// duplicate POST across crashes in the marker-to-response window.
   Future<bool> markAssistantCompletionSubmitted({
     required String chatId,
     required String messageId,
+    String? taskId,
   }) {
     return _updateAssistantPayload(
       chatId: chatId,
       messageId: messageId,
       mutate: (payload) {
         final metadata = _asJsonMap(payload['metadata'])
-          ..remove('responseDone');
+          ..remove('responseDone')
+          ..remove('completionTaskId');
         payload
           ..remove('error')
           ..remove('done')
@@ -165,6 +167,7 @@ class MessagesDao extends DatabaseAccessor<AppDatabase>
           ..['metadata'] = <String, dynamic>{
             ...metadata,
             'completionSubmitted': true,
+            if (taskId != null && taskId.isNotEmpty) 'completionTaskId': taskId,
           };
       },
     );

--- a/lib/core/services/conversation_parsing.dart
+++ b/lib/core/services/conversation_parsing.dart
@@ -669,7 +669,9 @@ Map<String, dynamic> _parseOpenWebUIMessageToJson(
     'content': contentString,
     'timestamp': _parseTimestamp(msgData['timestamp']).toIso8601String(),
     'model': (msgData['model'] ?? historyMsg?['model'])?.toString(),
-    'isStreaming': _safeBool(msgData['isStreaming']) ?? false,
+    'isStreaming':
+        _safeBool(msgData['isStreaming'] ?? historyMsg?['isStreaming']) ??
+        _safeBool(msgData['done'] ?? historyMsg?['done']) == false,
     'attachmentIds': ?attachmentIds,
     'files': ?files,
     if (embeds.isNotEmpty) 'embeds': embeds,

--- a/lib/core/services/native_sheet_hydration_service.dart
+++ b/lib/core/services/native_sheet_hydration_service.dart
@@ -63,19 +63,6 @@ class NativeSheetPresentationAdmission {
 }
 
 @visibleForTesting
-Future<bool> waitForNativeReasoningEffortHydration(
-  Future<Object?> hydration, {
-  Duration timeout = const Duration(seconds: 1),
-}) async {
-  try {
-    await hydration.timeout(timeout);
-    return true;
-  } on TimeoutException {
-    return false;
-  }
-}
-
-@visibleForTesting
 ReasoningEffortPolicy nativeModelSelectorReasoningEffortPolicy(
   bool hydrated,
   ReasoningEffortPolicy hydratedPolicy,
@@ -170,21 +157,15 @@ class NativeSheetHydrationService {
       Future<ServerModelReasoningEffort>? effortHydration;
       var effortHydrated = effortModel == null;
       if (effortModel != null) {
-        final pendingEffortHydration = _ref.read(
-          serverModelReasoningEffortProvider(effortModel).future,
+        final effortAsync = _ref.read(
+          serverModelReasoningEffortProvider(effortModel),
         );
-        effortHydration = pendingEffortHydration;
-        effortHydrated = await waitForNativeReasoningEffortHydration(
-          pendingEffortHydration,
-        );
+        effortHydrated = effortAsync.hasValue;
         if (!effortHydrated) {
-          DebugLogger.warning(
-            'reasoning-effort-hydration-timeout',
-            scope: 'native-sheet/models',
-            data: {'modelId': effortModel.id},
+          effortHydration = _ref.read(
+            serverModelReasoningEffortProvider(effortModel).future,
           );
         }
-        if (!context.mounted) return null;
       }
       final effortPolicy = nativeModelSelectorReasoningEffortPolicy(
         effortHydrated,

--- a/lib/features/auth/views/backend_chooser_page.dart
+++ b/lib/features/auth/views/backend_chooser_page.dart
@@ -143,11 +143,12 @@ class BackendChooserPage extends ConsumerWidget {
 bool debugShowAllAppleBackends = kDebugMode;
 
 bool _isAppleModelAvailable(AsyncValue<PlatformPccStatus>? status) =>
-    debugShowAllAppleBackends ||
-    (status?.hasValue == true &&
-        status!.requireValue.availability ==
-            PlatformPccAvailability.available &&
-        !status.requireValue.quotaLimitReached);
+    status != null &&
+    (debugShowAllAppleBackends ||
+        (status.hasValue == true &&
+            status.requireValue.availability ==
+                PlatformPccAvailability.available &&
+            !status.requireValue.quotaLimitReached));
 
 Future<void> _selectAppleModel(
   BuildContext context,

--- a/lib/features/chat/providers/chat_providers.dart
+++ b/lib/features/chat/providers/chat_providers.dart
@@ -10753,19 +10753,12 @@ Future<void> recoverSubmittedOpenWebUiCompletion(
   );
   if (landed == true) return;
   if (landed == null) return;
-  if (taskId == null || taskId.isEmpty) {
-    await _markHeadlessCompletionRecoveryFailed(
-      ref,
-      owner: owner,
-      assistantMessageId: assistantMessageId,
-    );
-    return;
-  }
   final taskFinished = await _waitForSubmittedOpenWebUiTask(
     ref,
     owner: owner,
     taskId: taskId,
     failureLimit: math.max(1, recoveryAttempts),
+    pollDelay: recoveryDelay,
   );
   if (taskFinished == null) return;
   if (taskFinished) {
@@ -10788,23 +10781,31 @@ Future<void> recoverSubmittedOpenWebUiCompletion(
 Future<bool?> _waitForSubmittedOpenWebUiTask(
   dynamic ref, {
   required OpenWebUiCompletionOwner owner,
-  required String taskId,
+  String? taskId,
   required int failureLimit,
   Duration pollDelay = const Duration(seconds: 2),
 }) async {
   final api = owner.api;
   if (api is! ApiService) return false;
   var consecutiveFailures = 0;
+  final trackedTaskIds = <String>{
+    if (taskId != null && taskId.isNotEmpty) taskId,
+  };
 
-  // Open WebUI registers this exact task before returning its ID. Once that
-  // durable identity leaves the active registry, bounded pulls recover the
-  // persisted result. Long-running active tasks have no client deadline.
+  // Open WebUI registers tasks before returning their IDs. New markers track
+  // the exact ID; legacy markers adopt the first active server snapshot. Once
+  // every tracked ID leaves, bounded pulls recover the persisted result.
   while (true) {
     if (!openWebUiCompletionContextIsCurrent(ref, owner)) return null;
     try {
       final taskIds = await api.getTaskIdsByChat(owner.chatId);
       if (!openWebUiCompletionContextIsCurrent(ref, owner)) return null;
-      if (!taskIds.contains(taskId)) return true;
+      if (trackedTaskIds.isEmpty) {
+        if (taskIds.isEmpty) return true;
+        trackedTaskIds.addAll(taskIds);
+      } else if (trackedTaskIds.every((id) => !taskIds.contains(id))) {
+        return true;
+      }
       consecutiveFailures = 0;
     } catch (error, stackTrace) {
       consecutiveFailures++;

--- a/lib/features/chat/providers/chat_providers.dart
+++ b/lib/features/chat/providers/chat_providers.dart
@@ -10779,6 +10779,8 @@ Future<bool?> _waitForSubmittedOpenWebUiTask(
   final api = owner.api;
   if (api is! ApiService) return false;
   var consecutiveFailures = 0;
+  var observedTask = false;
+  var unobservedEmptyPolls = 0;
 
   // A successfully active task has no wall-clock deadline: long generations
   // own the wakelock until the server reports completion. Only repeated status
@@ -10788,7 +10790,13 @@ Future<bool?> _waitForSubmittedOpenWebUiTask(
     try {
       final taskIds = await api.getTaskIdsByChat(owner.chatId);
       if (!openWebUiCompletionContextIsCurrent(ref, owner)) return null;
-      if (taskIds.isEmpty) return true;
+      if (taskIds.isNotEmpty) {
+        observedTask = true;
+        unobservedEmptyPolls = 0;
+      } else if (observedTask || ++unobservedEmptyPolls > 1) {
+        // A newly accepted task can briefly precede registry visibility.
+        return true;
+      }
       consecutiveFailures = 0;
     } catch (error, stackTrace) {
       consecutiveFailures++;

--- a/lib/features/chat/providers/chat_providers.dart
+++ b/lib/features/chat/providers/chat_providers.dart
@@ -10783,10 +10783,10 @@ Future<bool?> _waitForSubmittedOpenWebUiTask(
   if (api is! ApiService) return false;
   var consecutiveFailures = 0;
   var observedTask = false;
+  var unobservedPullMisses = 0;
 
-  // A successfully active task has no wall-clock deadline: long generations
-  // own the wakelock until the server reports completion. Only repeated status
-  // lookup failures terminate recovery as an error.
+  // Observed active tasks have no deadline. Before registry visibility, pull
+  // misses share the caller's bounded recovery budget.
   while (true) {
     if (!openWebUiCompletionContextIsCurrent(ref, owner)) return null;
     try {
@@ -10807,6 +10807,8 @@ Future<bool?> _waitForSubmittedOpenWebUiTask(
           delay: Duration.zero,
         );
         if (landed != false) return null;
+        unobservedPullMisses++;
+        if (unobservedPullMisses >= failureLimit) return true;
       }
       consecutiveFailures = 0;
     } catch (error, stackTrace) {

--- a/lib/features/chat/providers/chat_providers.dart
+++ b/lib/features/chat/providers/chat_providers.dart
@@ -14,6 +14,7 @@ import 'package:flutter/widgets.dart'
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 import 'package:uuid/uuid.dart';
+import 'package:wakelock_plus/wakelock_plus.dart';
 import 'package:yaml/yaml.dart' as yaml;
 
 import '../../../core/auth/auth_state_manager.dart';
@@ -1323,14 +1324,43 @@ final chatMessageByIdProvider = Provider.autoDispose
 /// Used by router to avoid showing connection issues during active streaming.
 /// Uses select() to only rebuild when the streaming state actually changes,
 /// not on every content update to the message list.
+bool _messagesAreStreaming(List<ChatMessage> messages) {
+  if (messages.isEmpty) return false;
+  final last = messages.last;
+  return last.role == 'assistant' && last.isStreaming;
+}
+
 final isChatStreamingProvider = Provider<bool>((ref) {
-  return ref.watch(
-    chatMessagesProvider.select((messages) {
-      if (messages.isEmpty) return false;
-      final last = messages.last;
-      return last.role == 'assistant' && last.isStreaming;
-    }),
+  return ref.watch(chatMessagesProvider.select(_messagesAreStreaming));
+});
+
+final chatWakelockCoordinatorProvider = Provider<void>((ref) {
+  var pendingToggle = Future<void>.value();
+
+  Future<void> toggle(bool enabled) async {
+    try {
+      await WakelockPlus.toggle(enable: enabled);
+    } catch (error, stackTrace) {
+      DebugLogger.error(
+        'toggle-failed',
+        scope: 'chat/wakelock',
+        error: error,
+        stackTrace: stackTrace,
+        data: {'enabled': enabled},
+      );
+    }
+  }
+
+  void enqueue(bool enabled) {
+    pendingToggle = pendingToggle.then((_) => toggle(enabled));
+  }
+
+  ref.listen<bool>(
+    chatMessagesProvider.select(_messagesAreStreaming),
+    (_, enabled) => enqueue(enabled),
+    fireImmediately: true,
   );
+  ref.onDispose(() => enqueue(false));
 });
 
 final shouldProtectLocalStreamingStateProvider = Provider<bool>((ref) {
@@ -1395,97 +1425,14 @@ class StreamingContent extends _$StreamingContent {
   void set(String? value) => state = value;
 }
 
-enum StreamingContentSizeBucket {
-  under1k,
-  from1k,
-  from2k,
-  from4k,
-  from8k,
-  from16k,
-}
-
-@immutable
-class StreamingContentUpdatePolicy {
-  const StreamingContentUpdatePolicy({
-    required this.interval,
-    required this.bucket,
-    required this.isMobileTarget,
-  });
-
-  final Duration interval;
-  final StreamingContentSizeBucket bucket;
-  final bool isMobileTarget;
-}
-
-@visibleForTesting
-StreamingContentUpdatePolicy debugStreamingContentUpdatePolicyForBuffer(
-  int length, {
-  bool isWeb = false,
-  TargetPlatform platform = TargetPlatform.android,
-}) {
-  return _streamingContentUpdatePolicyForTarget(
-    length,
-    isMobileTarget:
-        !isWeb &&
-        (platform == TargetPlatform.android || platform == TargetPlatform.iOS),
-  );
-}
+const _streamingContentUpdateInterval = Duration(milliseconds: 100);
 
 @visibleForTesting
 Duration debugStreamingContentUpdateIntervalForBuffer(
   int length, {
   bool isWeb = false,
   TargetPlatform platform = TargetPlatform.android,
-}) => debugStreamingContentUpdatePolicyForBuffer(
-  length,
-  isWeb: isWeb,
-  platform: platform,
-).interval;
-
-StreamingContentUpdatePolicy _streamingContentUpdatePolicyForTarget(
-  int length, {
-  required bool isMobileTarget,
-}) {
-  final bucket = switch (length) {
-    >= 16000 => StreamingContentSizeBucket.from16k,
-    >= 8000 => StreamingContentSizeBucket.from8k,
-    >= 4000 => StreamingContentSizeBucket.from4k,
-    >= 2000 => StreamingContentSizeBucket.from2k,
-    >= 1000 => StreamingContentSizeBucket.from1k,
-    _ => StreamingContentSizeBucket.under1k,
-  };
-  final interval = switch (bucket) {
-    StreamingContentSizeBucket.from16k =>
-      isMobileTarget
-          ? const Duration(milliseconds: 750)
-          : const Duration(milliseconds: 420),
-    StreamingContentSizeBucket.from8k =>
-      isMobileTarget
-          ? const Duration(milliseconds: 500)
-          : const Duration(milliseconds: 280),
-    StreamingContentSizeBucket.from4k =>
-      isMobileTarget
-          ? const Duration(milliseconds: 300)
-          : const Duration(milliseconds: 180),
-    StreamingContentSizeBucket.from2k =>
-      isMobileTarget
-          ? const Duration(milliseconds: 220)
-          : const Duration(milliseconds: 140),
-    StreamingContentSizeBucket.from1k =>
-      isMobileTarget
-          ? const Duration(milliseconds: 160)
-          : const Duration(milliseconds: 120),
-    StreamingContentSizeBucket.under1k =>
-      isMobileTarget
-          ? const Duration(milliseconds: 100)
-          : const Duration(milliseconds: 80),
-  };
-  return StreamingContentUpdatePolicy(
-    interval: interval,
-    bucket: bucket,
-    isMobileTarget: isMobileTarget,
-  );
-}
+}) => _streamingContentUpdateInterval;
 
 // Loading state for conversation (used to show chat skeletons during fetch)
 @Riverpod(keepAlive: true)
@@ -5781,16 +5728,13 @@ class ChatMessagesNotifier extends Notifier<List<ChatMessage>>
     if (_streamingContentFrameScheduled || _streamingContentTimer != null) {
       return;
     }
-    final policy = _streamingContentUpdatePolicyForBuffer(
-      _streamingBuffer!.length,
-    );
     final lastFlushAt = _lastStreamingContentFlushAt;
     if (lastFlushAt == null) {
       _scheduleStreamingContentFrame(reason: reason);
       return;
     }
     final elapsed = DateTime.now().difference(lastFlushAt);
-    final remaining = policy.interval - elapsed;
+    final remaining = _streamingContentUpdateInterval - elapsed;
     if (remaining <= Duration.zero) {
       _scheduleStreamingContentFrame(reason: reason);
       return;
@@ -5798,19 +5742,6 @@ class ChatMessagesNotifier extends Notifier<List<ChatMessage>>
     _streamingContentTimer = Timer(
       remaining,
       () => _scheduleStreamingContentFrame(reason: reason),
-    );
-  }
-
-  StreamingContentUpdatePolicy _streamingContentUpdatePolicyForBuffer(
-    int length,
-  ) {
-    final isMobileTarget =
-        !kIsWeb &&
-        (defaultTargetPlatform == TargetPlatform.android ||
-            defaultTargetPlatform == TargetPlatform.iOS);
-    return _streamingContentUpdatePolicyForTarget(
-      length,
-      isMobileTarget: isMobileTarget,
     );
   }
 
@@ -5873,7 +5804,6 @@ class ChatMessagesNotifier extends Notifier<List<ChatMessage>>
       _streamingCoalescedUpdateCount += coalescedUpdates;
       return;
     }
-    final policy = _streamingContentUpdatePolicyForBuffer(nextContent.length);
     _lastStreamingContentFlushAt = DateTime.now();
     _lastFlushedStreamingBufferVersion = _streamingBufferVersion;
     _streamingVisibleFlushCount += 1;
@@ -5888,9 +5818,7 @@ class ChatMessagesNotifier extends Notifier<List<ChatMessage>>
         'contentCharacters': nextContent.length,
         if (PerformanceProfiler.isEnabled)
           'contentUtf8Bytes': utf8.encode(nextContent).length,
-        'intervalMs': policy.interval.inMilliseconds,
-        'sizeBucket': policy.bucket.name,
-        'mobileTarget': policy.isMobileTarget,
+        'intervalMs': _streamingContentUpdateInterval.inMilliseconds,
       },
     );
     ref.read(streamingContentProvider.notifier).set(nextContent);

--- a/lib/features/chat/providers/chat_providers.dart
+++ b/lib/features/chat/providers/chat_providers.dart
@@ -10785,8 +10785,9 @@ Future<bool?> _waitForSubmittedOpenWebUiTask(
   var observedTask = false;
   var unobservedPullMisses = 0;
 
-  // Observed active tasks have no deadline. Before registry visibility, pull
-  // misses share the caller's bounded recovery budget.
+  // Open WebUI awaits task + Redis registration before returning its task ID.
+  // These bounded misses cover read visibility/persistence lag; an observed
+  // active task itself has no deadline.
   while (true) {
     if (!openWebUiCompletionContextIsCurrent(ref, owner)) return null;
     try {

--- a/lib/features/chat/providers/chat_providers.dart
+++ b/lib/features/chat/providers/chat_providers.dart
@@ -10703,6 +10703,7 @@ Future<void> _finishSubmittedOpenWebUiCompletionHeadlessly(
     final taskFinished = await _waitForSubmittedOpenWebUiTask(
       ref,
       owner: owner,
+      assistantMessageId: assistantMessageId,
       taskId: taskId,
       pollDelay: taskPollDelay,
       failureLimit: math.max(1, recoveryAttempts),
@@ -10756,6 +10757,7 @@ Future<void> recoverSubmittedOpenWebUiCompletion(
   final taskFinished = await _waitForSubmittedOpenWebUiTask(
     ref,
     owner: owner,
+    assistantMessageId: assistantMessageId,
     taskId: taskId,
     failureLimit: math.max(1, recoveryAttempts),
     pollDelay: recoveryDelay,
@@ -10781,45 +10783,51 @@ Future<void> recoverSubmittedOpenWebUiCompletion(
 Future<bool?> _waitForSubmittedOpenWebUiTask(
   dynamic ref, {
   required OpenWebUiCompletionOwner owner,
+  required String assistantMessageId,
   String? taskId,
   required int failureLimit,
   Duration pollDelay = const Duration(seconds: 2),
 }) async {
+  if (taskId == null || taskId.isEmpty) {
+    // ponytail: pre-task-ID markers get the existing five-minute headless
+    // window; remove this fallback once those legacy outbox rows age out.
+    final attempts = pollDelay <= Duration.zero
+        ? failureLimit
+        : math.max(
+            failureLimit,
+            (_headlessStreamDrainTimeout.inMicroseconds /
+                    pollDelay.inMicroseconds)
+                .ceil(),
+          );
+    for (var attempt = 0; attempt < attempts; attempt++) {
+      final landed = await _pullSubmittedOpenWebUiCompletion(
+        ref,
+        owner: owner,
+        assistantMessageId: assistantMessageId,
+        attempts: 1,
+        delay: Duration.zero,
+      );
+      if (landed == true) return true;
+      if (landed == null) return null;
+      if (attempt + 1 < attempts) {
+        await Future<void>.delayed(pollDelay);
+      }
+    }
+    return false;
+  }
+
   final api = owner.api;
   if (api is! ApiService) return false;
   var consecutiveFailures = 0;
-  var legacyActiveChecks = 0;
-  var legacyInactiveChecks = 0;
-  final trackedTaskIds = <String>{
-    if (taskId != null && taskId.isNotEmpty) taskId,
-  };
 
   // Open WebUI awaits task creation (and Redis registration) before returning
-  // an accepted task response. Exact IDs wait without a deadline; legacy
-  // markers allow a second inactive read for transient visibility skew, while
-  // bounded active checks prevent another session retaining this wakelock.
+  // an accepted task response, so exact IDs can wait without a deadline.
   while (true) {
     if (!openWebUiCompletionContextIsCurrent(ref, owner)) return null;
     try {
       final taskIds = await api.getTaskIdsByChat(owner.chatId);
       if (!openWebUiCompletionContextIsCurrent(ref, owner)) return null;
-      if (trackedTaskIds.isEmpty) {
-        var chatIsActive = taskIds.isNotEmpty;
-        if (!chatIsActive) {
-          final activeChatIds = await api.checkActiveChats([owner.chatId]);
-          if (!openWebUiCompletionContextIsCurrent(ref, owner)) return null;
-          chatIsActive = activeChatIds.contains(owner.chatId);
-        }
-        if (chatIsActive) {
-          legacyInactiveChecks = 0;
-          if (++legacyActiveChecks >= failureLimit) return true;
-        } else if (++legacyInactiveChecks >
-            ChatMessagesNotifier._unobservedReopenedEmptyPollGrace) {
-          return true;
-        }
-      } else if (trackedTaskIds.every((id) => !taskIds.contains(id))) {
-        return true;
-      }
+      if (!taskIds.contains(taskId)) return true;
       consecutiveFailures = 0;
     } catch (error, stackTrace) {
       consecutiveFailures++;
@@ -10930,6 +10938,8 @@ Future<void> finishSubmittedOpenWebUiCompletionHeadlesslyForTest(
 }
 
 bool _headlessAssistantLanded(ChatMessage message) {
+  if (message.error != null) return true;
+  if (!assistantMessageResponseCompleted(message)) return false;
   if (message.content.trim().isNotEmpty) return true;
   if (message.output?.isNotEmpty == true) return true;
   if (message.files?.isNotEmpty == true) return true;
@@ -10937,8 +10947,6 @@ bool _headlessAssistantLanded(ChatMessage message) {
   if (message.sources.isNotEmpty) return true;
   if (message.codeExecutions.isNotEmpty) return true;
   if (message.followUps.isNotEmpty) return true;
-  if (message.error != null) return true;
-
   return false;
 }
 

--- a/lib/features/chat/providers/chat_providers.dart
+++ b/lib/features/chat/providers/chat_providers.dart
@@ -10783,11 +10783,10 @@ Future<bool?> _waitForSubmittedOpenWebUiTask(
   if (api is! ApiService) return false;
   var consecutiveFailures = 0;
   var observedTask = false;
-  final registrationDeadline = DateTime.now().add(const Duration(minutes: 1));
 
   // A successfully active task has no wall-clock deadline: long generations
   // own the wakelock until the server reports completion. Only repeated status
-  // failures or a minute with neither registry nor persisted state terminate.
+  // lookup failures terminate recovery as an error.
   while (true) {
     if (!openWebUiCompletionContextIsCurrent(ref, owner)) return null;
     try {
@@ -10808,7 +10807,6 @@ Future<bool?> _waitForSubmittedOpenWebUiTask(
           delay: Duration.zero,
         );
         if (landed != false) return null;
-        if (DateTime.now().isAfter(registrationDeadline)) return false;
       }
       consecutiveFailures = 0;
     } catch (error, stackTrace) {

--- a/lib/features/chat/providers/chat_providers.dart
+++ b/lib/features/chat/providers/chat_providers.dart
@@ -10631,6 +10631,8 @@ Future<void> _finishSubmittedOpenWebUiCompletionHeadlessly(
   required String assistantMessageId,
   int recoveryAttempts = 6,
   Duration recoveryDelay = const Duration(seconds: 2),
+  Duration taskPollDelay = const Duration(seconds: 2),
+  Duration taskWaitTimeout = _headlessStreamDrainTimeout,
   bool requireDurableSubmittedMarker = true,
   bool submissionAlreadyMarked = false,
 }) async {
@@ -10684,7 +10686,7 @@ Future<void> _finishSubmittedOpenWebUiCompletionHeadlessly(
     }
   }
 
-  final landed = await _pullSubmittedOpenWebUiCompletion(
+  var landed = await _pullSubmittedOpenWebUiCompletion(
     ref,
     owner: owner,
     assistantMessageId: assistantMessageId,
@@ -10693,6 +10695,26 @@ Future<void> _finishSubmittedOpenWebUiCompletionHeadlessly(
   );
   if (landed == true) return;
   if (landed == null && drainFailure == null) return;
+  if (landed == false &&
+      session.transport == ChatCompletionTransport.taskSocket) {
+    final taskFinished = await _waitForSubmittedOpenWebUiTask(
+      ref,
+      owner: owner,
+      pollDelay: taskPollDelay,
+      timeout: taskWaitTimeout,
+    );
+    if (taskFinished == null) return;
+    if (taskFinished) {
+      landed = await _pullSubmittedOpenWebUiCompletion(
+        ref,
+        owner: owner,
+        assistantMessageId: assistantMessageId,
+        attempts: recoveryAttempts,
+        delay: recoveryDelay,
+      );
+      if (landed == true || landed == null) return;
+    }
+  }
 
   await _markHeadlessCompletionRecoveryFailed(
     ref,
@@ -10717,7 +10739,7 @@ Future<void> recoverSubmittedOpenWebUiCompletion(
   int recoveryAttempts = 6,
   Duration recoveryDelay = const Duration(seconds: 2),
 }) async {
-  final landed = await _pullSubmittedOpenWebUiCompletion(
+  var landed = await _pullSubmittedOpenWebUiCompletion(
     ref,
     owner: owner,
     assistantMessageId: assistantMessageId,
@@ -10726,11 +10748,53 @@ Future<void> recoverSubmittedOpenWebUiCompletion(
   );
   if (landed == true) return;
   if (landed == null) return;
+  final taskFinished = await _waitForSubmittedOpenWebUiTask(ref, owner: owner);
+  if (taskFinished == null) return;
+  if (taskFinished) {
+    landed = await _pullSubmittedOpenWebUiCompletion(
+      ref,
+      owner: owner,
+      assistantMessageId: assistantMessageId,
+      attempts: recoveryAttempts,
+      delay: recoveryDelay,
+    );
+    if (landed == true || landed == null) return;
+  }
   await _markHeadlessCompletionRecoveryFailed(
     ref,
     owner: owner,
     assistantMessageId: assistantMessageId,
   );
+}
+
+Future<bool?> _waitForSubmittedOpenWebUiTask(
+  dynamic ref, {
+  required OpenWebUiCompletionOwner owner,
+  Duration pollDelay = const Duration(seconds: 2),
+  Duration timeout = _headlessStreamDrainTimeout,
+}) async {
+  final api = owner.api;
+  if (api is! ApiService) return false;
+  final deadline = DateTime.now().add(timeout);
+
+  while (DateTime.now().isBefore(deadline)) {
+    if (!openWebUiCompletionContextIsCurrent(ref, owner)) return null;
+    try {
+      final taskIds = await api.getTaskIdsByChat(owner.chatId);
+      if (!openWebUiCompletionContextIsCurrent(ref, owner)) return null;
+      if (taskIds.isEmpty) return true;
+    } catch (error, stackTrace) {
+      DebugLogger.error(
+        'headless-task-status-failed',
+        scope: 'chat/completion',
+        error: error,
+        stackTrace: stackTrace,
+        data: {'chatId': owner.chatId},
+      );
+    }
+    await Future<void>.delayed(pollDelay);
+  }
+  return false;
 }
 
 Future<bool?> _pullSubmittedOpenWebUiCompletion(
@@ -10808,6 +10872,8 @@ Future<void> finishSubmittedOpenWebUiCompletionHeadlesslyForTest(
   required String assistantMessageId,
   int recoveryAttempts = 1,
   Duration recoveryDelay = Duration.zero,
+  Duration taskPollDelay = Duration.zero,
+  Duration taskWaitTimeout = const Duration(seconds: 1),
   bool requireDurableSubmittedMarker = true,
   bool submissionAlreadyMarked = false,
 }) {
@@ -10819,6 +10885,8 @@ Future<void> finishSubmittedOpenWebUiCompletionHeadlesslyForTest(
     assistantMessageId: assistantMessageId,
     recoveryAttempts: recoveryAttempts,
     recoveryDelay: recoveryDelay,
+    taskPollDelay: taskPollDelay,
+    taskWaitTimeout: taskWaitTimeout,
     requireDurableSubmittedMarker: requireDurableSubmittedMarker,
     submissionAlreadyMarked: submissionAlreadyMarked,
   );

--- a/lib/features/chat/providers/chat_providers.dart
+++ b/lib/features/chat/providers/chat_providers.dart
@@ -10632,7 +10632,6 @@ Future<void> _finishSubmittedOpenWebUiCompletionHeadlessly(
   int recoveryAttempts = 6,
   Duration recoveryDelay = const Duration(seconds: 2),
   Duration taskPollDelay = const Duration(seconds: 2),
-  Duration taskWaitTimeout = _headlessStreamDrainTimeout,
   bool requireDurableSubmittedMarker = true,
   bool submissionAlreadyMarked = false,
 }) async {
@@ -10701,7 +10700,6 @@ Future<void> _finishSubmittedOpenWebUiCompletionHeadlessly(
       ref,
       owner: owner,
       pollDelay: taskPollDelay,
-      timeout: taskWaitTimeout,
     );
     if (taskFinished == null) return;
     if (taskFinished) {
@@ -10771,13 +10769,11 @@ Future<bool?> _waitForSubmittedOpenWebUiTask(
   dynamic ref, {
   required OpenWebUiCompletionOwner owner,
   Duration pollDelay = const Duration(seconds: 2),
-  Duration timeout = _headlessStreamDrainTimeout,
 }) async {
   final api = owner.api;
   if (api is! ApiService) return false;
-  final deadline = DateTime.now().add(timeout);
 
-  while (DateTime.now().isBefore(deadline)) {
+  while (true) {
     if (!openWebUiCompletionContextIsCurrent(ref, owner)) return null;
     try {
       final taskIds = await api.getTaskIdsByChat(owner.chatId);
@@ -10794,7 +10790,6 @@ Future<bool?> _waitForSubmittedOpenWebUiTask(
     }
     await Future<void>.delayed(pollDelay);
   }
-  return false;
 }
 
 Future<bool?> _pullSubmittedOpenWebUiCompletion(
@@ -10873,7 +10868,6 @@ Future<void> finishSubmittedOpenWebUiCompletionHeadlesslyForTest(
   int recoveryAttempts = 1,
   Duration recoveryDelay = Duration.zero,
   Duration taskPollDelay = Duration.zero,
-  Duration taskWaitTimeout = const Duration(seconds: 1),
   bool requireDurableSubmittedMarker = true,
   bool submissionAlreadyMarked = false,
 }) {
@@ -10886,7 +10880,6 @@ Future<void> finishSubmittedOpenWebUiCompletionHeadlesslyForTest(
     recoveryAttempts: recoveryAttempts,
     recoveryDelay: recoveryDelay,
     taskPollDelay: taskPollDelay,
-    taskWaitTimeout: taskWaitTimeout,
     requireDurableSubmittedMarker: requireDurableSubmittedMarker,
     submissionAlreadyMarked: submissionAlreadyMarked,
   );

--- a/lib/features/chat/providers/chat_providers.dart
+++ b/lib/features/chat/providers/chat_providers.dart
@@ -10788,26 +10788,27 @@ Future<bool?> _waitForSubmittedOpenWebUiTask(
   final api = owner.api;
   if (api is! ApiService) return false;
   var consecutiveFailures = 0;
+  var legacyStatusChecks = 0;
   final trackedTaskIds = <String>{
     if (taskId != null && taskId.isNotEmpty) taskId,
   };
 
-  // New markers track the exact task ID. Legacy markers cross-check the
-  // server's chat-active state before accepting an empty registry, and adopt
-  // any active task IDs they observe.
+  // Exact task IDs wait without a deadline. Ownership-less legacy markers use
+  // bounded server activity checks so another session cannot retain this
+  // device's wakelock indefinitely.
   while (true) {
     if (!openWebUiCompletionContextIsCurrent(ref, owner)) return null;
     try {
       final taskIds = await api.getTaskIdsByChat(owner.chatId);
       if (!openWebUiCompletionContextIsCurrent(ref, owner)) return null;
       if (trackedTaskIds.isEmpty) {
-        if (taskIds.isNotEmpty) {
-          trackedTaskIds.addAll(taskIds);
-        } else {
+        var chatIsActive = taskIds.isNotEmpty;
+        if (!chatIsActive) {
           final activeChatIds = await api.checkActiveChats([owner.chatId]);
           if (!openWebUiCompletionContextIsCurrent(ref, owner)) return null;
-          if (!activeChatIds.contains(owner.chatId)) return true;
+          chatIsActive = activeChatIds.contains(owner.chatId);
         }
+        if (!chatIsActive || ++legacyStatusChecks >= failureLimit) return true;
       } else if (trackedTaskIds.every((id) => !taskIds.contains(id))) {
         return true;
       }

--- a/lib/features/chat/providers/chat_providers.dart
+++ b/lib/features/chat/providers/chat_providers.dart
@@ -10792,17 +10792,22 @@ Future<bool?> _waitForSubmittedOpenWebUiTask(
     if (taskId != null && taskId.isNotEmpty) taskId,
   };
 
-  // Open WebUI registers tasks before returning their IDs. New markers track
-  // the exact ID; legacy markers adopt the first active server snapshot. Once
-  // every tracked ID leaves, bounded pulls recover the persisted result.
+  // New markers track the exact task ID. Legacy markers cross-check the
+  // server's chat-active state before accepting an empty registry, and adopt
+  // any active task IDs they observe.
   while (true) {
     if (!openWebUiCompletionContextIsCurrent(ref, owner)) return null;
     try {
       final taskIds = await api.getTaskIdsByChat(owner.chatId);
       if (!openWebUiCompletionContextIsCurrent(ref, owner)) return null;
       if (trackedTaskIds.isEmpty) {
-        if (taskIds.isEmpty) return true;
-        trackedTaskIds.addAll(taskIds);
+        if (taskIds.isNotEmpty) {
+          trackedTaskIds.addAll(taskIds);
+        } else {
+          final activeChatIds = await api.checkActiveChats([owner.chatId]);
+          if (!openWebUiCompletionContextIsCurrent(ref, owner)) return null;
+          if (!activeChatIds.contains(owner.chatId)) return true;
+        }
       } else if (trackedTaskIds.every((id) => !taskIds.contains(id))) {
         return true;
       }

--- a/lib/features/chat/providers/chat_providers.dart
+++ b/lib/features/chat/providers/chat_providers.dart
@@ -10789,17 +10789,10 @@ Future<bool?> _waitForSubmittedOpenWebUiTask(
   Duration pollDelay = const Duration(seconds: 2),
 }) async {
   if (taskId == null || taskId.isEmpty) {
-    // ponytail: pre-task-ID markers get the existing five-minute headless
-    // window; remove this fallback once those legacy outbox rows age out.
-    final attempts = pollDelay <= Duration.zero
-        ? failureLimit
-        : math.max(
-            failureLimit,
-            (_headlessStreamDrainTimeout.inMicroseconds /
-                    pollDelay.inMicroseconds)
-                .ceil(),
-          );
-    for (var attempt = 0; attempt < attempts; attempt++) {
+    // Pre-task-ID markers cannot distinguish a lost task from a slow accepted
+    // task. Reconcile their exact assistant row until it becomes terminal or
+    // the captured owner is disposed/replaced.
+    while (true) {
       final landed = await _pullSubmittedOpenWebUiCompletion(
         ref,
         owner: owner,
@@ -10809,11 +10802,8 @@ Future<bool?> _waitForSubmittedOpenWebUiTask(
       );
       if (landed == true) return true;
       if (landed == null) return null;
-      if (attempt + 1 < attempts) {
-        await Future<void>.delayed(pollDelay);
-      }
+      await Future<void>.delayed(pollDelay);
     }
-    return false;
   }
 
   final api = owner.api;

--- a/lib/features/chat/providers/chat_providers.dart
+++ b/lib/features/chat/providers/chat_providers.dart
@@ -10789,10 +10789,17 @@ Future<bool?> _waitForSubmittedOpenWebUiTask(
   Duration pollDelay = const Duration(seconds: 2),
 }) async {
   if (taskId == null || taskId.isEmpty) {
-    // Pre-task-ID markers cannot distinguish a lost task from a slow accepted
-    // task. Reconcile their exact assistant row until it becomes terminal or
-    // the captured owner is disposed/replaced.
-    while (true) {
+    // ponytail: pre-task-ID markers get the existing five-minute headless
+    // window; remove this fallback once those legacy outbox rows age out.
+    final attempts = pollDelay <= Duration.zero
+        ? failureLimit
+        : math.max(
+            failureLimit,
+            (_headlessStreamDrainTimeout.inMicroseconds /
+                    pollDelay.inMicroseconds)
+                .ceil(),
+          );
+    for (var attempt = 0; attempt < attempts; attempt++) {
       final landed = await _pullSubmittedOpenWebUiCompletion(
         ref,
         owner: owner,
@@ -10802,8 +10809,11 @@ Future<bool?> _waitForSubmittedOpenWebUiTask(
       );
       if (landed == true) return true;
       if (landed == null) return null;
-      await Future<void>.delayed(pollDelay);
+      if (attempt + 1 < attempts) {
+        await Future<void>.delayed(pollDelay);
+      }
     }
+    return false;
   }
 
   final api = owner.api;

--- a/lib/features/chat/providers/chat_providers.dart
+++ b/lib/features/chat/providers/chat_providers.dart
@@ -1336,6 +1336,9 @@ final isChatStreamingProvider = Provider<bool>((ref) {
 
 final chatWakelockCoordinatorProvider = Provider<void>((ref) {
   var pendingToggle = Future<void>.value();
+  var localStream = false;
+  var backgroundStream = false;
+  bool? held;
 
   Future<void> toggle(bool enabled) async {
     try {
@@ -1352,12 +1355,24 @@ final chatWakelockCoordinatorProvider = Provider<void>((ref) {
   }
 
   void enqueue(bool enabled) {
+    if (held == enabled) return;
+    held = enabled;
     pendingToggle = pendingToggle.then((_) => toggle(enabled));
   }
 
+  ref.listen<bool>(chatMessagesProvider.select(_messagesAreStreaming), (
+    _,
+    enabled,
+  ) {
+    localStream = enabled;
+    enqueue(localStream || backgroundStream);
+  }, fireImmediately: true);
   ref.listen<bool>(
-    chatMessagesProvider.select(_messagesAreStreaming),
-    (_, enabled) => enqueue(enabled),
+    activeChatIdsProvider.select((chatIds) => chatIds.isNotEmpty),
+    (_, enabled) {
+      backgroundStream = enabled;
+      enqueue(localStream || backgroundStream);
+    },
     fireImmediately: true,
   );
   ref.onDispose(() => enqueue(false));

--- a/lib/features/chat/providers/chat_providers.dart
+++ b/lib/features/chat/providers/chat_providers.dart
@@ -10788,7 +10788,8 @@ Future<bool?> _waitForSubmittedOpenWebUiTask(
   final api = owner.api;
   if (api is! ApiService) return false;
   var consecutiveFailures = 0;
-  var legacyStatusChecks = 0;
+  var legacyActiveChecks = 0;
+  var legacyInactiveChecks = 0;
   final trackedTaskIds = <String>{
     if (taskId != null && taskId.isNotEmpty) taskId,
   };
@@ -10808,7 +10809,13 @@ Future<bool?> _waitForSubmittedOpenWebUiTask(
           if (!openWebUiCompletionContextIsCurrent(ref, owner)) return null;
           chatIsActive = activeChatIds.contains(owner.chatId);
         }
-        if (!chatIsActive || ++legacyStatusChecks >= failureLimit) return true;
+        if (chatIsActive) {
+          legacyInactiveChecks = 0;
+          if (++legacyActiveChecks >= failureLimit) return true;
+        } else if (++legacyInactiveChecks >
+            ChatMessagesNotifier._unobservedReopenedEmptyPollGrace) {
+          return true;
+        }
       } else if (trackedTaskIds.every((id) => !taskIds.contains(id))) {
         return true;
       }

--- a/lib/features/chat/providers/chat_providers.dart
+++ b/lib/features/chat/providers/chat_providers.dart
@@ -10794,9 +10794,10 @@ Future<bool?> _waitForSubmittedOpenWebUiTask(
     if (taskId != null && taskId.isNotEmpty) taskId,
   };
 
-  // Exact task IDs wait without a deadline. Ownership-less legacy markers use
-  // bounded server activity checks so another session cannot retain this
-  // device's wakelock indefinitely.
+  // Open WebUI awaits task creation (and Redis registration) before returning
+  // an accepted task response. Exact IDs wait without a deadline; legacy
+  // markers allow a second inactive read for transient visibility skew, while
+  // bounded active checks prevent another session retaining this wakelock.
   while (true) {
     if (!openWebUiCompletionContextIsCurrent(ref, owner)) return null;
     try {

--- a/lib/features/chat/providers/chat_providers.dart
+++ b/lib/features/chat/providers/chat_providers.dart
@@ -10642,6 +10642,7 @@ Future<void> _finishSubmittedOpenWebUiCompletionHeadlessly(
         ref,
         owner: owner,
         assistantMessageId: assistantMessageId,
+        taskId: session.taskId,
       );
   if (!markerPersisted && requireDurableSubmittedMarker) {
     // The request crossed the server boundary, but without a durable marker an
@@ -10694,12 +10695,15 @@ Future<void> _finishSubmittedOpenWebUiCompletionHeadlessly(
   );
   if (landed == true) return;
   if (landed == null && drainFailure == null) return;
+  final taskId = session.taskId;
   if (landed == false &&
-      session.transport == ChatCompletionTransport.taskSocket) {
+      session.transport == ChatCompletionTransport.taskSocket &&
+      taskId != null &&
+      taskId.isNotEmpty) {
     final taskFinished = await _waitForSubmittedOpenWebUiTask(
       ref,
       owner: owner,
-      assistantMessageId: assistantMessageId,
+      taskId: taskId,
       pollDelay: taskPollDelay,
       failureLimit: math.max(1, recoveryAttempts),
     );
@@ -10736,6 +10740,7 @@ Future<void> recoverSubmittedOpenWebUiCompletion(
   dynamic ref, {
   required OpenWebUiCompletionOwner owner,
   required String assistantMessageId,
+  String? taskId,
   int recoveryAttempts = 6,
   Duration recoveryDelay = const Duration(seconds: 2),
 }) async {
@@ -10748,10 +10753,18 @@ Future<void> recoverSubmittedOpenWebUiCompletion(
   );
   if (landed == true) return;
   if (landed == null) return;
+  if (taskId == null || taskId.isEmpty) {
+    await _markHeadlessCompletionRecoveryFailed(
+      ref,
+      owner: owner,
+      assistantMessageId: assistantMessageId,
+    );
+    return;
+  }
   final taskFinished = await _waitForSubmittedOpenWebUiTask(
     ref,
     owner: owner,
-    assistantMessageId: assistantMessageId,
+    taskId: taskId,
     failureLimit: math.max(1, recoveryAttempts),
   );
   if (taskFinished == null) return;
@@ -10775,42 +10788,23 @@ Future<void> recoverSubmittedOpenWebUiCompletion(
 Future<bool?> _waitForSubmittedOpenWebUiTask(
   dynamic ref, {
   required OpenWebUiCompletionOwner owner,
-  required String assistantMessageId,
+  required String taskId,
   required int failureLimit,
   Duration pollDelay = const Duration(seconds: 2),
 }) async {
   final api = owner.api;
   if (api is! ApiService) return false;
   var consecutiveFailures = 0;
-  var observedTask = false;
-  var unobservedPullMisses = 0;
 
-  // Open WebUI awaits task + Redis registration before returning its task ID.
-  // These bounded misses cover read visibility/persistence lag; an observed
-  // active task itself has no deadline.
+  // Open WebUI registers this exact task before returning its ID. Once that
+  // durable identity leaves the active registry, bounded pulls recover the
+  // persisted result. Long-running active tasks have no client deadline.
   while (true) {
     if (!openWebUiCompletionContextIsCurrent(ref, owner)) return null;
     try {
       final taskIds = await api.getTaskIdsByChat(owner.chatId);
       if (!openWebUiCompletionContextIsCurrent(ref, owner)) return null;
-      if (taskIds.isNotEmpty) {
-        observedTask = true;
-      } else if (observedTask) {
-        return true;
-      } else {
-        // Registration can trail acceptance. Keep the generation lease while
-        // checking whether a fast task already persisted before it was seen.
-        final landed = await _pullSubmittedOpenWebUiCompletion(
-          ref,
-          owner: owner,
-          assistantMessageId: assistantMessageId,
-          attempts: 1,
-          delay: Duration.zero,
-        );
-        if (landed != false) return null;
-        unobservedPullMisses++;
-        if (unobservedPullMisses >= failureLimit) return true;
-      }
+      if (!taskIds.contains(taskId)) return true;
       consecutiveFailures = 0;
     } catch (error, stackTrace) {
       consecutiveFailures++;
@@ -10976,6 +10970,7 @@ Future<void> _markAcceptedOpenWebUiCompletionOrAbort(
       ref,
       owner: owner,
       assistantMessageId: assistantMessageId,
+      taskId: session.taskId,
     );
   } catch (_) {
     // The server accepted the request, but without a durable marker a later
@@ -10990,6 +10985,7 @@ Future<bool> _markHeadlessCompletionSubmitted(
   dynamic ref, {
   required OpenWebUiCompletionOwner owner,
   required String assistantMessageId,
+  String? taskId,
 }) async {
   final chatId = owner.chatId;
   final db = owner.database;
@@ -10998,6 +10994,7 @@ Future<bool> _markHeadlessCompletionSubmitted(
     return await db.messagesDao.markAssistantCompletionSubmitted(
       chatId: chatId,
       messageId: assistantMessageId,
+      taskId: taskId,
     );
   } catch (error, stackTrace) {
     DebugLogger.error(
@@ -11021,11 +11018,13 @@ Future<void> beginOpenWebUiCompletionSubmission(
   dynamic ref, {
   required OpenWebUiCompletionOwner owner,
   required String assistantMessageId,
+  String? taskId,
 }) async {
   final persisted = await _markHeadlessCompletionSubmitted(
     ref,
     owner: owner,
     assistantMessageId: assistantMessageId,
+    taskId: taskId,
   );
   if (persisted) return;
   throw const SyncTerminalException(

--- a/lib/features/chat/providers/chat_providers.dart
+++ b/lib/features/chat/providers/chat_providers.dart
@@ -10699,6 +10699,7 @@ Future<void> _finishSubmittedOpenWebUiCompletionHeadlessly(
     final taskFinished = await _waitForSubmittedOpenWebUiTask(
       ref,
       owner: owner,
+      assistantMessageId: assistantMessageId,
       pollDelay: taskPollDelay,
       failureLimit: math.max(1, recoveryAttempts),
     );
@@ -10750,6 +10751,7 @@ Future<void> recoverSubmittedOpenWebUiCompletion(
   final taskFinished = await _waitForSubmittedOpenWebUiTask(
     ref,
     owner: owner,
+    assistantMessageId: assistantMessageId,
     failureLimit: math.max(1, recoveryAttempts),
   );
   if (taskFinished == null) return;
@@ -10773,6 +10775,7 @@ Future<void> recoverSubmittedOpenWebUiCompletion(
 Future<bool?> _waitForSubmittedOpenWebUiTask(
   dynamic ref, {
   required OpenWebUiCompletionOwner owner,
+  required String assistantMessageId,
   required int failureLimit,
   Duration pollDelay = const Duration(seconds: 2),
 }) async {
@@ -10780,11 +10783,11 @@ Future<bool?> _waitForSubmittedOpenWebUiTask(
   if (api is! ApiService) return false;
   var consecutiveFailures = 0;
   var observedTask = false;
-  var unobservedEmptyPolls = 0;
+  final registrationDeadline = DateTime.now().add(const Duration(minutes: 1));
 
   // A successfully active task has no wall-clock deadline: long generations
   // own the wakelock until the server reports completion. Only repeated status
-  // lookup failures terminate recovery as an error.
+  // failures or a minute with neither registry nor persisted state terminate.
   while (true) {
     if (!openWebUiCompletionContextIsCurrent(ref, owner)) return null;
     try {
@@ -10792,10 +10795,20 @@ Future<bool?> _waitForSubmittedOpenWebUiTask(
       if (!openWebUiCompletionContextIsCurrent(ref, owner)) return null;
       if (taskIds.isNotEmpty) {
         observedTask = true;
-        unobservedEmptyPolls = 0;
-      } else if (observedTask || ++unobservedEmptyPolls > 1) {
-        // A newly accepted task can briefly precede registry visibility.
+      } else if (observedTask) {
         return true;
+      } else {
+        // Registration can trail acceptance. Keep the generation lease while
+        // checking whether a fast task already persisted before it was seen.
+        final landed = await _pullSubmittedOpenWebUiCompletion(
+          ref,
+          owner: owner,
+          assistantMessageId: assistantMessageId,
+          attempts: 1,
+          delay: Duration.zero,
+        );
+        if (landed != false) return null;
+        if (DateTime.now().isAfter(registrationDeadline)) return false;
       }
       consecutiveFailures = 0;
     } catch (error, stackTrace) {

--- a/lib/features/chat/providers/chat_providers.dart
+++ b/lib/features/chat/providers/chat_providers.dart
@@ -1334,6 +1334,36 @@ final isChatStreamingProvider = Provider<bool>((ref) {
   return ref.watch(chatMessagesProvider.select(_messagesAreStreaming));
 });
 
+final _localChatGenerationCountProvider =
+    NotifierProvider<_LocalChatGenerationCount, int>(
+      _LocalChatGenerationCount.new,
+    );
+
+final localChatGenerationActiveProvider = Provider<bool>(
+  (ref) => ref.watch(_localChatGenerationCountProvider) > 0,
+);
+
+void Function() holdLocalChatGeneration(Ref ref) {
+  final counter = ref.read(_localChatGenerationCountProvider.notifier)..hold();
+  var released = false;
+  return () {
+    if (released) return;
+    released = true;
+    counter.release();
+  };
+}
+
+class _LocalChatGenerationCount extends Notifier<int> {
+  @override
+  int build() => 0;
+
+  void hold() => state++;
+
+  void release() {
+    if (ref.mounted && state > 0) state--;
+  }
+}
+
 final chatWakelockCoordinatorProvider = Provider<void>((ref) {
   var pendingToggle = Future<void>.value();
   var localStream = false;
@@ -1367,14 +1397,10 @@ final chatWakelockCoordinatorProvider = Provider<void>((ref) {
     localStream = enabled;
     enqueue(localStream || backgroundStream);
   }, fireImmediately: true);
-  ref.listen<bool>(
-    activeChatIdsProvider.select((chatIds) => chatIds.isNotEmpty),
-    (_, enabled) {
-      backgroundStream = enabled;
-      enqueue(localStream || backgroundStream);
-    },
-    fireImmediately: true,
-  );
+  ref.listen<bool>(localChatGenerationActiveProvider, (_, enabled) {
+    backgroundStream = enabled;
+    enqueue(localStream || backgroundStream);
+  }, fireImmediately: true);
   ref.onDispose(() => enqueue(false));
 });
 

--- a/lib/features/chat/providers/chat_providers.dart
+++ b/lib/features/chat/providers/chat_providers.dart
@@ -10700,6 +10700,7 @@ Future<void> _finishSubmittedOpenWebUiCompletionHeadlessly(
       ref,
       owner: owner,
       pollDelay: taskPollDelay,
+      failureLimit: math.max(1, recoveryAttempts),
     );
     if (taskFinished == null) return;
     if (taskFinished) {
@@ -10746,7 +10747,11 @@ Future<void> recoverSubmittedOpenWebUiCompletion(
   );
   if (landed == true) return;
   if (landed == null) return;
-  final taskFinished = await _waitForSubmittedOpenWebUiTask(ref, owner: owner);
+  final taskFinished = await _waitForSubmittedOpenWebUiTask(
+    ref,
+    owner: owner,
+    failureLimit: math.max(1, recoveryAttempts),
+  );
   if (taskFinished == null) return;
   if (taskFinished) {
     landed = await _pullSubmittedOpenWebUiCompletion(
@@ -10768,18 +10773,25 @@ Future<void> recoverSubmittedOpenWebUiCompletion(
 Future<bool?> _waitForSubmittedOpenWebUiTask(
   dynamic ref, {
   required OpenWebUiCompletionOwner owner,
+  required int failureLimit,
   Duration pollDelay = const Duration(seconds: 2),
 }) async {
   final api = owner.api;
   if (api is! ApiService) return false;
+  var consecutiveFailures = 0;
 
+  // A successfully active task has no wall-clock deadline: long generations
+  // own the wakelock until the server reports completion. Only repeated status
+  // lookup failures terminate recovery as an error.
   while (true) {
     if (!openWebUiCompletionContextIsCurrent(ref, owner)) return null;
     try {
       final taskIds = await api.getTaskIdsByChat(owner.chatId);
       if (!openWebUiCompletionContextIsCurrent(ref, owner)) return null;
       if (taskIds.isEmpty) return true;
+      consecutiveFailures = 0;
     } catch (error, stackTrace) {
+      consecutiveFailures++;
       DebugLogger.error(
         'headless-task-status-failed',
         scope: 'chat/completion',
@@ -10787,6 +10799,7 @@ Future<bool?> _waitForSubmittedOpenWebUiTask(
         stackTrace: stackTrace,
         data: {'chatId': owner.chatId},
       );
+      if (consecutiveFailures >= failureLimit) return false;
     }
     await Future<void>.delayed(pollDelay);
   }

--- a/lib/features/chat/providers/chat_providers.dart
+++ b/lib/features/chat/providers/chat_providers.dart
@@ -10819,15 +10819,21 @@ Future<bool?> _waitForSubmittedOpenWebUiTask(
   final api = owner.api;
   if (api is! ApiService) return false;
   var consecutiveFailures = 0;
+  var consecutiveMissing = 0;
 
-  // Open WebUI awaits task creation (and Redis registration) before returning
-  // an accepted task response, so exact IDs can wait without a deadline.
+  // Exact IDs can wait without a deadline. Confirm disappearance twice so a
+  // transient empty task-registry read cannot finish recovery early.
   while (true) {
     if (!openWebUiCompletionContextIsCurrent(ref, owner)) return null;
     try {
       final taskIds = await api.getTaskIdsByChat(owner.chatId);
       if (!openWebUiCompletionContextIsCurrent(ref, owner)) return null;
-      if (!taskIds.contains(taskId)) return true;
+      if (!taskIds.contains(taskId)) {
+        consecutiveMissing++;
+        if (consecutiveMissing >= 2) return true;
+      } else {
+        consecutiveMissing = 0;
+      }
       consecutiveFailures = 0;
     } catch (error, stackTrace) {
       consecutiveFailures++;

--- a/lib/features/chat/services/request_completion_runner.dart
+++ b/lib/features/chat/services/request_completion_runner.dart
@@ -208,6 +208,7 @@ class ChatRequestCompletionRunner implements RequestCompletionRunner {
         _ref,
         owner: owner,
         assistantMessageId: assistantMessageId,
+        taskId: _placeholderSubmittedTaskId(placeholder),
         recoveryAttempts: _recoveryAttempts,
         recoveryDelay: _recoveryDelay,
       );
@@ -292,6 +293,14 @@ bool _placeholderMarkedSubmitted(MessageRow placeholder) {
   final payload = _decodeMessagePayload(placeholder.payload);
   final metadata = _asJsonMap(payload['metadata']);
   return metadata['completionSubmitted'] == true;
+}
+
+String? _placeholderSubmittedTaskId(MessageRow placeholder) {
+  final payload = _decodeMessagePayload(placeholder.payload);
+  final taskId = _asJsonMap(
+    payload['metadata'],
+  )['completionTaskId']?.toString().trim();
+  return taskId == null || taskId.isEmpty ? null : taskId;
 }
 
 Map<String, dynamic> _decodeMessagePayload(String raw) {

--- a/lib/features/chat/services/request_completion_runner.dart
+++ b/lib/features/chat/services/request_completion_runner.dart
@@ -65,6 +65,17 @@ class ChatRequestCompletionRunner implements RequestCompletionRunner {
   Future<void> run({
     required String chatId,
     required Map<String, dynamic> payload,
+  }) {
+    final releaseGeneration = holdLocalChatGeneration(_ref);
+    return _run(
+      chatId: chatId,
+      payload: payload,
+    ).whenComplete(releaseGeneration);
+  }
+
+  Future<void> _run({
+    required String chatId,
+    required Map<String, dynamic> payload,
   }) async {
     final decoded = RequestCompletionPayload.fromJson(payload);
     final assistantMessageId = decoded.assistantMessageId;

--- a/lib/features/chat/services/request_completion_runner.dart
+++ b/lib/features/chat/services/request_completion_runner.dart
@@ -297,9 +297,10 @@ bool _placeholderMarkedSubmitted(MessageRow placeholder) {
 
 String? _placeholderSubmittedTaskId(MessageRow placeholder) {
   final payload = _decodeMessagePayload(placeholder.payload);
-  final taskId = _asJsonMap(
-    payload['metadata'],
-  )['completionTaskId']?.toString().trim();
+  final metadata = _asJsonMap(payload['metadata']);
+  final taskId = (metadata['completionTaskId'] ?? metadata['taskId'])
+      ?.toString()
+      .trim();
   return taskId == null || taskId.isEmpty ? null : taskId;
 }
 

--- a/lib/features/chat/views/chat_page.dart
+++ b/lib/features/chat/views/chat_page.dart
@@ -2971,6 +2971,10 @@ class _ChatPageState extends ConsumerState<ChatPage> {
             ),
       topContentInset: topPadding,
       bottomPadding: bottomPadding,
+      scrollbarBottomInset: math.max(
+        0,
+        bottomPadding - Spacing.lg - Spacing.xl,
+      ),
       horizontalPadding: Spacing.inputPadding,
       cacheExtent: _chatMessageScrollCachePixels,
       physics: platformAlwaysScrollablePhysics(context),

--- a/lib/features/chat/views/chat_page.dart
+++ b/lib/features/chat/views/chat_page.dart
@@ -703,6 +703,7 @@ class _ChatPageState extends ConsumerState<ChatPage> {
   }
 
   bool _isSavingTemporary = false;
+  bool _isOpeningModelSelector = false;
 
   /// Persists a temporary chat to the server, transitioning it
   /// into a permanent conversation.
@@ -4197,18 +4198,30 @@ class _ChatPageState extends ConsumerState<ChatPage> {
   }
 
   Future<void> _openModelSelector(BuildContext context) async {
+    if (_isOpeningModelSelector) return;
+    setState(() => _isOpeningModelSelector = true);
     try {
       final models = await ref
           .read(nativeSheetHydrationServiceProvider)
           .loadModels();
       if (!mounted || !context.mounted) return;
       await _showModelDropdown(context, ref, models);
-    } catch (e) {
+    } catch (error, stackTrace) {
       DebugLogger.error(
         'model-load-failed',
         scope: 'chat/model-selector',
-        error: e,
+        error: error,
+        stackTrace: stackTrace,
       );
+      if (mounted && context.mounted) {
+        ScaffoldMessenger.maybeOf(context)?.showSnackBar(
+          SnackBar(content: Text(AppLocalizations.of(context)!.errorMessage)),
+        );
+      }
+    } finally {
+      if (mounted) {
+        setState(() => _isOpeningModelSelector = false);
+      }
     }
   }
 
@@ -4308,7 +4321,7 @@ class _ChatPageState extends ConsumerState<ChatPage> {
     return ConduitAdaptiveAppBarModelSelector(
       label: modelLabel,
       maxWidth: maxModelWidth,
-      isLoading: isLoadingConversation,
+      isLoading: isLoadingConversation || _isOpeningModelSelector,
       showChevron: showModelDropdown,
       onPressed: () => _openModelSelector(context),
     );

--- a/lib/features/chat/widgets/chat_timeline_viewport.dart
+++ b/lib/features/chat/widgets/chat_timeline_viewport.dart
@@ -2142,10 +2142,9 @@ class _TimelineRowDelegate extends SliverChildBuilderDelegate {
     final laidOutCount = lastIndex - firstIndex + 1;
     final fallbackExtent = laidOutCount <= 0
         ? 52.0
-        : ((trailingScrollOffset - leadingScrollOffset) / laidOutCount).clamp(
-            48.0,
-            400.0,
-          );
+        : ((trailingScrollOffset - leadingScrollOffset) / laidOutCount)
+              .clamp(48.0, 400.0)
+              .toDouble();
     // ponytail: O(loaded rows); cache suffix sums if this scan appears in profiles.
     for (var index = lastIndex + 1; index < childCount; index += 1) {
       final chronologicalIndex = reversed

--- a/lib/features/chat/widgets/chat_timeline_viewport.dart
+++ b/lib/features/chat/widgets/chat_timeline_viewport.dart
@@ -1811,6 +1811,7 @@ class _ChatTimelineViewportState extends State<ChatTimelineViewport>
     }
     final ownerGeneration = widget.ownerGeneration;
     final row = MeasureSize(
+      key: ValueKey<int>(ownerGeneration),
       onChange: (size) {
         if (mounted &&
             widget.ownerGeneration == ownerGeneration &&
@@ -1968,6 +1969,7 @@ class _ChatTimelineViewportState extends State<ChatTimelineViewport>
                     rowBuilder: widget.rowBuilder,
                     entries: _timelineEntries,
                     centerIndex: centerIndex,
+                    ownerGeneration: widget.ownerGeneration,
                     rowExtents: _rowExtents,
                     reversed: true,
                   ),
@@ -1987,6 +1989,7 @@ class _ChatTimelineViewportState extends State<ChatTimelineViewport>
                     rowBuilder: widget.rowBuilder,
                     entries: _timelineEntries,
                     centerIndex: centerIndex,
+                    ownerGeneration: widget.ownerGeneration,
                     rowExtents: _rowExtents,
                     reversed: false,
                   ),
@@ -2045,7 +2048,7 @@ class _ChatTimelineViewportState extends State<ChatTimelineViewport>
     // Platform scrollbars read track padding from their nearest MediaQuery.
     // Restore the real metrics below them so message widgets stay unchanged.
     final scrollbarMediaQuery = mediaQuery.copyWith(
-      padding: EdgeInsets.only(
+      padding: mediaQuery.padding.copyWith(
         top: widget.topContentInset,
         bottom: widget.bottomPadding,
       ),
@@ -2110,6 +2113,7 @@ class _TimelineRowDelegate extends SliverChildBuilderDelegate {
     required this.rowBuilder,
     required this.entries,
     required this.centerIndex,
+    required this.ownerGeneration,
     required this.rowExtents,
     required this.reversed,
   }) : super(addSemanticIndexes: false);
@@ -2117,6 +2121,7 @@ class _TimelineRowDelegate extends SliverChildBuilderDelegate {
   final ChatTimelineRowBuilder rowBuilder;
   final List<({String id, int sourceIndex, Object? rebuildKey})> entries;
   final int centerIndex;
+  final int ownerGeneration;
   final Map<String, double> rowExtents;
   final bool reversed;
 
@@ -2150,6 +2155,7 @@ class _TimelineRowDelegate extends SliverChildBuilderDelegate {
     return !identical(rowBuilder, oldDelegate.rowBuilder) ||
         !identical(entries, oldDelegate.entries) ||
         centerIndex != oldDelegate.centerIndex ||
+        ownerGeneration != oldDelegate.ownerGeneration ||
         reversed != oldDelegate.reversed;
   }
 }

--- a/lib/features/chat/widgets/chat_timeline_viewport.dart
+++ b/lib/features/chat/widgets/chat_timeline_viewport.dart
@@ -15,6 +15,7 @@ import 'package:flutter/rendering.dart'
 
 import '../../../core/database/models/chat_transcript_window.dart';
 import '../../../core/utils/debug_logger.dart';
+import '../../../shared/widgets/measure_size.dart';
 
 @visibleForTesting
 const int debugChatTimelineInitialPositionMaxAttempts = 12;
@@ -363,6 +364,7 @@ class _ChatTimelineViewportState extends State<ChatTimelineViewport>
   final ValueNotifier<double> _pinSupportSpace = ValueNotifier<double>(0);
   final Map<String, GlobalKey> _rowKeys = <String, GlobalKey>{};
   final Map<String, int> _mountedRowCounts = <String, int>{};
+  final Map<String, double> _rowExtents = <String, double>{};
   final Map<String, ({int sourceIndex, Object? rebuildKey, Widget widget})>
   _rowWidgetCache = {};
   Map<String, Rect>? _cachedFrameRowRects;
@@ -511,6 +513,7 @@ class _ChatTimelineViewportState extends State<ChatTimelineViewport>
     _metricsSnapshot = null;
     _lastReportedMetrics = null;
     _rowWidgetCache.clear();
+    _rowExtents.clear();
     _anchorCorrectionAttempts = 0;
     _initialPositionResolved = false;
     _initialEmptyFallbackVisible = false;
@@ -662,6 +665,7 @@ class _ChatTimelineViewportState extends State<ChatTimelineViewport>
         entries[index].id: index,
     });
     _rowWidgetCache.removeWhere((id, _) => !seen.contains(id));
+    _rowExtents.removeWhere((id, _) => !seen.contains(id));
   }
 
   void _syncRowKeys() {
@@ -1805,15 +1809,25 @@ class _ChatTimelineViewportState extends State<ChatTimelineViewport>
         cached.rebuildKey == entry.rebuildKey) {
       return cached.widget;
     }
-    final row = _MountedTimelineRow(
-      key: _rowKeys[id],
-      messageId: id,
-      onMounted: _registerMountedRow,
-      onUnmounted: _unregisterMountedRow,
-      child: IndexedSemantics(
-        index: chronologicalIndex,
-        child: Builder(
-          builder: (context) => widget.rowBuilder(context, entry.sourceIndex),
+    final ownerGeneration = widget.ownerGeneration;
+    final row = MeasureSize(
+      onChange: (size) {
+        if (mounted &&
+            widget.ownerGeneration == ownerGeneration &&
+            _messageIdSet.contains(id)) {
+          _rowExtents[id] = size.height;
+        }
+      },
+      child: _MountedTimelineRow(
+        key: _rowKeys[id],
+        messageId: id,
+        onMounted: _registerMountedRow,
+        onUnmounted: _unregisterMountedRow,
+        child: IndexedSemantics(
+          index: chronologicalIndex,
+          child: Builder(
+            builder: (context) => widget.rowBuilder(context, entry.sourceIndex),
+          ),
         ),
       ),
     );
@@ -1954,6 +1968,8 @@ class _ChatTimelineViewportState extends State<ChatTimelineViewport>
                     rowBuilder: widget.rowBuilder,
                     entries: _timelineEntries,
                     centerIndex: centerIndex,
+                    rowExtents: _rowExtents,
+                    reversed: true,
                   ),
                 ),
               ),
@@ -1971,6 +1987,8 @@ class _ChatTimelineViewportState extends State<ChatTimelineViewport>
                     rowBuilder: widget.rowBuilder,
                     entries: _timelineEntries,
                     centerIndex: centerIndex,
+                    rowExtents: _rowExtents,
+                    reversed: false,
                   ),
                 ),
               ),
@@ -2023,9 +2041,25 @@ class _ChatTimelineViewportState extends State<ChatTimelineViewport>
       ),
     );
 
-    final scrollableTranscript = PlatformInfo.isIOS
-        ? CupertinoScrollbar(controller: _scrollController, child: transcript)
-        : Scrollbar(controller: _scrollController, child: transcript);
+    final mediaQuery = MediaQuery.of(context);
+    // Platform scrollbars read track padding from their nearest MediaQuery.
+    // Restore the real metrics below them so message widgets stay unchanged.
+    final scrollbarMediaQuery = mediaQuery.copyWith(
+      padding: EdgeInsets.only(
+        top: widget.topContentInset,
+        bottom: widget.bottomPadding,
+      ),
+    );
+    final scrollbarChild = MediaQuery(data: mediaQuery, child: transcript);
+    final scrollableTranscript = MediaQuery(
+      data: scrollbarMediaQuery,
+      child: PlatformInfo.isIOS
+          ? CupertinoScrollbar(
+              controller: _scrollController,
+              child: scrollbarChild,
+            )
+          : Scrollbar(controller: _scrollController, child: scrollbarChild),
+    );
 
     return Stack(
       key: _viewportKey,
@@ -2076,17 +2110,47 @@ class _TimelineRowDelegate extends SliverChildBuilderDelegate {
     required this.rowBuilder,
     required this.entries,
     required this.centerIndex,
+    required this.rowExtents,
+    required this.reversed,
   }) : super(addSemanticIndexes: false);
 
   final ChatTimelineRowBuilder rowBuilder;
   final List<({String id, int sourceIndex, Object? rebuildKey})> entries;
   final int centerIndex;
+  final Map<String, double> rowExtents;
+  final bool reversed;
+
+  // Keep lazy rows in the range estimate after they leave the render window.
+  // Otherwise one tall response can move the scrollbar thumb by thousands of
+  // pixels while the user traverses it.
+  @override
+  double? estimateMaxScrollOffset(
+    int firstIndex,
+    int lastIndex,
+    double leadingScrollOffset,
+    double trailingScrollOffset,
+  ) {
+    final childCount = reversed ? centerIndex : entries.length - centerIndex;
+    if (lastIndex >= childCount - 1) return trailingScrollOffset;
+    var estimate = trailingScrollOffset;
+    // ponytail: O(loaded rows); cache suffix sums if this scan appears in profiles.
+    for (var index = lastIndex + 1; index < childCount; index += 1) {
+      final chronologicalIndex = reversed
+          ? centerIndex - 1 - index
+          : centerIndex + index;
+      final extent = rowExtents[entries[chronologicalIndex].id];
+      if (extent == null) return null;
+      estimate += extent;
+    }
+    return estimate;
+  }
 
   @override
   bool shouldRebuild(covariant _TimelineRowDelegate oldDelegate) {
     return !identical(rowBuilder, oldDelegate.rowBuilder) ||
         !identical(entries, oldDelegate.entries) ||
-        centerIndex != oldDelegate.centerIndex;
+        centerIndex != oldDelegate.centerIndex ||
+        reversed != oldDelegate.reversed;
   }
 }
 

--- a/lib/features/chat/widgets/chat_timeline_viewport.dart
+++ b/lib/features/chat/widgets/chat_timeline_viewport.dart
@@ -263,6 +263,7 @@ class ChatTimelineViewport extends StatefulWidget {
     required this.rowBuilder,
     required this.topContentInset,
     required this.bottomPadding,
+    required this.scrollbarBottomInset,
     required this.horizontalPadding,
     required this.cacheExtent,
     required this.physics,
@@ -306,6 +307,7 @@ class ChatTimelineViewport extends StatefulWidget {
   final Widget? trailingContent;
   final double topContentInset;
   final double bottomPadding;
+  final double scrollbarBottomInset;
   final double horizontalPadding;
   final double cacheExtent;
   final ScrollPhysics physics;
@@ -2050,7 +2052,7 @@ class _ChatTimelineViewportState extends State<ChatTimelineViewport>
     final scrollbarMediaQuery = mediaQuery.copyWith(
       padding: mediaQuery.padding.copyWith(
         top: widget.topContentInset,
-        bottom: widget.bottomPadding,
+        bottom: widget.scrollbarBottomInset,
       ),
     );
     final scrollbarChild = MediaQuery(data: mediaQuery, child: transcript);
@@ -2125,9 +2127,8 @@ class _TimelineRowDelegate extends SliverChildBuilderDelegate {
   final Map<String, double> rowExtents;
   final bool reversed;
 
-  // Keep lazy rows in the range estimate after they leave the render window.
-  // Otherwise one tall response can move the scrollbar thumb by thousands of
-  // pixels while the user traverses it.
+  // Cache bounded first estimates for never-laid-out rows. Flutter's default
+  // would multiply one tall visible response across every unknown sibling.
   @override
   double? estimateMaxScrollOffset(
     int firstIndex,
@@ -2138,13 +2139,20 @@ class _TimelineRowDelegate extends SliverChildBuilderDelegate {
     final childCount = reversed ? centerIndex : entries.length - centerIndex;
     if (lastIndex >= childCount - 1) return trailingScrollOffset;
     var estimate = trailingScrollOffset;
+    final laidOutCount = lastIndex - firstIndex + 1;
+    final fallbackExtent = laidOutCount <= 0
+        ? 52.0
+        : ((trailingScrollOffset - leadingScrollOffset) / laidOutCount).clamp(
+            48.0,
+            400.0,
+          );
     // ponytail: O(loaded rows); cache suffix sums if this scan appears in profiles.
     for (var index = lastIndex + 1; index < childCount; index += 1) {
       final chronologicalIndex = reversed
           ? centerIndex - 1 - index
           : centerIndex + index;
-      final extent = rowExtents[entries[chronologicalIndex].id];
-      if (extent == null) return null;
+      final id = entries[chronologicalIndex].id;
+      final extent = rowExtents.putIfAbsent(id, () => fallbackExtent);
       estimate += extent;
     }
     return estimate;

--- a/lib/features/direct_connections/providers/direct_connection_providers.dart
+++ b/lib/features/direct_connections/providers/direct_connection_providers.dart
@@ -253,16 +253,28 @@ final applePccAdapterProvider = Provider<ApplePccAdapter>(
   ),
 );
 
-final applePccStatusProvider = FutureProvider<PlatformPccStatus>(
-  (ref) => ref
-      .watch(applePccAdapterProvider)
-      .status(PlatformAppleModel.privateCloudCompute),
+PlatformPccStatus _unsupportedAppleStatus() => PlatformPccStatus(
+  availability: PlatformPccAvailability.unavailable,
+  quotaStatus: PlatformPccQuotaStatus.unknown,
+  quotaLimitReached: false,
+  canIncreaseQuota: false,
 );
 
-final appleOnDeviceStatusProvider = FutureProvider<PlatformPccStatus>(
-  (ref) =>
-      ref.watch(applePccAdapterProvider).status(PlatformAppleModel.onDevice),
-);
+final applePccStatusProvider = FutureProvider<PlatformPccStatus>((ref) {
+  if (!ref.watch(applePccPlatformSupportedProvider)) {
+    return _unsupportedAppleStatus();
+  }
+  return ref
+      .watch(applePccAdapterProvider)
+      .status(PlatformAppleModel.privateCloudCompute);
+});
+
+final appleOnDeviceStatusProvider = FutureProvider<PlatformPccStatus>((ref) {
+  if (!ref.watch(applePccPlatformSupportedProvider)) {
+    return _unsupportedAppleStatus();
+  }
+  return ref.watch(applePccAdapterProvider).status(PlatformAppleModel.onDevice);
+});
 
 final directConnectionProfileStoreProvider =
     Provider<DirectConnectionProfileStore>((ref) {

--- a/lib/features/direct_connections/providers/direct_connection_providers.dart
+++ b/lib/features/direct_connections/providers/direct_connection_providers.dart
@@ -254,7 +254,7 @@ final applePccAdapterProvider = Provider<ApplePccAdapter>(
 );
 
 PlatformPccStatus _unsupportedAppleStatus() => PlatformPccStatus(
-  availability: PlatformPccAvailability.unavailable,
+  availability: PlatformPccAvailability.unsupported,
   quotaStatus: PlatformPccQuotaStatus.unknown,
   quotaLimitReached: false,
   canIncreaseQuota: false,

--- a/lib/features/direct_connections/views/direct_connections_page.dart
+++ b/lib/features/direct_connections/views/direct_connections_page.dart
@@ -131,17 +131,20 @@ class _DirectConnectionsPageState extends ConsumerState<DirectConnectionsPage>
       effectiveDirectConnectionProfilesProvider,
     );
     final historyPolicy = ref.watch(directHistoryPolicyProvider);
-    final appleOnDeviceEnabled = ref.watch(appleOnDeviceEnabledProvider);
+    final applePlatformSupported = ref.watch(applePccPlatformSupportedProvider);
+    final appleOnDeviceEnabled =
+        applePlatformSupported && ref.watch(appleOnDeviceEnabledProvider);
     final appleOnDeviceStatus = appleOnDeviceEnabled
         ? ref.watch(appleOnDeviceStatusProvider)
         : null;
-    final applePccEnabled = ref.watch(applePccEnabledProvider);
+    final applePccEnabled =
+        applePlatformSupported && ref.watch(applePccEnabledProvider);
     final applePccStatus = applePccEnabled
         ? ref.watch(applePccStatusProvider)
         : null;
-    final applePccOnDeviceFallback = ref.watch(
-      applePccOnDeviceFallbackProvider,
-    );
+    final applePccOnDeviceFallback = applePlatformSupported
+        ? ref.watch(applePccOnDeviceFallbackProvider)
+        : false;
     final directModels =
         ref.watch(directModelDiscoveryProvider).value?.models ??
         const <Model>[];

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -37,7 +37,8 @@ import 'core/utils/tts_voice_utils.dart';
 import 'core/utils/current_localizations.dart';
 import 'features/chat/services/request_completion_runner.dart';
 import 'features/chat/providers/text_to_speech_provider.dart';
-import 'features/chat/providers/chat_providers.dart' show restoreDefaultModel;
+import 'features/chat/providers/chat_providers.dart'
+    show chatWakelockCoordinatorProvider, restoreDefaultModel;
 import 'features/release_notes/release_notes_bootstrap.dart';
 import 'features/release_notes/release_notes_coordinator.dart';
 import 'features/release_notes/data/release_notes_repository.dart';
@@ -305,6 +306,7 @@ class _ConduitAppState extends ConsumerState<ConduitApp> {
     super.initState();
     ref.read(userScopedProviderCleanupProvider);
     ref.read(quickActionsCoordinatorProvider);
+    ref.read(chatWakelockCoordinatorProvider);
     _nativeSheetSubscription = NativeSheetBridge.instance.events.listen(
       _handleNativeSheetEvent,
     );
@@ -926,6 +928,7 @@ class _ConduitAppState extends ConsumerState<ConduitApp> {
   @override
   void dispose() {
     _nativeSheetSubscription?.cancel();
+    ref.invalidate(chatWakelockCoordinatorProvider);
     super.dispose();
   }
 

--- a/lib/shared/widgets/adaptive_toolbar_components.dart
+++ b/lib/shared/widgets/adaptive_toolbar_components.dart
@@ -1246,28 +1246,36 @@ class ConduitAdaptiveAppBarModelSelector extends StatelessWidget {
                 onPressed: onPressed,
               ),
               excludeSemantics: true,
-              child: SizedBox(
-                width: targetWidth,
-                height: controlExtent,
-                child: _ConduitNativeModelSelectorButton(
-                  key: conduitNativeModelSelectorViewKey(
-                    context.conduitTheme.textPrimary,
-                    titleFontSize: nativeTitleFontSize,
-                  ),
-                  label: resolveConduitNativeModelSelectorLabel(
-                    label: boundedLabel,
-                    isLoading: isLoading,
-                    showChevron: showChevron,
-                    availableWidth: targetWidth,
-                    textDirection: textDirection,
-                    titleFontSize: nativeTitleFontSize,
-                  ),
-                  symbolName: conduitNativeModelSelectorSymbol(
-                    showChevron: showChevron,
-                  ),
-                  foregroundColor: context.conduitTheme.textPrimary,
-                  enabled: !isLoading && showChevron,
+              child: GestureDetector(
+                behavior: HitTestBehavior.opaque,
+                onTap: conduitNativeModelSelectorActivation(
+                  isLoading: isLoading,
+                  showChevron: showChevron,
                   onPressed: onPressed,
+                ),
+                child: SizedBox(
+                  width: targetWidth,
+                  height: controlExtent,
+                  child: _ConduitNativeModelSelectorButton(
+                    key: conduitNativeModelSelectorViewKey(
+                      context.conduitTheme.textPrimary,
+                      titleFontSize: nativeTitleFontSize,
+                    ),
+                    label: resolveConduitNativeModelSelectorLabel(
+                      label: boundedLabel,
+                      isLoading: isLoading,
+                      showChevron: showChevron,
+                      availableWidth: targetWidth,
+                      textDirection: textDirection,
+                      titleFontSize: nativeTitleFontSize,
+                    ),
+                    symbolName: conduitNativeModelSelectorSymbol(
+                      showChevron: showChevron,
+                    ),
+                    foregroundColor: context.conduitTheme.textPrimary,
+                    enabled: !isLoading && showChevron,
+                    onPressed: onPressed,
+                  ),
                 ),
               ),
             )

--- a/lib/shared/widgets/markdown/markdown_preprocessor.dart
+++ b/lib/shared/widgets/markdown/markdown_preprocessor.dart
@@ -60,19 +60,19 @@ class ConduitMarkdownPreprocessor {
     caseSensitive: false,
   );
   static final _toolCallBlocks = RegExp(
-    r'''<details\b(?=[^>]*\btype\s*=\s*["']tool_calls["'])[^>]*>[\s\S]*?</details>''',
+    r'''<details\b(?=(?:[^>"']|"[^"]*"|'[^']*')*\s+type\s*=\s*["']tool_calls["'])(?:[^>"']|"[^"]*"|'[^']*')*>[\s\S]*?</details>''',
     multiLine: true,
     dotAll: true,
     caseSensitive: false,
   );
   static final _attachedToolCallDetailsOpen = RegExp(
-    r'''([^\n])(<details\b(?=[^>]*\btype\s*=\s*["']tool_calls["']))''',
+    r'''([^\n])(<details\b(?=(?:[^>"']|"[^"]*"|'[^']*')*\s+type\s*=\s*["']tool_calls["']))''',
     caseSensitive: false,
   );
   static final _detailsOpenTag = RegExp(r'<details\b', caseSensitive: false);
   static final _codeSpanOrFence = RegExp(r'(`+)([\s\S]*?)\1');
   static final _tildeFence = RegExp(
-    r'^[ \t]{0,3}~{3,}[^\n]*\n[\s\S]*?^[ \t]{0,3}~{3,}[ \t]*$',
+    r'^[ \t]{0,3}(~{3,})[^\n]*\n[\s\S]*?^[ \t]{0,3}\1~*[ \t]*$',
     multiLine: true,
   );
   static final _unterminatedTildeFence = RegExp(
@@ -407,8 +407,8 @@ class ConduitMarkdownPreprocessor {
     }
 
     var masked = input.replaceAllMapped(_tildeFence, mask);
-    masked = masked.replaceAllMapped(_unterminatedTildeFence, mask);
     masked = masked.replaceAllMapped(_codeSpanOrFence, mask);
+    masked = masked.replaceAllMapped(_unterminatedTildeFence, mask);
     var output = transform(masked);
 
     // Placeholders inside removed matches no longer exist, so only code from
@@ -449,7 +449,7 @@ class ConduitMarkdownPreprocessor {
       }
 
       if (end < 0) {
-        searchFrom = scanEnd;
+        searchFrom = opening.end;
         continue;
       }
 

--- a/lib/shared/widgets/markdown/markdown_preprocessor.dart
+++ b/lib/shared/widgets/markdown/markdown_preprocessor.dart
@@ -413,7 +413,7 @@ class ConduitMarkdownPreprocessor {
 
     // Placeholders inside removed matches no longer exist, so only code from
     // the retained content is restored.
-    for (var index = 0; index < codeSpans.length; index++) {
+    for (var index = codeSpans.length - 1; index >= 0; index--) {
       output = output.replaceAll('$marker$index\u0000', codeSpans[index]);
     }
     return output;

--- a/lib/shared/widgets/markdown/markdown_preprocessor.dart
+++ b/lib/shared/widgets/markdown/markdown_preprocessor.dart
@@ -449,8 +449,8 @@ class ConduitMarkdownPreprocessor {
       }
 
       if (end < 0) {
-        output.write(input.substring(copiedThrough));
-        return output.toString();
+        searchFrom = scanEnd;
+        continue;
       }
 
       output.write(input.substring(copiedThrough, opening.start));

--- a/lib/shared/widgets/markdown/markdown_preprocessor.dart
+++ b/lib/shared/widgets/markdown/markdown_preprocessor.dart
@@ -60,15 +60,22 @@ class ConduitMarkdownPreprocessor {
     caseSensitive: false,
   );
   static final _toolCallBlocks = RegExp(
-    r'<details\s+type="tool_calls"[^>]*>[\s\S]*?</details>',
+    r'''<details\b(?=[^>]*\btype\s*=\s*["']tool_calls["'])[^>]*>[\s\S]*?</details>''',
     multiLine: true,
     dotAll: true,
+    caseSensitive: false,
   );
   static final _attachedToolCallDetailsOpen = RegExp(
     r'''([^\n])(<details\b(?=[^>]*\btype\s*=\s*["']tool_calls["']))''',
     caseSensitive: false,
   );
+  static final _detailsOpenTag = RegExp(r'<details\b', caseSensitive: false);
   static final _codeSpanOrFence = RegExp(r'(`+)([\s\S]*?)\1');
+  static final _tildeFence = RegExp(
+    r'^[ \t]{0,3}~{3,}[^\n]*\n[\s\S]*?^[ \t]{0,3}~{3,}[ \t]*$',
+    multiLine: true,
+  );
+  static const _detailsOpenTagNormalizationLimit = 256 * 1024;
   static final _allDetailsBlocks = RegExp(
     r'<details[^>]*>[\s\S]*?</details>',
     multiLine: true,
@@ -158,6 +165,11 @@ class ConduitMarkdownPreprocessor {
 
     // Separate consecutive links
     output = _separateConsecutiveLinks(output);
+
+    if (output.length <= _detailsOpenTagNormalizationLimit &&
+        _detailsOpenTag.hasMatch(output)) {
+      output = _transformOutsideCode(output, _normalizeDetailsOpenTags);
+    }
 
     // Raw model output can attach Open WebUI's tool-call block directly to
     // answer text. Put it on a Markdown block boundary without rewriting
@@ -370,6 +382,14 @@ class ConduitMarkdownPreprocessor {
     String input,
     RegExp pattern,
     String Function(Match) replace,
+  ) => _transformOutsideCode(
+    input,
+    (content) => content.replaceAllMapped(pattern, replace),
+  );
+
+  static String _transformOutsideCode(
+    String input,
+    String Function(String) transform,
   ) {
     final codeSpans = <String>[];
     var marker = '\u0000conduit-code-span-';
@@ -377,12 +397,15 @@ class ConduitMarkdownPreprocessor {
       marker = '\u0000$marker';
     }
 
-    final masked = input.replaceAllMapped(_codeSpanOrFence, (match) {
+    String mask(Match match) {
       final index = codeSpans.length;
       codeSpans.add(match[0] ?? '');
       return '$marker$index\u0000';
-    });
-    var output = masked.replaceAllMapped(pattern, replace);
+    }
+
+    var masked = input.replaceAllMapped(_tildeFence, mask);
+    masked = masked.replaceAllMapped(_codeSpanOrFence, mask);
+    var output = transform(masked);
 
     // Placeholders inside removed matches no longer exist, so only code from
     // the retained content is restored.
@@ -390,6 +413,71 @@ class ConduitMarkdownPreprocessor {
       output = output.replaceAll('$marker$index\u0000', codeSpans[index]);
     }
     return output;
+  }
+
+  static String _normalizeDetailsOpenTags(String input) {
+    if (input.length > _detailsOpenTagNormalizationLimit) return input;
+
+    final output = StringBuffer();
+    var copiedThrough = 0;
+    var searchFrom = 0;
+
+    while (searchFrom < input.length) {
+      RegExpMatch? opening;
+      for (final match in _detailsOpenTag.allMatches(input, searchFrom)) {
+        opening = match;
+        break;
+      }
+      if (opening == null) break;
+
+      var quote = 0;
+      var end = -1;
+      for (var index = opening.end; index < input.length; index++) {
+        final unit = input.codeUnitAt(index);
+        if (quote != 0) {
+          if (unit == quote) quote = 0;
+        } else if (unit == 0x22 || unit == 0x27) {
+          quote = unit;
+        } else if (unit == 0x3E) {
+          end = index;
+          break;
+        }
+      }
+
+      if (end < 0) {
+        searchFrom = opening.end;
+        continue;
+      }
+
+      output.write(input.substring(copiedThrough, opening.start));
+      quote = 0;
+      for (var index = opening.start; index <= end; index++) {
+        final unit = input.codeUnitAt(index);
+        if (unit == 0x0A || unit == 0x0D) {
+          output.write(' ');
+        } else if (quote != 0) {
+          if (unit == quote) {
+            quote = 0;
+            output.writeCharCode(unit);
+          } else if (unit == 0x3C) {
+            output.write('&lt;');
+          } else if (unit == 0x3E) {
+            output.write('&gt;');
+          } else {
+            output.writeCharCode(unit);
+          }
+        } else {
+          if (unit == 0x22 || unit == 0x27) quote = unit;
+          output.writeCharCode(unit);
+        }
+      }
+      copiedThrough = end + 1;
+      searchFrom = end + 1;
+    }
+
+    if (copiedThrough == 0) return input;
+    output.write(input.substring(copiedThrough));
+    return output.toString();
   }
 
   static String _removeEmojis(String input) {

--- a/lib/shared/widgets/markdown/markdown_preprocessor.dart
+++ b/lib/shared/widgets/markdown/markdown_preprocessor.dart
@@ -75,6 +75,10 @@ class ConduitMarkdownPreprocessor {
     r'^[ \t]{0,3}~{3,}[^\n]*\n[\s\S]*?^[ \t]{0,3}~{3,}[ \t]*$',
     multiLine: true,
   );
+  static final _unterminatedTildeFence = RegExp(
+    r'^[ \t]{0,3}~{3,}[^\n]*(?:\n[\s\S]*)?(?![\s\S])',
+    multiLine: true,
+  );
   static const _detailsOpenTagNormalizationLimit = 256 * 1024;
   static final _allDetailsBlocks = RegExp(
     r'<details[^>]*>[\s\S]*?</details>',
@@ -166,8 +170,7 @@ class ConduitMarkdownPreprocessor {
     // Separate consecutive links
     output = _separateConsecutiveLinks(output);
 
-    if (output.length <= _detailsOpenTagNormalizationLimit &&
-        _detailsOpenTag.hasMatch(output)) {
+    if (_detailsOpenTag.hasMatch(output)) {
       output = _transformOutsideCode(output, _normalizeDetailsOpenTags);
     }
 
@@ -404,6 +407,7 @@ class ConduitMarkdownPreprocessor {
     }
 
     var masked = input.replaceAllMapped(_tildeFence, mask);
+    masked = masked.replaceAllMapped(_unterminatedTildeFence, mask);
     masked = masked.replaceAllMapped(_codeSpanOrFence, mask);
     var output = transform(masked);
 
@@ -416,8 +420,6 @@ class ConduitMarkdownPreprocessor {
   }
 
   static String _normalizeDetailsOpenTags(String input) {
-    if (input.length > _detailsOpenTagNormalizationLimit) return input;
-
     final output = StringBuffer();
     var copiedThrough = 0;
     var searchFrom = 0;
@@ -432,7 +434,9 @@ class ConduitMarkdownPreprocessor {
 
       var quote = 0;
       var end = -1;
-      for (var index = opening.end; index < input.length; index++) {
+      final candidateEnd = opening.start + _detailsOpenTagNormalizationLimit;
+      final scanEnd = candidateEnd < input.length ? candidateEnd : input.length;
+      for (var index = opening.end; index < scanEnd; index++) {
         final unit = input.codeUnitAt(index);
         if (quote != 0) {
           if (unit == quote) quote = 0;
@@ -445,8 +449,8 @@ class ConduitMarkdownPreprocessor {
       }
 
       if (end < 0) {
-        searchFrom = opening.end;
-        continue;
+        output.write(input.substring(copiedThrough));
+        return output.toString();
       }
 
       output.write(input.substring(copiedThrough, opening.start));

--- a/lib/shared/widgets/markdown/renderer/details_block_syntax.dart
+++ b/lib/shared/widgets/markdown/renderer/details_block_syntax.dart
@@ -24,7 +24,9 @@ class DetailsBlockSyntax extends md.BlockSyntax {
     r'</details>',
     caseSensitive: false,
   );
-  static final RegExp _attributePattern = RegExp(r'(\w+)="(.*?)"');
+  static final RegExp _attributePattern = RegExp(
+    r'''(\w+)\s*=\s*(["'])(.*?)\2''',
+  );
   static final RegExp _summaryPattern = RegExp(
     r'^\s*<summary>(.*?)</summary>\s*',
     caseSensitive: false,
@@ -74,7 +76,7 @@ class DetailsBlockSyntax extends md.BlockSyntax {
     final openingTag = openingMatch.group(0)!;
     final attributes = <String, String>{};
     for (final match in _attributePattern.allMatches(openingTag)) {
-      attributes[match.group(1)!] = match.group(2) ?? '';
+      attributes[match.group(1)!.toLowerCase()] = match.group(3) ?? '';
     }
 
     var innerContent = rawBlock.substring(openingMatch.end, closingIndex);

--- a/lib/shared/widgets/markdown/streaming_markdown_preparation.dart
+++ b/lib/shared/widgets/markdown/streaming_markdown_preparation.dart
@@ -21,7 +21,7 @@ final _detailsOpenPattern = RegExp(r'<details\b', caseSensitive: false);
 // inside, splitting prepared content mid-block.
 final _detailsClosePattern = RegExp(r'</details>', caseSensitive: false);
 final _toolCallDetailsOpenPattern = RegExp(
-  r'<details\b[^>]*type="tool_calls"[^>]*>',
+  r'''<details\b[^>]*type\s*=\s*["']tool_calls["'][^>]*>''',
   caseSensitive: false,
 );
 

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -309,10 +309,10 @@ packages:
     dependency: "direct main"
     description:
       name: cupertino_native_better
-      sha256: e9a09ec11f8fb62d04ca39fcfe1e6735945bd9ed5bf8990f6f494d64c3bc2127
+      sha256: "41c2a8ed69bc3448c2c05e3797e92e04fae340f1443ace396f8163035313903a"
       url: "https://pub.dev"
     source: hosted
-    version: "1.5.4"
+    version: "1.6.0"
   cupertino_ui:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -98,7 +98,7 @@ dependencies:
   home_widget: ^0.9.3
   flutter_highlight: ^0.7.0
   just_audio: ^0.10.5
-  cupertino_native_better: ^1.5.4
+  cupertino_native_better: ^1.6.0
   flutter_tex: ^5.2.6
   xterm: ^4.0.0
   web_socket: ^1.0.1

--- a/test/core/database/daos/messages_dao_test.dart
+++ b/test/core/database/daos/messages_dao_test.dart
@@ -582,6 +582,7 @@ void main() {
         final marked = await db.messagesDao.markAssistantCompletionSubmitted(
           chatId: 'chat-retry',
           messageId: 'assistant-retry',
+          taskId: 'task-retry',
         );
 
         check(marked).isTrue();
@@ -592,6 +593,7 @@ void main() {
         check(payload.containsKey('done')).isFalse();
         check(payload.containsKey('error')).isFalse();
         check(metadata['completionSubmitted']).equals(true);
+        check(metadata['completionTaskId']).equals('task-retry');
         check(metadata.containsKey('responseDone')).isFalse();
         check(metadata['checkpoint']).equals(true);
         check(row.dirty).isFalse();

--- a/test/core/services/conversation_parsing_test.dart
+++ b/test/core/services/conversation_parsing_test.dart
@@ -228,6 +228,24 @@ void main() {
         check(messages.first['content']).equals('Hi there');
       });
 
+      test('keeps an overlaid unfinished response streaming', () {
+        final result = parseFullConversation({
+          'id': 'conv-1',
+          'messages': [
+            {
+              'id': 'msg-1',
+              'role': 'assistant',
+              'content': 'Partial response',
+              'timestamp': 1700000000,
+              'done': false,
+            },
+          ],
+        });
+
+        final messages = result['messages'] as List<Map<String, dynamic>>;
+        check(messages.single['isStreaming']).equals(true);
+      });
+
       test('preserves Open WebUI modelName as display metadata', () {
         final result = parseFullConversation({
           'id': 'conv-1',

--- a/test/core/services/native_sheet_hydration_generation_test.dart
+++ b/test/core/services/native_sheet_hydration_generation_test.dart
@@ -1,5 +1,3 @@
-import 'dart:async';
-
 import 'package:checks/checks.dart';
 import 'package:conduit/core/models/model.dart';
 import 'package:conduit/core/services/native_sheet_hydration_service.dart';
@@ -7,20 +5,6 @@ import 'package:conduit/features/chat/providers/reasoning_effort_provider.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
-  test(
-    'reasoning effort hydration timeout does not block the picker',
-    () async {
-      final pending = Completer<void>();
-
-      check(
-        await waitForNativeReasoningEffortHydration(
-          pending.future,
-          timeout: Duration.zero,
-        ),
-      ).isFalse();
-    },
-  );
-
   test('timed-out effort hydration hides stale picker controls', () {
     final policy = nativeModelSelectorReasoningEffortPolicy(
       false,

--- a/test/features/auth/views/backend_onboarding_adaptive_test.dart
+++ b/test/features/auth/views/backend_onboarding_adaptive_test.dart
@@ -95,7 +95,7 @@ void main() {
     }
   });
 
-  testWidgets('debug chooser shows every backend on unsupported platforms', (
+  testWidgets('debug chooser hides Apple backends on unsupported platforms', (
     tester,
   ) async {
     final harness = AdaptiveAuthHarness(
@@ -109,9 +109,9 @@ void main() {
     );
     await tester.pumpAndSettle();
 
-    expect(find.text('Apple Intelligence'), findsOneWidget);
-    expect(find.text('Apple On-Device'), findsOneWidget);
-    expect(find.text('Apple Private Cloud Compute'), findsOneWidget);
+    expect(find.text('Apple Intelligence'), findsNothing);
+    expect(find.text('Apple On-Device'), findsNothing);
+    expect(find.text('Apple Private Cloud Compute'), findsNothing);
     expect(find.text('Open WebUI'), findsOneWidget);
     expect(find.text('Connect directly'), findsOneWidget);
 

--- a/test/features/auth/views/support/adaptive_auth_harness.dart
+++ b/test/features/auth/views/support/adaptive_auth_harness.dart
@@ -11,6 +11,7 @@ import 'package:conduit/features/auth/views/server_connection_page.dart';
 import 'package:conduit/features/direct_connections/views/direct_connection_editor_page.dart';
 import 'package:conduit/features/direct_connections/controllers/direct_connection_editor_draft.dart';
 import 'package:conduit/features/direct_connections/providers/direct_connection_providers.dart';
+import 'package:conduit/features/direct_connections/services/apple_pcc_adapter.dart';
 import 'package:conduit/features/direct_connections/views/direct_connections_page.dart';
 import 'package:conduit/features/hermes/views/hermes_settings_page.dart';
 import 'package:conduit/l10n/app_localizations.dart';
@@ -181,6 +182,10 @@ class BackendOnboardingHarness {
     return ProviderScope(
       overrides: [
         secureStorageProvider.overrideWithValue(const FlutterSecureStorage()),
+        applePccPlatformSupportedProvider.overrideWithValue(true),
+        applePccAdapterProvider.overrideWithValue(
+          ApplePccAdapter(hostApi: _AvailablePccHost()),
+        ),
         appleOnDeviceStatusProvider.overrideWith(
           (_) async => _unavailableAppleStatus(),
         ),
@@ -208,6 +213,17 @@ class BackendOnboardingHarness {
     PlatformUiCapabilities.debugPlatformOverride = null;
     router.dispose();
   }
+}
+
+final class _AvailablePccHost extends PccHostApi {
+  @override
+  Future<PlatformPccStatus> getStatus(PlatformAppleModel model) async =>
+      PlatformPccStatus(
+        availability: PlatformPccAvailability.available,
+        quotaStatus: PlatformPccQuotaStatus.belowLimit,
+        quotaLimitReached: false,
+        canIncreaseQuota: false,
+      );
 }
 
 Future<void> initializeBackendOnboardingStorage() async {

--- a/test/features/chat/providers/chat_messages_notifier_dedupe_test.dart
+++ b/test/features/chat/providers/chat_messages_notifier_dedupe_test.dart
@@ -537,101 +537,22 @@ void main() {
       },
     );
 
-    test('streaming cadence exposes stable size buckets', () {
-      expect(
-        debugStreamingContentUpdatePolicyForBuffer(999).bucket,
-        StreamingContentSizeBucket.under1k,
-      );
-      expect(
-        debugStreamingContentUpdatePolicyForBuffer(1000).bucket,
-        StreamingContentSizeBucket.from1k,
-      );
-      expect(
-        debugStreamingContentUpdatePolicyForBuffer(2000).bucket,
-        StreamingContentSizeBucket.from2k,
-      );
-      expect(
-        debugStreamingContentUpdatePolicyForBuffer(4000).bucket,
-        StreamingContentSizeBucket.from4k,
-      );
-      expect(
-        debugStreamingContentUpdatePolicyForBuffer(8000).bucket,
-        StreamingContentSizeBucket.from8k,
-      );
-      expect(
-        debugStreamingContentUpdatePolicyForBuffer(16000).bucket,
-        StreamingContentSizeBucket.from16k,
-      );
-    });
-
-    test('streaming cadence grows with mobile response length', () {
-      expect(
-        debugStreamingContentUpdateIntervalForBuffer(
-          999,
-          platform: TargetPlatform.android,
-        ),
-        const Duration(milliseconds: 100),
-      );
-      expect(
-        debugStreamingContentUpdateIntervalForBuffer(
-          1000,
-          platform: TargetPlatform.android,
-        ),
-        const Duration(milliseconds: 160),
-      );
-      expect(
-        debugStreamingContentUpdateIntervalForBuffer(
-          4000,
-          platform: TargetPlatform.android,
-        ),
-        const Duration(milliseconds: 300),
-      );
-      expect(
-        debugStreamingContentUpdateIntervalForBuffer(
-          8000,
-          platform: TargetPlatform.android,
-        ),
-        const Duration(milliseconds: 500),
-      );
-      expect(
-        debugStreamingContentUpdateIntervalForBuffer(
-          16000,
-          platform: TargetPlatform.android,
-        ),
-        const Duration(milliseconds: 750),
-      );
-    });
-
-    test('streaming cadence stays less aggressive off mobile', () {
-      expect(
-        debugStreamingContentUpdateIntervalForBuffer(
-          4000,
-          platform: TargetPlatform.macOS,
-        ),
-        const Duration(milliseconds: 180),
-      );
-      expect(
-        debugStreamingContentUpdateIntervalForBuffer(
-          8000,
-          platform: TargetPlatform.macOS,
-        ),
-        const Duration(milliseconds: 280),
-      );
-      expect(
-        debugStreamingContentUpdateIntervalForBuffer(
-          16000,
-          platform: TargetPlatform.macOS,
-        ),
-        const Duration(milliseconds: 420),
-      );
-      expect(
-        debugStreamingContentUpdateIntervalForBuffer(
-          16000,
-          isWeb: true,
-          platform: TargetPlatform.android,
-        ),
-        const Duration(milliseconds: 420),
-      );
+    test('streaming cadence is smooth for every target and response size', () {
+      for (final length in [0, 999, 1000, 4000, 8000, 16000, 100000]) {
+        for (final platform in TargetPlatform.values) {
+          expect(
+            debugStreamingContentUpdateIntervalForBuffer(
+              length,
+              platform: platform,
+            ),
+            const Duration(milliseconds: 100),
+          );
+        }
+        expect(
+          debugStreamingContentUpdateIntervalForBuffer(length, isWeb: true),
+          const Duration(milliseconds: 100),
+        );
+      }
     });
   });
 }

--- a/test/features/chat/providers/chat_openwebui_alignment_test.dart
+++ b/test/features/chat/providers/chat_openwebui_alignment_test.dart
@@ -178,6 +178,17 @@ void main() {
           ),
         ),
       ).isFalse();
+      check(
+        headlessAssistantLandedForTest(
+          ChatMessage(
+            id: 'a4',
+            role: 'assistant',
+            content: 'partial response',
+            timestamp: now,
+            isStreaming: true,
+          ),
+        ),
+      ).isFalse();
     });
 
     test('temporary chats keep full outbound history', () {

--- a/test/features/chat/providers/chat_openwebui_transport_ownership_test.dart
+++ b/test/features/chat/providers/chat_openwebui_transport_ownership_test.dart
@@ -1023,13 +1023,17 @@ void main() {
   });
 
   test(
-    'task status failure settles an accepted marker without resubmitting',
+    'legacy submitted marker adopts the active task without resubmitting',
     () async {
       const chatId = 'crash-window-chat';
       const assistantId = 'crash-window-assistant';
       await _seedChat(db, chatId, assistantId: assistantId);
       final release = Completer<void>()..complete();
-      final api = _GatedCompletionApi(release)..taskStatusFailures = 1;
+      final api = _GatedCompletionApi(release)
+        ..taskIdResponses.addAll([
+          const ['task-1'],
+          const [],
+        ]);
       final syncEngine = _PersistingSyncEngine(db, api, landResponse: false);
       final messages = <ChatMessage>[
         _user('user', 'hello'),
@@ -1053,7 +1057,6 @@ void main() {
         container,
         owner: owner,
         assistantMessageId: assistantId,
-        taskId: 'task-1',
       );
 
       final runnerProvider = Provider<RequestCompletionRunner>(
@@ -1073,7 +1076,8 @@ void main() {
       );
 
       check(api.completionCalls).equals(0);
-      check(syncEngine.pulls).equals(1);
+      check(api.taskIdResponses).isEmpty();
+      check(syncEngine.pulls).equals(2);
       final persisted = await db.messagesDao.getMessage(chatId, assistantId);
       final payload = jsonDecode(persisted!.payload) as Map<String, dynamic>;
       check(payload['done'] as bool).isTrue();

--- a/test/features/chat/providers/chat_openwebui_transport_ownership_test.dart
+++ b/test/features/chat/providers/chat_openwebui_transport_ownership_test.dart
@@ -1137,12 +1137,14 @@ void main() {
         ..assistantMessageId = assistantId
         ..taskIdResponses.addAll([
           const [],
+          const [],
+          const [],
           const ['task-1'],
           const ['task-1'],
           const ['task-1'],
           const [],
         ]);
-      final syncEngine = _PersistingSyncEngine(db, api, landAfterPull: 2);
+      final syncEngine = _PersistingSyncEngine(db, api, landAfterPull: 5);
       final messages = <ChatMessage>[
         _user('user', 'hello'),
         _streamingAssistant(assistantId, ''),
@@ -1168,7 +1170,7 @@ void main() {
         recoveryAttempts: 1,
       );
 
-      check(syncEngine.pulls).equals(2);
+      check(syncEngine.pulls).equals(5);
       check(api.taskIdResponses).isEmpty();
       final persisted = await db.messagesDao.getMessage(chatId, assistantId);
       check(persisted?.content).equals('A safely completed');

--- a/test/features/chat/providers/chat_openwebui_transport_ownership_test.dart
+++ b/test/features/chat/providers/chat_openwebui_transport_ownership_test.dart
@@ -1042,9 +1042,11 @@ void main() {
           const [],
           const ['task-1'],
           const [],
+          const [],
         ])
         ..activeChatResponses.addAll([
-          {chatId},
+          const <String>{},
+          const <String>{},
           const <String>{},
         ]);
       final syncEngine = _PersistingSyncEngine(db, api, landResponse: false);
@@ -1098,6 +1100,68 @@ void main() {
       check(payload['error']).isNotNull();
     },
   );
+
+  test('legacy submitted marker bounds unrelated active task checks', () async {
+    const chatId = 'legacy-foreign-task-chat';
+    const assistantId = 'legacy-foreign-task-assistant';
+    await _seedChat(db, chatId, assistantId: assistantId);
+    final release = Completer<void>()..complete();
+    final api = _GatedCompletionApi(release)
+      ..taskIdResponses.addAll([
+        const ['foreign-task'],
+        const ['foreign-task'],
+        const ['foreign-task'],
+      ]);
+    final syncEngine = _PersistingSyncEngine(db, api, landResponse: false);
+    final messages = <ChatMessage>[
+      _user('user', 'hello'),
+      _streamingAssistant(assistantId, ''),
+    ];
+    final container = _container(
+      db: db,
+      active: _conversation(chatId, messages, ChatStorageKind.openWebUi),
+      messages: messages,
+      api: api,
+      syncEngine: syncEngine,
+    );
+    addTearDown(container.dispose);
+    final owner = captureOpenWebUiCompletionOwner(
+      container,
+      chatId: chatId,
+      database: db,
+      api: api,
+    );
+    await beginOpenWebUiCompletionSubmission(
+      container,
+      owner: owner,
+      assistantMessageId: assistantId,
+    );
+
+    final runner = container.read(
+      Provider<RequestCompletionRunner>(
+        (ref) => ChatRequestCompletionRunner(
+          ref,
+          recoveryAttempts: 3,
+          recoveryDelay: Duration.zero,
+        ),
+      ),
+    );
+    await runner.run(
+      chatId: chatId,
+      payload: RequestCompletionPayload(
+        assistantMessageId: assistantId,
+        model: 'model-1',
+      ).toJson(),
+    );
+
+    check(api.completionCalls).equals(0);
+    check(api.taskIdResponses).isEmpty();
+    check(syncEngine.pulls).equals(6);
+    final persisted = await db.messagesDao.getMessage(chatId, assistantId);
+    final payload = jsonDecode(persisted!.payload) as Map<String, dynamic>;
+    check(payload['done'] as bool).isTrue();
+    check(payload['error']).isNotNull();
+  });
 
   test(
     'drain and pull failure settles the captured placeholder explicitly',

--- a/test/features/chat/providers/chat_openwebui_transport_ownership_test.dart
+++ b/test/features/chat/providers/chat_openwebui_transport_ownership_test.dart
@@ -157,6 +157,7 @@ class _GatedCompletionApi extends ApiService {
   final Completer<void> releasePost;
   final Completer<void> postEntered = Completer<void>();
   int completionCalls = 0;
+  final taskIdResponses = <List<String>>[];
   String? assistantMessageId;
   String? submittedModel;
   Map<String, dynamic>? submittedModelItem;
@@ -169,7 +170,8 @@ class _GatedCompletionApi extends ApiService {
       const {};
 
   @override
-  Future<List<String>> getTaskIdsByChat(String chatId) async => const [];
+  Future<List<String>> getTaskIdsByChat(String chatId) async =>
+      taskIdResponses.isEmpty ? const [] : taskIdResponses.removeAt(0);
 
   @override
   Future<ChatCompletionSession> sendMessageSession({
@@ -386,12 +388,14 @@ class _PersistingSyncEngine extends SyncEngine {
     this.api, {
     this.landResponse = true,
     this.throwOnPull = false,
+    this.landAfterPull = 1,
   });
 
   final AppDatabase db;
   final _GatedCompletionApi api;
   final bool landResponse;
   final bool throwOnPull;
+  final int landAfterPull;
   int pulls = 0;
 
   @override
@@ -401,7 +405,7 @@ class _PersistingSyncEngine extends SyncEngine {
   Future<Conversation?> pullChatNow(String requestedChatId) async {
     pulls += 1;
     if (throwOnPull) throw StateError('pull failed');
-    if (!landResponse) return null;
+    if (!landResponse || pulls < landAfterPull) return null;
     final assistantId = api.assistantMessageId!;
     final completed = ChatMessage(
       id: assistantId,
@@ -1060,7 +1064,7 @@ void main() {
       );
 
       check(api.completionCalls).equals(0);
-      check(syncEngine.pulls).equals(1);
+      check(syncEngine.pulls).equals(2);
       final persisted = await db.messagesDao.getMessage(chatId, assistantId);
       final payload = jsonDecode(persisted!.payload) as Map<String, dynamic>;
       check(payload['done'] as bool).isTrue();
@@ -1114,6 +1118,50 @@ void main() {
       final payload = jsonDecode(persisted!.payload) as Map<String, dynamic>;
       check(payload['done'] as bool).isTrue();
       check(payload['error']).isNotNull();
+    },
+  );
+
+  test(
+    'headless socket task waits for server completion before settling',
+    () async {
+      const chatId = 'headless-task-chat';
+      const assistantId = 'headless-task-assistant';
+      await _seedChat(db, chatId, assistantId: assistantId);
+      final api = _GatedCompletionApi(Completer<void>()..complete())
+        ..assistantMessageId = assistantId
+        ..taskIdResponses.addAll([
+          const ['task-1'],
+          const [],
+        ]);
+      final syncEngine = _PersistingSyncEngine(db, api, landAfterPull: 2);
+      final messages = <ChatMessage>[
+        _user('user', 'hello'),
+        _streamingAssistant(assistantId, ''),
+      ];
+      final container = _container(
+        db: db,
+        active: _conversation(chatId, messages, ChatStorageKind.openWebUi),
+        messages: messages,
+        api: api,
+        syncEngine: syncEngine,
+      );
+      addTearDown(container.dispose);
+
+      await finishSubmittedOpenWebUiCompletionHeadlesslyForTest(
+        container,
+        session: ChatCompletionSession.taskSocket(
+          messageId: assistantId,
+          conversationId: chatId,
+          taskId: 'task-1',
+        ),
+        chatId: chatId,
+        assistantMessageId: assistantId,
+        recoveryAttempts: 1,
+      );
+
+      check(syncEngine.pulls).equals(2);
+      final persisted = await db.messagesDao.getMessage(chatId, assistantId);
+      check(persisted?.content).equals('A safely completed');
     },
   );
 

--- a/test/features/chat/providers/chat_openwebui_transport_ownership_test.dart
+++ b/test/features/chat/providers/chat_openwebui_transport_ownership_test.dart
@@ -394,14 +394,14 @@ class _PersistingSyncEngine extends SyncEngine {
     this.api, {
     this.landResponse = true,
     this.throwOnPull = false,
-    this.landAfterPull = 1,
+    this.canLandResponse,
   });
 
   final AppDatabase db;
   final _GatedCompletionApi api;
   final bool landResponse;
   final bool throwOnPull;
-  final int landAfterPull;
+  final bool Function()? canLandResponse;
   int pulls = 0;
 
   @override
@@ -411,7 +411,9 @@ class _PersistingSyncEngine extends SyncEngine {
   Future<Conversation?> pullChatNow(String requestedChatId) async {
     pulls += 1;
     if (throwOnPull) throw StateError('pull failed');
-    if (!landResponse || pulls < landAfterPull) return null;
+    if (!landResponse || canLandResponse?.call() == false) {
+      return null;
+    }
     final assistantId = api.assistantMessageId!;
     final completed = ChatMessage(
       id: assistantId,
@@ -1144,7 +1146,11 @@ void main() {
           const ['task-1'],
           const [],
         ]);
-      final syncEngine = _PersistingSyncEngine(db, api, landAfterPull: 5);
+      final syncEngine = _PersistingSyncEngine(
+        db,
+        api,
+        canLandResponse: () => api.taskIdResponses.isEmpty,
+      );
       final messages = <ChatMessage>[
         _user('user', 'hello'),
         _streamingAssistant(assistantId, ''),
@@ -1172,6 +1178,7 @@ void main() {
 
       check(syncEngine.pulls).equals(5);
       check(api.taskIdResponses).isEmpty();
+      check(api.completionCalls).equals(0);
       final persisted = await db.messagesDao.getMessage(chatId, assistantId);
       check(persisted?.content).equals('A safely completed');
     },

--- a/test/features/chat/providers/chat_openwebui_transport_ownership_test.dart
+++ b/test/features/chat/providers/chat_openwebui_transport_ownership_test.dart
@@ -1136,6 +1136,7 @@ void main() {
       final api = _GatedCompletionApi(Completer<void>()..complete())
         ..assistantMessageId = assistantId
         ..taskIdResponses.addAll([
+          const [],
           const ['task-1'],
           const ['task-1'],
           const ['task-1'],

--- a/test/features/chat/providers/chat_openwebui_transport_ownership_test.dart
+++ b/test/features/chat/providers/chat_openwebui_transport_ownership_test.dart
@@ -1131,6 +1131,8 @@ void main() {
         ..assistantMessageId = assistantId
         ..taskIdResponses.addAll([
           const ['task-1'],
+          const ['task-1'],
+          const ['task-1'],
           const [],
         ]);
       final syncEngine = _PersistingSyncEngine(db, api, landAfterPull: 2);

--- a/test/features/chat/providers/chat_openwebui_transport_ownership_test.dart
+++ b/test/features/chat/providers/chat_openwebui_transport_ownership_test.dart
@@ -1199,7 +1199,7 @@ void main() {
   );
 
   test(
-    'headless socket task waits for server completion before settling',
+    'headless socket task ignores transient absence before completion',
     () async {
       const chatId = 'headless-task-chat';
       const assistantId = 'headless-task-assistant';
@@ -1207,6 +1207,7 @@ void main() {
       final api = _GatedCompletionApi(Completer<void>()..complete())
         ..assistantMessageId = assistantId
         ..taskIdResponses.addAll([
+          const [],
           const ['task-1'],
           const ['task-1'],
           const ['task-1'],

--- a/test/features/chat/providers/chat_openwebui_transport_ownership_test.dart
+++ b/test/features/chat/providers/chat_openwebui_transport_ownership_test.dart
@@ -1031,7 +1031,7 @@ void main() {
   });
 
   test(
-    'legacy submitted marker adopts the active task without resubmitting',
+    'legacy submitted marker checks active server state without resubmitting',
     () async {
       const chatId = 'crash-window-chat';
       const assistantId = 'crash-window-assistant';
@@ -1043,7 +1043,10 @@ void main() {
           const ['task-1'],
           const [],
         ])
-        ..activeChatResponses.add({chatId});
+        ..activeChatResponses.addAll([
+          {chatId},
+          const <String>{},
+        ]);
       final syncEngine = _PersistingSyncEngine(db, api, landResponse: false);
       final messages = <ChatMessage>[
         _user('user', 'hello'),
@@ -1072,7 +1075,7 @@ void main() {
       final runnerProvider = Provider<RequestCompletionRunner>(
         (ref) => ChatRequestCompletionRunner(
           ref,
-          recoveryAttempts: 1,
+          recoveryAttempts: 3,
           recoveryDelay: Duration.zero,
         ),
       );
@@ -1088,7 +1091,7 @@ void main() {
       check(api.completionCalls).equals(0);
       check(api.taskIdResponses).isEmpty();
       check(api.activeChatResponses).isEmpty();
-      check(syncEngine.pulls).equals(2);
+      check(syncEngine.pulls).equals(6);
       final persisted = await db.messagesDao.getMessage(chatId, assistantId);
       final payload = jsonDecode(persisted!.payload) as Map<String, dynamic>;
       check(payload['done'] as bool).isTrue();

--- a/test/features/chat/providers/chat_openwebui_transport_ownership_test.dart
+++ b/test/features/chat/providers/chat_openwebui_transport_ownership_test.dart
@@ -1168,6 +1168,7 @@ void main() {
       );
 
       check(syncEngine.pulls).equals(2);
+      check(api.taskIdResponses).isEmpty();
       final persisted = await db.messagesDao.getMessage(chatId, assistantId);
       check(persisted?.content).equals('A safely completed');
     },

--- a/test/features/chat/providers/chat_openwebui_transport_ownership_test.dart
+++ b/test/features/chat/providers/chat_openwebui_transport_ownership_test.dart
@@ -158,6 +158,7 @@ class _GatedCompletionApi extends ApiService {
   final Completer<void> postEntered = Completer<void>();
   int completionCalls = 0;
   final taskIdResponses = <List<String>>[];
+  final activeChatResponses = <Set<String>>[];
   int taskStatusFailures = 0;
   String? assistantMessageId;
   String? submittedModel;
@@ -177,6 +178,13 @@ class _GatedCompletionApi extends ApiService {
       throw StateError('task status unavailable');
     }
     return taskIdResponses.isEmpty ? const [] : taskIdResponses.removeAt(0);
+  }
+
+  @override
+  Future<Set<String>> checkActiveChats(List<String> chatIds) async {
+    return activeChatResponses.isEmpty
+        ? const <String>{}
+        : activeChatResponses.removeAt(0);
   }
 
   @override
@@ -1031,9 +1039,11 @@ void main() {
       final release = Completer<void>()..complete();
       final api = _GatedCompletionApi(release)
         ..taskIdResponses.addAll([
+          const [],
           const ['task-1'],
           const [],
-        ]);
+        ])
+        ..activeChatResponses.add({chatId});
       final syncEngine = _PersistingSyncEngine(db, api, landResponse: false);
       final messages = <ChatMessage>[
         _user('user', 'hello'),
@@ -1077,6 +1087,7 @@ void main() {
 
       check(api.completionCalls).equals(0);
       check(api.taskIdResponses).isEmpty();
+      check(api.activeChatResponses).isEmpty();
       check(syncEngine.pulls).equals(2);
       final persisted = await db.messagesDao.getMessage(chatId, assistantId);
       final payload = jsonDecode(persisted!.payload) as Map<String, dynamic>;

--- a/test/features/chat/providers/chat_openwebui_transport_ownership_test.dart
+++ b/test/features/chat/providers/chat_openwebui_transport_ownership_test.dart
@@ -1173,16 +1173,56 @@ void main() {
         ),
         chatId: chatId,
         assistantMessageId: assistantId,
-        recoveryAttempts: 1,
+        recoveryAttempts: 4,
       );
 
-      check(syncEngine.pulls).equals(5);
+      check(syncEngine.pulls).equals(8);
       check(api.taskIdResponses).isEmpty();
       check(api.completionCalls).equals(0);
       final persisted = await db.messagesDao.getMessage(chatId, assistantId);
       check(persisted?.content).equals('A safely completed');
     },
   );
+
+  test('unobserved socket task exhausts recovery after final pulls', () async {
+    const chatId = 'unobserved-task-chat';
+    const assistantId = 'unobserved-task-assistant';
+    await _seedChat(db, chatId, assistantId: assistantId);
+    final api = _GatedCompletionApi(Completer<void>()..complete())
+      ..assistantMessageId = assistantId;
+    final syncEngine = _PersistingSyncEngine(db, api, landResponse: false);
+    final messages = <ChatMessage>[
+      _user('user', 'hello'),
+      _streamingAssistant(assistantId, ''),
+    ];
+    final container = _container(
+      db: db,
+      active: _conversation(chatId, messages, ChatStorageKind.openWebUi),
+      messages: messages,
+      api: api,
+      syncEngine: syncEngine,
+    );
+    addTearDown(container.dispose);
+
+    await finishSubmittedOpenWebUiCompletionHeadlesslyForTest(
+      container,
+      session: ChatCompletionSession.taskSocket(
+        messageId: assistantId,
+        conversationId: chatId,
+        taskId: 'task-1',
+      ),
+      chatId: chatId,
+      assistantMessageId: assistantId,
+      recoveryAttempts: 2,
+    );
+
+    check(syncEngine.pulls).equals(6);
+    check(api.completionCalls).equals(0);
+    final persisted = await db.messagesDao.getMessage(chatId, assistantId);
+    final payload = jsonDecode(persisted!.payload) as Map<String, dynamic>;
+    check(payload['done'] as bool).isTrue();
+    check(payload['error']).isNotNull();
+  }, timeout: const Timeout(Duration(seconds: 5)));
 
   test(
     'socket bind loss returns unattached and cannot mutate the new chat',

--- a/test/features/chat/providers/chat_openwebui_transport_ownership_test.dart
+++ b/test/features/chat/providers/chat_openwebui_transport_ownership_test.dart
@@ -1093,12 +1093,18 @@ void main() {
     await _seedChat(db, chatId, assistantId: assistantId);
     final release = Completer<void>()..complete();
     final api = _GatedCompletionApi(release)
+      ..assistantMessageId = assistantId
       ..taskIdResponses.addAll([
         const ['foreign-task'],
         const ['foreign-task'],
         const ['foreign-task'],
       ]);
-    final syncEngine = _PersistingSyncEngine(db, api, landResponse: false);
+    var unresolvedPulls = 4;
+    final syncEngine = _PersistingSyncEngine(
+      db,
+      api,
+      canLandResponse: () => unresolvedPulls-- <= 0,
+    );
     final messages = <ChatMessage>[
       _user('user', 'hello'),
       _streamingAssistant(assistantId, ''),
@@ -1146,7 +1152,8 @@ void main() {
     final persisted = await db.messagesDao.getMessage(chatId, assistantId);
     final payload = jsonDecode(persisted!.payload) as Map<String, dynamic>;
     check(payload['done'] as bool).isTrue();
-    check(payload['error']).isNotNull();
+    check(payload['error']).isNull();
+    check(persisted.content).equals('A safely completed');
   });
 
   test(

--- a/test/features/chat/providers/chat_openwebui_transport_ownership_test.dart
+++ b/test/features/chat/providers/chat_openwebui_transport_ownership_test.dart
@@ -1093,18 +1093,12 @@ void main() {
     await _seedChat(db, chatId, assistantId: assistantId);
     final release = Completer<void>()..complete();
     final api = _GatedCompletionApi(release)
-      ..assistantMessageId = assistantId
       ..taskIdResponses.addAll([
         const ['foreign-task'],
         const ['foreign-task'],
         const ['foreign-task'],
       ]);
-    var unresolvedPulls = 4;
-    final syncEngine = _PersistingSyncEngine(
-      db,
-      api,
-      canLandResponse: () => unresolvedPulls-- <= 0,
-    );
+    final syncEngine = _PersistingSyncEngine(db, api, landResponse: false);
     final messages = <ChatMessage>[
       _user('user', 'hello'),
       _streamingAssistant(assistantId, ''),
@@ -1152,8 +1146,7 @@ void main() {
     final persisted = await db.messagesDao.getMessage(chatId, assistantId);
     final payload = jsonDecode(persisted!.payload) as Map<String, dynamic>;
     check(payload['done'] as bool).isTrue();
-    check(payload['error']).isNull();
-    check(persisted.content).equals('A safely completed');
+    check(payload['error']).isNotNull();
   });
 
   test(

--- a/test/features/chat/providers/chat_openwebui_transport_ownership_test.dart
+++ b/test/features/chat/providers/chat_openwebui_transport_ownership_test.dart
@@ -158,6 +158,7 @@ class _GatedCompletionApi extends ApiService {
   final Completer<void> postEntered = Completer<void>();
   int completionCalls = 0;
   final taskIdResponses = <List<String>>[];
+  int taskStatusFailures = 0;
   String? assistantMessageId;
   String? submittedModel;
   Map<String, dynamic>? submittedModelItem;
@@ -170,8 +171,13 @@ class _GatedCompletionApi extends ApiService {
       const {};
 
   @override
-  Future<List<String>> getTaskIdsByChat(String chatId) async =>
-      taskIdResponses.isEmpty ? const [] : taskIdResponses.removeAt(0);
+  Future<List<String>> getTaskIdsByChat(String chatId) async {
+    if (taskStatusFailures > 0) {
+      taskStatusFailures--;
+      throw StateError('task status unavailable');
+    }
+    return taskIdResponses.isEmpty ? const [] : taskIdResponses.removeAt(0);
+  }
 
   @override
   Future<ChatCompletionSession> sendMessageSession({
@@ -1015,13 +1021,13 @@ void main() {
   });
 
   test(
-    'a recreated runner treats an accepted marker as pull-only recovery',
+    'task status failure settles an accepted marker without resubmitting',
     () async {
       const chatId = 'crash-window-chat';
       const assistantId = 'crash-window-assistant';
       await _seedChat(db, chatId, assistantId: assistantId);
       final release = Completer<void>()..complete();
-      final api = _GatedCompletionApi(release);
+      final api = _GatedCompletionApi(release)..taskStatusFailures = 1;
       final syncEngine = _PersistingSyncEngine(db, api, landResponse: false);
       final messages = <ChatMessage>[
         _user('user', 'hello'),
@@ -1064,7 +1070,7 @@ void main() {
       );
 
       check(api.completionCalls).equals(0);
-      check(syncEngine.pulls).equals(2);
+      check(syncEngine.pulls).equals(1);
       final persisted = await db.messagesDao.getMessage(chatId, assistantId);
       final payload = jsonDecode(persisted!.payload) as Map<String, dynamic>;
       check(payload['done'] as bool).isTrue();

--- a/test/features/chat/providers/chat_openwebui_transport_ownership_test.dart
+++ b/test/features/chat/providers/chat_openwebui_transport_ownership_test.dart
@@ -158,7 +158,6 @@ class _GatedCompletionApi extends ApiService {
   final Completer<void> postEntered = Completer<void>();
   int completionCalls = 0;
   final taskIdResponses = <List<String>>[];
-  final activeChatResponses = <Set<String>>[];
   int taskStatusFailures = 0;
   String? assistantMessageId;
   String? submittedModel;
@@ -178,13 +177,6 @@ class _GatedCompletionApi extends ApiService {
       throw StateError('task status unavailable');
     }
     return taskIdResponses.isEmpty ? const [] : taskIdResponses.removeAt(0);
-  }
-
-  @override
-  Future<Set<String>> checkActiveChats(List<String> chatIds) async {
-    return activeChatResponses.isEmpty
-        ? const <String>{}
-        : activeChatResponses.removeAt(0);
   }
 
   @override
@@ -1031,25 +1023,20 @@ void main() {
   });
 
   test(
-    'legacy submitted marker checks active server state without resubmitting',
+    'legacy submitted marker reconciles durable response without resubmitting',
     () async {
       const chatId = 'crash-window-chat';
       const assistantId = 'crash-window-assistant';
       await _seedChat(db, chatId, assistantId: assistantId);
       final release = Completer<void>()..complete();
       final api = _GatedCompletionApi(release)
-        ..taskIdResponses.addAll([
-          const [],
-          const ['task-1'],
-          const [],
-          const [],
-        ])
-        ..activeChatResponses.addAll([
-          const <String>{},
-          const <String>{},
-          const <String>{},
-        ]);
-      final syncEngine = _PersistingSyncEngine(db, api, landResponse: false);
+        ..assistantMessageId = assistantId;
+      var unresolvedPulls = 4;
+      final syncEngine = _PersistingSyncEngine(
+        db,
+        api,
+        canLandResponse: () => unresolvedPulls-- <= 0,
+      );
       final messages = <ChatMessage>[
         _user('user', 'hello'),
         _streamingAssistant(assistantId, ''),
@@ -1091,17 +1078,16 @@ void main() {
       );
 
       check(api.completionCalls).equals(0);
-      check(api.taskIdResponses).isEmpty();
-      check(api.activeChatResponses).isEmpty();
       check(syncEngine.pulls).equals(6);
       final persisted = await db.messagesDao.getMessage(chatId, assistantId);
       final payload = jsonDecode(persisted!.payload) as Map<String, dynamic>;
       check(payload['done'] as bool).isTrue();
-      check(payload['error']).isNotNull();
+      check(payload['error']).isNull();
+      check(persisted.content).equals('A safely completed');
     },
   );
 
-  test('legacy submitted marker bounds unrelated active task checks', () async {
+  test('legacy submitted marker ignores unrelated task activity', () async {
     const chatId = 'legacy-foreign-task-chat';
     const assistantId = 'legacy-foreign-task-assistant';
     await _seedChat(db, chatId, assistantId: assistantId);
@@ -1155,7 +1141,7 @@ void main() {
     );
 
     check(api.completionCalls).equals(0);
-    check(api.taskIdResponses).isEmpty();
+    check(api.taskIdResponses).length.equals(3);
     check(syncEngine.pulls).equals(6);
     final persisted = await db.messagesDao.getMessage(chatId, assistantId);
     final payload = jsonDecode(persisted!.payload) as Map<String, dynamic>;

--- a/test/features/chat/providers/chat_openwebui_transport_ownership_test.dart
+++ b/test/features/chat/providers/chat_openwebui_transport_ownership_test.dart
@@ -1053,6 +1053,7 @@ void main() {
         container,
         owner: owner,
         assistantMessageId: assistantId,
+        taskId: 'task-1',
       );
 
       final runnerProvider = Provider<RequestCompletionRunner>(
@@ -1138,9 +1139,6 @@ void main() {
       final api = _GatedCompletionApi(Completer<void>()..complete())
         ..assistantMessageId = assistantId
         ..taskIdResponses.addAll([
-          const [],
-          const [],
-          const [],
           const ['task-1'],
           const ['task-1'],
           const ['task-1'],
@@ -1173,56 +1171,16 @@ void main() {
         ),
         chatId: chatId,
         assistantMessageId: assistantId,
-        recoveryAttempts: 4,
+        recoveryAttempts: 1,
       );
 
-      check(syncEngine.pulls).equals(8);
+      check(syncEngine.pulls).equals(2);
       check(api.taskIdResponses).isEmpty();
       check(api.completionCalls).equals(0);
       final persisted = await db.messagesDao.getMessage(chatId, assistantId);
       check(persisted?.content).equals('A safely completed');
     },
   );
-
-  test('unobserved socket task exhausts recovery after final pulls', () async {
-    const chatId = 'unobserved-task-chat';
-    const assistantId = 'unobserved-task-assistant';
-    await _seedChat(db, chatId, assistantId: assistantId);
-    final api = _GatedCompletionApi(Completer<void>()..complete())
-      ..assistantMessageId = assistantId;
-    final syncEngine = _PersistingSyncEngine(db, api, landResponse: false);
-    final messages = <ChatMessage>[
-      _user('user', 'hello'),
-      _streamingAssistant(assistantId, ''),
-    ];
-    final container = _container(
-      db: db,
-      active: _conversation(chatId, messages, ChatStorageKind.openWebUi),
-      messages: messages,
-      api: api,
-      syncEngine: syncEngine,
-    );
-    addTearDown(container.dispose);
-
-    await finishSubmittedOpenWebUiCompletionHeadlesslyForTest(
-      container,
-      session: ChatCompletionSession.taskSocket(
-        messageId: assistantId,
-        conversationId: chatId,
-        taskId: 'task-1',
-      ),
-      chatId: chatId,
-      assistantMessageId: assistantId,
-      recoveryAttempts: 2,
-    );
-
-    check(syncEngine.pulls).equals(6);
-    check(api.completionCalls).equals(0);
-    final persisted = await db.messagesDao.getMessage(chatId, assistantId);
-    final payload = jsonDecode(persisted!.payload) as Map<String, dynamic>;
-    check(payload['done'] as bool).isTrue();
-    check(payload['error']).isNotNull();
-  }, timeout: const Timeout(Duration(seconds: 5)));
 
   test(
     'socket bind loss returns unattached and cannot mutate the new chat',

--- a/test/features/chat/providers/chat_wakelock_coordinator_test.dart
+++ b/test/features/chat/providers/chat_wakelock_coordinator_test.dart
@@ -1,6 +1,7 @@
 // ignore_for_file: depend_on_referenced_packages
 
 import 'package:conduit/core/models/chat_message.dart';
+import 'package:conduit/core/providers/app_providers.dart';
 import 'package:conduit/features/chat/providers/chat_providers.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -47,7 +48,7 @@ void main() {
     wakelockPlusPlatformInstance = originalPlatform;
   });
 
-  test('holds the screen only while the assistant is streaming', () async {
+  test('holds the screen through foreground and headless streaming', () async {
     final container = ProviderContainer();
     container.read(chatWakelockCoordinatorProvider);
     await _flushPluginCall();
@@ -56,14 +57,23 @@ void main() {
       _assistantMessage(isStreaming: true),
     ]);
     await _flushPluginCall();
+    container.read(activeChatIdsProvider.notifier).setActive('background-chat');
     container.read(chatMessagesProvider.notifier).setMessages([
       _assistantMessage(isStreaming: false),
     ]);
     await _flushPluginCall();
+    expect(fakePlatform.toggles, [false, true]);
+
+    container
+        .read(activeChatIdsProvider.notifier)
+        .setInactive('background-chat');
+    await _flushPluginCall();
+    container.read(activeChatIdsProvider.notifier).setActive('background-chat');
+    await _flushPluginCall();
     container.dispose();
     await _flushPluginCall();
 
-    expect(fakePlatform.toggles, [false, true, false, false]);
+    expect(fakePlatform.toggles, [false, true, false, true, false]);
   });
 
   test('wakelock failures do not change generation state', () async {

--- a/test/features/chat/providers/chat_wakelock_coordinator_test.dart
+++ b/test/features/chat/providers/chat_wakelock_coordinator_test.dart
@@ -1,0 +1,82 @@
+// ignore_for_file: depend_on_referenced_packages
+
+import 'package:conduit/core/models/chat_message.dart';
+import 'package:conduit/features/chat/providers/chat_providers.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:wakelock_plus/wakelock_plus.dart';
+import 'package:wakelock_plus_platform_interface/wakelock_plus_platform_interface.dart';
+
+class _FakeWakelock extends WakelockPlusPlatformInterface {
+  final toggles = <bool>[];
+  bool throwOnToggle = false;
+
+  @override
+  Future<void> toggle({required bool enable}) async {
+    toggles.add(enable);
+    if (throwOnToggle) throw StateError('wakelock unavailable');
+  }
+
+  @override
+  Future<bool> get enabled async => toggles.lastOrNull ?? false;
+}
+
+ChatMessage _assistantMessage({required bool isStreaming}) => ChatMessage(
+  id: 'assistant',
+  role: 'assistant',
+  content: isStreaming ? '' : 'Done',
+  timestamp: DateTime(2026),
+  isStreaming: isStreaming,
+);
+
+Future<void> _flushPluginCall() => pumpEventQueue(times: 20);
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late WakelockPlusPlatformInterface originalPlatform;
+  late _FakeWakelock fakePlatform;
+
+  setUp(() {
+    originalPlatform = wakelockPlusPlatformInstance;
+    fakePlatform = _FakeWakelock();
+    wakelockPlusPlatformInstance = fakePlatform;
+  });
+
+  tearDown(() {
+    wakelockPlusPlatformInstance = originalPlatform;
+  });
+
+  test('holds the screen only while the assistant is streaming', () async {
+    final container = ProviderContainer();
+    container.read(chatWakelockCoordinatorProvider);
+    await _flushPluginCall();
+
+    container.read(chatMessagesProvider.notifier).setMessages([
+      _assistantMessage(isStreaming: true),
+    ]);
+    await _flushPluginCall();
+    container.read(chatMessagesProvider.notifier).setMessages([
+      _assistantMessage(isStreaming: false),
+    ]);
+    await _flushPluginCall();
+    container.dispose();
+    await _flushPluginCall();
+
+    expect(fakePlatform.toggles, [false, true, false, false]);
+  });
+
+  test('wakelock failures do not change generation state', () async {
+    fakePlatform.throwOnToggle = true;
+    final container = ProviderContainer();
+    addTearDown(container.dispose);
+    container.read(chatWakelockCoordinatorProvider);
+    container.read(chatMessagesProvider.notifier).setMessages([
+      _assistantMessage(isStreaming: true),
+    ]);
+    await _flushPluginCall();
+
+    expect(container.read(isChatStreamingProvider), isTrue);
+    expect(fakePlatform.toggles, contains(true));
+  });
+}

--- a/test/features/chat/providers/chat_wakelock_coordinator_test.dart
+++ b/test/features/chat/providers/chat_wakelock_coordinator_test.dart
@@ -8,6 +8,8 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:wakelock_plus/wakelock_plus.dart';
 import 'package:wakelock_plus_platform_interface/wakelock_plus_platform_interface.dart';
 
+final _testRefProvider = Provider<Ref>((ref) => ref);
+
 class _FakeWakelock extends WakelockPlusPlatformInterface {
   final toggles = <bool>[];
   bool throwOnToggle = false;
@@ -57,18 +59,21 @@ void main() {
       _assistantMessage(isStreaming: true),
     ]);
     await _flushPluginCall();
-    container.read(activeChatIdsProvider.notifier).setActive('background-chat');
+    container.read(activeChatIdsProvider.notifier).setActive('remote-chat');
     container.read(chatMessagesProvider.notifier).setMessages([
       _assistantMessage(isStreaming: false),
     ]);
     await _flushPluginCall();
-    expect(fakePlatform.toggles, [false, true]);
+    expect(fakePlatform.toggles, [false, true, false]);
 
-    container
-        .read(activeChatIdsProvider.notifier)
-        .setInactive('background-chat');
+    final releaseGeneration = holdLocalChatGeneration(
+      container.read(_testRefProvider),
+    );
+    await container.pump();
+    expect(container.read(localChatGenerationActiveProvider), isTrue);
     await _flushPluginCall();
-    container.read(activeChatIdsProvider.notifier).setActive('background-chat');
+    releaseGeneration();
+    await container.pump();
     await _flushPluginCall();
     container.dispose();
     await _flushPluginCall();

--- a/test/features/chat/services/request_completion_runner_test.dart
+++ b/test/features/chat/services/request_completion_runner_test.dart
@@ -150,7 +150,10 @@ void main() {
           'id': 'asst-submitted',
           'role': 'assistant',
           'content': 'partial submitted response',
-          'metadata': <String, dynamic>{'completionSubmitted': true},
+          'metadata': <String, dynamic>{
+            'completionSubmitted': true,
+            'completionTaskId': 'task-1',
+          },
         },
       );
 

--- a/test/features/chat/services/request_completion_runner_test.dart
+++ b/test/features/chat/services/request_completion_runner_test.dart
@@ -203,9 +203,9 @@ void main() {
         isStreaming: true,
       ),
     ]);
-
     await check(runner.run(chatId: chatId, payload: payload('asst-own')))
         .throws<StateError>();
+    check(container.read(localChatGenerationActiveProvider)).isFalse();
   });
 
   test('defers when no active database is attached', () async {

--- a/test/features/chat/widgets/chat_timeline_viewport_test.dart
+++ b/test/features/chat/widgets/chat_timeline_viewport_test.dart
@@ -180,11 +180,18 @@ void main() {
   ) async {
     final controller = _controller(tester);
     final ids = List<String>.generate(30, (index) => 'message-$index');
+    const sourcePadding = EdgeInsets.fromLTRB(11, 12, 13, 14);
+    const scrollbarPadding = EdgeInsets.fromLTRB(11, _topContentInset, 13, 80);
     addTearDown(PlatformUiCapabilities.resetDebugOverrides);
 
     PlatformUiCapabilities.debugPlatformOverride = TargetPlatform.android;
     await tester.pumpWidget(
-      _viewportHost(_viewport(controller: controller, ids: ids)),
+      _viewportHost(
+        MediaQuery(
+          data: const MediaQueryData(padding: sourcePadding),
+          child: _viewport(controller: controller, ids: ids),
+        ),
+      ),
     );
     await tester.pump();
 
@@ -198,16 +205,21 @@ void main() {
     );
     expect(
       MediaQuery.paddingOf(tester.element(find.byType(Scrollbar))),
-      const EdgeInsets.only(top: _topContentInset, bottom: 80),
+      scrollbarPadding,
     );
     expect(
       MediaQuery.paddingOf(tester.element(find.byType(CustomScrollView))),
-      EdgeInsets.zero,
+      sourcePadding,
     );
 
     PlatformUiCapabilities.debugPlatformOverride = TargetPlatform.iOS;
     await tester.pumpWidget(
-      _viewportHost(_viewport(controller: controller, ids: ids)),
+      _viewportHost(
+        MediaQuery(
+          data: const MediaQueryData(padding: sourcePadding),
+          child: _viewport(controller: controller, ids: ids),
+        ),
+      ),
     );
     await tester.pump();
 
@@ -223,11 +235,11 @@ void main() {
     );
     expect(
       MediaQuery.paddingOf(tester.element(find.byType(CupertinoScrollbar))),
-      const EdgeInsets.only(top: _topContentInset, bottom: 80),
+      scrollbarPadding,
     );
     expect(
       MediaQuery.paddingOf(tester.element(find.byType(CustomScrollView))),
-      EdgeInsets.zero,
+      sourcePadding,
     );
   });
 
@@ -267,6 +279,56 @@ void main() {
     for (final range in ranges.skip(1)) {
       check(range).isCloseTo(ranges.first, 1);
     }
+  });
+
+  _viewportTest('remeasures long rows after a same-ID owner change', (
+    tester,
+  ) async {
+    final controller = _controller(tester);
+    final ids = List<String>.generate(30, (index) => 'message-$index');
+    var ownerGeneration = 1;
+    var longRowHeight = 2400.0;
+    late StateSetter rebuild;
+    final rowBuilder = (BuildContext context, int index) {
+      final id = ids[index];
+      return SizedBox(
+        height: id == 'message-25' ? longRowHeight : 52,
+        child: Text(id),
+      );
+    };
+
+    await tester.pumpWidget(
+      _viewportHost(
+        StatefulBuilder(
+          builder: (context, setState) {
+            rebuild = setState;
+            return _viewport(
+              controller: controller,
+              ids: ids,
+              ownerGeneration: ownerGeneration,
+              followLatest: false,
+              rowBuilder: rowBuilder,
+            );
+          },
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    final position = tester
+        .widget<CustomScrollView>(find.byType(CustomScrollView))
+        .controller!
+        .position;
+    final originalRange = position.maxScrollExtent - position.minScrollExtent;
+
+    rebuild(() {
+      ownerGeneration = 2;
+      longRowHeight = 3200;
+    });
+    await tester.pumpAndSettle();
+
+    final updatedRange = position.maxScrollExtent - position.minScrollExtent;
+    check(updatedRange - originalRange).isCloseTo(800, 1);
   });
 
   test(

--- a/test/features/chat/widgets/chat_timeline_viewport_test.dart
+++ b/test/features/chat/widgets/chat_timeline_viewport_test.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:math' as math;
 
 import 'package:checks/checks.dart';
 import 'package:conduit/core/database/models/chat_transcript_window.dart';
@@ -195,6 +196,14 @@ void main() {
       identical(materialScrollbar.controller, scrollView.controller),
       true,
     );
+    expect(
+      MediaQuery.paddingOf(tester.element(find.byType(Scrollbar))),
+      const EdgeInsets.only(top: _topContentInset, bottom: 80),
+    );
+    expect(
+      MediaQuery.paddingOf(tester.element(find.byType(CustomScrollView))),
+      EdgeInsets.zero,
+    );
 
     PlatformUiCapabilities.debugPlatformOverride = TargetPlatform.iOS;
     await tester.pumpWidget(
@@ -212,6 +221,52 @@ void main() {
       identical(cupertinoScrollbar.controller, iosScrollView.controller),
       true,
     );
+    expect(
+      MediaQuery.paddingOf(tester.element(find.byType(CupertinoScrollbar))),
+      const EdgeInsets.only(top: _topContentInset, bottom: 80),
+    );
+    expect(
+      MediaQuery.paddingOf(tester.element(find.byType(CustomScrollView))),
+      EdgeInsets.zero,
+    );
+  });
+
+  _viewportTest('keeps the scroll range stable past a long response', (
+    tester,
+  ) async {
+    final controller = _controller(tester);
+    final ids = List<String>.generate(30, (index) => 'message-$index');
+
+    await tester.pumpWidget(
+      _viewportHost(
+        _viewport(
+          controller: controller,
+          ids: ids,
+          followLatest: false,
+          rowHeight: (id) => id == 'message-25' ? 2400 : 52,
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    final position = tester
+        .widget<CustomScrollView>(find.byType(CustomScrollView))
+        .controller!
+        .position;
+    final ranges = <double>[
+      position.maxScrollExtent - position.minScrollExtent,
+    ];
+    while (position.pixels > position.minScrollExtent) {
+      position.jumpTo(
+        math.max(position.minScrollExtent, position.pixels - 300),
+      );
+      await tester.pump();
+      ranges.add(position.maxScrollExtent - position.minScrollExtent);
+    }
+
+    for (final range in ranges.skip(1)) {
+      check(range).isCloseTo(ranges.first, 1);
+    }
   });
 
   test(

--- a/test/features/chat/widgets/chat_timeline_viewport_test.dart
+++ b/test/features/chat/widgets/chat_timeline_viewport_test.dart
@@ -181,7 +181,7 @@ void main() {
     final controller = _controller(tester);
     final ids = List<String>.generate(30, (index) => 'message-$index');
     const sourcePadding = EdgeInsets.fromLTRB(11, 12, 13, 14);
-    const scrollbarPadding = EdgeInsets.fromLTRB(11, _topContentInset, 13, 80);
+    const scrollbarPadding = EdgeInsets.fromLTRB(11, _topContentInset, 13, 40);
     addTearDown(PlatformUiCapabilities.resetDebugOverrides);
 
     PlatformUiCapabilities.debugPlatformOverride = TargetPlatform.android;
@@ -279,6 +279,55 @@ void main() {
     for (final range in ranges.skip(1)) {
       check(range).isCloseTo(ranges.first, 1);
     }
+  });
+
+  _viewportTest('does not amplify a long row across unmeasured siblings', (
+    tester,
+  ) async {
+    final controller = _controller(tester);
+    final ids = List<String>.generate(60, (index) => 'message-$index');
+
+    await tester.pumpWidget(
+      _viewportHost(
+        _viewport(
+          controller: controller,
+          ids: ids,
+          initialAnchor: const ChatScrollAnchor(
+            messageId: 'message-30',
+            offsetWithinMessage: 0,
+            loadedCount: 60,
+          ),
+          followLatest: false,
+          rowHeight: (id) =>
+              id == 'message-5' || id == 'message-50' ? 2400 : 52,
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    final position = tester
+        .widget<CustomScrollView>(find.byType(CustomScrollView))
+        .controller!
+        .position;
+    final ranges = <double>[
+      position.maxScrollExtent - position.minScrollExtent,
+    ];
+    while (position.pixels < position.maxScrollExtent) {
+      position.jumpTo(
+        math.min(position.maxScrollExtent, position.pixels + 300),
+      );
+      await tester.pump();
+      ranges.add(position.maxScrollExtent - position.minScrollExtent);
+    }
+    while (position.pixels > position.minScrollExtent) {
+      position.jumpTo(
+        math.max(position.minScrollExtent, position.pixels - 300),
+      );
+      await tester.pump();
+      ranges.add(position.maxScrollExtent - position.minScrollExtent);
+    }
+
+    check(ranges.reduce(math.max) - ranges.reduce(math.min)).isLessThan(2400);
   });
 
   _viewportTest('remeasures long rows after a same-ID owner change', (
@@ -2690,6 +2739,7 @@ Widget _viewport({
   // Defaults to the inverse so free-scroll anchor maintenance and automatic
   // latest ownership remain mutually exclusive in tests, as in ChatPage.
   bool? followLatest,
+  double scrollbarBottomInset = 40,
   Widget? liveFooter,
   Widget? trailingContent,
   bool hideUntilSettled = false,
@@ -2716,6 +2766,7 @@ Widget _viewport({
     trailingContent: trailingContent,
     topContentInset: _topContentInset,
     bottomPadding: 80,
+    scrollbarBottomInset: scrollbarBottomInset,
     horizontalPadding: 16,
     cacheExtent: 600,
     physics: const AlwaysScrollableScrollPhysics(),

--- a/test/features/direct_connections/direct_connections_management_test.dart
+++ b/test/features/direct_connections/direct_connections_management_test.dart
@@ -482,4 +482,59 @@ void main() {
     await tester.pumpAndSettle();
     expect(remoteController.reloadCount, 2);
   });
+
+  testWidgets('unsupported platforms neither show nor probe Apple models', (
+    tester,
+  ) async {
+    var appleStatusProbes = 0;
+    final availableStore = OpenWebUiDirectConnectionStore(
+      serverId: 'server',
+      accountId: 'account',
+      readSettings: () async => const <String, dynamic>{},
+      writeSettings: (_) async {},
+    );
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          applePccPlatformSupportedProvider.overrideWithValue(false),
+          appleOnDeviceStatusProvider.overrideWith((_) {
+            appleStatusProbes++;
+            throw StateError('Apple On-Device was probed');
+          }),
+          applePccStatusProvider.overrideWith((_) {
+            appleStatusProbes++;
+            throw StateError('Apple PCC was probed');
+          }),
+          directConnectionProfilesProvider.overrideWith(
+            () => DirectTestStaticDirectProfiles(const []),
+          ),
+          directHistoryPolicyProvider.overrideWith(
+            DirectTestStaticHistoryPolicy.new,
+          ),
+          openWebUiDirectConnectionStoreProvider.overrideWithValue(
+            availableStore,
+          ),
+          openWebUiDirectConnectionsProvider.overrideWith(
+            () => DirectTestStaticOpenWebUiConnections(
+              OpenWebUiDirectConnectionsCodec(
+                serverId: 'server',
+                accountId: 'account',
+              ).decode({'ui': <String, Object?>{}}),
+            ),
+          ),
+        ],
+        child: const MaterialApp(
+          localizationsDelegates: conduitLocalizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: DirectConnectionsPage(),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(appleStatusProbes, 0);
+    expect(find.text('Apple On-Device'), findsNothing);
+    expect(find.text('Apple Private Cloud Compute'), findsNothing);
+  });
 }

--- a/test/features/direct_connections/direct_providers_test.dart
+++ b/test/features/direct_connections/direct_providers_test.dart
@@ -12,6 +12,7 @@ import 'package:conduit/features/direct_connections/models/direct_completion.dar
 import 'package:conduit/features/direct_connections/models/direct_connection_profile.dart';
 import 'package:conduit/features/direct_connections/models/direct_remote_model.dart';
 import 'package:conduit/features/direct_connections/providers/direct_connection_providers.dart';
+import 'package:conduit/features/direct_connections/services/apple_pcc_adapter.dart';
 import 'package:conduit/features/direct_connections/services/direct_connection_profile_store.dart';
 import 'package:conduit/features/direct_connections/services/direct_model_cache_store.dart';
 import 'package:conduit/features/direct_connections/services/direct_model_registry.dart';
@@ -195,8 +196,14 @@ void main() {
   test(
     'Apple status providers do not call platform APIs when unsupported',
     () async {
+      final host = _ThrowingPccHost();
       final container = ProviderContainer(
-        overrides: [applePccPlatformSupportedProvider.overrideWithValue(false)],
+        overrides: [
+          applePccPlatformSupportedProvider.overrideWithValue(false),
+          applePccAdapterProvider.overrideWithValue(
+            ApplePccAdapter(hostApi: host),
+          ),
+        ],
       );
       addTearDown(container.dispose);
 
@@ -209,6 +216,7 @@ void main() {
         statuses.map((status) => status.availability),
         everyElement(PlatformPccAvailability.unsupported),
       );
+      expect(host.statusCalls, 0);
     },
   );
 
@@ -1665,6 +1673,16 @@ Future<List<DirectConnectionProfile>> _loadDurableProfiles() =>
     DirectConnectionProfileStore(
       SecureCredentialStorage(instance: const FlutterSecureStorage()),
     ).load();
+
+final class _ThrowingPccHost extends PccHostApi {
+  int statusCalls = 0;
+
+  @override
+  Future<PlatformPccStatus> getStatus(PlatformAppleModel model) {
+    statusCalls++;
+    throw StateError('Apple platform API must not be called');
+  }
+}
 
 final class _QueuedAdapter implements DirectProviderAdapter {
   final List<List<DirectRemoteModel>> responses = [];

--- a/test/features/direct_connections/direct_providers_test.dart
+++ b/test/features/direct_connections/direct_providers_test.dart
@@ -4,6 +4,7 @@ import 'dart:typed_data';
 
 import 'package:checks/checks.dart';
 import 'package:conduit/core/persistence/persistence_keys.dart';
+import 'package:conduit/core/platform/conduit_platform_apis.g.dart';
 import 'package:conduit/core/persistence/preferences_store.dart';
 import 'package:conduit/core/providers/app_providers.dart';
 import 'package:conduit/core/services/secure_credential_storage.dart';
@@ -190,6 +191,26 @@ void main() {
 
     expect(profiles, isEmpty);
   });
+
+  test(
+    'Apple status providers do not call platform APIs when unsupported',
+    () async {
+      final container = ProviderContainer(
+        overrides: [applePccPlatformSupportedProvider.overrideWithValue(false)],
+      );
+      addTearDown(container.dispose);
+
+      final statuses = await Future.wait([
+        container.read(appleOnDeviceStatusProvider.future),
+        container.read(applePccStatusProvider.future),
+      ]);
+
+      expect(
+        statuses.map((status) => status.availability),
+        everyElement(PlatformPccAvailability.unavailable),
+      );
+    },
+  );
 
   test(
     'enabled Apple On-Device is exposed as a built-in Direct profile',

--- a/test/features/direct_connections/direct_providers_test.dart
+++ b/test/features/direct_connections/direct_providers_test.dart
@@ -207,7 +207,7 @@ void main() {
 
       expect(
         statuses.map((status) => status.availability),
-        everyElement(PlatformPccAvailability.unavailable),
+        everyElement(PlatformPccAvailability.unsupported),
       );
     },
   );

--- a/test/shared/widgets/markdown/markdown_compile_service_test.dart
+++ b/test/shared/widgets/markdown/markdown_compile_service_test.dart
@@ -509,6 +509,30 @@ void main() {
       expect(detailsBlock.toolCallData, toolCallData);
     });
 
+    test('prepares multiline single-quoted tool calls semantically', () {
+      const content = '''<DeTaIlS
+ TYPE='tool_calls'
+ done='true'
+ name='search'
+ arguments='{"html":"<br><span>value</span>"}'>
+</details>''';
+
+      final document = compilePreparedMarkdownSync(
+        prepareMarkdownContent(content, streaming: false),
+      );
+      final details =
+          (document.nodes.first as CompiledMarkdownElement).detailsData!;
+
+      expect(details.kind, CompiledMarkdownDetailsKind.toolCall);
+      expect(details.name, 'search');
+      expect(details.isDone, isTrue);
+      expect(details.toolCallData!.argumentEntries.single.label, 'html');
+      expect(
+        details.toolCallData!.argumentEntries.single.value,
+        '<br><span>value</span>',
+      );
+    });
+
     test('stores details bodies as lazy markdown payloads', () {
       final document = compilePreparedMarkdownSync(
         [

--- a/test/shared/widgets/markdown/markdown_preprocessor_test.dart
+++ b/test/shared/widgets/markdown/markdown_preprocessor_test.dart
@@ -75,6 +75,66 @@ void main() {
       check(result).contains('Answer\n\n$details');
       check(result).contains('`Example$details`');
     });
+
+    test('repairs multiline details tags and quoted raw HTML', () {
+      const input = '''Answer<DeTaIlS
+ TYPE='tool_calls'
+ done='true'
+ name='search'
+ arguments='{"html":"<br><span>value</span>"}'>
+</details>''';
+
+      final result = ConduitMarkdownPreprocessor.normalize(input);
+
+      check(result).startsWith('Answer\n\n<DeTaIlS');
+      check(result).contains("TYPE='tool_calls'");
+      check(result).contains('&lt;br&gt;&lt;span&gt;value&lt;/span&gt;');
+      check(result).not((value) => value.contains("TYPE='tool_calls'\n"));
+    });
+
+    test('repairs double-quoted multiline details attributes', () {
+      const input = '''<details
+ type="tool_calls"
+ arguments="{&quot;html&quot;:&quot;<br>&quot;}">
+</details>''';
+
+      final result = ConduitMarkdownPreprocessor.normalize(input);
+
+      check(result)
+          .contains('arguments="{&quot;html&quot;:&quot;&lt;br&gt;&quot;}"');
+      check(result).not((value) => value.contains('<details\n'));
+    });
+
+    test(
+      'leaves details examples inside backtick and tilde fences unchanged',
+      () {
+        const backticks = '''```
+<details
+ type='tool_calls'
+ arguments='{"html":"<br>"}'>
+</details>
+```''';
+        const tildes = '''~~~html
+<details
+ type='tool_calls'
+ arguments='{"html":"<br>"}'>
+</details>
+~~~''';
+
+        check(ConduitMarkdownPreprocessor.normalize(backticks))
+            .equals(backticks);
+        check(ConduitMarkdownPreprocessor.normalize(tildes)).equals(tildes);
+      },
+    );
+
+    test('leaves malformed and oversized details tags unchanged', () {
+      const malformed = '<details\n type="tool_calls"';
+      final oversized =
+          '<details\n type="tool_calls" data="${'x' * (256 * 1024)}">';
+
+      check(ConduitMarkdownPreprocessor.normalize(malformed)).equals(malformed);
+      check(ConduitMarkdownPreprocessor.normalize(oversized)).equals(oversized);
+    });
   });
 
   group('ConduitMarkdownPreprocessor.sanitize', () {

--- a/test/shared/widgets/markdown/markdown_preprocessor_test.dart
+++ b/test/shared/widgets/markdown/markdown_preprocessor_test.dart
@@ -76,6 +76,20 @@ void main() {
       check(result).contains('`Example$details`');
     });
 
+    test('matches only quote-aware tool-call type attributes', () {
+      const generic =
+          '<details data-type="tool_calls"><summary>Keep</summary></details>';
+      const toolCall =
+          '''<details arguments='{"comparison":"1 > 0"}' type="tool_calls"><summary>Hide</summary></details>''';
+
+      check(ConduitMarkdownPreprocessor.sanitizeForClipboard(generic))
+          .equals(generic);
+      check(ConduitMarkdownPreprocessor.sanitizeForClipboard(toolCall))
+          .equals('');
+      check(ConduitMarkdownPreprocessor.normalize('Answer$toolCall'))
+          .contains('Answer\n\n<details');
+    });
+
     test('repairs multiline details tags and quoted raw HTML', () {
       const input = '''Answer<DeTaIlS
  TYPE='tool_calls'
@@ -145,17 +159,46 @@ void main() {
       check(ConduitMarkdownPreprocessor.normalize(input)).equals(input);
     });
 
+    test('keeps tilde fences nested in backticks from masking later tags', () {
+      const input = '''```
+~~~
+```
+<details
+ type='tool_calls'>''';
+
+      check(ConduitMarkdownPreprocessor.normalize(input))
+          .contains("```\n~~~\n```\n<details  type='tool_calls'>");
+    });
+
+    test('requires a tilde closing fence as long as its opener', () {
+      const input = '''~~~~
+<details
+ type='tool_calls'>
+~~~
+<details
+ type='tool_calls'>
+~~~~''';
+
+      check(ConduitMarkdownPreprocessor.normalize(input)).equals(input);
+    });
+
     test('leaves malformed and oversized details tags unchanged', () {
       const malformed = '<details\n type="tool_calls"';
       final oversized =
           '<details\n type="tool_calls" data="${'x' * (256 * 1024)}">';
       final followedByValid = '$oversized\n<details\n type="tool_calls">';
+      const malformedBeforeValid = '''<details data="unterminated
+<details
+ type="tool_calls">''';
 
       check(ConduitMarkdownPreprocessor.normalize(malformed)).equals(malformed);
       check(ConduitMarkdownPreprocessor.normalize(oversized)).equals(oversized);
       check(ConduitMarkdownPreprocessor.normalize(followedByValid))
         ..startsWith(oversized)
         ..contains('<details  type="tool_calls">');
+      check(
+        ConduitMarkdownPreprocessor.normalize(malformedBeforeValid),
+      ).contains('<details data="unterminated\n<details  type="tool_calls">');
     });
 
     test('repairs bounded details tags in oversized messages', () {

--- a/test/shared/widgets/markdown/markdown_preprocessor_test.dart
+++ b/test/shared/widgets/markdown/markdown_preprocessor_test.dart
@@ -149,9 +149,13 @@ void main() {
       const malformed = '<details\n type="tool_calls"';
       final oversized =
           '<details\n type="tool_calls" data="${'x' * (256 * 1024)}">';
+      final followedByValid = '$oversized\n<details\n type="tool_calls">';
 
       check(ConduitMarkdownPreprocessor.normalize(malformed)).equals(malformed);
       check(ConduitMarkdownPreprocessor.normalize(oversized)).equals(oversized);
+      check(ConduitMarkdownPreprocessor.normalize(followedByValid))
+        ..startsWith(oversized)
+        ..contains('<details  type="tool_calls">');
     });
 
     test('repairs bounded details tags in oversized messages', () {

--- a/test/shared/widgets/markdown/markdown_preprocessor_test.dart
+++ b/test/shared/widgets/markdown/markdown_preprocessor_test.dart
@@ -133,6 +133,18 @@ void main() {
       },
     );
 
+    test('restores nested code fence placeholders', () {
+      const input = '''````markdown
+~~~html
+<details
+ type='tool_calls'>
+</details>
+~~~
+````''';
+
+      check(ConduitMarkdownPreprocessor.normalize(input)).equals(input);
+    });
+
     test('leaves malformed and oversized details tags unchanged', () {
       const malformed = '<details\n type="tool_calls"';
       final oversized =

--- a/test/shared/widgets/markdown/markdown_preprocessor_test.dart
+++ b/test/shared/widgets/markdown/markdown_preprocessor_test.dart
@@ -120,10 +120,16 @@ void main() {
  arguments='{"html":"<br>"}'>
 </details>
 ~~~''';
+        const unterminatedTildes = '''~~~html
+<details
+ type='tool_calls'
+ arguments='{"html":"<br>"}'>''';
 
         check(ConduitMarkdownPreprocessor.normalize(backticks))
             .equals(backticks);
         check(ConduitMarkdownPreprocessor.normalize(tildes)).equals(tildes);
+        check(ConduitMarkdownPreprocessor.normalize(unterminatedTildes))
+            .equals(unterminatedTildes);
       },
     );
 
@@ -134,6 +140,16 @@ void main() {
 
       check(ConduitMarkdownPreprocessor.normalize(malformed)).equals(malformed);
       check(ConduitMarkdownPreprocessor.normalize(oversized)).equals(oversized);
+    });
+
+    test('repairs bounded details tags in oversized messages', () {
+      final input = '''${'x' * (256 * 1024 + 1)}
+<details
+ type="tool_calls">
+</details>''';
+
+      check(ConduitMarkdownPreprocessor.normalize(input))
+          .contains('<details  type="tool_calls">');
     });
   });
 

--- a/test/shared/widgets/markdown/streaming_markdown_preparation_test.dart
+++ b/test/shared/widgets/markdown/streaming_markdown_preparation_test.dart
@@ -209,6 +209,19 @@ result
     );
   });
 
+  test('single-quoted multiline incomplete tool calls stay hidden', () {
+    const content = '''Visible
+
+<DeTaIlS
+ TYPE='tool_calls'
+ name='search'>''';
+
+    expect(
+      prepareMarkdownContentCanonical(content, streaming: true),
+      'Visible',
+    );
+  });
+
   test('base revision mismatch returns a full reset patch', () {
     final engine = StreamingMarkdownPreparationEngine();
     engine.prepare(

--- a/test/shared/widgets/themed_sheets_test.dart
+++ b/test/shared/widgets/themed_sheets_test.dart
@@ -86,6 +86,47 @@ void main() {
     await tester.pump(const Duration(milliseconds: 500));
   });
 
+  testWidgets(
+    'native model selector owns taps inside a tablet drag hierarchy',
+    (tester) async {
+      PlatformUiCapabilities.debugPlatformOverride = TargetPlatform.iOS;
+      PlatformUiCapabilities.debugIOSMajorVersionOverride = 26;
+      PlatformUiCapabilities.debugNativeIOS26Override = true;
+      addTearDown(PlatformUiCapabilities.resetDebugOverrides);
+      tester.view.physicalSize = const Size(1366, 1024);
+      tester.view.devicePixelRatio = 1;
+      addTearDown(tester.view.resetPhysicalSize);
+      addTearDown(tester.view.resetDevicePixelRatio);
+      var activations = 0;
+
+      await tester.pumpWidget(
+        MaterialApp(
+          theme: AppTheme.light(TweakcnThemes.t3Chat)
+              .copyWith(platform: TargetPlatform.iOS),
+          home: Scaffold(
+            body: GestureDetector(
+              behavior: HitTestBehavior.opaque,
+              onHorizontalDragUpdate: (_) {},
+              child: Align(
+                alignment: Alignment.topLeft,
+                child: ConduitAdaptiveAppBarModelSelector(
+                  label: 'Inkling',
+                  maxWidth: 240,
+                  onPressed: () => activations++,
+                ),
+              ),
+            ),
+          ),
+        ),
+      );
+
+      await tester.tap(find.byType(ConduitAdaptiveAppBarModelSelector));
+      await tester.pump();
+
+      expect(activations, 1);
+    },
+  );
+
   test('toolbar icons preserve their SF Symbol lookup values', () {
     check(conduitToolbarSfSymbolForIcon(CupertinoIcons.line_horizontal_3))
         .equals('line.3.horizontal');


### PR DESCRIPTION
## Summary

- hide Apple On-Device and Private Cloud Compute UI and status probes outside iOS
- upgrade cupertino_native_better to 1.6.0, retain one connected CNGlassButtonGroup, and make the iPad model selector Flutter-tappable with immediate loading and progressive metadata
- use a fixed 100 ms streaming render cadence with no user-facing cadence setting
- repair multiline Open WebUI tool-call details markup across streaming and saved Markdown
- hold the screen awake only while an assistant response is thinking or streaming
- stabilize lazy-list scroll metrics for long responses and bound the native scrollbar track to the unobscured chat viewport

## Verification

- focused chat, Direct Connections, Markdown, native-sheet, and wakelock suite: 200 passed
- native toolbar and composer regression suite: 75 passed
- rebased Open WebUI API, workspace, prompt, and Socket.IO compatibility suite: 123 passed
- flutter analyze lib: clean
- iOS Simulator and Android debug builds succeeded
- verified model selection and connected toolbar actions on fresh iPhone and iPad simulators
- verified a 120-line response across the full iOS scrollbar range; 116 focused timeline and layout tests pass
- verified both onboarding and Direct Connections hide Apple backends on a fresh Android API 24 emulator

## Compatibility

The branch is rebased on the Open WebUI v0.11.3 compatibility update. A read-only drift audit found no removed routes or Socket.IO event names; response changes used by Conduit are additive, and focused API/socket tests pass.

Includes and extends the raw tool-call repair from #685.

Closes #694
Closes #692
Closes #688
Closes #686
Closes #677
Closes #681

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Keeps the device screen awake while chat responses stream, including in the background.
  * Improves model selector tap handling and prevents duplicate openings.
  * Stabilizes chat timeline scrolling and scrollbar range estimates.

* **Bug Fixes**
  * Makes reasoning-effort hydration more responsive.
  * Hides Apple-specific backends and avoids unavailable service checks on unsupported platforms.
  * Improves Markdown handling for multiline details and tool-call blocks.
  * Uses a consistent cadence for streaming updates.
  * Improves recovery and persistence of submitted background responses.

* **Tests**
  * Added coverage for chat generation, platform availability, recovery, model selection, timeline scrolling, and Markdown parsing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->





















































<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This change strengthens recovery of accepted chat completions by retaining a local generation lease through task-aware recovery, scopes wakelock ownership to work running on this device, and improves long-response rendering and scrolling. It also updates adaptive native controls, platform behavior, and persisted message metadata.

No blocking failure remains.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

No blocking failure remains.

No accepted blocking finding remains in the current implementation.
</details>


<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- The focused Flutter test attempt ran but the Flutter toolchain was unavailable, resulting in a flutter: not found blocker.
- A current wakelock and recovery flow capture was recorded, detailing the lease wrapper, two-absence logic, failure budget, final pulls, and assertions.
- The focused Flutter test command and the current-flow inspection command sources were authored and uploaded for review.
- It was confirmed that Dart and Flutter toolchains are unavailable in the environment, preventing runtime observation of the markdown normalization function.
- The markdown normalization probe command sources and related Flutter markdown test artifacts, including the normalization change diff, were uploaded to support the validation work.

<a href="https://app.greptile.com/trex/runs/22323606/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (27): Last reviewed commit: ["fix: type scrollbar fallback explicitly"](https://github.com/cogwheel0/conduit/commit/ade2561a0b73e63107847d0203863c29c625e78d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59307093)</sub>

<!-- /greptile_comment -->